### PR TITLE
Store iso & interfaces in electron, remove default cuts in ElectronProdu...

### DIFF
--- a/MicroAODFormats/interface/Electron.h
+++ b/MicroAODFormats/interface/Electron.h
@@ -13,10 +13,15 @@ namespace flashgg {
 			Electron(const pat::Electron& );
 			~Electron();
 
-			float nontrigmva;
+			float getNonTrigMVA() const {return nontrigmva_;}
+			void setNonTrigMVA(float val) { nontrigmva_ = val; }
 
-			float getNonTrigMVA() const {return nontrigmva;}
+			float getStandardHggIso() const { return PfRhoAreaCorrectedIso_; }
+			void setStandardHggIso( float val ) { PfRhoAreaCorrectedIso_ = val; }
 
+		private:
+			float nontrigmva_;
+			float PfRhoAreaCorrectedIso_;
 	};
 }	
 


### PR DESCRIPTION
* Store isolation in flashgg::Electron
* Regularize interfaces for flashgg::Electron
* Remove all cuts from ElectronProducer (except eta) unless an optional flag is set to true (false by default)