### PR TITLE
remove extra crab memory demand

### DIFF
--- a/MetaData/work/crabConfig_TEMPLATE.py
+++ b/MetaData/work/crabConfig_TEMPLATE.py
@@ -13,7 +13,7 @@ config.General.transferLogs = False
 config.section_("JobType")
 config.JobType.pluginName = "Analysis"
 config.JobType.psetName = "PSET"
-config.JobType.maxMemoryMB = 3000
+## config.JobType.maxMemoryMB = 3000 # For memory leaks. NB. will block jobs on many sites
 ## config.JobType.scriptExe = "cmsWrapper.sh"
 
 config.section_("Data")


### PR DESCRIPTION
We had a 3GB requirement in the crab template.  This was keeping jobs from running on some sites, because no machines offered 3 GB of memory.  Commenting out the line to restore default and ensure all sites work.