### PR TITLE
get sigEOverE from regression in reco (default energy already regressed)

### DIFF
--- a/DataFormats/interface/Photon.h
+++ b/DataFormats/interface/Photon.h
@@ -49,7 +49,6 @@ namespace flashgg {
     void setpfChgIsoWrtChosenVtx03(float val) {pfChgIsoWrtChosenVtx03_=val;};
     void setESEffSigmaRR(float val) {ESEffSigmaRR_=val;};  
     void setPhoIdMvaD( std::map<edm::Ptr<reco::Vertex>,float> valmap ) {  phoIdMvaD_ = valmap; };   // concept: pass the pre-computed map when calling this in the producer
-    void setEnergyAtStep(std::string key,float val);
     void updateEnergy(std::string key,float val);
     //    void setSigEOverE(float val) { sigEOverE_ = val; };
 
@@ -88,7 +87,7 @@ namespace flashgg {
 
     bool hasEnergyAtStep(std::string key) const;
     float const energyAtStep(std::string key) const;
-    float const sigEOverE() const { return (getCorrectedEnergyError(regression_type) / energy()); } // Regression + error now in reco and base object
+    float const sigEOverE() const;
     
     std::map<edm::Ptr<reco::Vertex>,float> const phoIdMvaD() const {return phoIdMvaD_;};
     float const phoIdMvaDWrtVtx( const edm::Ptr<reco::Vertex>& vtx, bool lazy=false ) const { return findVertexFloat(vtx,phoIdMvaD_,lazy); }; // if lazy flag is true only compare key (needed since fwlite does not fill provenance info)
@@ -105,6 +104,7 @@ namespace flashgg {
     bool passElectronVeto() const { return passElecVeto_ ; };
 
   private:
+    void setEnergyAtStep(std::string key,float val); // updateEnergy should be used from outside the class to access this
     float const findVertexFloat(const edm::Ptr<reco::Vertex>& vtx, const std::map<edm::Ptr<reco::Vertex>,float> & mp, bool lazy) const;
     
     float sipip_;

--- a/DataFormats/interface/Photon.h
+++ b/DataFormats/interface/Photon.h
@@ -1,9 +1,9 @@
 #ifndef FLASHgg_Photon_h
 #define FLASHgg_Photon_h
 
+#include "DataFormats/EgammaCandidates/interface/Photon.h"
 #include "DataFormats/PatCandidates/interface/Photon.h"
 #include "DataFormats/PatCandidates/interface/PackedGenParticle.h"
-
 
 namespace flashgg {
 
@@ -51,7 +51,10 @@ namespace flashgg {
     void setPhoIdMvaD( std::map<edm::Ptr<reco::Vertex>,float> valmap ) {  phoIdMvaD_ = valmap; };   // concept: pass the pre-computed map when calling this in the producer
     void setEnergyAtStep(std::string key,float val);
     void updateEnergy(std::string key,float val);
-    void setSigEOverE(float val) { sigEOverE_ = val; };
+    //    void setSigEOverE(float val) { sigEOverE_ = val; };
+
+    // define which regression from reco we use - only this one is valid as of 74X
+    static const reco::Photon::P4type regression_type = reco::Photon::regression1;
 
     float const sipip() const {return sipip_;};
     float const sieip() const {return sieip_;};
@@ -85,7 +88,7 @@ namespace flashgg {
 
     bool hasEnergyAtStep(std::string key) const;
     float const energyAtStep(std::string key) const;
-    float const sigEOverE() const { return sigEOverE_; };
+    float const sigEOverE() const { return (getCorrectedEnergyError(regression_type) / energy()); } // Regression + error now in reco and base object
     
     std::map<edm::Ptr<reco::Vertex>,float> const phoIdMvaD() const {return phoIdMvaD_;};
     float const phoIdMvaDWrtVtx( const edm::Ptr<reco::Vertex>& vtx, bool lazy=false ) const { return findVertexFloat(vtx,phoIdMvaD_,lazy); }; // if lazy flag is true only compare key (needed since fwlite does not fill provenance info)
@@ -129,7 +132,7 @@ namespace flashgg {
     float pfChgIsoWrtChosenVtx02_;
     float pfChgIsoWrtChosenVtx03_;
     float ESEffSigmaRR_;
-    float sigEOverE_;
+    //    float sigEOverE_;
     std::map<edm::Ptr<reco::Vertex>,float> pfChgIso04_; 
     std::map<edm::Ptr<reco::Vertex>,float> pfChgIso03_; 
     std::map<edm::Ptr<reco::Vertex>,float> pfChgIso02_; 

--- a/DataFormats/src/Photon.cc
+++ b/DataFormats/src/Photon.cc
@@ -26,7 +26,6 @@ Photon::Photon() {
   pfChgIsoWrtWorstVtx03_ = 0.;
   pfChgIsoWrtChosenVtx02_ = 0.;
   ESEffSigmaRR_ = 0.;
-  sigEOverE_ = 0.;
   pfChgIso03_.clear();
   pfChgIso02_.clear();
   phoIdMvaD_.clear();

--- a/DataFormats/src/Photon.cc
+++ b/DataFormats/src/Photon.cc
@@ -41,6 +41,10 @@ void Photon::setEnergyAtStep(std::string key, float val) {
   addUserFloat(key,val);
 }
 float const Photon::energyAtStep(std::string key) const {
+  if (key=="initial" && !hasEnergyAtStep("initial")) {
+    return energy(); // "initial" is always set whenever any other value is set
+    		     // So if it's not present we can skip this mechanism for now
+  }
   return userFloat(key);
 }
 bool Photon::hasEnergyAtStep(std::string key) const {
@@ -74,4 +78,9 @@ void Photon::updateEnergy(std::string key, float val) {
   
   // Update 4-vector
   setP4((val/energy())*p4());
+}
+
+float const Photon::sigEOverE() const {
+  // Use uncertainty and error stored from reco because we want this fraction to be constant
+  return (getCorrectedEnergyError(regression_type) / getCorrectedEnergy(regression_type));
 }


### PR DESCRIPTION
Regression and regression errors are defined in reco and the code is now setup to use them.  Note that the following are equal by definition (for fg a `flashgg::Photon`):

`fg.energy() == fg.getCorrectedEnergy(flashgg::Photon::regression_type)` [set in reco]
`fg.sigEOverE() == fg.getCorrectedEnergyError(flashgg::Photon::regression_type)/fg.energy()` [flashgg]