### PR TITLE
Created classes to interpret photon and vertexes under the diphoton event hypotesis.

### DIFF
--- a/MicroAODFormats/BuildFile.xml
+++ b/MicroAODFormats/BuildFile.xml
@@ -5,6 +5,7 @@
 <use   name="DataFormats/Common"/>
 <use   name="DataFormats/JetReco"/>
 <use name="rootrflx"/>
+<!-- Flags CXXFLAGS="-ggdb"/ -->
 <export>
   <lib   name="1"/>
 </export>

--- a/MicroAODFormats/interface/DiPhotonCandidate.h
+++ b/MicroAODFormats/interface/DiPhotonCandidate.h
@@ -5,8 +5,9 @@
 #include "flashgg/MicroAODFormats/interface/Photon.h"
 #include "DataFormats/VertexReco/interface/Vertex.h"
 
-
 namespace flashgg {
+  class SinglePhotonView;
+
   class DiPhotonCandidate : public reco::CompositeCandidate {
   public:
     DiPhotonCandidate();
@@ -17,6 +18,9 @@ namespace flashgg {
     const edm::Ptr<reco::Vertex> getVertex() const { return vertex_; }
     const flashgg::Photon* leadingPhoton() const;
     const flashgg::Photon* subLeadingPhoton() const;
+
+    flashgg::SinglePhotonView leadingView() const;
+    flashgg::SinglePhotonView subLeadingView() const;
 
     void setLogSumPt2(float val) { logsumpt2_ = val; }
     void setPtBal(float val) { ptbal_ = val; }
@@ -53,9 +57,9 @@ namespace flashgg {
     float getDZ1() const { return dZ1_; }
     float getDZ2() const { return dZ2_; }
     float getVtxProbMVA() const { return vtxprobmva_; }
-		float getSumPt() const {
-		return (this->leadingPhoton()->pt() + this->subLeadingPhoton()->pt()); 
-		}
+    float getSumPt() const {
+	    return (this->daughter(0)->pt() + this->daughter(1)->pt()); 
+    }
     int vertex_index() const { return vertex_index_; }
 
     unsigned int getnVtxInfoSize() const { return (vlogsumpt2_.size()) ;}

--- a/MicroAODFormats/interface/SinglePhotonView.h
+++ b/MicroAODFormats/interface/SinglePhotonView.h
@@ -1,0 +1,43 @@
+#ifndef FLASHgg_SinglePhotonView_h
+#define FLASHgg_SinglePhotonView_h
+
+#include "flashgg/MicroAODFormats/interface/Photon.h"
+#include "flashgg/MicroAODFormats/interface/DiPhotonCandidate.h"
+#include "DataFormats/Common/interface/Ptr.h"
+
+#include <string>
+
+namespace flashgg {
+	
+  class SinglePhotonView  {
+
+  public:
+	  typedef edm::Ptr<DiPhotonCandidate> dipho_ptr_type;
+	  typedef Photon cand_type;
+	  
+	  SinglePhotonView() : pho_(0), dipho_(0) {}
+	  SinglePhotonView(dipho_ptr_type dipho, int daughter) : edmdipho_(dipho), daughter_(daughter), pho_(0), dipho_(0) {}
+	  SinglePhotonView(const DiPhotonCandidate * dipho, int daughter) : daughter_(daughter), pho_(0), dipho_(dipho) {}
+	  
+	  const cand_type& photon() const { getDaughterMaybe(); return *pho_; }
+	  
+	  const cand_type* operator->() const { getDaughterMaybe(); return pho_; }
+	  
+	  float pfChIso02WrtChosenVtx() const { return photon().getpfChgIso02WrtVtx(dipho_->getVertex()); }
+	  float pfChIso03WrtChosenVtx() const { return photon().getpfChgIso03WrtVtx(dipho_->getVertex()); }
+	  float pfChIso04WrtChosenVtx() const { return photon().getpfChgIso04WrtVtx(dipho_->getVertex()); }
+	  					       
+	  float phoIdMvaWrtChosenVtx() const { return photon().getPhoIdMvaDWrtVtx(dipho_->getVertex()); }
+	  
+  private:
+	  void getDaughterMaybe() const;
+	  
+	  dipho_ptr_type edmdipho_;
+	  int daughter_;
+	  mutable const Photon* pho_;
+	  mutable const DiPhotonCandidate * dipho_;
+
+  };
+}
+
+#endif

--- a/MicroAODFormats/interface/SingleVertexView.h
+++ b/MicroAODFormats/interface/SingleVertexView.h
@@ -1,0 +1,51 @@
+#ifndef FLASHgg_SingleVertexView_h
+#define FLASHgg_SingleVertexView_h
+
+#include "flashgg/MicroAODFormats/interface/DiPhotonCandidate.h"
+#include "DataFormats/Common/interface/Ptr.h"
+
+#include <string>
+
+namespace flashgg {
+	
+  class SingleVertexView  {
+
+  public:
+	  typedef edm::Ptr<DiPhotonCandidate> dipho_ptr_type;
+	  typedef reco::Vertex cand_type;
+	  
+	  SingleVertexView() : isClosestToGen_(false), dZtoGen_(0.), vtx_(0), dipho_(0) {}
+	  SingleVertexView(dipho_ptr_type dipho, int ivtx) : isClosestToGen_(false), dZtoGen_(0.), edmdipho_(dipho), ivtx_(ivtx), vtx_(0), dipho_(0) {}
+	  SingleVertexView(const DiPhotonCandidate * dipho, int ivtx) : isClosestToGen_(false), dZtoGen_(0.), ivtx_(ivtx), vtx_(0), dipho_(dipho) {}
+	  
+	  const cand_type& pos() const { getVertexMaybe(); return *vtx_; }
+	  
+	  const cand_type* operator->() const { getVertexMaybe(); return vtx_; }
+	  
+          float logSumPt2() const { getVertexMaybe(); return dipho_->getLogSumPt2(ivtx_); } 
+	  float ptBal() const { getVertexMaybe(); return dipho_->getPtBal(ivtx_);     }
+	  float ptAsym() const { getVertexMaybe(); return dipho_->getPtAsym(ivtx_);    }
+	  float nConv() const { getVertexMaybe(); return dipho_->getNConv(ivtx_);     }
+	  float pullConv() const { getVertexMaybe(); return dipho_->getPullConv(ivtx_);  }
+	  float mva() const { getVertexMaybe(); return dipho_->getMVA(ivtx_);       }
+	  
+	  bool isClosestToGen() const { return isClosestToGen_; }
+	  float dZtoGen() const { return dZtoGen_; }
+	  
+	  void setDzToGen(float x) { dZtoGen_=x; };
+	  void setIsClosestToGen(bool x=true) { isClosestToGen_=x; };
+	  
+  private:
+	  void getVertexMaybe() const;
+	  bool isClosestToGen_;
+	  float dZtoGen_;
+	  
+	  dipho_ptr_type edmdipho_;
+	  int ivtx_;
+	  mutable const cand_type* vtx_;
+	  mutable const DiPhotonCandidate * dipho_;
+
+  };
+}
+
+#endif

--- a/MicroAODFormats/src/DiPhotonCandidate.cc
+++ b/MicroAODFormats/src/DiPhotonCandidate.cc
@@ -1,5 +1,6 @@
 #include "flashgg/MicroAODFormats/interface/DiPhotonCandidate.h"
 #include "flashgg/MicroAODFormats/interface/Photon.h"
+#include "flashgg/MicroAODFormats/interface/SinglePhotonView.h"
 #include "CommonTools/CandUtils/interface/AddFourMomenta.h"
 
 using namespace flashgg;
@@ -45,5 +46,21 @@ const flashgg::Photon * DiPhotonCandidate::subLeadingPhoton() const {
     return dynamic_cast<const flashgg::Photon*> (daughter(1));
   } else {
     return dynamic_cast<const flashgg::Photon*> (daughter(0));
+  }
+}
+
+SinglePhotonView DiPhotonCandidate::leadingView() const {
+  if (daughter(0)->pt() > daughter(1)->pt()) {
+	  return SinglePhotonView(this,0);
+  } else {
+	  return SinglePhotonView(this,1);
+  }
+}
+
+SinglePhotonView DiPhotonCandidate::subLeadingView() const {
+  if (daughter(0)->pt() > daughter(1)->pt()) {
+	  return SinglePhotonView(this,1);
+  } else {
+	  return SinglePhotonView(this,0);
   }
 }

--- a/MicroAODFormats/src/SinglePhotonView.cc
+++ b/MicroAODFormats/src/SinglePhotonView.cc
@@ -1,0 +1,14 @@
+#include "flashgg/MicroAODFormats/interface/SinglePhotonView.h"
+
+namespace flashgg {
+
+	void SinglePhotonView::getDaughterMaybe() const
+	{
+		if(pho_ == 0) { 
+			if( dipho_ == 0 ) { dipho_ = &(*edmdipho_); }
+			if( dipho_ == 0 ) throw;
+			pho_ = dynamic_cast<const Photon *>(dipho_->daughter(daughter_)); 
+			if( pho_ == 0 ) throw;
+		}
+	}
+}

--- a/MicroAODFormats/src/SingleVertexView.cc
+++ b/MicroAODFormats/src/SingleVertexView.cc
@@ -1,0 +1,14 @@
+#include "flashgg/MicroAODFormats/interface/SingleVertexView.h"
+
+namespace flashgg {
+
+	void SingleVertexView::getVertexMaybe() const
+	{
+		if(vtx_ == 0) { 
+			if( dipho_ == 0 ) { dipho_ = &(*edmdipho_); }
+			if( dipho_ == 0 ) throw;
+			vtx_ = &*(dipho_->getVertexPtr(ivtx_)); 
+			if( vtx_ == 0 ) throw;
+		}
+	}
+}

--- a/MicroAODFormats/src/classes.h
+++ b/MicroAODFormats/src/classes.h
@@ -8,6 +8,8 @@
 #include "DataFormats/PatCandidates/interface/Muon.h"
 #include "DataFormats/JetReco/interface/PileupJetIdentifier.h"
 #include "flashgg/MicroAODFormats/interface/GenPhotonExtra.h"
+#include "flashgg/MicroAODFormats/interface/SinglePhotonView.h"
+#include "flashgg/MicroAODFormats/interface/SingleVertexView.h" 
 
 #include <vector>
 #include <map>
@@ -29,6 +31,19 @@ namespace  { struct dictionary {
 
   edm::Ptr<reco::Vertex>                                        ptr_rec_vtx;
   std::vector<edm::Ptr<reco::Vertex> >                      vec_ptr_rec_vtx;
+
+  flashgg::SinglePhotonView                                      fgg_phoview;
+  edm::Ptr<flashgg::SinglePhotonView>                        ptr_fgg_phoview;
+  edm::Wrapper<flashgg::SinglePhotonView>                    wrp_fgg_phoview;
+  std::vector<flashgg::SinglePhotonView>                     vec_fgg_phoview;
+  edm::Wrapper<std::vector<flashgg::SinglePhotonView> >  wrp_vec_fgg_phoview;
+
+  flashgg::SingleVertexView                                      fgg_vtxview;
+  edm::Ptr<flashgg::SingleVertexView>                        ptr_fgg_vtxview;
+  edm::Wrapper<flashgg::SingleVertexView>                    wrp_fgg_vtxview;
+  std::vector<flashgg::SingleVertexView>                     vec_fgg_vtxview;
+  edm::Wrapper<std::vector<flashgg::SingleVertexView> >  wrp_vec_fgg_vtxview;
+  
 
   flashgg::MinimalPileupJetIdentifier                                               pujetid;
   std::pair<edm::Ptr<reco::Vertex>,flashgg::MinimalPileupJetIdentifier>                    pair_ptr_vtx_pujetid;

--- a/MicroAODFormats/src/classes_def.xml
+++ b/MicroAODFormats/src/classes_def.xml
@@ -12,6 +12,14 @@
  <class name="edm::Wrapper<edm::Ptr<flashgg::DiPhotonCandidate> >"/>
  <class name="std::vector<edm::Ptr<flashgg::DiPhotonCandidate> >"/>
  <class name="edm::Wrapper<std::vector<edm::Ptr<flashgg::DiPhotonCandidate> > >"/>
+ <class name="flashgg::SinglePhotonView"/>
+ <class name="edm::Ptr<flashgg::SinglePhotonView>"/>
+ <class name="std::vector<flashgg::SinglePhotonView>"/>
+ <class name="edm::Wrapper<std::vector<flashgg::SinglePhotonView> >"/>
+ <class name="flashgg::SingleVertexView"/>
+ <class name="edm::Ptr<flashgg::SingleVertexView>"/>
+ <class name="std::vector<flashgg::SingleVertexView>"/>
+ <class name="edm::Wrapper<std::vector<flashgg::SingleVertexView> >"/>
  <class name="flashgg::MinimalPileupJetIdentifier"/>
  <class name="std::pair<edm::Ptr<reco::Vertex>,flashgg::MinimalPileupJetIdentifier>"/>
  <class name="std::map<edm::Ptr<reco::Vertex>,flashgg::MinimalPileupJetIdentifier>"/>

--- a/MicroAODProducers/plugins/SinglePhotonViewProducer.cc
+++ b/MicroAODProducers/plugins/SinglePhotonViewProducer.cc
@@ -1,0 +1,70 @@
+#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "DataFormats/Common/interface/Handle.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/EDMException.h"
+
+#include "flashgg/MicroAODFormats/interface/SinglePhotonView.h"
+
+#include <vector>
+#include <algorithm>
+
+using namespace std;
+using namespace edm;
+
+namespace flashgg {
+
+	class SinglePhotonViewProducer : public EDProducer {
+		
+	public:
+		SinglePhotonViewProducer( const ParameterSet & );
+	private:
+		void produce( Event &, const EventSetup & ) override;
+		
+		EDGetTokenT<View<DiPhotonCandidate> > diPhotonToken_;
+		int maxCandidates_;
+		
+	};
+	
+	SinglePhotonViewProducer::SinglePhotonViewProducer(const ParameterSet & iConfig) :
+		diPhotonToken_(consumes<View<flashgg::DiPhotonCandidate> >(iConfig.getUntrackedParameter<InputTag> ("DiPhotonTag", InputTag("flashggDiPhotons")))),
+		maxCandidates_(iConfig.getUntrackedParameter("maxCandidates",1))
+	{
+		produces<vector<SinglePhotonView> >();
+	}
+	
+	void SinglePhotonViewProducer::produce( Event & evt, const EventSetup & ) {
+		
+		Handle<View<flashgg::DiPhotonCandidate> > diPhotons;
+		evt.getByToken(diPhotonToken_,diPhotons);
+		const PtrVector<flashgg::DiPhotonCandidate>& diPhotonPointers = diPhotons->ptrVector();
+		
+		std::auto_ptr<vector<SinglePhotonView> > photonViews(new vector<SinglePhotonView>); 
+		
+		int nCand = maxCandidates_;
+		for(auto & dipho : diPhotonPointers) {
+			
+			SinglePhotonView leg0(dipho,0);
+			SinglePhotonView leg1(dipho,1);
+			
+			if( leg0->pt() < leg1->pt() ) { std::swap(leg0,leg1); }
+			
+			photonViews->push_back(leg0);
+			photonViews->push_back(leg1);
+			
+			if( --nCand == 0 ) { break; }
+		}
+		
+		//// if( photonViews->size() != 0 ) { 
+		//// 	cout << photonViews->size() << endl;
+		//// }
+		evt.put(photonViews);
+		
+	}
+}
+
+typedef flashgg::SinglePhotonViewProducer FlashggSinglePhotonViewProducer;
+DEFINE_FWK_MODULE(FlashggSinglePhotonViewProducer);

--- a/MicroAODProducers/plugins/SingleVertexViewProducer.cc
+++ b/MicroAODProducers/plugins/SingleVertexViewProducer.cc
@@ -1,0 +1,96 @@
+#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "DataFormats/Common/interface/Handle.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/EDMException.h"
+
+#include "flashgg/MicroAODFormats/interface/SingleVertexView.h"
+#include "DataFormats/HepMCCandidate/interface/GenParticleFwd.h"
+#include "DataFormats/HepMCCandidate/interface/GenParticle.h"
+
+#include <vector>
+#include <algorithm>
+
+using namespace std;
+using namespace edm;
+
+namespace flashgg {
+
+	class SingleVertexViewProducer : public EDProducer {
+		
+	public:
+		SingleVertexViewProducer( const ParameterSet & );
+	private:
+		void produce( Event &, const EventSetup & ) override;
+		
+		EDGetTokenT<View<DiPhotonCandidate> > diPhotonToken_;
+		EDGetTokenT<View<reco::GenParticle> > genPartToken_;
+		int maxCandidates_;
+		
+	};
+	
+	SingleVertexViewProducer::SingleVertexViewProducer(const ParameterSet & iConfig) :
+		diPhotonToken_(consumes<View<flashgg::DiPhotonCandidate> >(iConfig.getUntrackedParameter<InputTag> ("DiPhotonTag", InputTag("flashggDiPhotons")))),
+		genPartToken_(consumes<View<reco::GenParticle> >(iConfig.getUntrackedParameter<InputTag> ("GenParticlesTag", InputTag("flashggPrunedGenParticles")))),
+		maxCandidates_(iConfig.getUntrackedParameter("maxCandidates",1))
+	{
+		produces<vector<SingleVertexView> >();
+	}
+	
+	void SingleVertexViewProducer::produce( Event & evt, const EventSetup & ) {
+		
+		
+		Handle<View<flashgg::DiPhotonCandidate> > diPhotons;
+		evt.getByToken(diPhotonToken_,diPhotons);
+		const PtrVector<flashgg::DiPhotonCandidate>& diPhotonPointers = diPhotons->ptrVector();
+		// FIXME: move gen vertex finding to dedicated producer
+		bool isData = evt.isRealData();
+		reco::GenParticle::Point genV;
+		if( ! isData ) {
+			Handle<View<reco::GenParticle> > genParts;
+			evt.getByToken(genPartToken_,genParts);
+			bool found = false;
+			for(auto & part : *genParts ) {
+				if( part.pdgId() != 2212 || part.vertex().z() != 0. ) {
+					genV = part.vertex();
+					found = true;
+					break;
+				}
+			}
+			assert( found );
+		}
+		
+		std::auto_ptr<vector<SingleVertexView> > vertexViews(new vector<SingleVertexView>); 
+		std::map<float, int> sortViews;
+		
+		int nCand = maxCandidates_;
+		for(auto & dipho : diPhotonPointers) {
+			
+			for(unsigned int iv=0; iv<dipho->getnVtxInfoSize(); ++iv) {
+				vertexViews->push_back(SingleVertexView(dipho,iv));
+				auto & vi = vertexViews->back();
+				float dz = genV.z() - vi.pos().z();
+				vi.setDzToGen(dz);
+				sortViews[ dz  ] = iv;
+			}
+			
+			if( --nCand == 0 ) { break; }
+		}
+		
+		if( ! isData && vertexViews->size() > 0 ) {
+			vertexViews->at(sortViews.begin()->second).setIsClosestToGen();
+		}
+		
+		//// if( vertexViews->size() != 0 ) { 
+		//// 	cout << vertexViews->size() << endl;
+		//// }
+		evt.put(vertexViews);
+		
+	}
+}
+
+typedef flashgg::SingleVertexViewProducer FlashggSingleVertexViewProducer;
+DEFINE_FWK_MODULE(FlashggSingleVertexViewProducer);

--- a/TagAlgos/interface/PhotonDumpers.h
+++ b/TagAlgos/interface/PhotonDumpers.h
@@ -3,6 +3,8 @@
 
 #include "flashgg/MicroAODFormats/interface/Photon.h"
 #include "flashgg/MicroAODFormats/interface/DiPhotonCandidate.h"
+#include "flashgg/MicroAODFormats/interface/SinglePhotonView.h"
+#include "flashgg/MicroAODFormats/interface/SingleVertexView.h"
 #include "flashgg/TagFormats/interface/DiPhotonTagBase.h"
 
 #include "flashgg/TagAlgos/interface/CollectionDumper.h"
@@ -19,6 +21,12 @@ namespace flashgg
 	typedef CollectionDumper<std::vector<DiPhotonCandidate>,
 				 DiPhotonCandidate,
 				 CutBasedClassifier<DiPhotonCandidate> > CutBasedDiPhotonDumper;
+	typedef CollectionDumper<std::vector<SinglePhotonView>,
+				 SinglePhotonView,
+				 CutBasedClassifier<SinglePhotonView> > CutBasedSinglePhotonViewDumper;
+	typedef CollectionDumper<std::vector<SingleVertexView>,
+				 SingleVertexView,
+				 CutBasedClassifier<SingleVertexView> > CutBasedSingleVertexViewDumper;
 	typedef CollectionDumper<edm::OwnVector<DiPhotonTagBase>,
 				 DiPhotonTagBase,
 				 ClassNameClassifier<DiPhotonTagBase> > DiPhotonTagDumper;

--- a/TagAlgos/python/vertexViewDumpConfig_cff.py
+++ b/TagAlgos/python/vertexViewDumpConfig_cff.py
@@ -1,0 +1,28 @@
+import FWCore.ParameterSet.Config as cms
+
+vertexViewDumpConfig = cms.PSet(
+    className  = cms.untracked.string("VertexViewPhotonDumper"),
+    src = cms.InputTag("flashggSingleVertexViews"),
+    generatorInfo = cms.InputTag("generator"),
+    processId = cms.string(""),
+    maxCandPerEvent = cms.int32(2),
+    lumiWeight = cms.double(1.0),
+    classifierCfg = cms.PSet(categories=cms.VPSet()),
+    categories = cms.VPSet(),
+
+    workspaceName = cms.untracked.string("cms_hgg_$SQRTS"),
+    nameTemplate = cms.untracked.string("$LABEL"),
+    
+    dumpHistos = cms.untracked.bool(True),
+    dumpWorkspace = cms.untracked.bool(False),
+    dumpTrees = cms.untracked.bool(False),
+    
+    quietRooFit = cms.untracked.bool(False),
+    
+    dumpGlobalVariables = cms.untracked.bool(True),
+    globalVariables = cms.PSet(
+        rho =  cms.InputTag('fixedGridRhoAll'),
+        vertexes = cms.InputTag("offlineSlimmedPrimaryVertices"),
+        )
+    
+)

--- a/TagAlgos/python/vertexViewDumpConfig_cff.py
+++ b/TagAlgos/python/vertexViewDumpConfig_cff.py
@@ -5,7 +5,7 @@ vertexViewDumpConfig = cms.PSet(
     src = cms.InputTag("flashggSingleVertexViews"),
     generatorInfo = cms.InputTag("generator"),
     processId = cms.string(""),
-    maxCandPerEvent = cms.int32(2),
+    maxCandPerEvent = cms.int32(2000),
     lumiWeight = cms.double(1.0),
     classifierCfg = cms.PSet(categories=cms.VPSet()),
     categories = cms.VPSet(),

--- a/TagAlgos/src/PhotonDumpers.cc
+++ b/TagAlgos/src/PhotonDumpers.cc
@@ -9,6 +9,8 @@ namespace flashgg {
 		PLUGGABLE_ANALYZER(CutBasedPhotonDumper);
 		PLUGGABLE_ANALYZER(DiPhotonDumper);
 		PLUGGABLE_ANALYZER(CutBasedDiPhotonDumper);
+		PLUGGABLE_ANALYZER(CutBasedSinglePhotonViewDumper);
+		PLUGGABLE_ANALYZER(CutBasedSingleVertexViewDumper);
 		PLUGGABLE_ANALYZER(DiPhotonTagDumper);
 	}
 }

--- a/TagAlgos/test/diphotonsDumper_cfg.py
+++ b/TagAlgos/test/diphotonsDumper_cfg.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env cmsRun
+
+import FWCore.ParameterSet.Config as cms
+import FWCore.Utilities.FileUtils as FileUtils
+
+process = cms.Process("Analysis")
+
+process.load("FWCore.MessageService.MessageLogger_cfi")
+process.source = cms.Source("PoolSource",
+                            fileNames=cms.untracked.vstring(
+        )
+)
+process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(-1) )
+process.MessageLogger.cerr.FwkReport.reportEvery = cms.untracked.int32( 1000 )
+
+process.TFileService = cms.Service("TFileService",
+                                   fileName = cms.string("test.root")
+)
+
+from flashgg.MicroAODProducers.flashggPreselectedDiPhotons_cfi import flashggPreselectedDiPhotons
+process.kinPreselDiPhotons = flashggPreselectedDiPhotons.clone(
+cut=cms.string(
+        "leadingPhoton.pt > 40 && subLeadingPhoton.pt > 30"
+        " && abs(leadingPhoton.superCluster.eta)<2.5 && abs(subLeadingPhoton.superCluster.eta)<2.5 "
+        " && ( abs(leadingPhoton.superCluster.eta)<1.4442 || abs(leadingPhoton.superCluster.eta)>1.566)"
+        " && ( abs(subLeadingPhoton.superCluster.eta)<1.4442 || abs(subLeadingPhoton.superCluster.eta)>1.566)"
+        )
+                                                              )
+
+process.load("flashgg.TagProducers.diphotonDumper_cfi") ##  import diphotonDumper 
+import flashgg.TagAlgos.dumperConfigTools as cfgTools
+
+process.diphotonDumper.src = "kinPreselDiPhotons"
+
+process.diphotonDumper.dumpTrees = True
+process.diphotonDumper.dumpWorkspace = False
+process.diphotonDumper.quietRooFit = True
+
+
+# split tree, histogram and datasets by process
+process.diphotonDumper.nameTemplate ="$PROCESS_$SQRTS_$LABEL_$SUBCAT"
+## do not split by process
+## process.diphotonDumper.nameTemplate = "minitree_$SQRTS_$LABEL_$SUBCAT"
+
+## define categories and associated objects to dump
+cfgTools.addCategory(process.diphotonDumper,
+                     "Reject",
+                     "abs(leadingPhoton.superCluster.eta)>=1.4442&&abs(leadingPhoton.superCluster.eta)<=1.566||abs(leadingPhoton.superCluster.eta)>=2.5"
+                     "||abs(subLeadingPhoton.superCluster.eta)>=1.4442 && abs(subLeadingPhoton.superCluster.eta)<=1.566||abs(subLeadingPhoton.superCluster.eta)>=2.5",
+                      -1 ## if nSubcat is -1 do not store anythings
+                     )
+
+# interestng categories 
+cfgTools.addCategories(process.diphotonDumper,
+                       ## categories definition
+                       ## cuts are applied in cascade. Events getting to these categories have already failed the "Reject" selection
+                       [("EBHighR9","max(abs(leadingPhoton.superCluster.eta),abs(leadingPhoton.superCluster.eta))<1.4442"
+                         "&& min(leadingPhoton.r9,subLeadingPhoton.r9)>0.94",0), ## EB high R9
+                        ("EBLowR9","max(abs(leadingPhoton.superCluster.eta),abs(leadingPhoton.superCluster.eta))<1.4442",0), ## remaining EB is low R9
+                        ("EEHighR9","min(leadingPhoton.r9,subLeadingPhoton.r9)>0.94",0), ## then EE high R9
+                        ("EELowR9","1",0), ## evereything elese is EE low R9
+                        ],
+                       ## variables to be dumped in trees/datasets. Same variables for all categories
+                       ## if different variables wanted for different categories, can add categorie one by one with cfgTools.addCategory
+                       variables=["CMS_hgg_mass[320,100,180]:=mass", 
+                                  "leadPt                   :=leadingPhoton.pt",
+                                  "subleadPt                :=subLeadingPhoton.pt",
+                                  "minR9                    :=min(leadingPhoton.r9,subLeadingPhoton.r9)",
+                                  "maxEta                   :=max(abs(leadingPhoton.superCluster.eta),abs(leadingPhoton.superCluster.eta))",
+                                  "leadIDMVA                :=leadingView.phoIdMvaWrtChosenVtx",
+                                  "subleadIDMVA             :=subLeadingView.phoIdMvaWrtChosenVtx",
+                                  ],
+                       ## histograms to be plotted. 
+                       ## the variables need to be defined first
+                       histograms=["CMS_hgg_mass>>mass(320,100,180)",
+                                   "subleadPt:leadPt>>ptSubVsLead(180,20,200:180,20,200)",
+                                   "minR9>>minR9(110,0,1.1)",
+                                   "maxEta>>maxEta[0.,0.1,0.2,0.3,0.4,0.6,0.8,1.0,1.2,1.4442,1.566,1.7,1.8,2.,2.2,2.3,2.5]"
+                                   ]
+                       )
+
+
+process.p1 = cms.Path(
+    process.kinPreselDiPhotons*process.diphotonDumper
+    )
+
+
+
+from flashgg.MetaData.JobConfig import customize
+customize.setDefault("maxEvents",100)
+customize(process)
+

--- a/TagAlgos/test/singlePhotonViewDumper_cfg.py
+++ b/TagAlgos/test/singlePhotonViewDumper_cfg.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env cmsRun
+
+import FWCore.ParameterSet.Config as cms
+import FWCore.Utilities.FileUtils as FileUtils
+
+process = cms.Process("Analysis")
+
+process.load("FWCore.MessageService.MessageLogger_cfi")
+
+process.source = cms.Source("PoolSource",
+                            fileNames=cms.untracked.vstring(
+        )
+)
+process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(-1) )
+process.MessageLogger.cerr.FwkReport.reportEvery = cms.untracked.int32( 1000 )
+
+process.TFileService = cms.Service("TFileService",
+                                   fileName = cms.string("test.root")
+)
+
+from flashgg.MicroAODProducers.flashggPreselectedDiPhotons_cfi import flashggPreselectedDiPhotons
+process.kinPreselDiPhotons = flashggPreselectedDiPhotons.clone(
+cut=cms.string(
+        "mass > 100"
+        " && leadingPhoton.pt > 30 && subLeadingPhoton.pt > 30"
+        " && abs(leadingPhoton.superCluster.eta)<2.5 && abs(subLeadingPhoton.superCluster.eta)<2.5 "
+        " && ( abs(leadingPhoton.superCluster.eta)<1.4442 || abs(leadingPhoton.superCluster.eta)>1.566)"
+        " && ( abs(subLeadingPhoton.superCluster.eta)<1.4442 || abs(subLeadingPhoton.superCluster.eta)>1.566)"
+        ## " && leadingPhoton.genMatchType != subLeadingPhoton.genMatchType " ## selects only prompt-fake pairs
+        )
+                                                              )
+
+
+process.flashggSinglePhotonViews = cms.EDProducer("FlashggSinglePhotonViewProducer",
+                                          DiPhotonTag=cms.untracked.InputTag('kinPreselDiPhotons'),
+                                                  
+                                          )
+
+process.load("flashgg.TagProducers.photonViewDumper_cfi") ##  import diphotonDumper 
+import flashgg.TagAlgos.dumperConfigTools as cfgTools
+
+process.photonViewDumper.src = "flashggSinglePhotonViews"
+process.photonViewDumper.dumpTrees = True
+process.photonViewDumper.dumpWorkspace = False
+process.photonViewDumper.quietRooFit = True
+
+## define categories and associated objects to dump
+cfgTools.addCategory(process.photonViewDumper,
+                     "Reject",
+                     "abs(photon.superCluster.eta)>=1.4442&&abs(photon.superCluster.eta)<=1.566||abs(photon.superCluster.eta)>=2.5",
+                     -1 ## if nSubcat is -1 do not store anythings
+                     )
+
+# interestng categories 
+cfgTools.addCategories(process.photonViewDumper,
+                       ## categories definition
+                       ## cuts are applied in cascade. Events getting to these categories have already failed the "Reject" selection
+                       [("promptPhotons","photon.genMatchType == 1",0),
+                        ("fakePhotons",  "photon.genMatchType != 1",0),
+                        ],
+                       ## variables to be dumped in trees/datasets. Same variables for all categories
+                       ## if different variables wanted for different categories, can add categorie one by one with cfgTools.addCategory
+                       variables=["pt := photon.pt","energy := photon.energy","eta := photon.eta","phi := photon.phi","scEta:=photon.superCluster.eta",
+                                  "r9 := photon.r9",
+                                  "chgIsoWrtWorstVtx := photon.getpfChgIsoWrtWorstVtx03",
+                                  "chgIsoWrtChosenVtx := pfChIso03WrtChosenVtx",
+                                  "idMVA := phoIdMvaWrtChosenVtx",
+                                  "genIso := photon.userFloat('genIso')", "eTrue := ? photon.hasMatchedGenPhoton ? photon.matchedGenPhoton.energy : 0"
+                                  ],
+                       ## histograms to be plotted. 
+                       ## the variables need to be defined first
+                       histograms=["r9>>r9(110,0,1.1)",
+                                   "scEta>>scEta(100,-2.5,2.5)"
+                                   ]
+                       )
+
+
+
+process.p1 = cms.Path(
+    process.kinPreselDiPhotons*process.flashggSinglePhotonViews*process.photonViewDumper
+    )
+
+
+
+from flashgg.MetaData.JobConfig import customize
+customize.setDefault("maxEvents",100)
+customize(process)
+

--- a/TagAlgos/test/singleVertexViewDumper_cfg.py
+++ b/TagAlgos/test/singleVertexViewDumper_cfg.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env cmsRun
+
+import FWCore.ParameterSet.Config as cms
+import FWCore.Utilities.FileUtils as FileUtils
+
+process = cms.Process("Analysis")
+
+process.load("FWCore.MessageService.MessageLogger_cfi")
+
+process.source = cms.Source("PoolSource",
+                            fileNames=cms.untracked.vstring(
+        )
+)
+process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(-1) )
+process.MessageLogger.cerr.FwkReport.reportEvery = cms.untracked.int32( 1000 )
+
+process.TFileService = cms.Service("TFileService",
+                                   fileName = cms.string("test.root")
+)
+
+from flashgg.MicroAODProducers.flashggPreselectedDiPhotons_cfi import flashggPreselectedDiPhotons
+process.kinPreselDiPhotons = flashggPreselectedDiPhotons.clone(
+cut=cms.string(
+        "mass > 100"
+        " && leadingPhoton.pt > 30 && subLeadingPhoton.pt > 30"
+        " && abs(leadingPhoton.superCluster.eta)<2.5 && abs(subLeadingPhoton.superCluster.eta)<2.5 "
+        " && ( abs(leadingPhoton.superCluster.eta)<1.4442 || abs(leadingPhoton.superCluster.eta)>1.566)"
+        " && ( abs(subLeadingPhoton.superCluster.eta)<1.4442 || abs(subLeadingPhoton.superCluster.eta)>1.566)"
+        ## " && leadingPhoton.genMatchType != subLeadingPhoton.genMatchType " ## selects only prompt-fake pairs
+        )
+                                                              )
+
+
+process.flashggSingleVertexViews = cms.EDProducer("FlashggSingleVertexViewProducer",
+                                          DiPhotonTag=cms.untracked.InputTag('kinPreselDiPhotons'),
+                                                  
+                                          )
+
+process.load("flashgg.TagProducers.vertexViewDumper_cfi") ##  import diphotonDumper 
+import flashgg.TagAlgos.dumperConfigTools as cfgTools
+
+process.vertexViewDumper.dumpTrees = True
+process.vertexViewDumper.dumpWorkspace = False
+process.vertexViewDumper.quietRooFit = True
+
+# interestng categories 
+cfgTools.addCategories(process.vertexViewDumper,
+                       ## categories definition
+                       ## cuts are applied in cascade. Events getting to these categories have already failed the "Reject" selection
+                       [("trueVertexes","isClosestToGen",0),
+                        ("puVertexes",  "!isClosestToGen",0),
+                        ],
+                       ## variables to be dumped in trees/datasets. Same variables for all categories
+                       ## if different variables wanted for different categories, can add categorie one by one with cfgTools.addCategory
+                       variables=["logSumPt2","ptBal","ptAsym","nConv","pullConv",
+                                  "vx := pos.x", "vy := pos.y", "vx := pos.y", 
+                                  "dZtoGen"
+                                  ],
+                       ## histograms to be plotted. 
+                       ## the variables need to be defined first
+                       histograms=["dZtoGen>>dZtoGen(100,-10.,10.)",
+                                   "logSumPt2>>logSumPt2(100,-2,10)",
+                                   ]
+                       )
+
+
+
+process.p1 = cms.Path(
+    process.kinPreselDiPhotons*process.flashggSingleVertexViews*process.vertexViewDumper
+    )
+
+
+
+from flashgg.MetaData.JobConfig import customize
+customize.setDefault("maxEvents",100)
+customize(process)
+

--- a/TagProducers/plugins/BuildFile.xml
+++ b/TagProducers/plugins/BuildFile.xml
@@ -1,6 +1,7 @@
 <library   name="FlashggTagProducerPlugins" file="*.cc">
 <use   name="FWCore/Framework"/>
 <use   name="FWCore/PluginManager"/>
+<use   name="flashgg/MicroAODFormats"/>
 <use   name="flashgg/TagFormats"/>
 <use   name="flashgg/TagAlgos"/>
 <use name="FWCore/Utilities"/>

--- a/TagProducers/plugins/EDPhotonDumpers.cc
+++ b/TagProducers/plugins/EDPhotonDumpers.cc
@@ -5,10 +5,14 @@
 typedef edm::AnalyzerWrapper<flashgg::PhotonDumper> PhotonDumper;
 typedef edm::AnalyzerWrapper<flashgg::DiPhotonDumper> DiPhotonDumper;
 typedef edm::AnalyzerWrapper<flashgg::CutBasedDiPhotonDumper> CutBasedDiPhotonDumper;
+typedef edm::AnalyzerWrapper<flashgg::CutBasedSinglePhotonViewDumper> CutBasedSinglePhotonViewDumper;
+typedef edm::AnalyzerWrapper<flashgg::CutBasedSingleVertexViewDumper> CutBasedSingleVertexViewDumper;
 typedef edm::AnalyzerWrapper<flashgg::DiPhotonTagDumper> DiPhotonTagDumper;
 
 DEFINE_FWK_MODULE(PhotonDumper);
 DEFINE_FWK_MODULE(DiPhotonDumper);
 DEFINE_FWK_MODULE(CutBasedDiPhotonDumper);
+DEFINE_FWK_MODULE(CutBasedSinglePhotonViewDumper);
+DEFINE_FWK_MODULE(CutBasedSingleVertexViewDumper);
 DEFINE_FWK_MODULE(DiPhotonTagDumper);
 

--- a/TagProducers/python/photonDumper_cfi.py
+++ b/TagProducers/python/photonDumper_cfi.py
@@ -1,0 +1,9 @@
+import FWCore.ParameterSet.Config as cms
+
+from flashgg.TagAlgos.photonDumpConfig_cff import photonDumpConfig
+
+photonDumper = cms.EDAnalyzer('CutBasedPhotonDumper',
+                                **photonDumpConfig.parameters_()
+                                )
+
+

--- a/TagProducers/python/photonViewDumper_cfi.py
+++ b/TagProducers/python/photonViewDumper_cfi.py
@@ -1,0 +1,11 @@
+import FWCore.ParameterSet.Config as cms
+
+from flashgg.TagAlgos.photonDumpConfig_cff import photonDumpConfig
+
+photonViewDumper = cms.EDAnalyzer('CutBasedSinglePhotonViewDumper',
+                                  **photonDumpConfig.parameters_()
+                                  )
+
+
+photonViewDumper.className = 'CutBasedSinglePhotonViewDumper'
+photonViewDumper.src = "flashggSinglePhotonViews"

--- a/TagProducers/python/vertexViewDumper_cfi.py
+++ b/TagProducers/python/vertexViewDumper_cfi.py
@@ -1,0 +1,9 @@
+import FWCore.ParameterSet.Config as cms
+
+from flashgg.TagAlgos.vertexViewDumpConfig_cff import vertexViewDumpConfig
+
+vertexViewDumper = cms.EDAnalyzer('CutBasedSingleVertexViewDumper',
+                                  **vertexViewDumpConfig.parameters_()
+                                  )
+
+


### PR DESCRIPTION
- SinglePhotonView
- SingleVertexView

Corresponding producers and dumpers also instantiated.

Configuration examples also committed:
- TagAlgos/test/singlePhotonViewDumper_cfg.py
- TagAlgos/test/singleVertexViewDumper_cfg.py
(will move those and other classes/python out of TagAlgos and TagProducers
as soon as dumper machienery is moved to UtilsAlgos).

Above configurations can be used for photonID and vertexID trainings.