### PR TITLE
Switch Jet Collection to PFCHSLeg as default

### DIFF
--- a/JetValidation/configs/simple_Producer_jets.py
+++ b/JetValidation/configs/simple_Producer_jets.py
@@ -149,7 +149,7 @@ process.combinedSecondaryVertex.trackMultiplicityMin = 1  #needed for CMSSW < 71
 process.flashggCHSLegacyVertexCandidates = cms.EDProducer('FlashggCHSLegacyVertexCandidateProducer',
                                                           PFCandidatesTag=cms.untracked.InputTag('packedPFCandidates'),
                                                           DiPhotonTag=cms.untracked.InputTag('flashggDiPhotons'),
-                                                          VertexCandidateMapTag = cms.InputTag("flashggVertexMapUnique"),
+                                                          VertexCandidateMapTag = cms.InputTag("flashggVertexMapForCHS"),
                                                           VertexTag=cms.untracked.InputTag('offlineSlimmedPrimaryVertices')
                                                           )
 # first select the packedCandidates passing the loose "fromPV()" requirement (equivalent to CHS definition used for Jets in Run I)

--- a/JetValidation/configs/simple_Producer_jets_local.py
+++ b/JetValidation/configs/simple_Producer_jets_local.py
@@ -404,7 +404,7 @@ process.flashggJets = cms.EDProducer('FlashggJetProducer',
                                      DiPhotonTag=cms.untracked.InputTag('flashggDiPhotons'),
                                      VertexTag=cms.untracked.InputTag('offlineSlimmedPrimaryVertices'),
                                      JetTag=cms.untracked.InputTag('patJetsAK4PF'),
-                                     VertexCandidateMapTag = cms.InputTag("flashggVertexMapUnique"),
+                                     VertexCandidateMapTag = cms.InputTag("flashggVertexMapForCHS"),
                                      PileupJetIdParameters=cms.PSet(full_53x) # from PileupJetIDParams_cfi
                                  )
 
@@ -412,7 +412,7 @@ process.flashggJetsPFCHS0 = cms.EDProducer('FlashggJetProducer',
                                            DiPhotonTag=cms.untracked.InputTag('flashggDiPhotons'),
                                            VertexTag=cms.untracked.InputTag('offlineSlimmedPrimaryVertices'),
                                            JetTag=cms.untracked.InputTag('patJetsAK4PFCHS0'),
-                                           VertexCandidateMapTag = cms.InputTag("flashggVertexMapUnique"),
+                                           VertexCandidateMapTag = cms.InputTag("flashggVertexMapForCHS"),
                                            PileupJetIdParameters=cms.PSet(full_53x) # from PileupJetIDParams_cfi
                                            )
 
@@ -420,7 +420,7 @@ process.flashggJetsPFCHSLeg = cms.EDProducer('FlashggJetProducer',
                                              DiPhotonTag=cms.untracked.InputTag('flashggDiPhotons'),
                                              VertexTag=cms.untracked.InputTag('offlineSlimmedPrimaryVertices'),
                                              JetTag=cms.untracked.InputTag('patJetsAK4PFCHSLeg'),
-                                             VertexCandidateMapTag = cms.InputTag("flashggVertexMapUnique"),
+                                             VertexCandidateMapTag = cms.InputTag("flashggVertexMapForCHS"),
                                              PileupJetIdParameters=cms.PSet(full_53x) # from PileupJetIDParams_cfi
                                              )
 #process.flashggJetsPUPPI0 = cms.EDProducer('FlashggJetProducer',
@@ -440,19 +440,19 @@ process.flashggJetsPFCHSLeg = cms.EDProducer('FlashggJetProducer',
 #                                             PileupJetIdParameters=cms.PSet(full_53x) # from PileupJetIDParams_cfi
 #                                             )
 ##Tag stuff
-process.load("flashgg/TagProducers/flashggDiPhotonMVA_cfi")
-process.load("flashgg/TagProducers/flashggVBFMVA_cff")
+#process.load("flashgg/TagProducers/flashggDiPhotonMVA_cfi")
+#process.load("flashgg/TagProducers/flashggVBFMVA_cff")
 #process.load("flashgg/TagProducers/flashggVBFDiPhoDiJetMVA_cfi")
-process.load("flashgg/TagProducers/flashggTags_cff")
+#process.load("flashgg/TagProducers/flashggTags_cff")
 
-process.flashggTagSorter = cms.EDProducer('FlashggTagSorter',
-                                          DiPhotonTag = cms.untracked.InputTag('flashggDiPhotons'),
-                                          TagVectorTag = cms.untracked.VInputTag(cms.untracked.InputTag('flashggVBFTag'),
-                                                                                 cms.untracked.InputTag('flashggUntaggedCategory'),
-                                                                                 ),
-                                          massCutUpper=cms.untracked.double(180),
-                                          massCutLower=cms.untracked.double(100)
-                                          )
+#process.flashggTagSorter = cms.EDProducer('FlashggTagSorter',
+#                                          DiPhotonTag = cms.untracked.InputTag('flashggDiPhotons'),
+#                                          TagVectorTag = cms.untracked.VInputTag(cms.untracked.InputTag('flashggVBFTag'),
+#                                                                                 cms.untracked.InputTag('flashggUntaggedCategory'),
+#                                                                                 ),
+#                                          massCutUpper=cms.untracked.double(180),
+#                                          massCutLower=cms.untracked.double(100)
+#                                          )
 
 process.MessageLogger.cerr.threshold = 'ERROR' # can't get suppressWarning to work: disable all warnings for now
 # process.MessageLogger.suppressWarning.extend(['SimpleMemoryCheck','MemoryCheck']) # this would have been better...
@@ -467,7 +467,7 @@ process.MessageLogger.cerr.threshold = 'ERROR' # can't get suppressWarning to wo
 process.load("flashgg/MicroAODProducers/flashggMicroAODSequence_cff")
 
 from flashgg.MicroAODProducers.flashggMicroAODOutputCommands_cff import microAODDefaultOutputCommand,microAODDebugOutputCommand
-process.out = cms.OutputModule("PoolOutputModule", fileName = cms.untracked.string('/afs/cern.ch/work/y/yhaddad/myMicroAODOutputFile.root'),
+process.out = cms.OutputModule("PoolOutputModule", fileName = cms.untracked.string('myMicroAODOutputFile.root'),
                                outputCommands = microAODDefaultOutputCommand
                                )
 process.out.outputCommands += microAODDebugOutputCommand # extra items for debugging, CURRENTLY REQUIRED

--- a/MicroAODProducers/plugins/CHSLegacyVertexCandidateProducer.cc
+++ b/MicroAODProducers/plugins/CHSLegacyVertexCandidateProducer.cc
@@ -71,7 +71,7 @@ namespace flashgg {
     evt.getByToken(vertexCandidateMapToken_,vtxmap);
     edm::Ptr<reco::Vertex> flashVertex;
     
-    std::cout <<"Run[" << evt.run() <<  "]=evt["<< evt.id().event() << "]\t npart::" <<  pfPtrs.size() << std::endl;
+    //std::cout <<"Run[" << evt.run() <<  "]=evt["<< evt.id().event() << "]\t npart::" <<  pfPtrs.size() << std::endl;
     if(useZeroth) flashVertex =  pvPtrs[0];
     else {
       if ( diPhotonPointers.size()==0 ){

--- a/MicroAODProducers/plugins/DzVertexMapProducerForCHS.cc
+++ b/MicroAODProducers/plugins/DzVertexMapProducerForCHS.cc
@@ -1,0 +1,88 @@
+#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "DataFormats/Common/interface/Handle.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "DataFormats/VertexReco/interface/Vertex.h"
+#include "DataFormats/PatCandidates/interface/PackedCandidate.h"
+#include "flashgg/MicroAODFormats/interface/VertexCandidateMap.h"
+
+using namespace edm;
+using namespace std;
+
+// if the track did not attach to any vertex, attach it to ALL vertices!                                                                                                   
+// This probably mimics better how PFCHS works
+// We want to keep all the tracks for the vertex that's ultimately selected, 
+// unless they're clearly close to another vertex
+
+namespace flashgg {
+
+  class DzVertexMapProducerForCHS : public EDProducer {
+    
+  public:
+    DzVertexMapProducerForCHS( const ParameterSet & );
+  private:
+    void produce( Event &, const EventSetup & ) override;
+    EDGetTokenT<View<reco::Vertex> > vertexToken_;
+    EDGetTokenT<View<pat::PackedCandidate> > pfcandidateToken_;
+    double maxAllowedDz_;
+  };
+
+  DzVertexMapProducerForCHS::DzVertexMapProducerForCHS(const ParameterSet & iConfig) :
+    vertexToken_(consumes<View<reco::Vertex> >(iConfig.getUntrackedParameter<InputTag> ("VertexTag", InputTag("offlineSlimmedPrimaryVertices")))),
+    pfcandidateToken_(consumes<View<pat::PackedCandidate> >(iConfig.getUntrackedParameter<InputTag> ("PFCandidatesTag", InputTag("packedPFCandidates")))),
+    maxAllowedDz_(iConfig.getParameter<double>("MaxAllowedDz")) // in cm
+  {
+    produces<VertexCandidateMap>();
+  }
+
+  void DzVertexMapProducerForCHS::produce( Event & evt, const EventSetup & ) {
+    
+    Handle<View<reco::Vertex> > primaryVertices;
+    evt.getByToken(vertexToken_,primaryVertices);
+    const PtrVector<reco::Vertex>& pvPtrs = primaryVertices->ptrVector();
+
+    Handle<View<pat::PackedCandidate> > pfCandidates;
+    evt.getByToken(pfcandidateToken_,pfCandidates);
+    const PtrVector<pat::PackedCandidate>& pfPtrs = pfCandidates->ptrVector();
+
+    std::auto_ptr<VertexCandidateMap> assoc(new VertexCandidateMap);
+    
+    // Create empty vector for each vertex in advance
+    for (unsigned int j = 0 ; j < pvPtrs.size() ; j++) {
+      assoc->insert(std::make_pair(pvPtrs[j],edm::PtrVector<pat::PackedCandidate>()));
+    }
+
+    for (unsigned int i = 0 ; i < pfPtrs.size() ; i++) {
+      Ptr<pat::PackedCandidate> cand = pfPtrs[i];
+      if (cand->charge() == 0) continue; // skip neutrals
+      double closestDz = maxAllowedDz_;
+      unsigned int closestDzIndex = -1;
+      for (unsigned int j = 0 ; j < pvPtrs.size() ; j++) {
+	Ptr<reco::Vertex> vtx = pvPtrs[j];
+	double dz = fabs(cand->dz(vtx->position()));
+	if (dz < closestDz) {
+	  closestDz = dz;
+	  closestDzIndex = j;
+	}
+      }
+      if (closestDz < maxAllowedDz_) {
+	// Within specified distance of a vertex, so attach only to it (or the closest one if multiple)
+	Ptr<reco::Vertex> vtx =pvPtrs[closestDzIndex];
+	assoc->at(vtx).push_back(cand);
+      } else { 
+	// if the track did not attach to any vertex, attach it to ALL vertices!
+	for (unsigned int j = 0 ; j < pvPtrs.size() ; j++) {
+	  Ptr<reco::Vertex> vtx = pvPtrs[j];
+	  assoc->at(vtx).push_back(cand);
+	}
+      }
+    } // loop over pf 
+    evt.put(assoc);
+  } // produce method
+} // namespace flashgg
+
+typedef flashgg::DzVertexMapProducerForCHS FlashggDzVertexMapProducerForCHS;
+DEFINE_FWK_MODULE(FlashggDzVertexMapProducerForCHS);

--- a/MicroAODProducers/python/flashggJets_cfi.py
+++ b/MicroAODProducers/python/flashggJets_cfi.py
@@ -9,10 +9,6 @@ def addFlashggPFCHSLegJets(process):
 	# load various necessary plugins.
   process.load("PhysicsTools.PatAlgos.producersLayer1.patCandidates_cff")
   process.load('PhysicsTools.PatAlgos.slimming.unpackedTracksAndVertices_cfi')
-  process.load("Configuration.EventContent.EventContent_cff")
-  process.load('Configuration.StandardSequences.MagneticField_38T_cff')
-  process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
-  process.GlobalTag.globaltag = 'PLS170_V7AN1::All'
 	# leptons to remove as per default CHS workflow
   process.selectedMuons = cms.EDFilter("CandPtrSelector", src = cms.InputTag("slimmedMuons"), cut = cms.string('''abs(eta)<2.5 && pt>10. &&
 				(pfIsolationR04().sumChargedHadronPt+

--- a/MicroAODProducers/python/flashggJets_cfi.py
+++ b/MicroAODProducers/python/flashggJets_cfi.py
@@ -1,12 +1,74 @@
 import FWCore.ParameterSet.Config as cms
 
 from RecoJets.JetProducers.PileupJetIDParams_cfi import cutbased as pu_jetid
+from PhysicsTools.PatAlgos.tools.jetTools import addJetCollection
 
+# define a function to add in the jet collection, as the reclustering need to know about the process
+# but we obviously don't want all this stuff clogging up python configs. 
+def addFlashggPFCHSLegJets(process):
+	# load various necessary plugins.
+  process.load("PhysicsTools.PatAlgos.producersLayer1.patCandidates_cff")
+  process.load('PhysicsTools.PatAlgos.slimming.unpackedTracksAndVertices_cfi')
+  process.load("Configuration.EventContent.EventContent_cff")
+  process.load('Configuration.StandardSequences.MagneticField_38T_cff')
+  process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+  process.GlobalTag.globaltag = 'PLS170_V7AN1::All'
+	# leptons to remove as per default CHS workflow
+  process.selectedMuons = cms.EDFilter("CandPtrSelector", src = cms.InputTag("slimmedMuons"), cut = cms.string('''abs(eta)<2.5 && pt>10. &&
+				(pfIsolationR04().sumChargedHadronPt+
+				 max(0.,pfIsolationR04().sumNeutralHadronEt+
+					 pfIsolationR04().sumPhotonEt-
+					 0.50*pfIsolationR04().sumPUPt))/pt < 0.20 && 
+				(isPFMuon && (isGlobalMuon || isTrackerMuon) )'''))
+  process.selectedElectrons = cms.EDFilter("CandPtrSelector", src = cms.InputTag("slimmedElectrons"), cut = cms.string('''abs(eta)<2.5 && pt>20. &&
+				gsfTrack.isAvailable() &&
+				gsfTrack.hitPattern().numberOfLostHits(\'MISSING_INNER_HITS\') < 2 &&
+				(pfIsolationVariables().sumChargedHadronPt+
+				 max(0.,pfIsolationVariables().sumNeutralHadronEt+
+					 pfIsolationVariables().sumPhotonEt-
+					 0.5*pfIsolationVariables().sumPUPt))/pt < 0.15'''))
+	# Simple producer which just removes the Candidates which don't come from the legacy vertex according to the Flashgg Vertex Map
+  process.flashggCHSLegacyVertexCandidates = cms.EDProducer('FlashggCHSLegacyVertexCandidateProducer',
+                                                          PFCandidatesTag=cms.untracked.InputTag('packedPFCandidates'),
+                                                          DiPhotonTag=cms.untracked.InputTag('flashggDiPhotons'),
+                                                          VertexCandidateMapTag = cms.InputTag("flashggVertexMapForCHS"),
+                                                          VertexTag=cms.untracked.InputTag('offlineSlimmedPrimaryVertices')
+                                                  )
+  process.pfCHSLeg = cms.EDFilter("CandPtrSelector", src = cms.InputTag("flashggCHSLegacyVertexCandidates"), cut = cms.string(""))
+  # then remove the previously selected muons
+  process.pfNoMuonCHSLeg =  cms.EDProducer("CandPtrProjector", src = cms.InputTag("pfCHSLeg"), veto = cms.InputTag("selectedMuons"))
+  # then remove the previously selected electrons
+  process.pfNoElectronsCHSLeg = cms.EDProducer("CandPtrProjector", src = cms.InputTag("pfNoMuonCHSLeg"), veto =  cms.InputTag("selectedElectrons"))
+  #Import RECO jet producer for ak4 PF and GEN jet
+  from RecoJets.JetProducers.ak4PFJets_cfi import ak4PFJets
+  from RecoJets.JetProducers.ak4GenJets_cfi import ak4GenJets
+  process.ak4PFJetsCHSLeg = ak4PFJets.clone(src = 'pfNoElectronsCHSLeg', doAreaFastjet = True)
+  process.ak4GenJetsLeg = ak4GenJets.clone(src = 'packedGenParticles')
+	# cluster the jets
+  addJetCollection(
+      process,
+      postfix   = "",
+      labelName = 'AK4PFCHSLeg',
+      jetSource = cms.InputTag('ak4PFJetsCHSLeg'),
+      trackSource = cms.InputTag('unpackedTracksAndVertices'), 
+      pvSource = cms.InputTag('unpackedTracksAndVertices'), 
+      jetCorrections = ('AK4PFchs', cms.vstring(['L1FastJet', 'L2Relative', 'L3Absolute']), 'None'),
+      btagDiscriminators = [      'combinedSecondaryVertexBJetTags'     ]
+      ,algo= 'AK', rParam = 0.4
+      )
+  # adjust MC matching
+  process.patJetGenJetMatchAK4PFCHSLeg.matched = "ak4GenJetsLeg"
+  process.patJetPartonMatchAK4PFCHSLeg.matched = "prunedGenParticles"
+  process.patJetPartons.particles = "prunedGenParticles"
+  # adjust PV collection used for Jet Corrections
+  process.patJetCorrFactorsAK4PFCHSLeg.primaryVertices = "offlineSlimmedPrimaryVertices"
+	
+# Flashgg Jet producer using the collection created with function above.
 flashggJets = cms.EDProducer('FlashggJetProducer',
 		DiPhotonTag=cms.untracked.InputTag('flashggDiPhotons'),
 		VertexTag=cms.untracked.InputTag('offlineSlimmedPrimaryVertices'),
-		JetTag=cms.untracked.InputTag('slimmedJets'),
-		VertexCandidateMapTag = cms.InputTag("flashggVertexMapUnique"),
+		JetTag=cms.untracked.InputTag('patJetsAK4PFCHSLeg'),
+		VertexCandidateMapTag = cms.InputTag("flashggVertexMapForCHS"),
 		PileupJetIdParameters=cms.PSet(pu_jetid),
                 MinJetPt=cms.untracked.double(0.)             
 		)

--- a/MicroAODProducers/python/flashggMicroAODSequence_cff.py
+++ b/MicroAODProducers/python/flashggMicroAODSequence_cff.py
@@ -1,5 +1,5 @@
 import FWCore.ParameterSet.Config as cms
-from flashgg.MicroAODProducers.flashggTkVtxMap_cfi import flashggVertexMapUnique,flashggVertexMapNonUnique
+from flashgg.MicroAODProducers.flashggTkVtxMap_cfi import flashggVertexMapUnique,flashggVertexMapNonUnique,flashggVertexMapForCHS
 from flashgg.MicroAODProducers.flashggPhotons_cfi import flashggPhotons
 from flashgg.MicroAODProducers.flashggDiPhotons_cfi import flashggDiPhotons
 from flashgg.MicroAODProducers.flashggPreselectedDiPhotons_cfi import flashggPreselectedDiPhotons
@@ -19,9 +19,10 @@ weightsCount = cms.EDProducer("WeightsCountProducer",
                               )
 
 flashggMicroAODSequence = cms.Sequence((eventCount+weightsCount
-                                        +flashggVertexMapUnique+flashggVertexMapNonUnique+flashggElectrons
+                                        +flashggVertexMapUnique+flashggVertexMapNonUnique
+                                        +flashggElectrons
                                         +flashggMicroAODGenSequence
                                         )
                                        *flashggPhotons*flashggDiPhotons
-                                       *(flashggPreselectedDiPhotons+flashggJets)
+                                       *(flashggPreselectedDiPhotons+flashggVertexMapForCHS*flashggJets)
                                        )

--- a/MicroAODProducers/python/flashggTkVtxMap_cfi.py
+++ b/MicroAODProducers/python/flashggTkVtxMap_cfi.py
@@ -12,3 +12,9 @@ flashggVertexMapNonUnique = cms.EDProducer('FlashggDzVertexMapProducer',
                                            MaxAllowedDz=cms.double(0.2), 
                                            UseEachTrackOnce=cms.untracked.bool(False)
                                            )
+
+flashggVertexMapForCHS = cms.EDProducer('FlashggDzVertexMapProducerForCHS',
+                                        PFCandidatesTag=cms.untracked.InputTag('packedPFCandidates'),
+                                        VertexTag=cms.untracked.InputTag('offlineSlimmedPrimaryVertices'),
+                                        MaxAllowedDz=cms.double(0.1)
+                                        )

--- a/MicroAODProducers/test/simple_Producer_test.py
+++ b/MicroAODProducers/test/simple_Producer_test.py
@@ -9,7 +9,7 @@ process.load("FWCore.MessageService.MessageLogger_cfi")
 process.load("Configuration.StandardSequences.GeometryDB_cff")
 process.load("Configuration.StandardSequences.MagneticField_cff")
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
-process.GlobalTag.globaltag = 'POSTLS170_V5::All'
+process.GlobalTag.globaltag = 'PLS170_V7AN1::All'
 
 process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32( 1000) )
 process.MessageLogger.cerr.FwkReport.reportEvery = cms.untracked.int32( 1000 )

--- a/MicroAODProducers/test/simple_Producer_test.py
+++ b/MicroAODProducers/test/simple_Producer_test.py
@@ -40,6 +40,17 @@ process.out = cms.OutputModule("PoolOutputModule", fileName = cms.untracked.stri
                                )
 process.out.outputCommands += microAODDebugOutputCommand # extra items for debugging, CURRENTLY REQUIRED
 
+# need to allow unscheduled processes otherwise reclustering function will fail
+# this is because of the jet clustering tool, and we have to live with it for now.
+process.options = cms.untracked.PSet(
+    allowUnscheduled = cms.untracked.bool(True)
+    )
+# import function which takes care of reclustering the jets using legacy vertex		
+from flashgg.MicroAODProducers.flashggJets_cfi import addFlashggPFCHSLegJets 
+# call the function, it takes care of everything else.
+addFlashggPFCHSLegJets(process)
+
+
 process.p = cms.Path(process.flashggMicroAODSequence)
 process.e = cms.EndPath(process.out)
 

--- a/TagProducers/test/MicroAOD_plus_Tag_test.py
+++ b/TagProducers/test/MicroAOD_plus_Tag_test.py
@@ -8,7 +8,7 @@ process.load("FWCore.MessageService.MessageLogger_cfi")
 process.load("Configuration.StandardSequences.GeometryDB_cff")
 process.load("Configuration.StandardSequences.MagneticField_cff")
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
-process.GlobalTag.globaltag = 'POSTLS170_V5::All'
+process.GlobalTag.globaltag = 'PLS170_V7AN1::All'
 
 process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32( 1000) )
 process.MessageLogger.cerr.FwkReport.reportEvery = cms.untracked.int32( 1000 )

--- a/TagProducers/test/MicroAOD_plus_Tag_test.py
+++ b/TagProducers/test/MicroAOD_plus_Tag_test.py
@@ -28,5 +28,15 @@ process.out = cms.OutputModule("PoolOutputModule", fileName = cms.untracked.stri
                                )
 process.out.outputCommands += microAODDebugOutputCommand # extra items for debugging, CURRENTLY REQUIRED
 
+# need to allow unscheduled processes otherwise reclustering function will fail
+# this is because of the jet clustering tool, and we have to live with it for now.
+process.options = cms.untracked.PSet(
+    allowUnscheduled = cms.untracked.bool(True)
+    )
+# import function which takes care of reclustering the jets using legacy vertex		
+from flashgg.MicroAODProducers.flashggJets_cfi import addFlashggPFCHSLegJets 
+# call the function, it takes care of everything else.
+addFlashggPFCHSLegJets(process)
+
 process.p = cms.Path(process.flashggMicroAODSequence*process.flashggTagSequence*process.flashggTagTester)
 process.e = cms.EndPath(process.out)


### PR DESCRIPTION
Hi,

This PR switches the default Input Jet Collection for FLASHggJets from PFCHS0 (the miniAOD default, pre-clustered Jets which do Charged Hadron Subtraction using the 0th Vertex in the PV collection) to PFCHSLeg ( now re-clustering Jets, following the CHS procedure but with "legacy" (ie Hgg-selected) vertex rather than 0th Vertex). This now is consistent with the current PFCHS0 JEC, but it also logically conssitent with the vertex we use for the rest of the analysis.

Any issues, please shout,

Louie