### PR TITLE
Added extra MC truth

### DIFF
--- a/MicroAODAlgos/interface/PhotonIdUtils.h
+++ b/MicroAODAlgos/interface/PhotonIdUtils.h
@@ -68,8 +68,7 @@ namespace flashgg {
     
     static void recomputeNonZsClusterShapes(reco::Photon & pho, noZS::EcalClusterLazyTools &tools);
     static void recomputeNonZsClusterShapes(reco::Photon & pho, const EcalRecHitCollection* ebRecHists, const EcalRecHitCollection * eeRecHist, const CaloTopology * topology);
-    static void determineMatchType(flashgg::Photon & pho, flashgg::Photon::mcMatch_t defaultType=flashgg::Photon::kFake); // FIXME should move to some MC utils class
-    
+   
     template <class T> static void fillExtraClusterShapes(flashgg::Photon & pho, T & lazyTool) {
       const reco::CaloClusterPtr  seed_clu = pho.superCluster()->seed();
       const reco::SuperClusterRef super_clu= pho.superCluster();

--- a/MicroAODAlgos/interface/PhotonMCUtils.h
+++ b/MicroAODAlgos/interface/PhotonMCUtils.h
@@ -1,0 +1,64 @@
+#ifndef _PhotonMCUtils_h_
+#define _PhotonMCUtils_h_
+
+#include "DataFormats/Math/interface/deltaR.h"
+#include "flashgg/MicroAODFormats/interface/Photon.h"
+
+namespace flashgg {
+
+	class PhotonMCUtils {
+		
+	public:
+		template<class GenT, class GenCollT> static float getIsoSum(const GenT & genp, const GenCollT & coll, float dRMax) {
+			float sum = 0.;
+			for(auto & part : coll) {
+				if( reco::deltaR(genp,part) >= dRMax || part.p4() == genp.p4() ) { continue; }
+				sum += part.et();
+			}
+			return sum;
+		}
+		
+		template<class GenT, class GenCollT> static bool frixioneIso(const GenT & genp, const GenCollT & coll, float delta0, float eps0, float n0) {
+			// Phys.Lett. B429 (1998) 369-374 - arXiv:hep-ph/9801442
+			std::map<float,float> slices;
+			for(auto & part : coll) {
+				float dR = reco::deltaR(genp,part);
+				if(dR  >= delta0 || part.p4() == genp.p4() ) { continue; }
+				slices[dR] += part.et();
+			}
+			float sum = 0.;
+			const float eTimesEps        = genp.et()*eps0;
+			const float oneMinusCosDelta0 = 1 - cos(delta0);
+			for( auto & slice : slices ) {
+				auto& delta = slice.first;
+				sum  += slice.second;
+				const float chi = eTimesEps*pow( (1-cos(delta))/oneMinusCosDelta0, n0 );
+				if( sum >= chi ) { return false; }
+			}
+			return true;
+		}
+
+		static void determineMatchType(flashgg::Photon & pho, flashgg::Photon::mcMatch_t defaultType=flashgg::Photon::kFake);
+		template<class GenT> static flashgg::Photon::mcMatch_t determineMatchType(const GenT & gen, flashgg::Photon::mcMatch_t defaultType=flashgg::Photon::kFake) {
+			auto matchType = defaultType;
+			for(size_t imom=0; imom<gen.numberOfMothers(); ++imom) {
+				int mstat = gen.mother(imom)->status();
+				int mpdgId = abs(gen.mother(imom)->pdgId());
+				if( mpdgId > 0 && mpdgId <= 25 && (mstat == 3 || mstat == 23 || mstat == 22) ) {
+					matchType = flashgg::Photon::kPrompt;
+				}
+				if( mstat == 2 && mpdgId != 22 ) {
+					matchType = flashgg::Photon::kFake;
+				}
+			}
+			return matchType;
+		}
+
+		
+	};
+
+
+}
+
+
+#endif // _PhotonMCUtils_h_

--- a/MicroAODAlgos/src/PhotonIdUtils.cc
+++ b/MicroAODAlgos/src/PhotonIdUtils.cc
@@ -384,20 +384,3 @@ void PhotonIdUtils::recomputeNonZsClusterShapes(reco::Photon & pho, const EcalRe
 	pho.full5x5_setShowerShapeVariables(showerShape);
 }
 
-void PhotonIdUtils::determineMatchType(flashgg::Photon & fg, flashgg::Photon::mcMatch_t defaultType) 
-{
-	if( ! fg.hasMatchedGenPhoton() ) { return; }
-	auto gen = fg.matchedGenPhoton();
-	auto matchType = defaultType;
-	for(size_t imom=0; imom<gen->numberOfMothers(); ++imom) {
-	  int mstat = gen->mother(imom)->status();
-	  int mpdgId = abs(gen->mother(imom)->pdgId());
-	  if( mpdgId > 0 && mpdgId <= 25 && (mstat == 3 || mstat == 23 || mstat == 22) ) {
-	    matchType = flashgg::Photon::kPrompt;
-	  }
-	  if( mstat == 2 && mpdgId != 22 ) {
-	    matchType = flashgg::Photon::kFake;
-	  }
-	}
-	fg.setGenMatchType(matchType);
-}

--- a/MicroAODAlgos/src/PhotonMCUtils.cc
+++ b/MicroAODAlgos/src/PhotonMCUtils.cc
@@ -1,0 +1,11 @@
+#include "flashgg/MicroAODAlgos/interface/PhotonMCUtils.h"
+
+using namespace flashgg;
+void PhotonMCUtils::determineMatchType(flashgg::Photon & fg, flashgg::Photon::mcMatch_t defaultType) 
+{
+	if( ! fg.hasMatchedGenPhoton() ) { return; }
+	auto gen = fg.matchedGenPhoton();
+	auto matchType = determineMatchType(*gen,defaultType);
+	fg.setGenMatchType(matchType);
+}
+

--- a/MicroAODFormats/interface/GenPhotonExtra.h
+++ b/MicroAODFormats/interface/GenPhotonExtra.h
@@ -1,0 +1,54 @@
+#ifndef FLASHgg_GenPhotonExtra_h
+#define FLASHgg_GenPhotonExtra_h
+
+#include "flashgg/MicroAODFormats/interface/Photon.h"
+#include "DataFormats/PatCandidates/interface/PackedGenParticle.h"
+#include "DataFormats/Common/interface/Ptr.h"
+
+#include <string>
+
+namespace flashgg {
+
+  class GenPhotonExtra  {
+
+  public:
+    typedef edm::Ptr<pat::PackedGenParticle> ptr_type;
+    typedef ptr_type::value_type cand_type;
+    typedef Photon::mcMatch_t match_type;
+    
+    GenPhotonExtra() {}
+    GenPhotonExtra(ptr_type ptr) : ptr_(ptr) {}
+
+   
+    bool operator==(const ptr_type & rhs) const { return ptr_ == rhs; }
+    bool operator!=(const ptr_type & rhs) const { return ptr_ != rhs; }
+
+    const cand_type& cand() const { return *ptr_; }
+    ptr_type ptr() const { return ptr_; }
+    void setPtr(ptr_type x) { ptr_ = x; }
+    
+    match_type type() const { return type_; }
+    void setType(match_type x) { type_ = x; }
+
+    float genIso() const { return genIso_; }
+    void setGenIso(float x) { genIso_ = x; }
+    
+    bool frixioneIso() const { return frixioneIso_; }
+    void setFrixioneIso(bool x) { frixioneIso_ = x; }
+    
+    void copyTo(flashgg::Photon & fg, const std::string & postFix="") const { 
+	    fg.setGenMatchType(type_);
+	    fg.addUserFloat("genIso"+postFix,genIso_);
+	    fg.addUserInt("frixioneIso"+postFix,frixioneIso_);
+    }
+
+  private:
+    ptr_type ptr_;
+    match_type type_;
+    float genIso_;
+    bool  frixioneIso_;
+
+  };
+}
+
+#endif

--- a/MicroAODFormats/src/classes.h
+++ b/MicroAODFormats/src/classes.h
@@ -7,6 +7,7 @@
 #include "DataFormats/Common/interface/Ptr.h"
 #include "DataFormats/PatCandidates/interface/Muon.h"
 #include "DataFormats/JetReco/interface/PileupJetIdentifier.h"
+#include "flashgg/MicroAODFormats/interface/GenPhotonExtra.h"
 
 #include <vector>
 #include <map>
@@ -56,4 +57,12 @@ namespace  { struct dictionary {
   std::vector<flashgg::Electron>				  vec_fgg_ele;
   edm::Wrapper<std::vector<flashgg::Electron> >               wrp_vec_fgg_ele;					
   std::vector<reco::Conversion>					  vec_rec_con;		
+	
+  
+  edm::Ptr<pat::PackedGenParticle>                                     ptr_pat_pak_cand;
+  flashgg::GenPhotonExtra                                                   fgg_pho_xtra;
+  edm::Ptr<flashgg::GenPhotonExtra>                                     ptr_fgg_pho_xtra;
+  edm::Wrapper<flashgg::GenPhotonExtra>                                 wrp_fgg_pho_xtra;
+  std::vector<flashgg::GenPhotonExtra>                                  vec_fgg_pho_xtra;
+  edm::Wrapper<std::vector<flashgg::GenPhotonExtra> >               wrp_vec_fgg_pho_xtra;
 };}

--- a/MicroAODFormats/src/classes_def.xml
+++ b/MicroAODFormats/src/classes_def.xml
@@ -33,6 +33,11 @@
  <class name="edm::PtrVector<flashgg::Electron>"/>
  <class name="std::vector<flashgg::Electron>"/>
  <class name="edm::Wrapper<std::vector<flashgg::Electron> >"/>
+ <class name="edm::Ptr<pat::PackedGenParticle>"/>
+ <class name="flashgg::GenPhotonExtra"/>
+ <class name="edm::Ptr<flashgg::GenPhotonExtra>"/>
+ <class name="std::vector<flashgg::GenPhotonExtra>"/>
+ <class name="edm::Wrapper<std::vector<flashgg::GenPhotonExtra> >"/>
 </lcgdict>
 
 

--- a/MicroAODProducers/plugins/GenPhotonExtraProducer.cc
+++ b/MicroAODProducers/plugins/GenPhotonExtraProducer.cc
@@ -1,0 +1,69 @@
+
+#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "DataFormats/Common/interface/Handle.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "flashgg/MicroAODFormats/interface/GenPhotonExtra.h"
+#include "flashgg/MicroAODFormats/interface/VertexCandidateMap.h"
+#include "flashgg/MicroAODAlgos/interface/PhotonMCUtils.h"
+
+
+using namespace std;
+using namespace edm;
+
+namespace flashgg {
+
+  class GenPhotonExtraProducer : public EDProducer {
+
+  public:
+    GenPhotonExtraProducer( const ParameterSet & );
+  private:
+    void produce( Event &, const EventSetup & ) override;
+    
+    EDGetTokenT<View<pat::PackedGenParticle> > genPhotonsToken_;
+    EDGetTokenT<View<pat::PackedGenParticle> > genParticlesToken_;
+    double isoConeSize_, epsilon0_, n0_;
+  };
+
+
+  GenPhotonExtraProducer::GenPhotonExtraProducer(const ParameterSet & iConfig) :
+    genPhotonsToken_(consumes<View<pat::PackedGenParticle> >(iConfig.getParameter<InputTag>("genPhotons"))),
+    genParticlesToken_(consumes<View<pat::PackedGenParticle> >(iConfig.getParameter<InputTag>("genParticles"))),
+    isoConeSize_(iConfig.getParameter<double>("isoConeSize")),
+    epsilon0_(iConfig.getParameter<double>("epsilon0")),
+    n0_(iConfig.getParameter<double>("n0"))
+  {
+    produces<vector<flashgg::GenPhotonExtra> >();
+  }
+
+  void GenPhotonExtraProducer::produce( Event & evt, const EventSetup & iSetup) {
+
+    Handle<View<pat::PackedGenParticle> > genPhotons, genParticles;
+    evt.getByToken(genPhotonsToken_,genPhotons);
+    evt.getByToken(genParticlesToken_,genParticles);
+
+    auto_ptr<vector<flashgg::GenPhotonExtra> > extraColl(new vector<flashgg::GenPhotonExtra>);
+
+    auto & genPhotonPointers = genPhotons->ptrVector();
+    for (auto & genPho : genPhotonPointers ) {
+
+	    flashgg::GenPhotonExtra extra(genPho);
+	    extra.setType(PhotonMCUtils::determineMatchType(*genPho));
+	    extra.setGenIso(PhotonMCUtils::getIsoSum(*genPho, *genParticles, isoConeSize_));
+	    extra.setFrixioneIso(PhotonMCUtils::frixioneIso(*genPho, *genParticles, isoConeSize_, epsilon0_, n0_));
+	    
+	    extraColl->push_back(extra);
+    }
+    
+    evt.put(extraColl);
+
+    /// orig_collection = 0;
+  }
+}
+
+
+
+typedef flashgg::GenPhotonExtraProducer FlashggGenPhotonExtraProducer;
+DEFINE_FWK_MODULE(FlashggGenPhotonExtraProducer);

--- a/MicroAODProducers/python/flashggGenPhotonsExtra_cfi.py
+++ b/MicroAODProducers/python/flashggGenPhotonsExtra_cfi.py
@@ -1,0 +1,10 @@
+import FWCore.ParameterSet.Config as cms
+
+flashggGenPhotonsExtra = cms.EDProducer("FlashggGenPhotonExtraProducer",
+                                      genPhotons = cms.InputTag("flashggGenPhotons"),
+                                      genParticles = cms.InputTag("packedGenParticles"),
+                                      isoConeSize = cms.double(0.3),
+                                      epsilon0 = cms.double(1.0), ## for Frixione isolation
+                                      n0 = cms.double(1.0)
+                                    )
+

--- a/MicroAODProducers/python/flashggMicroAODGenSequence_cff.py
+++ b/MicroAODProducers/python/flashggMicroAODGenSequence_cff.py
@@ -1,0 +1,8 @@
+import FWCore.ParameterSet.Config as cms
+from flashgg.MicroAODProducers.flashggPrunedGenParticles_cfi import flashggPrunedGenParticles
+from flashgg.MicroAODProducers.flashggGenPhotons_cfi import flashggGenPhotons
+from flashgg.MicroAODProducers.flashggGenPhotonsExtra_cfi import flashggGenPhotonsExtra
+
+
+flashggMicroAODGenSequence = cms.Sequence(flashggPrunedGenParticles+flashggGenPhotons*flashggGenPhotonsExtra
+                                        )

--- a/MicroAODProducers/python/flashggMicroAODSequence_cff.py
+++ b/MicroAODProducers/python/flashggMicroAODSequence_cff.py
@@ -4,9 +4,9 @@ from flashgg.MicroAODProducers.flashggPhotons_cfi import flashggPhotons
 from flashgg.MicroAODProducers.flashggDiPhotons_cfi import flashggDiPhotons
 from flashgg.MicroAODProducers.flashggPreselectedDiPhotons_cfi import flashggPreselectedDiPhotons
 from flashgg.MicroAODProducers.flashggJets_cfi import flashggJets
-from flashgg.MicroAODProducers.flashggPrunedGenParticles_cfi import flashggPrunedGenParticles
-from flashgg.MicroAODProducers.flashggGenPhotons_cfi import flashggGenPhotons
 from flashgg.MicroAODProducers.flashggElectrons_cfi import flashggElectrons
+
+from flashgg.MicroAODProducers.flashggMicroAODGenSequence_cff import *
 
 eventCount = cms.EDProducer("EventCountProducer")
 weightsCount = cms.EDProducer("WeightsCountProducer",
@@ -18,8 +18,10 @@ weightsCount = cms.EDProducer("WeightsCountProducer",
                               nbinsObsPileup=cms.int32(101),
                               )
 
-flashggMicroAODSequence = cms.Sequence((eventCount+weightsCount+flashggVertexMapUnique+flashggVertexMapNonUnique+flashggPrunedGenParticles+flashggGenPhotons+flashggElectrons)*
-                                       flashggPhotons*
-                                       flashggDiPhotons*
-                                       (flashggPreselectedDiPhotons+flashggJets)
+flashggMicroAODSequence = cms.Sequence((eventCount+weightsCount
+                                        +flashggVertexMapUnique+flashggVertexMapNonUnique+flashggElectrons
+                                        +flashggMicroAODGenSequence
+                                        )
+                                       *flashggPhotons*flashggDiPhotons
+                                       *(flashggPreselectedDiPhotons+flashggJets)
                                        )

--- a/MicroAODProducers/python/flashggPhotons_cfi.py
+++ b/MicroAODProducers/python/flashggPhotons_cfi.py
@@ -1,20 +1,27 @@
 import FWCore.ParameterSet.Config as cms
 
 flashggPhotons = cms.EDProducer('FlashggPhotonProducer',
-                                PhotonTag = cms.untracked.InputTag('slimmedPhotons'),
+                                photonTag = cms.InputTag('slimmedPhotons'),
+                                pfCandidatesTag = cms.InputTag("packedPFCandidates"),
                                 reducedBarrelRecHitCollection = cms.InputTag('reducedEgamma','reducedEBRecHits'),
                                 reducedEndcapRecHitCollection = cms.InputTag('reducedEgamma','reducedEERecHits'),
                                 reducedPreshowerRecHitCollection = cms.InputTag('reducedEgamma','reducedESRecHits'),
-                                VertexCandidateMapTag = cms.InputTag("flashggVertexMapNonUnique"),
+                                
+                                vertexTag = cms.InputTag("offlineSlimmedPrimaryVertices"),
+                                vertexCandidateMapTag = cms.InputTag("flashggVertexMapNonUnique"),
                                 rhoFixedGridCollection = cms.InputTag('fixedGridRhoAll'),
+                                
                                 photonIdMVAweightfile_EB = cms.FileInPath("flashgg/MicroAODProducers/data/2013FinalPaper_PhotonID_Barrel_BDT_TrainRangePT15_8TeV.weights.xml"),
                                 photonIdMVAweightfile_EE = cms.FileInPath("flashgg/MicroAODProducers/data/2013FinalPaper_PhotonID_Endcap_BDT_TrainRangePT15_8TeV.weights.xml"),
 #                                regressionWeightFile = cms.FileInPath("HiggsAnalysis/GBRLikelihoodEGTools/data/regweights_v8_8TeV_forest_ph.root"),
+
                                 useNonZsLazyTools = cms.bool(False),
                                 recomputeNonZsClusterShapes = cms.bool(True),
                                 doOverlapRemovalForIsolation = cms.bool(True),
                                 useVtx0ForNeutralIso = cms.bool(True),
                                 extraCaloIsolations = cms.VPSet(),
-                                MaxGenDeltaR = cms.untracked.double(0.1),
-                                GenPhotonTag = cms.InputTag("flashggGenPhotons")
+                                
+                                genPhotonTag = cms.InputTag("flashggGenPhotonsExtra"),
+                                maxGenDeltaR = cms.double(0.1),
+                                copyExtraGenInfo = cms.bool(False),
                                 )


### PR DESCRIPTION
- PhotonMCUtils class to compute gen-level isolation and truth-determination algos
- Added GenPhotonExtra collection to miniAOD to store gen-level info
- Optionially to copy extra info to flashgg::Photon
- Factorized gen-related info into dedicated sequence

Also made PhotonProducer parameters tracked such that settings are stored in provenence info
by CMSSW.

Note: having the GenPhotonExtra in the event we should be in a position to drop the packedGenCandidates, except for jet flavour tagging (which will be eventually be needed for b-tagging systematic uncertainties).

Apologies, I for not having included this in #140. I though it would have taken me longer to complete this stuff, so I went ahead with #140.
