### PR TITLE
fix prepareCrabJob naming and setup for the data case

### DIFF
--- a/MetaData/work/prepareCrabJobs.py
+++ b/MetaData/work/prepareCrabJobs.py
@@ -201,6 +201,10 @@ if options.createCrabConfig:
             label = options.label
         # Increment flashgg- processing index if job has been launched before (ie if crab dir already exists)
         itry = 0
+        if sample in data:
+            if ProcessedDataset.count("201"):
+                position = ProcessedDataset.find("201")
+                PrimaryDataset = PrimaryDataset +"-"+ ProcessedDataset[position:]
         jobname = "_".join([flashggVersion, PrimaryDataset, str(itry).zfill(2)])
         while os.path.isdir("crab_" + jobname):
             itry += 1
@@ -222,7 +226,7 @@ if options.createCrabConfig:
         # specific replacements for data and MC
         if sample in data:
             replacements["SPLITTING"]   = "LumiBased"
-            replacements["UNITSPERJOB"] = str(options.lumisPerJob),
+            replacements["UNITSPERJOB"] = str(options.lumisPerJob)
             replacements["PYCFG_PARAMS"].append("processType=data")
             ## FIXME: lumi mask, run ranges, etc.
         if sample in sig:


### PR DESCRIPTION
While setting up some test jobs on rerecoed data, I encountered 2 issues with prepareCrabJobs.py:

1. Stray comma in data splitting setup caused a crash
2. DoubleElectron 2011A and DoubleElectron 2012D were given the same job name.

These are addressed in this PR. @musella, can you comment on whether there are other outstanding issues that would prevent jobs on data from working? There's a FIXME comment in the file that implies there might be.