### PR TITLE
Fix problem of charged pf iso calculation

### DIFF
--- a/MicroAODAlgos/src/PhotonIdUtils.cc
+++ b/MicroAODAlgos/src/PhotonIdUtils.cc
@@ -69,7 +69,8 @@ float PhotonIdUtils::pfIsoChgWrtVtx( edm::Ptr<pat::Photon>& photon,
     for( size_t ipf = 0; ipf < pfcandidates.size(); ipf++ ) { 
 	    
       edm::Ptr<pat::PackedCandidate> pfcand = pfcandidates[ipf];
-      
+
+      if( abs(pfcand->pdgId()) == 11 || abs(pfcand->pdgId()) == 13 ) continue; //J. Tao not e/mu       
       if( removeOverlappingCandidates_ && vetoPackedCand(*photon,pfcand) ) { continue; }
       
       if( pfcand->pt() < ptMin )         continue;    


### PR DESCRIPTION
Fix the problem of pf charged iso calculation by removing e/mu pf candidates from all the charged pf candidates 