### PR TITLE
add min jet pt, set it to 0

### DIFF
--- a/MicroAODProducers/plugins/JetProducer.cc
+++ b/MicroAODProducers/plugins/JetProducer.cc
@@ -33,6 +33,7 @@ namespace flashgg {
     unique_ptr<PileupJetIdAlgo>  pileupJetIdAlgo_;
     ParameterSet pileupJetIdParameters_;
     //    bool useAODOnlyPileupJetIdMethod_;
+    double minJetPt_; // GeV
   };
 
 
@@ -42,7 +43,8 @@ namespace flashgg {
     //    vertexToken_(consumes<View<reco::Vertex> >(iConfig.getUntrackedParameter<InputTag> ("VertexTag", InputTag("offlineSlimmedPrimaryVertices")))),
     //    vertexToken_(consumes<reco::VertexCollection>(iConfig.getUntrackedParameter<InputTag> ("VertexTag", InputTag("offlineSlimmedPrimaryVertices")))),
     vertexCandidateMapToken_(consumes<VertexCandidateMap>(iConfig.getParameter<InputTag>("VertexCandidateMapTag"))),
-    pileupJetIdParameters_(iConfig.getParameter<ParameterSet>("PileupJetIdParameters"))
+    pileupJetIdParameters_(iConfig.getParameter<ParameterSet>("PileupJetIdParameters")),
+    minJetPt_(iConfig.getUntrackedParameter<double>("MinJetPt",0.))
     //    useAODOnlyPileupJetIdMethod_(iConfig.getUntrackedParameter<bool>("UseAODOnlyPileupJetIdMethod",false))
     
   {
@@ -73,6 +75,7 @@ namespace flashgg {
 
     for (unsigned int i = 0 ; i < jetPointers.size() ; i++) {
       Ptr<pat::Jet> pjet = jetPointers[i];
+      if (pjet->pt() < minJetPt_) continue;
       flashgg::Jet fjet = flashgg::Jet(*pjet);
       for (unsigned int j = 0 ; j < diPhotonPointers.size() ; j++) {
 	Ptr<DiPhotonCandidate> diPhoton = diPhotonPointers[j];

--- a/MicroAODProducers/python/flashggJets_cfi.py
+++ b/MicroAODProducers/python/flashggJets_cfi.py
@@ -7,5 +7,6 @@ flashggJets = cms.EDProducer('FlashggJetProducer',
 		VertexTag=cms.untracked.InputTag('offlineSlimmedPrimaryVertices'),
 		JetTag=cms.untracked.InputTag('slimmedJets'),
 		VertexCandidateMapTag = cms.InputTag("flashggVertexMapUnique"),
-		PileupJetIdParameters=cms.PSet(pu_jetid) # from PileupJetIDParams_cfi
+		PileupJetIdParameters=cms.PSet(pu_jetid),
+                MinJetPt=cms.untracked.double(0.)             
 		)


### PR DESCRIPTION
Add handle to set minimum flashgg jet pt.  Currently the default setting is no cut, but we can reduce the size of the jet collection by about 50% if we set it to 15 GeV.
