### PR TITLE
synchronize btag discriminant name, restore untagged 2

### DIFF
--- a/MicroAOD/python/flashggJets_cfi.py
+++ b/MicroAOD/python/flashggJets_cfi.py
@@ -4,6 +4,9 @@ from RecoJets.JetProducers.PileupJetIDParams_cfi import cutbased as pu_jetid
 from PhysicsTools.PatAlgos.tools.jetTools import addJetCollection
 #from Configuration.Geometry.GeometryAll_cff import *
 
+#flashggBTag = "pfCombinedInclusiveSecondaryVertexV2BJetTags"
+flashggBTag = "pfJetProbabilityBJetTags" # we pick this one because it doesn't require an extra recipe
+
 # define a function to add in the jet collection, as the reclustering need to know about the process
 # but we obviously don't want all this stuff clogging up python configs. 
 def addFlashggPFCHSLegJets(process):
@@ -55,8 +58,7 @@ def addFlashggPFCHSLegJets(process):
       #trackSource = cms.InputTag('unpackedTracksAndVertices'), 
       pvSource = cms.InputTag('unpackedTracksAndVertices'), 
       jetCorrections = ('AK4PFchs', cms.vstring(['L1FastJet', 'L2Relative', 'L3Absolute']), 'None'),
-      #btagDiscriminators = [      'combinedSecondaryVertexBJetTags'     ]
-      btagDiscriminators = [      'pfJetProbabilityBJetTags'     ]
+      btagDiscriminators = [ flashggBTag ]
       ,algo= 'AK', rParam = 0.4
       )
   # adjust MC matching

--- a/MicroAOD/test/microAODstd.py
+++ b/MicroAOD/test/microAODstd.py
@@ -18,17 +18,17 @@ process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:run2_mc')
 process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32( 1000) )
 process.MessageLogger.cerr.FwkReport.reportEvery = cms.untracked.int32( 1000 )
 
-#process.source = cms.Source("PoolSource",fileNames=cms.untracked.vstring("/store/mc/Spring14miniaod/GluGluToHToGG_M-125_13TeV-powheg-pythia6/MINIAODSIM/PU20bx25_POSTLS170_V5-v2/00000/24926621-F11C-E411-AB9A-02163E008D0B.root"))
-#process.source = cms.Source("PoolSource",fileNames=cms.untracked.vstring("/store/mc/Spring14miniaod/TTbarH_HToGG_M-125_13TeV_amcatnlo-pythia8-tauola/MINIAODSIM/PU20bx25_POSTLS170_V5-v1/00000/049C0F9C-E61E-E411-9388-D8D385AE8466.root"))                                                                                                                            
-##  process.source = cms.Source("PoolSource",fileNames=cms.untracked.vstring("/store/mc/Spring14miniaod/WH_ZH_HToGG_M-125_13TeV_pythia6/MINIAODSIM/PU20bx25_POSTLS170_V5-v2/30000/E0D066C6-2219-E411-BD9A-02163E00ECDF.root"))
-
+# PHYS14 Files
+process.source = cms.Source("PoolSource",fileNames=cms.untracked.vstring("/store/mc/Phys14DR/TTbarH_HToGG_M-125_13TeV_amcatnlo-pythia8-tauola/MINIAODSIM/PU20bx25_PHYS14_25_V1-v1/10000/7CD4EFBC-9C70-E411-94A0-002590200828.root"))
 #process.source = cms.Source("PoolSource",fileNames=cms.untracked.vstring("/store/mc/Phys14DR/GluGluToHToGG_M-125_13TeV-powheg-pythia6/MINIAODSIM/PU20bx25_tsg_PHYS14_25_V1-v1/00000/3C2EFAB1-B16F-E411-AB34-7845C4FC39FB.root"))
 #process.source = cms.Source("PoolSource",fileNames=cms.untracked.vstring("/store/mc/Phys14DR/VBF_HToGG_M-125_13TeV-powheg-pythia6/MINIAODSIM/PU20bx25_PHYS14_25_V1-v1/00000/4A8E0BD1-026C-E411-8760-00266CFFA418.root")
 #process.source = cms.Source("PoolSource",fileNames=cms.untracked.vstring("/store/mc/Phys14DR/WH_ZH_HToGG_M-125_13TeV_pythia6/MINIAODSIM/PU20bx25_PHYS14_25_V1-v1/00000/24B70163-5769-E411-93CA-002590200A28.root"))
-process.source = cms.Source("PoolSource",fileNames=cms.untracked.vstring("/store/relval/CMSSW_7_4_0_pre9_ROOT6/RelValH130GGgluonfusion_13/MINIAODSIM/MCRUN2_74_V7-v1/00000/0A35F6CD-DAD1-E411-A8CC-0026189438CC.root"))
-
 ### process.source = cms.Source("PoolSource",fileNames=cms.untracked.vstring("/store/mc/Phys14DR/GJet_Pt40_doubleEMEnriched_TuneZ2star_13TeV-pythia6/MINIAODSIM/PU20bx25_PHYS14_25_V1-v1/00000/101611CC-026E-E411-B8D7-00266CFFBF88.root"))
 ## process.source = cms.Source("PoolSource",fileNames=cms.untracked.vstring("/store/mc/Phys14DR/GJets_HT-100to200_Tune4C_13TeV-madgraph-tauola/MINIAODSIM/PU20bx25_PHYS14_25_V1-v1/00000/00D67F78-2873-E411-B3BB-0025907DC9C0.root"))
+
+# 740 RelVal
+#process.source = cms.Source("PoolSource",fileNames=cms.untracked.vstring("/store/relval/CMSSW_7_4_0_pre9_ROOT6/RelValH130GGgluonfusion_13/MINIAODSIM/MCRUN2_74_V7-v1/00000/0A35F6D-DAD1-E411-A8CC-0026189438CC.root"))                                                                                                                                             
+
 
 process.MessageLogger.cerr.threshold = 'ERROR' # can't get suppressWarning to work: disable all warnings for now
 # process.MessageLogger.suppressWarning.extend(['SimpleMemoryCheck','MemoryCheck']) # this would have been better...

--- a/Taggers/plugins/TTHHadronicTagProducer.cc
+++ b/Taggers/plugins/TTHHadronicTagProducer.cc
@@ -36,16 +36,17 @@ namespace flashgg {
         EDGetTokenT<View<DiPhotonMVAResult> > mvaResultToken_;
 
         int count = 0;
+        string bTag_;
     };
 
     TTHHadronicTagProducer::TTHHadronicTagProducer( const ParameterSet &iConfig ) :
         diPhotonToken_( consumes<View<flashgg::DiPhotonCandidate> >( iConfig.getUntrackedParameter<InputTag> ( "DiPhotonTag", InputTag( "flashggDiPhotons" ) ) ) ),
         thejetToken_( consumes<View<flashgg::Jet> >( iConfig.getUntrackedParameter<InputTag>( "TTHJetTag", InputTag( "flashggJets" ) ) ) ),
         mvaResultToken_( consumes<View<flashgg::DiPhotonMVAResult> >( iConfig.getUntrackedParameter<InputTag>( "MVAResultTag", InputTag( "flashggDiPhotonMVA" ) ) ) )
-
-
-
     {
+        string default_bTag_ = "combinedInclusiveSecondaryVertexV2BJetTags";
+        bTag_ = iConfig.getUntrackedParameter<string>( "bTag", default_bTag_ );
+
         produces<vector<TTHHadronicTag> >();
     }
 
@@ -107,7 +108,7 @@ namespace flashgg {
                 jetcount++;
                 JetVect.push_back( thejet );
 
-                bDiscriminatorValue = thejet->bDiscriminator( "combinedInclusiveSecondaryVertexV2BJetTags" );
+                bDiscriminatorValue = thejet->bDiscriminator( bTag_ );
 
                 if( bDiscriminatorValue > 0.244 ) { njets_btagloose++; }
                 if( bDiscriminatorValue > 0.679 ) {

--- a/Taggers/python/flashggTagSorter_cfi.py
+++ b/Taggers/python/flashggTagSorter_cfi.py
@@ -22,7 +22,7 @@ flashggTagSorter = cms.EDProducer('FlashggTagSorter',
                                                                          MaxCategory = cms.untracked.int32(2)
                                                                          ),
                                                                 cms.PSet(TagName = cms.InputTag('flashggUntaggedCategory'),
-                                                                         MinCategory = cms.untracked.int32(3),
+                                                                         MinCategory = cms.untracked.int32(2),
                                                                          MaxCategory = cms.untracked.int32(4)
                                                                          )
                                                                 ),

--- a/Taggers/python/flashggTags_cff.py
+++ b/Taggers/python/flashggTags_cff.py
@@ -1,4 +1,5 @@
 import FWCore.ParameterSet.Config as cms
+from flashgg.MicroAOD.flashggJets_cfi import flashggBTag
 
 flashggUntaggedCategory = cms.EDProducer("FlashggUntaggedCategoryProducer",
 #                                         DiPhotonTag=cms.untracked.InputTag('flashggPreselectedDiPhotons'), # why doesn't this work?
@@ -8,7 +9,8 @@ flashggUntaggedCategory = cms.EDProducer("FlashggUntaggedCategoryProducer",
 		)
 
 flashggTTHHadronicTag = cms.EDProducer("FlashggTTHHadronicTagProducer",
-		TTHJetTag=cms.untracked.InputTag('flashggJets')
+                                       TTHJetTag=cms.untracked.InputTag('flashggJets'),
+                                       bTag = cms.untracked.string(flashggBTag)
 		)
 
 flashggVBFTag = cms.EDProducer("FlashggVBFTagProducer",
@@ -38,7 +40,7 @@ flashggTTHLeptonicTag = cms.EDProducer("FlashggTTHLeptonicTagProducer",
 					deltaRJetLeadPhoThreshold = cms.untracked.double(0.5),
 					deltaRJetSubLeadPhoThreshold = cms.untracked.double(0.5),
 					bDiscriminator=cms.untracked.vdouble(0.244,0.679),
-					bTag = cms.untracked.string("combinedInclusiveSecondaryVertexV2BJetTags"),
+					bTag = cms.untracked.string(flashggBTag),
 					muPFIsoSumRelThreshold = cms.untracked.double(0.2),
 					deltaRMuonJetcountThreshold = cms.untracked.double(2.),
 					PuIDCutoffThreshold = cms.untracked.double(0.8),


### PR DESCRIPTION
Fix a few bugs that were keeping some tags from showing up:

Untagged 2 was missing from the tag sorted (again!?) -- fixed.  

The btag discriminant was not synchronized between MicroAOD and Tag steps -- this is now fixed, and set from a central place: `MicroAOD/python/flashggJets_cfi.py`.  The Taggers are now all set up to get import this value.  However, note that if you run on PHYS14 MicroAOD the value should be changed to the discriminant that was used in that release.  Finally, note that our current discriminant is probably not the best one, it's just the one we can get to run correctly on 7_4_0_pre9!   There should soon be more general instructions and it will be updated then.