### PR TITLE
Removing Zernike cluster shape variables

### DIFF
--- a/MicroAODFormats/interface/Photon.h
+++ b/MicroAODFormats/interface/Photon.h
@@ -14,8 +14,6 @@ namespace flashgg {
     
     void  setSipip(float val) {sipip=val;};
     void  setSieip(float val) {sieip=val;};
-    void  setZernike20(float val) {zernike20=val;};
-    void  setZernike42(float val) {zernike42=val;};
     void  setE2nd(float val) {e2nd=val;};
     void  setE2x5right(float val) {e2x5right=val;};
     void  setE2x5left(float val) {e2x5left=val;};
@@ -30,8 +28,6 @@ namespace flashgg {
 
     float const getSipip() const {return sipip;};
     float const getSieip() const {return sieip;};
-    float const getZernike20() const {return zernike20;};
-    float const getZernike42() const {return zernike42;};
     float const getE2nd() const {return e2nd;};
     float const getE2x5right() const {return e2x5right;};
     float const getE2x5left() const {return e2x5left;};

--- a/MicroAODProducers/plugins/PhotonProducer.cc
+++ b/MicroAODProducers/plugins/PhotonProducer.cc
@@ -76,8 +76,6 @@ namespace flashgg {
       
       fg.setSipip(viCov[2]);
       fg.setSieip(viCov[1]);
-      fg.setZernike20(lazyTool.zernike20(*seed_clu));
-      fg.setZernike42(lazyTool.zernike42(*seed_clu));
       fg.setE2nd(lazyTool.e2nd(*seed_clu));
       fg.setE2x5right(lazyTool.e2x5Right(*seed_clu));
       fg.setE2x5left(lazyTool.e2x5Left(*seed_clu));

--- a/MicroAODProducers/test/simple_Producer_test.py
+++ b/MicroAODProducers/test/simple_Producer_test.py
@@ -21,7 +21,7 @@ process.GlobalTag.globaltag = 'POSTLS170_V5::All'
 #             )
 #    )
 
-process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(10) )
+process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(100) )
 
 process.source = cms.Source("PoolSource",fileNames=cms.untracked.vstring("file:/afs/cern.ch/work/s/sethzenz/public/Hgg_miniAOD_run0/miniAOD_3.root"))
 


### PR DESCRIPTION
This was provoking a crash when no photon preselection is applied.

As discussed two weeks ago during the regular meeting, these variables are probably not used anyway.
