### PR TITLE
templating for systematics factories and producers

### DIFF
--- a/Systematics/interface/BaseSystMethods.h
+++ b/Systematics/interface/BaseSystMethods.h
@@ -3,8 +3,6 @@
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "DataFormats/Common/interface/Handle.h"
-#include "flashgg/DataFormats/interface/Photon.h"
-#include "flashgg/DataFormats/interface/DiPhotonCandidate.h"
 
 namespace flashgg {
 
@@ -35,11 +33,20 @@ namespace flashgg {
         const std::string _Label;
         //typename flashgg_object object;
 
-
     };
 }
+
 #include "FWCore/PluginManager/interface/PluginFactory.h"
-typedef edmplugin::PluginFactory< flashgg::BaseSystMethods<flashgg::Photon, int>* ( const edm::ParameterSet & ) > FlashggSystematicPhotonMethodsFactory;
+#include "flashgg/DataFormats/interface/Photon.h"
+//template <class T, class U> struct A {
+//    typedef edmplugin::PluginFactory< flashgg::BaseSystMethods<T,U>* (const edm::ParameterSet & ) > FlashggSystematicMethodsFactory;
+//}
+
+//typedef template< class T, class U> edmplugin::PluginFactory< flashgg::BaseSystMethods<T,U>* (const edm::ParameterSet & ) > FlashggSystematicMethodsFactory;
+template< class T, class U > using FlashggSystematicMethodsFactory = edmplugin::PluginFactory< flashgg::BaseSystMethods<T, U>* ( const edm::ParameterSet & ) >;
+typedef FlashggSystematicMethodsFactory<flashgg::Photon,int> FlashggSystematicPhotonMethodsFactory;
+
+//typedef edmplugin::PluginFactory< flashgg::BaseSystMethods<flashgg::Photon, int>* ( const edm::ParameterSet & ) > FlashggSystematicPhotonMethodsFactory;
 //typedef edmplugin::PluginFactory< flashgg::BaseSystMethods<flashgg::Photon,float>* ( const edm::ParameterSet&) > FlashggSystematicPhotonMethodsFactory;
 //typedef edmplugin::PluginFactory< flashgg::BaseSystMethods<flashgg::DiPhotonCandidate>* ( const edm::ParameterSet&) > FlashggSystematicDiPhotonMethodsFactory;
 

--- a/Systematics/interface/ObjectSystematicProducer.h
+++ b/Systematics/interface/ObjectSystematicProducer.h
@@ -1,0 +1,142 @@
+#ifndef FLASHgg_ObjectSystematicProducer_h
+#define FLASHgg_ObjectSystematicProducer_h
+
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "DataFormats/Common/interface/Handle.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "TrackingTools/IPTools/interface/IPTools.h"
+
+#include "flashgg/Systematics/interface/BaseSystMethods.h"
+
+using namespace edm;
+using namespace std;
+
+namespace flashgg {
+
+    template <typename flashgg_object, typename param_var>
+    class ObjectSystematicProducer : public edm::EDProducer
+    {
+    public:
+
+        ObjectSystematicProducer( const edm::ParameterSet & );
+
+    private:
+
+        void produce( edm::Event &, const edm::EventSetup & ) override;
+        void ApplyCorrections( flashgg_object &y, shared_ptr<BaseSystMethods<flashgg_object, param_var> > CorrToShift, param_var syst_shift );
+
+        edm::EDGetTokenT<View<flashgg_object> > ObjectToken_;
+
+        std::vector<shared_ptr<BaseSystMethods<flashgg_object, param_var> > > Corrections_;
+        std::vector<std::vector<param_var> > sigmas_;
+
+        std::vector<std::string> collectionLabelsNonCentral_;
+    };
+
+    template <typename flashgg_object, typename param_var>
+    ObjectSystematicProducer<flashgg_object,param_var>::ObjectSystematicProducer( const ParameterSet &iConfig ) :
+        ObjectToken_( consumes<View<flashgg_object> >( iConfig.getUntrackedParameter<InputTag>( "InputTag", InputTag( "flashggPhotons" ) ) ) )
+    {
+        produces<std::vector<flashgg_object> >(); // Central value
+        std::vector<edm::ParameterSet> vpset = iConfig.getParameter<std::vector<edm::ParameterSet> >( "SystMethods" );
+
+        Corrections_.resize( vpset.size() );
+
+        unsigned int ipset = 0;
+        for( const auto &pset : vpset ) {
+            std::string methodName = pset.getParameter<string>( "MethodName" );
+
+            // If nsigmas ends up being empty for a given corrector,
+            // the central operation will still be applied to all collections
+            std::vector<param_var> nsigmas = pset.getParameter<vector<param_var> >( "NSigmas" );
+
+            // Remove 0 values, because we always have a central collection
+            nsigmas.erase( std::remove( nsigmas.begin(), nsigmas.end(), 0 ), nsigmas.end() );
+
+            sigmas_.push_back( nsigmas );
+            Corrections_.at( ipset ).reset( FlashggSystematicMethodsFactory<flashgg_object,param_var>::get()->create( methodName, pset ) );
+            for( const auto &sig : sigmas_.at( ipset ) ) {
+                std::string collection_label = Corrections_.at( ipset )->shiftLabel( sig );
+                produces<vector<flashgg_object> >( collection_label );
+                collectionLabelsNonCentral_.push_back( collection_label ); // 2N elements, current code gets labels right only if loops are consistent
+            }
+            ipset++;
+        }
+    }
+
+    ///fucntion takes in the current corection one is looping through and compares with its own internal loop, given that this will be within the corr and sys loop it takes care of the 2n+1 collection number////
+    template <typename flashgg_object, typename param_var>
+    void ObjectSystematicProducer<flashgg_object,param_var>::ApplyCorrections( flashgg_object &y, shared_ptr<BaseSystMethods<flashgg_object, param_var> > CorrToShift, param_var syst_shift )
+    {
+        for( unsigned int shift = 0; shift < Corrections_.size(); shift++ ) {
+            if( CorrToShift == Corrections_.at( shift ) ) {
+                Corrections_.at( shift )->applyCorrection( y, syst_shift );
+            } else {
+                Corrections_.at( shift )->applyCorrection( y, 0 );
+            }
+        }
+    }
+
+    template <typename flashgg_object, typename param_var>
+    void ObjectSystematicProducer<flashgg_object,param_var>::produce( Event &evt, const EventSetup & )
+    {
+
+        Handle<View<flashgg_object> > objects;
+        evt.getByToken( ObjectToken_, objects );
+
+        // Build central collection
+        auto_ptr<vector<flashgg_object> > centralObjectColl( new vector<flashgg_object> );
+        for( unsigned int i = 0; i < objects->size(); i++ ) {
+            flashgg_object obj = flashgg_object( *objects->ptrAt( i ) );
+            ApplyCorrections( obj, nullptr, 0 );
+            centralObjectColl->push_back( obj );
+        }
+        evt.put( centralObjectColl ); // put central collection in event
+
+        // build 2N shifted collections
+        // A dynamically allocated array of auto_ptrs may be a bit "unsafe" to maintain,
+        // although I think I have done it correctly - the delete[] statement below is vital
+        // Problem: vector<auto_ptr> is not allowed
+        // Possible alternate solutions: map, multimap, vector<unique_ptr> + std::move ??
+        std::auto_ptr<std::vector<flashgg_object> > *all_shifted_collections;
+        all_shifted_collections = new std::auto_ptr<std::vector<flashgg_object> >[collectionLabelsNonCentral_.size()];
+        for( unsigned int ncoll = 0 ; ncoll < collectionLabelsNonCentral_.size() ; ncoll++ ) {
+            all_shifted_collections[ncoll].reset( new std::vector<flashgg_object> );
+        }
+        for( unsigned int i = 0; i < objects->size(); i++ ) {
+            unsigned int ncoll = 0;
+            for( unsigned int ncorr = 0 ; ncorr < Corrections_.size() ; ncorr++ ) {
+                for( const auto &sig : sigmas_.at( ncorr ) ) {
+                    flashgg_object obj = flashgg_object( *objects->ptrAt( i ) );
+                    ApplyCorrections( obj, Corrections_.at( ncorr ), sig );
+                    all_shifted_collections[ncoll]->push_back( obj );
+                    ncoll++;
+                }
+            }
+        }
+
+        // Put shifted collections in event
+        for( unsigned int ncoll = 0 ; ncoll < collectionLabelsNonCentral_.size() ; ncoll++ ) {
+            evt.put( all_shifted_collections[ncoll], collectionLabelsNonCentral_[ncoll] );
+        }
+
+        // See note above about array of auto_ptr
+        delete[] all_shifted_collections;
+
+    } // end of event
+}
+
+#endif
+
+// Local Variables:
+// mode:c++
+// indent-tabs-mode:nil
+// tab-width:4
+// c-basic-offset:4
+// End:
+// vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4
+

--- a/Systematics/plugins/PhotonSystematicProducer.cc
+++ b/Systematics/plugins/PhotonSystematicProducer.cc
@@ -1,132 +1,16 @@
-#include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
-#include "FWCore/Utilities/interface/InputTag.h"
-#include "DataFormats/Common/interface/Handle.h"
-#include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/MakerMacros.h"
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "TrackingTools/IPTools/interface/IPTools.h"
-
+#include "flashgg/DataFormats/interface/Photon.h"
 #include "flashgg/Systematics/interface/BaseSystMethods.h"
-
-using namespace edm;
-using namespace std;
+#include "flashgg/Systematics/interface/ObjectSystematicProducer.h"
 
 namespace flashgg {
 
-    class PhotonSystematicProducer : public edm::EDProducer
-    {
-    public:
+    typedef ObjectSystematicProducer<flashgg::Photon,int> PhotonSystematicProducer;
 
-        PhotonSystematicProducer( const edm::ParameterSet & );
-
-    private:
-
-        void produce( edm::Event &, const edm::EventSetup & ) override;
-        void ApplyCorrections( flashgg::Photon &y, shared_ptr<BaseSystMethods<flashgg::Photon, int> > CorrToShift, int syst_shift );
-
-        edm::EDGetTokenT<View<flashgg::Photon> > PhotonToken_;
-
-        std::vector<shared_ptr<BaseSystMethods<flashgg::Photon, int> > > Corrections_;
-        std::vector<std::vector<int> > sigmas_;
-
-        std::vector<std::string> collectionLabelsNonCentral_;
-    };
-
-    PhotonSystematicProducer::PhotonSystematicProducer( const ParameterSet &iConfig ) :
-        PhotonToken_( consumes<View<flashgg::Photon> >( iConfig.getUntrackedParameter<InputTag>( "PhotonTag", InputTag( "flashggPhotons" ) ) ) )
-    {
-        produces<std::vector<flashgg::Photon> >(); // Central value
-        std::vector<edm::ParameterSet> vpset = iConfig.getParameter<std::vector<edm::ParameterSet> >( "SystMethods" );
-
-        Corrections_.resize( vpset.size() );
-
-        unsigned int ipset = 0;
-        for( const auto &pset : vpset ) {
-            std::string methodName = pset.getParameter<string>( "MethodName" );
-
-            // If nsigmas ends up being empty for a given corrector,
-            // the central operation will still be applied to all collections
-            std::vector<int> nsigmas = pset.getParameter<vector<int> >( "NSigmas" );
-
-            // Remove 0 values, because we always have a central collection
-            nsigmas.erase( std::remove( nsigmas.begin(), nsigmas.end(), 0 ), nsigmas.end() );
-
-            sigmas_.push_back( nsigmas );
-            Corrections_.at( ipset ).reset( FlashggSystematicPhotonMethodsFactory::get()->create( methodName, pset ) );
-            for( const auto &sig : sigmas_.at( ipset ) ) {
-                std::string collection_label = Corrections_.at( ipset )->shiftLabel( sig );
-                produces<vector<flashgg::Photon> >( collection_label );
-                collectionLabelsNonCentral_.push_back( collection_label ); // 2N elements, current code gets labels right only if loops are consistent
-            }
-            ipset++;
-        }
-    }
-
-    ///fucntion takes in the current corection one is looping through and compares with its own internal loop, given that this will be within the corr and sys loop it takes care of the 2n+1 collection number////
-    void PhotonSystematicProducer::ApplyCorrections( flashgg::Photon &y, shared_ptr<BaseSystMethods<flashgg::Photon, int> > CorrToShift, int syst_shift )
-    {
-        for( unsigned int shift = 0; shift < Corrections_.size(); shift++ ) {
-            if( CorrToShift == Corrections_.at( shift ) ) {
-                Corrections_.at( shift )->applyCorrection( y, syst_shift );
-            } else {
-                Corrections_.at( shift )->applyCorrection( y, 0 );
-            }
-        }
-    }
-
-    void PhotonSystematicProducer::produce( Event &evt, const EventSetup & )
-    {
-
-        Handle<View<flashgg::Photon> > photons;
-        evt.getByToken( PhotonToken_, photons );
-        //	const PtrVector<flashgg::Photon>& photonPointers = photons->ptrVector();
-
-        // Build central collection
-        auto_ptr<vector<flashgg::Photon> > centralPhotonColl( new vector<flashgg::Photon> );
-        for( unsigned int i = 0; i < photons->size(); i++ ) {
-            flashgg::Photon pho = flashgg::Photon( *photons->ptrAt( i ) );
-            ApplyCorrections( pho, nullptr, 0 );
-            centralPhotonColl->push_back( pho );
-        }
-        evt.put( centralPhotonColl ); // put central collection in event
-
-        // build 2N shifted collections
-        // A dynamically allocated array of auto_ptrs may be a bit "unsafe" to maintain,
-        // although I think I have done it correctly - the delete[] statement below is vital
-        // Problem: vector<auto_ptr> is not allowed
-        // Possible alternate solutions: map, multimap, vector<unique_ptr> + std::move ??
-        std::auto_ptr<std::vector<flashgg::Photon> > *all_shifted_collections;
-        all_shifted_collections = new std::auto_ptr<std::vector<flashgg::Photon> >[collectionLabelsNonCentral_.size()];
-        for( unsigned int ncoll = 0 ; ncoll < collectionLabelsNonCentral_.size() ; ncoll++ ) {
-            all_shifted_collections[ncoll].reset( new std::vector<flashgg::Photon> );
-        }
-        for( unsigned int i = 0; i < photons->size(); i++ ) {
-            unsigned int ncoll = 0;
-            for( unsigned int ncorr = 0 ; ncorr < Corrections_.size() ; ncorr++ ) {
-                for( const auto &sig : sigmas_.at( ncorr ) ) {
-                    flashgg::Photon pho = flashgg::Photon( *photons->ptrAt( i ) );
-                    ApplyCorrections( pho, Corrections_.at( ncorr ), sig );
-                    all_shifted_collections[ncoll]->push_back( pho );
-                    ncoll++;
-                }
-            }
-        }
-
-        // Put shifted collections in event
-        for( unsigned int ncoll = 0 ; ncoll < collectionLabelsNonCentral_.size() ; ncoll++ ) {
-            evt.put( all_shifted_collections[ncoll], collectionLabelsNonCentral_[ncoll] );
-        }
-
-        // See note above about array of auto_ptr
-        delete[] all_shifted_collections;
-
-    } // end of event
 }
-
 
 typedef flashgg::PhotonSystematicProducer FlashggPhotonSystematicProducer;
 DEFINE_FWK_MODULE( FlashggPhotonSystematicProducer );
+
 // Local Variables:
 // mode:c++
 // indent-tabs-mode:nil
@@ -134,4 +18,3 @@ DEFINE_FWK_MODULE( FlashggPhotonSystematicProducer );
 // c-basic-offset:4
 // End:
 // vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4
-


### PR DESCRIPTION
PhotonSystematicProducer is now generalized.  Functionality is still the same, but smearing other objects can use the same code.