### PR TITLE
Added templated MVAComputer and prepared submission scripts for automatic resubmission

### DIFF
--- a/DataFormats/interface/DiPhotonCandidate.h
+++ b/DataFormats/interface/DiPhotonCandidate.h
@@ -19,6 +19,9 @@ namespace flashgg {
     const flashgg::Photon* leadingPhoton() const;
     const flashgg::Photon* subLeadingPhoton() const;
 
+    flashgg::Photon & getLeadingPhoton();
+    flashgg::Photon & getSubLeadingPhoton();
+
     flashgg::SinglePhotonView leadingView() const;
     flashgg::SinglePhotonView subLeadingView() const;
 

--- a/DataFormats/src/DiPhotonCandidate.cc
+++ b/DataFormats/src/DiPhotonCandidate.cc
@@ -33,6 +33,22 @@ DiPhotonCandidate::DiPhotonCandidate(const flashgg::Photon & photon1,const flash
   addP4.set(*this);
 }
 
+flashgg::Photon & DiPhotonCandidate::getLeadingPhoton() {
+  if (daughter(0)->pt() > daughter(1)->pt()) {
+    return dynamic_cast<flashgg::Photon&> (*daughter(0));
+  } else {
+    return dynamic_cast<flashgg::Photon&> (*daughter(1));
+  }
+}
+
+flashgg::Photon & DiPhotonCandidate::getSubLeadingPhoton() {
+  if (daughter(0)->pt() > daughter(1)->pt()) {
+    return dynamic_cast<flashgg::Photon&> (*daughter(1));
+  } else {
+    return dynamic_cast<flashgg::Photon&> (*daughter(0));
+  }
+}
+
 const flashgg::Photon * DiPhotonCandidate::leadingPhoton() const {
   if (daughter(0)->pt() > daughter(1)->pt()) {
     return dynamic_cast<const flashgg::Photon*> (daughter(0));

--- a/MetaData/plugins/IdleWatchdog.cc
+++ b/MetaData/plugins/IdleWatchdog.cc
@@ -1,0 +1,117 @@
+// -*- C++ -*-
+//
+// Package:    IdleWatchdog
+// Class:      IdleWatchdog
+// 
+/**\class IdleWatchdog IdleWatchdog.cc CommonTools/UtilAlgos/plugins/IdleWatchdog.cc
+
+Description: An event counter that can store the number of events in the lumi block 
+
+*/
+
+
+// system include files
+#include <memory>
+#include <vector>
+#include <algorithm>
+#include <iostream>
+
+// user include files
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/LuminosityBlock.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "SimDataFormats/GeneratorProducts/interface/GenEventInfoProduct.h"
+#include "SimDataFormats/PileupSummaryInfo/interface/PileupSummaryInfo.h"
+#include "DataFormats/Common/interface/Handle.h"
+#include "FWCore/Framework/interface/Event.h"
+
+#include "TStopwatch.h"
+
+class IdleWatchdog : public edm::EDAnalyzer {
+public:
+	explicit IdleWatchdog(const edm::ParameterSet&);
+	~IdleWatchdog();
+	
+private:
+	virtual void analyze(const edm::Event &, const edm::EventSetup&);
+	virtual void respondToOpenInputFile(edm::FileBlock const&);
+        void check();
+	void reset();
+	
+	double minIdleFraction_;
+	int checkEvery_, tolerance_;
+	int nFailures_, ievent_;
+	
+	TStopwatch stopWatch_;
+};
+
+
+
+using namespace edm;
+using namespace std;
+
+
+
+IdleWatchdog::IdleWatchdog(const edm::ParameterSet& iConfig) :
+	minIdleFraction_(iConfig.getUntrackedParameter<double>("minIdleFraction",0.2)),
+	checkEvery_(iConfig.getUntrackedParameter<int>("checkEvery",1000)),
+	tolerance_(iConfig.getUntrackedParameter<int>("tolerance",5))
+{
+	
+}
+
+
+IdleWatchdog::~IdleWatchdog(){}
+
+
+void
+IdleWatchdog::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) 
+{
+	/// cout << ievent_ << " " << checkEvery_ << " " << nFailures_ << " " << tolerance_ << " " << minIdleFraction_ << endl;
+	if( ievent_ % checkEvery_ == 0 ) {
+		check();
+	}
+	++ievent_;
+	return;
+}
+
+void IdleWatchdog::respondToOpenInputFile(edm::FileBlock const&)
+{
+	reset();
+}
+
+
+void IdleWatchdog::check()
+{
+	/// cout << "checking " << endl;
+	stopWatch_.Stop();
+	float cputime  = stopWatch_.CpuTime();
+	float realtime = stopWatch_.RealTime();
+	
+	/// std::cout << cputime << " " << realtime << std::endl;
+	if( cputime / realtime < minIdleFraction_ ) {
+		--nFailures_;
+	} else {
+		nFailures_ = tolerance_;
+	}
+	
+	if( nFailures_ == 0 ) {
+		cerr << "too inefficient: " << minIdleFraction_ << " " << tolerance_ << " aborting " << endl;
+		exit(99);
+	}
+	stopWatch_.Start();
+}
+
+void IdleWatchdog::reset()
+{
+	ievent_ = 0;
+	nFailures_ = tolerance_;
+	stopWatch_.Stop();
+	stopWatch_.Start();
+}
+
+//define this as a plug-in
+DEFINE_FWK_MODULE(IdleWatchdog);

--- a/MetaData/python/parallel.py
+++ b/MetaData/python/parallel.py
@@ -12,51 +12,61 @@ class LsfJob:
     """ a thread to run bsub and wait until it completes """
 
     #----------------------------------------
-    def __init__(self, lsfQueue, jobName=""):
+    def __init__(self, lsfQueue, jobName="", retry=5):
         """ @param cmd is the command to be executed inside the bsub script. Some CMSSW specific wrapper
             code will be added
         """
         self.lsfQueue = lsfQueue
         self.jobName = jobName
-    
+        self.retry=retry
+        
     def __str__(self):
         return "LsfJob: %s %s" % ( self.lsfQueue, self.jobName )
         
     #----------------------------------------
     def __call__(self,cmd):
+        
+        print cmd, "attempt", itry
+        
         bsubCmdParts = [ "bsub",
                          "-q " + self.lsfQueue,
                          "-K",  # bsub waits until job completes
                          ]
-
+        
         if( self.jobName ):
             bsubCmdParts.append("-J " + self.jobName)
             bsubCmdParts.append("-o %s.log" % self.jobName)
-
+        
         bsubCmd = " ".join(bsubCmdParts)
-
+        
         import subprocess
         lsf = subprocess.Popen(bsubCmd, shell=True, # bufsize=bufsize,
                                stdin=subprocess.PIPE,
                                close_fds=True)
         
         print >> lsf.stdin, "#!/bin/sh"
-
+        
         print >> lsf.stdin, "cd " + os.environ['CMSSW_BASE']
         print >> lsf.stdin, "eval `scram runtime -sh`"
         print >> lsf.stdin, "cd " + os.getcwd()
-
+        
         # the user command
         print >> lsf.stdin, cmd
         lsf.stdin.close()
         
         # wait for the job to complete
         self.exitStatus = lsf.wait()
-
-        if self.exitStatus != 0:
-            print "error running job",self.jobName
         
-        return self.exitStatus, ""
+        if self.exitStatus != 0:
+            print "error running job",self.jobName, self.exitStatus
+        
+        output = ""
+        if self.jobName:
+            with open("%s.log" % self.jobName) as lf:
+                output = lf.read()
+                lf.close()
+
+        return self.exitStatus, output
     
 class Wrap:
     def __init__(self, func, args, retqueue, runqueue):
@@ -130,7 +140,7 @@ class Parallel:
         ## print "ok"
         return cmd,args,ret
 
-    def wait(self):
+    def wait(self,handler=None):
         returns = []
         self.sem.acquire()
         njobs = self.njobs
@@ -139,10 +149,14 @@ class Parallel:
             print "Finished jobs: %d. Total jobs: %d" % (i, self.njobs)
             job, jobargs, ret = self.returned.get()
             if type(job) == str:
-                print "finished: %s %s" % ( job, " ".join(jobargs) )
-                for line in ret[1].split("\n"):
-                    print line
-            returns.append(ret)
+                print "finished: '%s' '%s'" % ( job, " ".join(jobargs) )
+                if not handler:
+                    for line in ret[1].split("\n"):
+                        print line
+            if handler:
+                handler.handleJobOutput(job, jobargs, ret)
+            else:
+                returns.append( (job,jobargs,ret) )
         
         self.sem.acquire()
         self.njobs -= njobs

--- a/MetaData/python/samples_utils.py
+++ b/MetaData/python/samples_utils.py
@@ -479,10 +479,11 @@ Commands:
         for d in datasets:
             nevents = 0.
             weights = 0.
+            nfiles = len(catalog[d]["files"])
             for fil in catalog[d]["files"]:
                 nevents += fil.get("nevents",0.)
                 weights += fil.get("weights",0.)
-            print d.ljust(largest), ("%d" % int(nevents)).rjust(8),
+            print d.ljust(largest), ("%d" % int(nevents)).rjust(8), ("%d" % nfiles).rjust(3),
             if weights != 0.: print ("%1.2g" % ( weights/nevents ) )
             else: print
             

--- a/MicroAOD/BuildFile.xml
+++ b/MicroAOD/BuildFile.xml
@@ -8,6 +8,7 @@
 <use name="FWCore/Utilities"/>
 <use name="CommonTools/Utils"/>
 <use name="roottmva"/>
+<Flags CXXFLAGS="-ggdb"/>
 <export>
   <lib   name="1"/>
 </export>

--- a/MicroAOD/BuildFile.xml
+++ b/MicroAOD/BuildFile.xml
@@ -8,7 +8,7 @@
 <use name="FWCore/Utilities"/>
 <use name="CommonTools/Utils"/>
 <use name="roottmva"/>
-<Flags CXXFLAGS="-ggdb"/>
+<!-- Flags CXXFLAGS="-ggdb"/ -->
 <export>
   <lib   name="1"/>
 </export>

--- a/MicroAOD/interface/GlobalVariablesComputer.h
+++ b/MicroAOD/interface/GlobalVariablesComputer.h
@@ -1,0 +1,29 @@
+#ifndef flashgg_GlobalVariablesComputer_h
+#define flashgg_GlobalVariablesComputer_h
+
+#include "FWCore/Common/interface/EventBase.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+namespace flashgg {
+
+	class GlobalVariablesComputer {
+	public:
+		struct cache_t {
+			float rho;
+			int   nvtx;
+		};
+		
+		GlobalVariablesComputer(const edm::ParameterSet & cfg);
+		
+		void update(const edm::EventBase & event);
+		
+		float * addressOf(const std::string & varName);
+		
+	protected:
+		edm::InputTag rhoTag_, vtxTag_;
+		cache_t cache_;
+	};	
+}
+
+#endif // flashgg_GlobalVariablesComputer_h

--- a/MicroAOD/interface/MVAComputer.h
+++ b/MicroAOD/interface/MVAComputer.h
@@ -1,0 +1,112 @@
+#ifndef flashgg_MVAComputer_h
+#define flashgg_MVAComputer_h
+
+#include <tuple>
+#include <vector>
+#include <string>
+
+#include "CommonTools/Utils/interface/TFileDirectory.h"
+
+#include "flashgg/Taggers/interface/StringHelpers.h"
+
+#include "CommonTools/Utils/interface/StringObjectFunction.h"
+#include "CommonTools/Utils/interface/StringCutObjectSelector.h"
+
+#include "TMVA/Reader.h"
+#include "flashgg/Taggers/interface/GlobalVariablesDumper.h"
+
+namespace flashgg {
+	
+	template<class ObjectT, class FunctorT=StringObjectFunction<ObjectT,true> >
+	class MVAComputer {
+	public:
+		typedef ObjectT object_type;
+		typedef FunctorT functor_type;
+		
+		MVAComputer(const edm::ParameterSet & cfg, GlobalVariablesComputer * global=0);
+		~MVAComputer();
+		
+		float operator()(const object_type & obj) const;
+		
+	private:
+		void bookMVA() const;
+
+		mutable TMVA::Reader * reader_; 
+		GlobalVariablesComputer * global_;
+		
+		std::string classifier_, weights_;
+		std::vector<std::tuple<std::string,int> > variables_;
+		mutable std::vector<float> values_;
+		std::vector<functor_type> functors_;
+	};
+	
+	template<class F, class O>
+	MVAComputer<F,O>::MVAComputer(const edm::ParameterSet & cfg, GlobalVariablesComputer * global) :
+		reader_(0),
+		global_(global),
+		classifier_(cfg.getParameter<std::string>("classifier"))
+	{
+		using namespace std;
+
+		weights_    = cfg.getParameter<edm::FileInPath>("weights").fullPath();
+				
+		auto variables = cfg.getParameter<vector<edm::ParameterSet> >("variables");
+		for( auto & var : variables ) {
+			auto expr = var.getParameter<string>("expr");
+			auto name = var.getUntrackedParameter<string>("name",expr);
+			auto pos = expr.find("global.");
+			if( pos == 0 ) {
+				assert( global != 0 );
+				variables_.push_back( std::make_tuple(name+"::"+expr.substr(7),-1) );
+			} else {
+				functors_.push_back( functor_type(expr) );
+				variables_.push_back( std::make_tuple(name,functors_.size()-1) );
+			}
+		}
+	}
+	
+	template<class F, class O>
+	MVAComputer<F,O>::~MVAComputer()
+	{
+		if( reader_ ) { 
+			delete reader_;
+		}
+	}
+	
+	template<class F, class O>
+	void MVAComputer<F,O>::bookMVA() const 
+	{
+		if( reader_ ) { return; }
+		reader_ = new TMVA::Reader("!Color");
+		values_.resize(functors_.size(),0.);
+		for(auto & var : variables_ ) {
+			auto & name = std::get<0>(var);
+			auto ivar = std::get<1>(var);
+			if( ivar >= 0 ) {
+				reader_->AddVariable(name,&values_[ivar]);
+			} else {
+				assert( global_ != 0 );
+				auto pos = name.find("::");
+				auto vname = name.substr(0,pos);
+				auto gname = name.substr(pos+2);
+				reader_->AddVariable(vname,global_->addressOf(gname));
+			}
+		}
+		reader_->BookMVA(classifier_,weights_);
+
+	}
+
+	template<class F, class O>
+	float MVAComputer<F,O>::operator()(const object_type & obj) const
+	{
+		if( ! reader_ ) { bookMVA(); }
+		for(size_t ivar=0; ivar<functors_.size(); ++ivar) {
+			values_[ivar] = functors_[ivar](obj);
+		}
+		return reader_->EvaluateMVA(classifier_.c_str());
+	}
+
+}
+
+
+#endif  // flashgg_MVAComputer_h

--- a/MicroAOD/interface/PerPhotonMVADiPhotonPostProcess.h
+++ b/MicroAOD/interface/PerPhotonMVADiPhotonPostProcess.h
@@ -1,0 +1,35 @@
+#ifndef flashgg_PerPhotonMVADiPhotonComputer_h
+#define flashgg_PerPhotonMVADiPhotonComputer_h
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "FWCore/Common/interface/EventBase.h"
+
+#include "flashgg/MicroAOD/interface/PhotonMVAComputer.h"
+
+#include <tuple>
+#include <vector>
+#include <map>
+
+namespace flashgg
+{
+	template<class OutputCollection> class PerPhotonMVADiPhotonPostProcess {
+
+	public:
+		PerPhotonMVADiPhotonPostProcess(const edm::ParameterSet & config, edm::ConsumesCollector && cc) : computer_(config) {};
+		
+		template<class EdmFilter> void init( EdmFilter & ) { }
+		
+		void process( edm::OrphanHandle<OutputCollection> output, edm::EventBase & event) {
+			computer_.update(event);
+			for( auto & dipho : *output ) {
+				computer_.fill(dipho.getLeadingPhoton());
+				computer_.fill(dipho.getSubLeadingPhoton());
+			}
+		};
+	private:
+		PhotonMVAComputer computer_;
+	};
+}
+
+#endif // flashgg_PerPhotonMVADiPhotonComputer_h

--- a/MicroAOD/interface/PhotonMVAComputer.h
+++ b/MicroAOD/interface/PhotonMVAComputer.h
@@ -1,0 +1,48 @@
+#ifndef flashgg_PhotonMVAComputer_h
+#define flashgg_PhotonMVAComputer_h
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "CommonTools/Utils/interface/StringObjectFunction.h"
+#include "CommonTools/Utils/interface/StringCutObjectSelector.h"
+
+#include "flashgg/MicroAOD/interface/CutBasedClassifier.h"
+#include "flashgg/DataFormats/interface/Photon.h"
+
+#include "FWCore/Common/interface/EventBase.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
+
+#include "flashgg/MicroAOD/interface/GlobalVariablesComputer.h"
+#include "flashgg/MicroAOD/interface/MVAComputer.h"
+
+#include <tuple>
+#include <vector>
+#include <map>
+
+namespace flashgg
+{
+	class PhotonMVAComputer : public GlobalVariablesComputer {
+
+	public:
+		typedef CutBasedClassifier<Photon> classifier_type;
+		typedef StringCutObjectSelector<Photon> selector_type;
+		typedef MVAComputer<Photon> mva_type;
+		
+		PhotonMVAComputer(const edm::ParameterSet & config, edm::ConsumesCollector && cc);
+		PhotonMVAComputer(const edm::ParameterSet & config);
+		~PhotonMVAComputer();
+
+		void fill(Photon &);
+		
+	private:
+		classifier_type classifier_;
+		selector_type selector_;
+		// mva_names, default
+		std::vector<std::tuple<std::string,float> > toFill_;
+		// category -> vector< <min,max,rhocorr> >
+		std::map<std::string,std::vector<mva_type *> >  mvas_;
+		
+	};
+
+}
+
+#endif // flashgg_PhotonMVAComputer_h

--- a/MicroAOD/plugins/DiPhotonCandidateSelector.cc
+++ b/MicroAOD/plugins/DiPhotonCandidateSelector.cc
@@ -22,18 +22,13 @@
 #include "CommonTools/UtilAlgos/interface/ObjectSelectorStream.h"
 #include "CommonTools/UtilAlgos/interface/SingleElementCollectionSelectorPlusEvent.h"
 
+#include "flashgg/MicroAOD/interface/PerPhotonMVADiPhotonPostProcess.h"
+
 typedef SingleObjectSelector<
 	edm::View<flashgg::DiPhotonCandidate>,
 	StringCutObjectSelector<flashgg::DiPhotonCandidate, true>,
 	std::vector<flashgg::DiPhotonCandidate>
        > DiPhotonCandidateSelector;
-
-/// typedef SingleObjectSelector<
-/// 	edm::View<flashgg::DiPhotonCandidate>,
-/// 	flashgg::CutBasedDiPhotonObjectSelector,
-/// 	std::vector<flashgg::DiPhotonCandidate>
-//       > GenericDiPhotonCandidateSelector;
-
 
 typedef ObjectSelectorStream<
 	SingleElementCollectionSelectorPlusEvent<

--- a/MicroAOD/plugins/PerPhotonMVADiPhotonProducer.cc
+++ b/MicroAOD/plugins/PerPhotonMVADiPhotonProducer.cc
@@ -1,0 +1,57 @@
+#ifndef flashgg_PerPhotonMVADiPhotonComputer_h
+#define flashgg_PerPhotonMVADiPhotonComputer_h
+
+#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "DataFormats/Common/interface/Handle.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/EDMException.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "flashgg/DataFormats/interface/DiPhotonCandidate.h"
+
+#include "flashgg/MicroAOD/interface/PhotonMVAComputer.h"
+
+#include <tuple>
+#include <vector>
+#include <map>
+
+using namespace std;
+using namespace edm;
+
+namespace flashgg
+{
+	class PerPhotonMVADiPhotonProducer : public EDProducer {
+
+	public:
+		PerPhotonMVADiPhotonProducer(const edm::ParameterSet & config) : 
+			srcToken_(consumes<View<flashgg::DiPhotonCandidate> >(config.getParameter<InputTag>("src"))),
+			computer_(config,this->consumesCollector()) {
+			produces<vector<flashgg::DiPhotonCandidate> >();
+		};
+		
+		void produce( Event & evt, const EventSetup & ) {
+			Handle<View<flashgg::DiPhotonCandidate> > input;
+			evt.getByToken(srcToken_,input);
+			auto_ptr<vector<DiPhotonCandidate> > output(new vector<DiPhotonCandidate>);
+			computer_.update(evt);
+			for( auto dipho : *input ) {
+				computer_.fill(dipho.getLeadingPhoton());
+				computer_.fill(dipho.getSubLeadingPhoton());
+				output->push_back(dipho);
+			}
+			evt.put(output);
+		};
+		
+	private:
+		EDGetTokenT<View<DiPhotonCandidate> > srcToken_;
+		PhotonMVAComputer computer_;
+	};
+}
+
+typedef flashgg::PerPhotonMVADiPhotonProducer FlashggPerPhotonMVADiPhotonProducer;
+DEFINE_FWK_MODULE(FlashggPerPhotonMVADiPhotonProducer);
+
+#endif // flashgg_PerPhotonMVADiPhotonComputer_h

--- a/MicroAOD/src/GlobalVariablesComputer.cc
+++ b/MicroAOD/src/GlobalVariablesComputer.cc
@@ -1,9 +1,7 @@
-#include "flashgg/Taggers/interface/GlobalVariablesDumper.h"
+#include "flashgg/MicroAOD/interface/GlobalVariablesComputer.h"
 
 #include "DataFormats/VertexReco/interface/VertexFwd.h"
 #include "DataFormats/VertexReco/interface/Vertex.h"
-
-#include "TTree.h"
 
 using namespace edm;
 using namespace reco;
@@ -17,9 +15,6 @@ namespace flashgg {
 	{
 	}
 	
-	// GlobalVariablesComputer::~GlobalVariablesComputer()
-	// {}
-
 	float * GlobalVariablesComputer::addressOf(const std::string & varName)
 	{
 		if( varName == "rho" ) { return &cache_.rho; }
@@ -38,25 +33,4 @@ namespace flashgg {
 		cache_.rho = *rhoHandle;
 		cache_.nvtx = vertices->size();
 	}
-
-	GlobalVariablesDumper::GlobalVariablesDumper(const edm::ParameterSet & cfg) : 
-		GlobalVariablesComputer(cfg)
-	{}
-
-	
-	GlobalVariablesDumper::~GlobalVariablesDumper()
-	{}
-
-	void GlobalVariablesDumper::bookTreeVariables(TTree *tree, const std::map<std::string,std::string> & replacements)
-	{
-		tree->Branch("rho",&cache_.rho);
-		tree->Branch("nvtx",&cache_.nvtx);
-	}
-
-	void GlobalVariablesDumper::fill(const EventBase & evt)
-	{
-		update(evt);
-	}
-
-
 }

--- a/MicroAOD/src/PhotonMVAComputer.cc
+++ b/MicroAOD/src/PhotonMVAComputer.cc
@@ -1,0 +1,68 @@
+#include "flashgg/MicroAOD/interface/PhotonMVAComputer.h"
+#include "FWCore/Framework/interface/Event.h"
+
+using namespace edm;
+using namespace std;
+
+namespace flashgg
+{
+	PhotonMVAComputer::PhotonMVAComputer(const ParameterSet & cfg, edm::ConsumesCollector && cc) : 
+		PhotonMVAComputer(cfg)
+	{
+	}
+	
+	PhotonMVAComputer::PhotonMVAComputer(const ParameterSet & cfg) : 
+		GlobalVariablesComputer(cfg),
+		classifier_(cfg),
+		selector_(cfg.getParameter<string>("mvaPreselection"))
+	{
+		auto mvas = cfg.getParameter<vector<edm::ParameterSet> >("mvas");
+		for( auto & mva : mvas ) {
+			toFill_.push_back( std::make_tuple(mva.getParameter<std::string>("name"),mva.getParameter<double>("default")));
+		}
+		auto categories = cfg.getParameter<vector<edm::ParameterSet> >("categories");
+		
+		for(auto & cat : categories ) {
+			auto name = cat.getUntrackedParameter<string>("name",Form("cat%lu",mvas_.size()));
+			for( auto & toFill : toFill_ ) {
+				mvas_[name].push_back( new mva_type(cat.getParameter<edm::ParameterSet>(std::get<0>(toFill)),this) );
+			}
+			// cout << name << " " << mvas_[name].size() << endl;
+		}
+	}
+
+	PhotonMVAComputer::~PhotonMVAComputer()
+	{
+		for(auto & mva  : mvas_ ) {
+			for(auto & func : mva.second) {
+				delete func;
+			}
+			mva.second.clear();
+		}
+	}
+
+	void PhotonMVAComputer::fill(Photon & pho)
+	{
+		bool selected = selector_(pho);
+		auto isel = mvas_.end();
+		if( selected ) {
+			auto cat = classifier_(pho);
+			isel = mvas_.find(cat.first);
+			
+			// cout << cat.first << endl;
+			selected = ( isel != mvas_.end() );
+		}
+		
+		if( selected ) {
+			for(size_t imva=0; imva<toFill_.size(); ++imva) {
+				// cout << isel->second.size() << " " << imva << endl;
+				pho.addUserFloat(std::get<0>(toFill_[imva]),(*isel->second[imva])(pho));
+			}
+		} else { 
+			for( auto & toFill : toFill_ ) {
+				pho.addUserFloat(std::get<0>(toFill),std::get<1>(toFill));
+			}
+		}
+	}
+	
+}

--- a/Taggers/BuildFile.xml
+++ b/Taggers/BuildFile.xml
@@ -10,7 +10,7 @@
 <use   name="roofit"/>
 <use   name="roofitcore"/>
 <use   name="boost_python"/>
-<Flags CXXFLAGS="-ggdb"/>
+<!-- Flags CXXFLAGS="-ggdb"/ -->
 <export>
   <lib   name="1"/>
 </export>

--- a/Taggers/BuildFile.xml
+++ b/Taggers/BuildFile.xml
@@ -10,7 +10,7 @@
 <use   name="roofit"/>
 <use   name="roofitcore"/>
 <use   name="boost_python"/>
-<!-- Flags CXXFLAGS="-ggdb"/ -->
+<Flags CXXFLAGS="-ggdb"/>
 <export>
   <lib   name="1"/>
 </export>

--- a/Taggers/interface/GlobalVariablesDumper.h
+++ b/Taggers/interface/GlobalVariablesDumper.h
@@ -5,27 +5,20 @@
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
+#include "flashgg/MicroAOD/interface/GlobalVariablesComputer.h"
+
 class TTree;
 
 namespace flashgg {
 	
-	class GlobalVariablesDumper {
+	class GlobalVariablesDumper : public GlobalVariablesComputer {
 	public:
-		struct DumpCache {
-			float rho;
-			int   nvtx;
-		};
-		
 		GlobalVariablesDumper(const edm::ParameterSet & cfg);
 		~GlobalVariablesDumper();
 		
 		void bookTreeVariables(TTree * target, const std::map<std::string,std::string> & replacements);
-
-		void fill(const edm::EventBase & event);
 		
-	private:
-		edm::InputTag rhoTag_, vtxTag_;
-		DumpCache cache_;
+		void fill(const edm::EventBase & event);
 	};	
 
 }

--- a/Taggers/plugins/BuildFile.xml
+++ b/Taggers/plugins/BuildFile.xml
@@ -8,5 +8,6 @@
 <use   name="PhysicsTools/UtilAlgos"/>
 <use   name="roofit"/>
 <use   name="roottmva"/>
+<Flags CXXFLAGS="-ggdb"/>
 <flags   EDM_PLUGIN="1"/>
 </library>

--- a/Taggers/test/singlePhotonViewDumper_cfg.py
+++ b/Taggers/test/singlePhotonViewDumper_cfg.py
@@ -44,6 +44,31 @@ process.photonViewDumper.dumpTrees = True
 process.photonViewDumper.dumpWorkspace = False
 process.photonViewDumper.quietRooFit = True
 
+## list of variables to be dumped in trees/datasets. Same variables for all categories
+variables=["pt := photon.pt","energy := photon.energy","eta := photon.eta","phi := photon.phi",
+           "scEta:=photon.superCluster.eta", "SCRawE := photon.superCluster.rawEnergy",
+           "etaWidth := photon.superCluster.etaWidth","phiWidth := photon.superCluster.phiWidth",
+           "covIphiIphi := photon.sipip",
+           "chgIsoWrtWorstVtx := photon.pfChgIsoWrtWorstVtx03","phoIso03 := photon.pfPhoIso03",
+           "chgIsoWrtChosenVtx := pfChIso03WrtChosenVtx",
+           "hcalTowerSumEtConeDR03 := photon.hcalTowerSumEtConeDR03",
+           "trkSumPtHollowConeDR03 := photon.trkSumPtHollowConeDR03",
+           "hadTowOverEm := photon.hadTowOverEm",
+           "idMVA := phoIdMvaWrtChosenVtx",
+           "genIso := photon.userFloat('genIso')", 
+           "eTrue := ? photon.hasMatchedGenPhoton ? photon.matchedGenPhoton.energy : 0",
+           "sigmaIetaIeta := photon.sigmaIetaIeta",
+           "r9 := photon.r9",
+           "esEffSigmaRR := photon.esEffSigmaRR",
+           "s4 := photon.s4",
+           "covIEtaIPhi := photon.sieip"
+           ]
+
+## list of histograms to be plotted
+histograms=["r9>>r9(110,0,1.1)",
+            "scEta>>scEta(100,-2.5,2.5)"
+            ]
+
 ## define categories and associated objects to dump
 cfgTools.addCategory(process.photonViewDumper,
                      "Reject",
@@ -55,25 +80,70 @@ cfgTools.addCategory(process.photonViewDumper,
 cfgTools.addCategories(process.photonViewDumper,
                        ## categories definition
                        ## cuts are applied in cascade. Events getting to these categories have already failed the "Reject" selection
-                       [("promptPhotons","photon.genMatchType == 1",0),
-                        ("fakePhotons",  "photon.genMatchType != 1",0),
+                       [("promptPhotonsEB","abs(photon.superCluster.eta)<1.5 && photon.genMatchType == 1",0),
+                        ("fakePhotonsEB",  "abs(photon.superCluster.eta)<1.5 && photon.genMatchType != 1",0),
                         ],
                        ## variables to be dumped in trees/datasets. Same variables for all categories
                        ## if different variables wanted for different categories, can add categorie one by one with cfgTools.addCategory
-                       variables=["pt := photon.pt","energy := photon.energy","eta := photon.eta","phi := photon.phi","scEta:=photon.superCluster.eta",
-                                  "r9 := photon.r9",
-                                  "chgIsoWrtWorstVtx := photon.getpfChgIsoWrtWorstVtx03",
-                                  "chgIsoWrtChosenVtx := pfChIso03WrtChosenVtx",
-                                  "idMVA := phoIdMvaWrtChosenVtx",
-                                  "genIso := photon.userFloat('genIso')", "eTrue := ? photon.hasMatchedGenPhoton ? photon.matchedGenPhoton.energy : 0"
-                                  ],
+                       variables=variables,
                        ## histograms to be plotted. 
                        ## the variables need to be defined first
-                       histograms=["r9>>r9(110,0,1.1)",
-                                   "scEta>>scEta(100,-2.5,2.5)"
-                                   ]
+                       histograms=histograms,
+                       ## compute MVA on the fly. More then one MVA can be tested at once
+                       mvas = [ ("myMVA", 
+                                 ["ph.scrawe:=photon.superCluster.rawEnergy",
+                                  "ph.r9:=photon.r9",
+                                  "ph.sigietaieta:=photon.sigmaIetaIeta",
+                                  "ph.scetawidth:=photon.superCluster.etaWidth",
+                                  "ph.scphiwidth:=photon.superCluster.phiWidth",
+                                  "ph.idmva_CoviEtaiPhi:=photon.sieip",
+                                  "ph.idmva_s4ratio:=photon.s4",
+                                  "ph.idmva_GammaIso:=photon.pfPhoIso03",
+                                  "ph.idmva_ChargedIso_selvtx:=pfChIso03WrtChosenVtx",
+                                  "ph.idmva_ChargedIso_worstvtx:=photon.pfChgIsoWrtWorstVtx03",
+                                  "ph.sceta:=photon.superCluster.eta",
+                                  "rho:=global.rho"
+                                  ],
+                                 "BDT",
+                                 "flashgg/MicroAOD/data/2013FinalPaper_PhotonID_Barrel_BDT_TrainRangePT15_8TeV.weights.xml",
+                                 )
+                                ]
                        )
 
+
+cfgTools.addCategories(process.photonViewDumper,
+                       ## categories definition
+                       ## cuts are applied in cascade. Events getting to these categories have already failed the "Reject" selection
+                       [("promptPhotonsEE","abs(photon.superCluster.eta)>=1.5 && photon.genMatchType == 1",0),
+                        ("fakePhotonsEE",  "abs(photon.superCluster.eta)>=1.5 && photon.genMatchType != 1",0),
+                        ],
+                       ## variables to be dumped in trees/datasets. Same variables for all categories
+                       ## if different variables wanted for different categories, can add categorie one by one with cfgTools.addCategory
+                       variables=variables,
+                       ## histograms to be plotted. 
+                       ## the variables need to be defined first
+                       histograms=histograms,
+                       ## compute MVA on the fly. More then one MVA can be tested at once
+                       mvas = [ ("myMVA", 
+                                 ["ph.scrawe:=photon.superCluster.rawEnergy",
+                                  "ph.r9:=photon.r9",
+                                  "ph.sigietaieta:=photon.sigmaIetaIeta",
+                                  "ph.scetawidth:=photon.superCluster.etaWidth",
+                                  "ph.scphiwidth:=photon.superCluster.phiWidth",
+                                  "ph.idmva_CoviEtaiPhi:=photon.sieip",
+                                  "ph.idmva_s4ratio:=photon.s4",
+                                  "ph.idmva_GammaIso:=photon.pfPhoIso03",
+                                  "ph.idmva_ChargedIso_selvtx:=pfChIso03WrtChosenVtx",
+                                  "ph.idmva_ChargedIso_worstvtx:=photon.pfChgIsoWrtWorstVtx03",
+                                  "ph.sceta:=photon.superCluster.eta",
+                                  "rho:=global.rho",
+                                  "ph.idmva_PsEffWidthSigmaRR:=photon.esEffSigmaRR"
+                                  ],
+                                 "BDT",
+                                 "flashgg/MicroAOD/data/2013FinalPaper_PhotonID_Endcap_BDT_TrainRangePT15_8TeV.weights.xml",
+                                 )
+                                ]
+                       )
 
 
 process.p1 = cms.Path(


### PR DESCRIPTION
Details of the MVAComputer: generic code to evaluate TMVA classifiers based on string expression for variables (handled by StringObjectParser). 

Goal is to allow on-the-fly computation of MVAs in dumpers to have fast turnaround for analysis optimization.
Example of MVA computation in dumpers provided in Taggers/test/singlePhotonViewDumper_cfg.py

Also added extra DiPhoton producer computing per-photon MVAs.

