### PR TITLE
Jet Validation plugin for 74X

### DIFF
--- a/DataFormats/src/Jet.cc
+++ b/DataFormats/src/Jet.cc
@@ -47,7 +47,7 @@ float Jet::betaStar( const edm::Ptr<reco::Vertex> vtx ) const
 
 bool Jet::passesPuJetId( const edm::Ptr<DiPhotonCandidate> dipho, PileupJetIdentifier::Id level ) const
 {
-    return passesPuJetId( dipho->vtx() );
+    return passesPuJetId( dipho->vtx(), level );
 }
 
 float Jet::rms( const edm::Ptr<DiPhotonCandidate> dipho ) const

--- a/MicroAOD/plugins/JetProducer.cc
+++ b/MicroAOD/plugins/JetProducer.cc
@@ -21,7 +21,7 @@ namespace flashgg {
 
     class JetProducer : public EDProducer
     {
-
+        
     public:
         JetProducer( const ParameterSet & );
     private:
@@ -58,9 +58,7 @@ namespace flashgg {
         Handle<View<pat::Jet> > jets;
         evt.getByToken( jetToken_, jets );
         // const PtrVector<pat::Jet>& jetPointers = jets->ptrVector();
-
-
-
+        
         // input DiPhoton candidates
         Handle<View<DiPhotonCandidate> > diPhotons;
         evt.getByToken( diPhotonToken_, diPhotons );
@@ -69,22 +67,22 @@ namespace flashgg {
         Handle<View<reco::Vertex> > primaryVertices;
         evt.getByToken( vertexToken_, primaryVertices );
         // const PtrVector<reco::Vertex>& pvPointers = primaryVertices->ptrVector();
-
-
+        // std::cout << " jet test ==" << primaryVertices->size() <<  std::endl;
+        
         Handle<VertexCandidateMap> vertexCandidateMap;
         evt.getByToken( vertexCandidateMapToken_, vertexCandidateMap );
-
+        // std::cout << " vtx map ==" << vertexCandidateMap->size() <<  std::endl;
         // output jets
         auto_ptr<vector<flashgg::Jet> > jetColl( new vector<flashgg::Jet> );
-
+        
         for( unsigned int i = 0 ; i < jets->size() ; i++ ) {
             Ptr<pat::Jet> pjet = jets->ptrAt( i );
             if( pjet->pt() < minJetPt_ ) { continue; }
             flashgg::Jet fjet = flashgg::Jet( *pjet );
+                        
             for( unsigned int j = 0 ; j < diPhotons->size() ; j++ ) {
                 Ptr<DiPhotonCandidate> diPhoton = diPhotons->ptrAt( j );
                 Ptr<reco::Vertex> vtx = diPhoton->vtx();
-
                 if( !usePuppi ) {
                     if( !fjet.hasPuJetId( vtx ) ) {
                         PileupJetIdentifier lPUJetId = pileupJetIdAlgo_->computeIdVariables( pjet.get(), vtx, *vertexCandidateMap, true );
@@ -94,14 +92,13 @@ namespace flashgg {
             }
             if( !usePuppi ) {
                 if( primaryVertices->size() > 0 && !fjet.hasPuJetId( primaryVertices->ptrAt( 0 ) ) ) {
-                    //	PileupJetIdentifier lPUJetId = pileupJetIdAlgo_->computeIdVariables(pjet.get(),primaryVertices->ptrAt(0),*vertexCandidateMap,true);
-                    //	PileupJetIdentifier lPUJetId = pileupJetIdAlgo_->computeIdVariables(pjet.get(),1.,(primaryVertices->ptrAt(0).get()),vc,true);
-                    //		fjet.setPuJetId(primaryVertices->ptrAt(0),lPUJetId);
+                    PileupJetIdentifier lPUJetId = pileupJetIdAlgo_->computeIdVariables(pjet.get(),primaryVertices->ptrAt(0),*vertexCandidateMap,true);
+                    fjet.setPuJetId(primaryVertices->ptrAt(0),lPUJetId);
                 }
             }
             jetColl->push_back( fjet );
         }
-
+        
         evt.put( jetColl );
     }
 }

--- a/MicroAOD/python/flashggExtraJets_cfi.py
+++ b/MicroAOD/python/flashggExtraJets_cfi.py
@@ -1,47 +1,58 @@
-import FWCore.ParameterSet.Config as cms
+# this is based on the jet 74X recipe for jet re-clustering
+# twiki source : https://twiki.cern.ch/twiki/bin/view/CMSPublic/WorkBookMiniAOD2015#Advanced_topics_re_clustering_ev
 
+import FWCore.ParameterSet.Config as cms
 from RecoJets.JetProducers.PileupJetIDParams_cfi import cutbased as pu_jetid
 from PhysicsTools.PatAlgos.tools.jetTools import addJetCollection
 
+
+bTagDiscriminators = ['pfCombinedInclusiveSecondaryVertexV2BJetTags']
+
 def addFlashggPF(process):
-  print "JET PRODUCER :: Flashgg PF producer +++++ "
+  print "JET PRODUCER :: Flashgg PF producer ::"
   from RecoJets.JetProducers.ak4PFJets_cfi  import ak4PFJets
   from RecoJets.JetProducers.ak4GenJets_cfi import ak4GenJets
-
+  
   process.ak4PFJets  = ak4PFJets.clone (src = 'packedPFCandidates', doAreaFastjet = True)
   process.ak4GenJets = ak4GenJets.clone(src = 'packedGenParticles')
   ## cluster the jets
   addJetCollection(
     process,
-    postfix      = "",
-    labelName    = 'AK4PF',
-    pfCandidates = cms.InputTag('packedPFCandidates'),
-    jetSource    = cms.InputTag('ak4PFJets'),
-    pvSource     = cms.InputTag('unpackedTracksAndVertices'), 
-    jetCorrections     = ('AK4PFchs', cms.vstring(['L1FastJet', 'L2Relative', 'L3Absolute']), 'None'),
-    btagDiscriminators = [      'pfJetProbabilityBJetTags'     ] ,algo= 'AK', rParam = 0.4
+    labelName      = 'AK4PF',
+    jetSource      = cms.InputTag('ak4PFJets'),
+    pvSource       = cms.InputTag('offlineSlimmedPrimaryVertices'),
+    pfCandidates   = cms.InputTag('packedPFCandidates'),
+    svSource       = cms.InputTag('slimmedSecondaryVertices'),
+    btagDiscriminators = bTagDiscriminators,
+    jetCorrections = ('AK4PFchs', ['L1FastJet', 'L2Relative', 'L3Absolute'], 'None'),
+    
+    genJetCollection = cms.InputTag('ak4GenJets'),
+    genParticles     = cms.InputTag('prunedGenParticles'),
+    # jet param
+    algo = 'AK', rParam = 0.4
   )
-  #
   ## adjust MC matching
   process.patJetGenJetMatchAK4PF.matched = "ak4GenJets"
   process.patJetPartonMatchAK4PF.matched = "prunedGenParticles"
+  #process.patJetPartons.particles        = "prunedGenParticles"
+  
+  #adjust PV used for Jet Corrections
   process.patJetCorrFactorsAK4PF.primaryVertices = "offlineSlimmedPrimaryVertices"
-  process.patJetPartons.particles        = "prunedGenParticles"
 
 def addFlashggPFCHS0(process):
-  print "JET PRODUCER :: Flashgg PFCHS0 producer +++++ "
-  # load various necessary plugins.
-  process.load("PhysicsTools.PatAlgos.producersLayer1.patCandidates_cff")
-  process.load('PhysicsTools.PatAlgos.slimming.unpackedTracksAndVertices_cfi')
+  print "JET PRODUCER :: Flashgg PFCHS producer ::"
+  
   # leptons to remove as per default CHS workflow
-  process.selectedMuons = cms.EDFilter("CandPtrSelector", 
-                                       src = cms.InputTag("slimmedMuons"), 
-                                       cut = cms.string('''abs(eta)<2.5 && pt>10. &&
-                                       (pfIsolationR04().sumChargedHadronPt+
-                                       max(0.,pfIsolationR04().sumNeutralHadronEt+
-                                       pfIsolationR04().sumPhotonEt-
-                                       0.50*pfIsolationR04().sumPUPt))/pt < 0.20 && 
-                                       (isPFMuon && (isGlobalMuon || isTrackerMuon) )'''))
+  # select the isolated leptons : electrons + muons
+  process.selectedMuons     = cms.EDFilter("CandPtrSelector", 
+                                           src = cms.InputTag("slimmedMuons"), 
+                                           cut = cms.string('''abs(eta)<2.5 && pt>10. &&
+                                           (pfIsolationR04().sumChargedHadronPt+
+                                           max(0.,pfIsolationR04().sumNeutralHadronEt+
+                                           pfIsolationR04().sumPhotonEt-
+                                           0.50*pfIsolationR04().sumPUPt))/pt < 0.20 && 
+                                           (isPFMuon && (isGlobalMuon || isTrackerMuon) )'''))
+  
   process.selectedElectrons = cms.EDFilter("CandPtrSelector", 
                                            src = cms.InputTag("slimmedElectrons"), 
                                            cut = cms.string('''abs(eta)<2.5 && pt>20. &&
@@ -51,55 +62,73 @@ def addFlashggPFCHS0(process):
                                            max(0.,pfIsolationVariables().sumNeutralHadronEt+
                                            pfIsolationVariables().sumPhotonEt-
                                            0.5*pfIsolationVariables().sumPUPt))/pt < 0.15'''))
-
+  
   # Simple producer which just removes the Candidates which
   # don't come from the legacy vertex according to the Flashgg Vertex Map
-  process.pfCHS0       = cms.EDFilter("CandPtrSelector",
-                                      src = cms.InputTag("packedPFCandidates"),
-                                      cut = cms.string("fromPV"))
+  process.flashggCHSLegacyVertexCandidates = cms.EDProducer('FlashggCHSLegacyVertexCandidateProducer',
+                                                            PFCandidatesTag       = cms.untracked.InputTag('packedPFCandidates'),
+                                                            DiPhotonTag           = cms.untracked.InputTag('flashggDiPhotons'),
+                                                            VertexCandidateMapTag = cms.InputTag("flashggVertexMapForCHS"),
+                                                            VertexTag = cms.untracked.InputTag('offlineSlimmedPrimaryVertices')
+                                                          )
   
-  process.pfNoMuonCHS0 = cms.EDProducer("CandPtrProjector",
-                                        src = cms.InputTag("pfCHS0"),
-                                        veto = cms.InputTag("selectedMuons"))
+  process.pfCHS0 = cms.EDFilter("CandPtrSelector", 
+                                src = cms.InputTag("flashggCHSLegacyVertexCandidates"), 
+                                cut = cms.string(""))
   
-  process.pfNoElectronsCHS0 = cms.EDProducer("CandPtrProjector",
-                                             src = cms.InputTag("pfNoMuonCHS0"),
-                                             veto =  cms.InputTag("selectedElectrons"))
-
+  # then remove the previously selected muons
+  process.pfNoMuonCHS0      = cms.EDProducer("CandPtrProjector", 
+                                             src  = cms.InputTag("pfCHS0"), 
+                                             veto = cms.InputTag("selectedMuons"))
+  # then remove the previously selected electrons
+  process.pfNoElectronsCHS0 = cms.EDProducer("CandPtrProjector", 
+                                             src  = cms.InputTag("pfNoMuonCHS0"), 
+                                             veto = cms.InputTag("selectedElectrons"))
+  
   #Import RECO jet producer for ak4 PF and GEN jet
   from RecoJets.JetProducers.ak4PFJets_cfi  import ak4PFJets
   from RecoJets.JetProducers.ak4GenJets_cfi import ak4GenJets
-  process.ak4PFJetsCHS0  = ak4PFJets.clone ( src = 'pfNoElectronsCHS0', doAreaFastjet = True)
-  process.ak4GenJetsCHS0 = ak4GenJets.clone( src = 'packedGenParticles')
+  process.ak4PFJetsCHS0 = ak4PFJets.clone ( src = 'pfNoElectronsCHS0', doAreaFastjet = True)
+  process.ak4GenJets    = ak4GenJets.clone( src = 'packedGenParticles')
+  
+  # NOTE : these line are from the new Jet recipe 
+  # The following is make patJets, but EI is done with the above
+  process.load("Configuration.StandardSequences.MagneticField_cff")
+  process.load("Configuration.Geometry.GeometryRecoDB_cff")
+  process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
+  
+  
   
   # cluster the jets
+  # NOTE: this is the 74X recipe for the jet clustering 
   addJetCollection(
     process,
-    postfix   = "",
-    labelName = 'AK4PFCHS0',
-    pfCandidates = cms.InputTag('packedPFCandidates'),
-    jetSource = cms.InputTag('ak4PFJetsCHS0'),
-    #trackSource = cms.InputTag('unpackedTracksAndVertices'), 
-    pvSource = cms.InputTag('unpackedTracksAndVertices'), 
-    jetCorrections = ('AK4PFchs', cms.vstring(['L1FastJet', 'L2Relative', 'L3Absolute']), 'None'),
-    #btagDiscriminators = [      'combinedSecondaryVertexBJetTags'     ]
-    btagDiscriminators = [      'pfJetProbabilityBJetTags'     ]
-    ,algo= 'AK', rParam = 0.4
+    labelName      = 'AK4PFCHS0',
+    jetSource      = cms.InputTag('ak4PFJetsCHS0'),
+    pvSource       = cms.InputTag('offlineSlimmedPrimaryVertices'),
+    pfCandidates   = cms.InputTag('packedPFCandidates'),
+    svSource       = cms.InputTag('slimmedSecondaryVertices'),
+    btagDiscriminators = bTagDiscriminators,
+    jetCorrections = ('AK4PFchs', ['L1FastJet', 'L2Relative', 'L3Absolute'], 'None'),
+    
+    genJetCollection = cms.InputTag('ak4GenJets0'),
+    genParticles     = cms.InputTag('prunedGenParticles'),
+    # jet param
+    algo = 'AK', rParam = 0.4
   )
+  
   # adjust MC matching
   process.patJetGenJetMatchAK4PFCHS0.matched = "ak4GenJetsLeg"
   process.patJetPartonMatchAK4PFCHS0.matched = "prunedGenParticles"
-  process.patJetPartons.particles            = "prunedGenParticles"
-  # adjust PV collection used for Jet Corrections
+  #process.patJetPartons.particles = "prunedGenParticles"
+
+  #adjust PV used for Jet Corrections
   process.patJetCorrFactorsAK4PFCHS0.primaryVertices = "offlineSlimmedPrimaryVertices"
   
 
 
 
 
-
-
-  
 flashggJetsPF     = cms.EDProducer('FlashggJetProducer',
                                    DiPhotonTag=cms.untracked.InputTag('flashggDiPhotons'),
                                    VertexTag=cms.untracked.InputTag('offlineSlimmedPrimaryVertices'),

--- a/MicroAOD/python/flashggExtraJets_cfi.py
+++ b/MicroAOD/python/flashggExtraJets_cfi.py
@@ -1,0 +1,120 @@
+import FWCore.ParameterSet.Config as cms
+
+from RecoJets.JetProducers.PileupJetIDParams_cfi import cutbased as pu_jetid
+from PhysicsTools.PatAlgos.tools.jetTools import addJetCollection
+
+def addFlashggPF(process):
+  print "JET PRODUCER :: Flashgg PF producer +++++ "
+  from RecoJets.JetProducers.ak4PFJets_cfi  import ak4PFJets
+  from RecoJets.JetProducers.ak4GenJets_cfi import ak4GenJets
+
+  process.ak4PFJets  = ak4PFJets.clone (src = 'packedPFCandidates', doAreaFastjet = True)
+  process.ak4GenJets = ak4GenJets.clone(src = 'packedGenParticles')
+  ## cluster the jets
+  addJetCollection(
+    process,
+    postfix      = "",
+    labelName    = 'AK4PF',
+    pfCandidates = cms.InputTag('packedPFCandidates'),
+    jetSource    = cms.InputTag('ak4PFJets'),
+    pvSource     = cms.InputTag('unpackedTracksAndVertices'), 
+    jetCorrections     = ('AK4PFchs', cms.vstring(['L1FastJet', 'L2Relative', 'L3Absolute']), 'None'),
+    btagDiscriminators = [      'pfJetProbabilityBJetTags'     ] ,algo= 'AK', rParam = 0.4
+  )
+  #
+  ## adjust MC matching
+  process.patJetGenJetMatchAK4PF.matched = "ak4GenJets"
+  process.patJetPartonMatchAK4PF.matched = "prunedGenParticles"
+  process.patJetCorrFactorsAK4PF.primaryVertices = "offlineSlimmedPrimaryVertices"
+  process.patJetPartons.particles        = "prunedGenParticles"
+
+def addFlashggPFCHS0(process):
+  print "JET PRODUCER :: Flashgg PFCHS0 producer +++++ "
+  # load various necessary plugins.
+  process.load("PhysicsTools.PatAlgos.producersLayer1.patCandidates_cff")
+  process.load('PhysicsTools.PatAlgos.slimming.unpackedTracksAndVertices_cfi')
+  # leptons to remove as per default CHS workflow
+  process.selectedMuons = cms.EDFilter("CandPtrSelector", 
+                                       src = cms.InputTag("slimmedMuons"), 
+                                       cut = cms.string('''abs(eta)<2.5 && pt>10. &&
+                                       (pfIsolationR04().sumChargedHadronPt+
+                                       max(0.,pfIsolationR04().sumNeutralHadronEt+
+                                       pfIsolationR04().sumPhotonEt-
+                                       0.50*pfIsolationR04().sumPUPt))/pt < 0.20 && 
+                                       (isPFMuon && (isGlobalMuon || isTrackerMuon) )'''))
+  process.selectedElectrons = cms.EDFilter("CandPtrSelector", 
+                                           src = cms.InputTag("slimmedElectrons"), 
+                                           cut = cms.string('''abs(eta)<2.5 && pt>20. &&
+                                           gsfTrack.isAvailable() &&
+                                           gsfTrack.hitPattern().numberOfLostHits(\'MISSING_INNER_HITS\') < 2 &&
+                                           (pfIsolationVariables().sumChargedHadronPt+
+                                           max(0.,pfIsolationVariables().sumNeutralHadronEt+
+                                           pfIsolationVariables().sumPhotonEt-
+                                           0.5*pfIsolationVariables().sumPUPt))/pt < 0.15'''))
+
+  # Simple producer which just removes the Candidates which
+  # don't come from the legacy vertex according to the Flashgg Vertex Map
+  process.pfCHS0       = cms.EDFilter("CandPtrSelector",
+                                      src = cms.InputTag("packedPFCandidates"),
+                                      cut = cms.string("fromPV"))
+  
+  process.pfNoMuonCHS0 = cms.EDProducer("CandPtrProjector",
+                                        src = cms.InputTag("pfCHS0"),
+                                        veto = cms.InputTag("selectedMuons"))
+  
+  process.pfNoElectronsCHS0 = cms.EDProducer("CandPtrProjector",
+                                             src = cms.InputTag("pfNoMuonCHS0"),
+                                             veto =  cms.InputTag("selectedElectrons"))
+
+  #Import RECO jet producer for ak4 PF and GEN jet
+  from RecoJets.JetProducers.ak4PFJets_cfi  import ak4PFJets
+  from RecoJets.JetProducers.ak4GenJets_cfi import ak4GenJets
+  process.ak4PFJetsCHS0  = ak4PFJets.clone ( src = 'pfNoElectronsCHS0', doAreaFastjet = True)
+  process.ak4GenJetsCHS0 = ak4GenJets.clone( src = 'packedGenParticles')
+  
+  # cluster the jets
+  addJetCollection(
+    process,
+    postfix   = "",
+    labelName = 'AK4PFCHS0',
+    pfCandidates = cms.InputTag('packedPFCandidates'),
+    jetSource = cms.InputTag('ak4PFJetsCHS0'),
+    #trackSource = cms.InputTag('unpackedTracksAndVertices'), 
+    pvSource = cms.InputTag('unpackedTracksAndVertices'), 
+    jetCorrections = ('AK4PFchs', cms.vstring(['L1FastJet', 'L2Relative', 'L3Absolute']), 'None'),
+    #btagDiscriminators = [      'combinedSecondaryVertexBJetTags'     ]
+    btagDiscriminators = [      'pfJetProbabilityBJetTags'     ]
+    ,algo= 'AK', rParam = 0.4
+  )
+  # adjust MC matching
+  process.patJetGenJetMatchAK4PFCHS0.matched = "ak4GenJetsLeg"
+  process.patJetPartonMatchAK4PFCHS0.matched = "prunedGenParticles"
+  process.patJetPartons.particles            = "prunedGenParticles"
+  # adjust PV collection used for Jet Corrections
+  process.patJetCorrFactorsAK4PFCHS0.primaryVertices = "offlineSlimmedPrimaryVertices"
+  
+
+
+
+
+
+
+  
+flashggJetsPF     = cms.EDProducer('FlashggJetProducer',
+                                   DiPhotonTag=cms.untracked.InputTag('flashggDiPhotons'),
+                                   VertexTag=cms.untracked.InputTag('offlineSlimmedPrimaryVertices'),
+                                   JetTag=cms.untracked.InputTag('patJetsAK4PF'),
+                                   VertexCandidateMapTag = cms.InputTag("flashggVertexMapForCHS"),
+                                   PileupJetIdParameters=cms.PSet(pu_jetid),
+                                   MinJetPt=cms.untracked.double(0.)             
+                                 )
+
+flashggJetsPFCHS0 = cms.EDProducer('FlashggJetProducer',
+                                   DiPhotonTag=cms.untracked.InputTag('flashggDiPhotons'),
+                                   VertexTag=cms.untracked.InputTag('offlineSlimmedPrimaryVertices'),
+                                   JetTag=cms.untracked.InputTag('patJetsAK4PFCHS0'),
+                                   VertexCandidateMapTag = cms.InputTag("flashggVertexMapForCHS"),
+                                   PileupJetIdParameters=cms.PSet(pu_jetid),
+                                   MinJetPt=cms.untracked.double(0.)             
+                                 )
+

--- a/MicroAOD/python/flashggExtraJets_cfi.py
+++ b/MicroAOD/python/flashggExtraJets_cfi.py
@@ -6,7 +6,7 @@ from RecoJets.JetProducers.PileupJetIDParams_cfi import cutbased as pu_jetid
 from PhysicsTools.PatAlgos.tools.jetTools import addJetCollection
 
 
-bTagDiscriminators = ['pfCombinedInclusiveSecondaryVertexV2BJetTags']
+flashggBtag = 'pfCombinedInclusiveSecondaryVertexV2BJetTags'
 
 def addFlashggPF(process):
   print "JET PRODUCER :: Flashgg PF producer ::"
@@ -23,7 +23,7 @@ def addFlashggPF(process):
     pvSource       = cms.InputTag('offlineSlimmedPrimaryVertices'),
     pfCandidates   = cms.InputTag('packedPFCandidates'),
     svSource       = cms.InputTag('slimmedSecondaryVertices'),
-    btagDiscriminators = bTagDiscriminators,
+    btagDiscriminators = [ flashggBtag ],
     jetCorrections = ('AK4PFchs', ['L1FastJet', 'L2Relative', 'L3Absolute'], 'None'),
     
     genJetCollection = cms.InputTag('ak4GenJets'),
@@ -108,7 +108,7 @@ def addFlashggPFCHS0(process):
     pvSource       = cms.InputTag('offlineSlimmedPrimaryVertices'),
     pfCandidates   = cms.InputTag('packedPFCandidates'),
     svSource       = cms.InputTag('slimmedSecondaryVertices'),
-    btagDiscriminators = bTagDiscriminators,
+    btagDiscriminators =  [ flashggBtag ],
     jetCorrections = ('AK4PFchs', ['L1FastJet', 'L2Relative', 'L3Absolute'], 'None'),
     
     genJetCollection = cms.InputTag('ak4GenJets0'),

--- a/MicroAOD/python/flashggJets_cfi.py
+++ b/MicroAOD/python/flashggJets_cfi.py
@@ -1,28 +1,34 @@
-import FWCore.ParameterSet.Config as cms
+# this is based on the jet 74X recipe for jet re-clustering
+# twiki source : https://twiki.cern.ch/twiki/bin/view/CMSPublic/WorkBookMiniAOD2015#Advanced_topics_re_clustering_ev
 
+import FWCore.ParameterSet.Config as cms
 from RecoJets.JetProducers.PileupJetIDParams_cfi import cutbased as pu_jetid
 from PhysicsTools.PatAlgos.tools.jetTools import addJetCollection
-#from Configuration.Geometry.GeometryAll_cff import *
 
-# define a function to add in the jet collection, as the reclustering need to know about the process
-# but we obviously don't want all this stuff clogging up python configs. 
+
+
+bTagDiscriminators = ['pfCombinedInclusiveSecondaryVertexV2BJetTags']
+
+
 def addFlashggPFCHSLegJets(process):
-  #process.load("Configuration.StandardSequences.Geometry_cff")
-  #process.myPrefer = cms.ESPrefer("CaloSubdetectorGeometry" [,"ZDC"
-  #                   [,ZdcGeometryFromDBEP = cms.vstring("<C++ data type>[/<data label>]"[,...])]
-  
+
+  # NOTE : these lines are not longer needed
   # load various necessary plugins.
-  process.load("PhysicsTools.PatAlgos.producersLayer1.patCandidates_cff")
-  process.load('PhysicsTools.PatAlgos.slimming.unpackedTracksAndVertices_cfi')
+  ## process.load("PhysicsTools.PatAlgos.producersLayer1.patCandidates_cff")
+  ## process.load('PhysicsTools.PatAlgos.slimming.unpackedTracksAndVertices_cfi')
+  
   # leptons to remove as per default CHS workflow
-  process.selectedMuons = cms.EDFilter("CandPtrSelector", 
-                                       src = cms.InputTag("slimmedMuons"), 
-                                       cut = cms.string('''abs(eta)<2.5 && pt>10. &&
-                                       (pfIsolationR04().sumChargedHadronPt+
-                                       max(0.,pfIsolationR04().sumNeutralHadronEt+
-                                       pfIsolationR04().sumPhotonEt-
-                                       0.50*pfIsolationR04().sumPUPt))/pt < 0.20 && 
-                                       (isPFMuon && (isGlobalMuon || isTrackerMuon) )'''))
+  # select the isolated leptons : electrons + muons
+  
+  process.selectedMuons     = cms.EDFilter("CandPtrSelector", 
+                                           src = cms.InputTag("slimmedMuons"), 
+                                           cut = cms.string('''abs(eta)<2.5 && pt>10. &&
+                                           (pfIsolationR04().sumChargedHadronPt+
+                                           max(0.,pfIsolationR04().sumNeutralHadronEt+
+                                           pfIsolationR04().sumPhotonEt-
+                                           0.50*pfIsolationR04().sumPUPt))/pt < 0.20 && 
+                                           (isPFMuon && (isGlobalMuon || isTrackerMuon) )'''))
+  
   process.selectedElectrons = cms.EDFilter("CandPtrSelector", 
                                            src = cms.InputTag("slimmedElectrons"), 
                                            cut = cms.string('''abs(eta)<2.5 && pt>20. &&
@@ -32,62 +38,75 @@ def addFlashggPFCHSLegJets(process):
                                            max(0.,pfIsolationVariables().sumNeutralHadronEt+
                                            pfIsolationVariables().sumPhotonEt-
                                            0.5*pfIsolationVariables().sumPUPt))/pt < 0.15'''))
-
+  
   # Simple producer which just removes the Candidates which
   # don't come from the legacy vertex according to the Flashgg Vertex Map
-  
   process.flashggCHSLegacyVertexCandidates = cms.EDProducer('FlashggCHSLegacyVertexCandidateProducer',
                                                             PFCandidatesTag       = cms.untracked.InputTag('packedPFCandidates'),
                                                             DiPhotonTag           = cms.untracked.InputTag('flashggDiPhotons'),
                                                             VertexCandidateMapTag = cms.InputTag("flashggVertexMapForCHS"),
-                                                            VertexTag=cms.untracked.InputTag('offlineSlimmedPrimaryVertices')
+                                                            VertexTag = cms.untracked.InputTag('offlineSlimmedPrimaryVertices')
                                                           )
+  
   process.pfCHSLeg = cms.EDFilter("CandPtrSelector", 
                                   src = cms.InputTag("flashggCHSLegacyVertexCandidates"), 
                                   cut = cms.string(""))
+  
   # then remove the previously selected muons
-  process.pfNoMuonCHSLeg =  cms.EDProducer("CandPtrProjector", 
-                                           src  = cms.InputTag("pfCHSLeg"), 
-                                           veto = cms.InputTag("selectedMuons"))
+  process.pfNoMuonCHSLeg      = cms.EDProducer("CandPtrProjector", 
+                                               src  = cms.InputTag("pfCHSLeg"), 
+                                               veto = cms.InputTag("selectedMuons"))
   # then remove the previously selected electrons
   process.pfNoElectronsCHSLeg = cms.EDProducer("CandPtrProjector", 
                                                src  = cms.InputTag("pfNoMuonCHSLeg"), 
                                                veto = cms.InputTag("selectedElectrons"))
+  
   #Import RECO jet producer for ak4 PF and GEN jet
   from RecoJets.JetProducers.ak4PFJets_cfi  import ak4PFJets
   from RecoJets.JetProducers.ak4GenJets_cfi import ak4GenJets
   process.ak4PFJetsCHSLeg = ak4PFJets.clone ( src = 'pfNoElectronsCHSLeg', doAreaFastjet = True)
   process.ak4GenJetsLeg   = ak4GenJets.clone( src = 'packedGenParticles')
   
+  # NOTE : these line are from the new Jet recipe 
+  # The following is make patJets, but EI is done with the above
+  process.load("Configuration.StandardSequences.MagneticField_cff")
+  process.load("Configuration.Geometry.GeometryRecoDB_cff")
+  process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
+  
   # cluster the jets
+  # NOTE: this is the 74X recipe for the jet clustering 
   addJetCollection(
     process,
-    postfix   = "",
-    labelName = 'AK4PFCHSLeg',
-    pfCandidates = cms.InputTag('packedPFCandidates'),
-    jetSource = cms.InputTag('ak4PFJetsCHSLeg'),
-    #trackSource = cms.InputTag('unpackedTracksAndVertices'), 
-    pvSource = cms.InputTag('unpackedTracksAndVertices'), 
-    jetCorrections = ('AK4PFchs', cms.vstring(['L1FastJet', 'L2Relative', 'L3Absolute']), 'None'),
-    #btagDiscriminators = [      'combinedSecondaryVertexBJetTags'     ]
-    btagDiscriminators = [      'pfJetProbabilityBJetTags'     ]
-    ,algo= 'AK', rParam = 0.4
+    labelName      = 'AK4PFCHSLeg',
+    jetSource      = cms.InputTag('ak4PFJetsCHSLeg'),
+    pvSource       = cms.InputTag('offlineSlimmedPrimaryVertices'),
+    pfCandidates   = cms.InputTag('packedPFCandidates'),
+    svSource       = cms.InputTag('slimmedSecondaryVertices'),
+    btagDiscriminators = bTagDiscriminators,
+    jetCorrections = ('AK4PFchs', ['L1FastJet', 'L2Relative', 'L3Absolute'], 'None'),
+    
+    genJetCollection = cms.InputTag('ak4GenJetsLeg'),
+    genParticles     = cms.InputTag('prunedGenParticles'),
+    # jet param
+    algo = 'AK', rParam = 0.4
   )
+
+  #adjust PV used for Jet Corrections
+  process.patJetCorrFactorsAK4PFCHSLeg.primaryVertices = "offlineSlimmedPrimaryVertices"
+  
   # adjust MC matching
   process.patJetGenJetMatchAK4PFCHSLeg.matched = "ak4GenJetsLeg"
   process.patJetPartonMatchAK4PFCHSLeg.matched = "prunedGenParticles"
-  process.patJetPartons.particles = "prunedGenParticles"
-  # adjust PV collection used for Jet Corrections
-  process.patJetCorrFactorsAK4PFCHSLeg.primaryVertices = "offlineSlimmedPrimaryVertices"
-
-
+  #process.patJetPartons.particles = "prunedGenParticles"
+  
+  
 # Flashgg Jet producer using the collection created with function above.
 flashggJets = cms.EDProducer('FlashggJetProducer',
-                             DiPhotonTag=cms.untracked.InputTag('flashggDiPhotons'),
-                             VertexTag=cms.untracked.InputTag('offlineSlimmedPrimaryVertices'),
-                             JetTag=cms.untracked.InputTag('patJetsAK4PFCHSLeg'),
+                             DiPhotonTag = cms.untracked.InputTag('flashggDiPhotons'),
+                             VertexTag   = cms.untracked.InputTag('offlineSlimmedPrimaryVertices'),
+                             JetTag      = cms.untracked.InputTag('patJetsAK4PFCHSLeg'),
                              VertexCandidateMapTag = cms.InputTag("flashggVertexMapForCHS"),
-                             PileupJetIdParameters=cms.PSet(pu_jetid),
+                             PileupJetIdParameters = cms.PSet(pu_jetid),
                              MinJetPt=cms.untracked.double(0.)             
 )
   

--- a/MicroAOD/python/flashggJets_cfi.py
+++ b/MicroAOD/python/flashggJets_cfi.py
@@ -7,7 +7,7 @@ from PhysicsTools.PatAlgos.tools.jetTools import addJetCollection
 
 
 
-bTagDiscriminators = ['pfCombinedInclusiveSecondaryVertexV2BJetTags']
+flashggBtag = 'pfCombinedInclusiveSecondaryVertexV2BJetTags'
 
 
 def addFlashggPFCHSLegJets(process):
@@ -82,7 +82,7 @@ def addFlashggPFCHSLegJets(process):
     pvSource       = cms.InputTag('offlineSlimmedPrimaryVertices'),
     pfCandidates   = cms.InputTag('packedPFCandidates'),
     svSource       = cms.InputTag('slimmedSecondaryVertices'),
-    btagDiscriminators = bTagDiscriminators,
+    btagDiscriminators = [ flashggBtag ],
     jetCorrections = ('AK4PFchs', ['L1FastJet', 'L2Relative', 'L3Absolute'], 'None'),
     
     genJetCollection = cms.InputTag('ak4GenJetsLeg'),

--- a/MicroAOD/python/flashggJets_cfi.py
+++ b/MicroAOD/python/flashggJets_cfi.py
@@ -4,76 +4,91 @@ from RecoJets.JetProducers.PileupJetIDParams_cfi import cutbased as pu_jetid
 from PhysicsTools.PatAlgos.tools.jetTools import addJetCollection
 #from Configuration.Geometry.GeometryAll_cff import *
 
-#flashggBTag = "pfCombinedInclusiveSecondaryVertexV2BJetTags"
-flashggBTag = "pfJetProbabilityBJetTags" # we pick this one because it doesn't require an extra recipe
-
 # define a function to add in the jet collection, as the reclustering need to know about the process
 # but we obviously don't want all this stuff clogging up python configs. 
 def addFlashggPFCHSLegJets(process):
   #process.load("Configuration.StandardSequences.Geometry_cff")
-	#process.myPrefer = cms.ESPrefer("CaloSubdetectorGeometry" [,"ZDC"
-	#                                   [,ZdcGeometryFromDBEP = cms.vstring("<C++ data type>[/<data label>]"[,...])]
-	#																	                                   )
-	# load various necessary plugins.
+  #process.myPrefer = cms.ESPrefer("CaloSubdetectorGeometry" [,"ZDC"
+  #                   [,ZdcGeometryFromDBEP = cms.vstring("<C++ data type>[/<data label>]"[,...])]
+  
+  # load various necessary plugins.
   process.load("PhysicsTools.PatAlgos.producersLayer1.patCandidates_cff")
   process.load('PhysicsTools.PatAlgos.slimming.unpackedTracksAndVertices_cfi')
-	# leptons to remove as per default CHS workflow
-  process.selectedMuons = cms.EDFilter("CandPtrSelector", src = cms.InputTag("slimmedMuons"), cut = cms.string('''abs(eta)<2.5 && pt>10. &&
-				(pfIsolationR04().sumChargedHadronPt+
-				 max(0.,pfIsolationR04().sumNeutralHadronEt+
-					 pfIsolationR04().sumPhotonEt-
-					 0.50*pfIsolationR04().sumPUPt))/pt < 0.20 && 
-				(isPFMuon && (isGlobalMuon || isTrackerMuon) )'''))
-  process.selectedElectrons = cms.EDFilter("CandPtrSelector", src = cms.InputTag("slimmedElectrons"), cut = cms.string('''abs(eta)<2.5 && pt>20. &&
-				gsfTrack.isAvailable() &&
-				gsfTrack.hitPattern().numberOfLostHits(\'MISSING_INNER_HITS\') < 2 &&
-				(pfIsolationVariables().sumChargedHadronPt+
-				 max(0.,pfIsolationVariables().sumNeutralHadronEt+
-					 pfIsolationVariables().sumPhotonEt-
-					 0.5*pfIsolationVariables().sumPUPt))/pt < 0.15'''))
-	# Simple producer which just removes the Candidates which don't come from the legacy vertex according to the Flashgg Vertex Map
+  # leptons to remove as per default CHS workflow
+  process.selectedMuons = cms.EDFilter("CandPtrSelector", 
+                                       src = cms.InputTag("slimmedMuons"), 
+                                       cut = cms.string('''abs(eta)<2.5 && pt>10. &&
+                                       (pfIsolationR04().sumChargedHadronPt+
+                                       max(0.,pfIsolationR04().sumNeutralHadronEt+
+                                       pfIsolationR04().sumPhotonEt-
+                                       0.50*pfIsolationR04().sumPUPt))/pt < 0.20 && 
+                                       (isPFMuon && (isGlobalMuon || isTrackerMuon) )'''))
+  process.selectedElectrons = cms.EDFilter("CandPtrSelector", 
+                                           src = cms.InputTag("slimmedElectrons"), 
+                                           cut = cms.string('''abs(eta)<2.5 && pt>20. &&
+                                           gsfTrack.isAvailable() &&
+                                           gsfTrack.hitPattern().numberOfLostHits(\'MISSING_INNER_HITS\') < 2 &&
+                                           (pfIsolationVariables().sumChargedHadronPt+
+                                           max(0.,pfIsolationVariables().sumNeutralHadronEt+
+                                           pfIsolationVariables().sumPhotonEt-
+                                           0.5*pfIsolationVariables().sumPUPt))/pt < 0.15'''))
+
+  # Simple producer which just removes the Candidates which
+  # don't come from the legacy vertex according to the Flashgg Vertex Map
+  
   process.flashggCHSLegacyVertexCandidates = cms.EDProducer('FlashggCHSLegacyVertexCandidateProducer',
-                                                          PFCandidatesTag=cms.untracked.InputTag('packedPFCandidates'),
-                                                          DiPhotonTag=cms.untracked.InputTag('flashggDiPhotons'),
-                                                          VertexCandidateMapTag = cms.InputTag("flashggVertexMapForCHS"),
-                                                          VertexTag=cms.untracked.InputTag('offlineSlimmedPrimaryVertices')
-                                                  )
-  process.pfCHSLeg = cms.EDFilter("CandPtrSelector", src = cms.InputTag("flashggCHSLegacyVertexCandidates"), cut = cms.string(""))
+                                                            PFCandidatesTag       = cms.untracked.InputTag('packedPFCandidates'),
+                                                            DiPhotonTag           = cms.untracked.InputTag('flashggDiPhotons'),
+                                                            VertexCandidateMapTag = cms.InputTag("flashggVertexMapForCHS"),
+                                                            VertexTag=cms.untracked.InputTag('offlineSlimmedPrimaryVertices')
+                                                          )
+  process.pfCHSLeg = cms.EDFilter("CandPtrSelector", 
+                                  src = cms.InputTag("flashggCHSLegacyVertexCandidates"), 
+                                  cut = cms.string(""))
   # then remove the previously selected muons
-  process.pfNoMuonCHSLeg =  cms.EDProducer("CandPtrProjector", src = cms.InputTag("pfCHSLeg"), veto = cms.InputTag("selectedMuons"))
+  process.pfNoMuonCHSLeg =  cms.EDProducer("CandPtrProjector", 
+                                           src  = cms.InputTag("pfCHSLeg"), 
+                                           veto = cms.InputTag("selectedMuons"))
   # then remove the previously selected electrons
-  process.pfNoElectronsCHSLeg = cms.EDProducer("CandPtrProjector", src = cms.InputTag("pfNoMuonCHSLeg"), veto =  cms.InputTag("selectedElectrons"))
+  process.pfNoElectronsCHSLeg = cms.EDProducer("CandPtrProjector", 
+                                               src  = cms.InputTag("pfNoMuonCHSLeg"), 
+                                               veto = cms.InputTag("selectedElectrons"))
   #Import RECO jet producer for ak4 PF and GEN jet
-  from RecoJets.JetProducers.ak4PFJets_cfi import ak4PFJets
+  from RecoJets.JetProducers.ak4PFJets_cfi  import ak4PFJets
   from RecoJets.JetProducers.ak4GenJets_cfi import ak4GenJets
-  process.ak4PFJetsCHSLeg = ak4PFJets.clone(src = 'pfNoElectronsCHSLeg', doAreaFastjet = True)
-  process.ak4GenJetsLeg = ak4GenJets.clone(src = 'packedGenParticles')
-	# cluster the jets
+  process.ak4PFJetsCHSLeg = ak4PFJets.clone ( src = 'pfNoElectronsCHSLeg', doAreaFastjet = True)
+  process.ak4GenJetsLeg   = ak4GenJets.clone( src = 'packedGenParticles')
+  
+  # cluster the jets
   addJetCollection(
-      process,
-      postfix   = "",
-      labelName = 'AK4PFCHSLeg',
-		  pfCandidates = cms.InputTag('packedPFCandidates'),
-      jetSource = cms.InputTag('ak4PFJetsCHSLeg'),
-      #trackSource = cms.InputTag('unpackedTracksAndVertices'), 
-      pvSource = cms.InputTag('unpackedTracksAndVertices'), 
-      jetCorrections = ('AK4PFchs', cms.vstring(['L1FastJet', 'L2Relative', 'L3Absolute']), 'None'),
-      btagDiscriminators = [ flashggBTag ]
-      ,algo= 'AK', rParam = 0.4
-      )
+    process,
+    postfix   = "",
+    labelName = 'AK4PFCHSLeg',
+    pfCandidates = cms.InputTag('packedPFCandidates'),
+    jetSource = cms.InputTag('ak4PFJetsCHSLeg'),
+    #trackSource = cms.InputTag('unpackedTracksAndVertices'), 
+    pvSource = cms.InputTag('unpackedTracksAndVertices'), 
+    jetCorrections = ('AK4PFchs', cms.vstring(['L1FastJet', 'L2Relative', 'L3Absolute']), 'None'),
+    #btagDiscriminators = [      'combinedSecondaryVertexBJetTags'     ]
+    btagDiscriminators = [      'pfJetProbabilityBJetTags'     ]
+    ,algo= 'AK', rParam = 0.4
+  )
   # adjust MC matching
   process.patJetGenJetMatchAK4PFCHSLeg.matched = "ak4GenJetsLeg"
   process.patJetPartonMatchAK4PFCHSLeg.matched = "prunedGenParticles"
   process.patJetPartons.particles = "prunedGenParticles"
   # adjust PV collection used for Jet Corrections
   process.patJetCorrFactorsAK4PFCHSLeg.primaryVertices = "offlineSlimmedPrimaryVertices"
-	
+
+
 # Flashgg Jet producer using the collection created with function above.
 flashggJets = cms.EDProducer('FlashggJetProducer',
-		DiPhotonTag=cms.untracked.InputTag('flashggDiPhotons'),
-		VertexTag=cms.untracked.InputTag('offlineSlimmedPrimaryVertices'),
-		JetTag=cms.untracked.InputTag('patJetsAK4PFCHSLeg'),
-		VertexCandidateMapTag = cms.InputTag("flashggVertexMapForCHS"),
-		PileupJetIdParameters=cms.PSet(pu_jetid),
-                MinJetPt=cms.untracked.double(0.)             
-		)
+                             DiPhotonTag=cms.untracked.InputTag('flashggDiPhotons'),
+                             VertexTag=cms.untracked.InputTag('offlineSlimmedPrimaryVertices'),
+                             JetTag=cms.untracked.InputTag('patJetsAK4PFCHSLeg'),
+                             VertexCandidateMapTag = cms.InputTag("flashggVertexMapForCHS"),
+                             PileupJetIdParameters=cms.PSet(pu_jetid),
+                             MinJetPt=cms.untracked.double(0.)             
+)
+  
+

--- a/MicroAOD/python/flashggMicroAODExtraJetsSequence_cff.py
+++ b/MicroAOD/python/flashggMicroAODExtraJetsSequence_cff.py
@@ -1,0 +1,6 @@
+import FWCore.ParameterSet.Config as cms
+from flashgg.MicroAOD.flashggExtraJets_cfi import flashggJetsPF, flashggJetsPFCHS0 
+
+from flashgg.MicroAOD.flashggMicroAODGenSequence_cff import *
+
+flashggMicroAODExtraJetsSequence = cms.Sequence( flashggJetsPF + flashggJetsPFCHS0)

--- a/Validation/plugins/JetValidationTreeMaker.cc
+++ b/Validation/plugins/JetValidationTreeMaker.cc
@@ -633,9 +633,8 @@ JetValidationTreeMaker::analyze(const edm::Event& iEvent, const edm::EventSetup&
     double betaStar = 0;
     //if(debug_ && std::abs(jetsDz->ptrAt( jdz )->eta())<2.5){
     if(debug_ && std::abs(jetsDz->ptrAt( jdz )->eta())<2.5 && jetsDz->ptrAt( jdz )->pt() > 20.0 ){
-      std::cout << setw(12)<<"jet["<< jdz
-		<<"] nPuJetId( "   << jetsDz->ptrAt( jdz )->nPuJetId() << " )"
-		<<" vtx0==vtxgg( " << jInfo.LegIsPV0 << " )"
+      std::cout << setw(12)<<"jet[" << jdz
+		<<"] vtx0==vtxgg( " << jInfo.LegIsPV0 << " )"
 		<< std::endl ;
       std::cout << setw(6) <<"";
       std::cout << setw(6) <<"=======================================================" << std::endl;

--- a/Validation/plugins/JetValidationTreeMaker.cc
+++ b/Validation/plugins/JetValidationTreeMaker.cc
@@ -1,6 +1,6 @@
 // -----------------------
 // By Y.Haddad & L.Corpe  12/2014
-//
+// 
 // Jet validation analyzer: tree maker for the jet studies in flashgg
 // -----------------------
 
@@ -17,159 +17,231 @@
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "DataFormats/Common/interface/Handle.h"
 #include "DataFormats/Common/interface/Ptr.h"
-//#include "DataFormats/Common/interface/PtrVector.h"
+#include "DataFormats/Common/interface/PtrVector.h"
 
 #include "DataFormats/VertexReco/interface/Vertex.h"
 #include "DataFormats/PatCandidates/interface/PackedGenParticle.h"
 
+#include "DataFormats/VertexReco/interface/Vertex.h"
+#include "DataFormats/PatCandidates/interface/PackedGenParticle.h"
 #include "flashgg/MicroAOD/interface/VertexSelectorBase.h"
 #include "flashgg/DataFormats/interface/Photon.h"
 #include "flashgg/DataFormats/interface/DiPhotonCandidate.h"
-
 #include "flashgg/MicroAOD/interface/PhotonIdUtils.h"
 
 #include "flashgg/DataFormats/interface/VertexCandidateMap.h"
 #include "flashgg/DataFormats/interface/Jet.h"
-
 #include "DataFormats/Math/interface/deltaR.h"
+
+#include "DataFormats/JetReco/interface/PileupJetIdentifier.h"
 
 
 #include "TTree.h"
+#include "TMatrix.h"
+#include "TVector.h"
+#include "TLorentzVector.h"
 
 // **********************************************************************
+#ifndef FLASHgg_VertexCandidateMap_h
+#define FLASHgg_VertexCandidateMap_h
+namespace flashgg {
+  // typedef std::map<edm::Ptr<reco::Vertex>,edm::PtrVector<pat::PackedCandidate> > VertexCandidateMap;
+  typedef std::pair<edm::Ptr<reco::Vertex>,edm::Ptr<pat::PackedCandidate> > VertexCandidatePair;
+  typedef std::vector<VertexCandidatePair> VertexCandidateMap;
+
+  struct compare_by_vtx {
+    bool operator()(const VertexCandidatePair& left, const VertexCandidatePair& right) {
+      return (left.first < right.first);
+    }
+  };
+
+  struct compare_with_vtx {
+    bool operator()(const VertexCandidatePair& left, const edm::Ptr<reco::Vertex>& right) {
+      return (left.first < right);
+    }
+    bool operator()(const edm::Ptr<reco::Vertex>& left,const VertexCandidatePair& right) {
+      return(left < right.first);
+    }
+  };
+
+  struct compare_by_cand {
+    bool operator()(const VertexCandidatePair& left, const VertexCandidatePair& right) {
+      return (left.second < right.second);
+    }
+  };
+  
+  struct compare_with_cand {
+    bool operator()(const VertexCandidatePair& left, const edm::Ptr<pat::PackedCandidate>& right) {
+      return (left.second < right);
+    }
+    bool operator()(const edm::Ptr<pat::PackedCandidate>& left,const VertexCandidatePair& right) {
+      return(left < right.second);
+    }
+  };
+}
+#endif
+
+
+double delta_R(const reco::GenJet *genJet, edm::Ptr<flashgg::Jet> jet){
+  float dphi  = deltaPhi(genJet->phi(),jet->phi());
+  float deta  = genJet->eta() -  jet->eta();
+  return std::sqrt(deta*deta + dphi*dphi);
+}
 
 struct eventInfo {
-
-    float genVertexZ;
-    float zerothVertexZ;
-    float diphotonVertexZ;
-    int legacyEqZeroth;
-    int nDiphotons;
-
-    unsigned int nJet;
-    unsigned int nPV;
-    unsigned int nSV;
-
-    float higgsPt;
-
-    void init()
-    {
-        genVertexZ      = -999.;
-        zerothVertexZ   = -999.;
-        diphotonVertexZ = -999.;
-        higgsPt         = -999.;
-    }
+  
+  float genVertexZ;
+  float zerothVertexZ;
+  float diphotonVertexZ;
+  int   legacyEqZeroth;
+  int   nDiphotons;
+  
+  unsigned int nJet;
+  unsigned int nPV;
+  unsigned int nSV;
+  
+  float leadJet_pt;
+  float leadJet_eta;
+  float leadJet_phi;
+  
+  float subleadJet_pt;
+  float subleadJet_eta;
+  float subleadJet_phi;
+  
+  float higgsPt;
+  
+  void init()  { 
+    genVertexZ      =-999.;
+    zerothVertexZ   =-999.;
+    diphotonVertexZ =-999.;
+    higgsPt         =-999.;
+  }
 };
 
 // per-vertex tree
 struct GenPartInfo {
-    float pt;
-    float eta;
-    float phi;
-    int   pdgid;
-    int   status;
-
-    void init()
-    {
-        pt  = -999;
-        eta = -999;
-    }
+  float pt;
+  float eta;
+  float y;
+  float phi;
+  int   pdgid;
+  int   status;
+  
+  void init(){
+    pt  =-999;
+    eta =-999; 
+  }
 };
 
 // per-genJet tree
 struct GenJetInfo {
-    float pt;
-    float eta;
-    float phi;
-    float recoJetPt   ;
-    float recoJetRawPt ;
-    float recoJetBestPt;
-    int   recoJetMatch ;
-    float recoJetEta   ;
-    float dR   ;
-    int legacyEqZeroth;
-    int nDiphotons;
-    float PUJetID_betaStar;
-    float PUJetID_rms;
-    int passesPUJetID;
+  float pt;
+  float eta;
+  float phi;
+  float recoJetPt   ; 
+  float recoJetRawPt ;
+  float recoJetBestPt;
+  int   recoJetMatch ;
+  float recoJetEta   ;
+  float dRmin        ;
+  float dR   ;
+  int   legacyEqZeroth;
+  int   nDiphotons;
+  float PUJetID_betaStar;
+  float PUJetID_rms;
+  int   passesPUJetID;
+  
 
-
-    int   photonMatch;
-    float photondRmin;
-    float GenPhotonPt;
-
-
-    void init()
-    {
-        pt  = -999;
-        eta = -999;
-    }
+  int   photonMatch;
+  float photondRmin;
+  float GenPhotonPt;
+  
+  
+  void init(){
+    pt  =-999;
+    eta =-999; 
+  }
 };
 // per recoJet tree
 struct jetInfo {
-    float pt;
-    float rawPt;
-    float bestPt;
-    float energy;
-    float mass;
-    float area;
-    float eta;
-    float phi;
-    float PUJetID_betaStar;
-    float PUJetID_rms;
-    int passesPUJetID;
-    int legacyEqZeroth;
-    int nDiphotons;
+  float pt;
+  float rawPt;
+  float bestPt;
+  float energy;
+  float mass;
+  float area;
+  float eta;
+  float phi;
 
-    int   npart_0 ;    // number of particles at pt>0
-    int   npart_5 ;    // number of particles at pt>5
-    int   npart_10;    // number of particles at pt>10
-    int   npart_20;    // number of particles at pt>20
+  float PlanarFlow;
+  float S;
+  float Q;
+  
+  float jet_W;
+  float jet_dR2Mean;
+  float jet_dRMean;
+  float jet_dZ;
+  float jet_ptD;
+  float jet_betaClassic;
+  float jet_betaStarClassic;
+  
+  float PUJetID_betaStar;
+  float PUJetID_beta;
+  float PUJetID_rms;
+  
+  float mybetaStar;
+  float mybeta;
+  
+  int   passesPUJetID;
+  int   LegIsPV0;
+  int   nDiphotons;
+  
+  int   nPV;
+  int   nJets;
+  
+  int   nPart ;  
+  int   nCharged ; // number of particles at pt>0
+  int   nNeutral ;  // number of particles at pt>0
+  
+  float chgEmFrac;
+  float neuEmFrac;
 
-    int   ncharged_0 ; // number of particles at pt>0
-    int   ncharged_5 ; // number of particles at pt>5
-    int   ncharged_10; // number of particles at pt>10
-    int   ncharged_20; // number of particles at pt>20
+  float genJetPt;
+  float genJetEta;
+  float genJetPhi;
+  float genJetdRmin;
+  int   genJetMatch;
 
-    int   nphoton_0 ;  // number of particles at pt>0
-    int   nphoton_5 ;  // number of particles at pt>5
-    int   nphoton_10;  // number of particles at pt>10
-    int   nphoton_20;  // number of particles at pt>20
+  
+  float genQuarkPt;
+  float genQuarkEta;
+  int   genQuarkMatch;
+  int   genQuarkPdgId;
+  void init(){
+    pt  =-999;
+    eta =-999; 
+  }
+  // jets Id
+  int id;
+  // photon matching part
+  int   photonMatch;
+  float photondRmin;
+  float GenPhotonEta;
+  float GenPhotonPhi;
+  float GenPhotonPt;
+  
+};  
 
-    float genJetPt;
-    float genJetEta;
-    int   genJetMatch;
-    float genQuarkPt;
-    float genQuarkEta;
-    int   genQuarkMatch;
-    int   genQuarkPdgId;
-    void init()
-    {
-        pt  = -999;
-        eta = -999;
-    }
-
-
-    // photon matching part
-    int   photonMatch;
-    float photondRmin;
-    float GenPhotonEta;
-    float GenPhotonPhi;
-    float GenPhotonPt;
-
-};
-
-struct GenPhotonInfo {
-    float pt;
-    float phi;
-    float eta;
-    float DRmin;
-    void init()
-    {
-        pt  = -999;
-        eta = -999;
-    }
-
+struct GenPhotonInfo{
+  float pt;
+  float phi;
+  float eta;
+  float DRmin;
+  void init(){
+    pt  =-999;
+    eta =-999; 
+  }
+  
 };
 
 // **********************************************************************
@@ -180,490 +252,738 @@ using namespace flashgg;
 
 // **********************************************************************
 
-class JetValidationTreeMaker : public edm::EDAnalyzer
-{
+class JetValidationTreeMaker : public edm::EDAnalyzer {
 public:
-    explicit JetValidationTreeMaker( const edm::ParameterSet & );
-    ~JetValidationTreeMaker();
+  explicit JetValidationTreeMaker(const edm::ParameterSet&);
+  ~JetValidationTreeMaker();
 
-    static void fillDescriptions( edm::ConfigurationDescriptions &descriptions );
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
-
+  
 private:
-
-    edm::Service<TFileService> fs_;
-
-    virtual void beginJob() override;
-    virtual void analyze( const edm::Event &, const edm::EventSetup & ) override;
-    virtual void endJob() override;
-
-
-    // Additional methods
-    void initEventStructure();
-
-    //EDGetTokenT< VertexCandidateMap > vertexCandidateMapTokenDz_;
-    //EDGetTokenT< VertexCandidateMap > vertexCandidateMapTokenAOD_;
-
-    EDGetTokenT< edm::View<reco::GenParticle> > genPartToken_;
-    EDGetTokenT< edm::View<reco::GenJet> >      genJetToken_;
-    EDGetTokenT< edm::View<flashgg::Jet> >      jetDzToken_;
-    EDGetTokenT<edm::View<flashgg::DiPhotonCandidate> > diPhotonToken_;
-    EDGetTokenT< View<reco::Vertex> > vertexToken_;
-
-    TTree     *eventTree;
-    TTree     *jetTree;
-    TTree     *genPartTree;
-    TTree     *genJetTree;
-
-    eventInfo   eInfo;
-    jetInfo     jInfo;
-    GenPartInfo genInfo;
-    GenJetInfo  genJetInfo;
-    Int_t       event_number;
-    std::string jetCollectionName;
-
-    GenPartInfo jGenPhotonInfo;
-
-    bool        usePUJetID;
-
+  
+  edm::Service<TFileService> fs_;
+  
+  virtual void beginJob() override;
+  virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
+  virtual void endJob() override;
+  
+  // Additional methods
+  void initEventStructure();
+  
+  
+  //bool GenRecoMatching(reco::GenJet genjet, const PtrVector<flashgg::Jet>& RecoJets){}
+  //EDGetTokenT< VertexCandidateMap > vertexCandidateMapTokenDz_;
+  //EDGetTokenT< VertexCandidateMap > vertexCandidateMapTokenAOD_;
+  
+  EDGetTokenT< edm::View<reco::GenParticle> > genPartToken_;
+  EDGetTokenT< edm::View<reco::GenJet> >      genJetToken_;
+  EDGetTokenT< edm::View<flashgg::Jet> >      jetDzToken_;
+  EDGetTokenT<edm::View<flashgg::DiPhotonCandidate> > diPhotonToken_;
+  EDGetTokenT< View<reco::Vertex> >           vertexToken_;
+  EDGetTokenT< VertexCandidateMap > vertexCandidateMapToken_;
+  
+  TTree*     eventTree;
+  TTree*     jetTree;
+  TTree*     genPartTree;
+  TTree*     genJetTree;
+  
+  eventInfo   eInfo;
+  jetInfo     jInfo;
+  GenPartInfo genInfo;
+  GenJetInfo  genJetInfo;
+  Int_t       event_number;
+  std::string jetCollectionName; 
+  
+  GenPartInfo jGenPhotonInfo;
+  
+  bool        usePUJetID;
+  bool        photonJetVeto;
+  bool        homeGenJetMatching_;
+  bool        debug_;
+  
 };
 
-JetValidationTreeMaker::JetValidationTreeMaker( const edm::ParameterSet &iConfig ):
-    genPartToken_( consumes<View<reco::GenParticle> >( iConfig.getUntrackedParameter<InputTag> ( "GenParticleTag", InputTag( "prunedGenParticles" ) ) ) ),
-    genJetToken_( consumes<View<reco::GenJet> >( iConfig.getUntrackedParameter<InputTag> ( "GenJetTag", InputTag( "slimmedGenJets" ) ) ) ),
-    jetDzToken_( consumes<View<flashgg::Jet> >( iConfig.getParameter<InputTag>( "JetTagDz" ) ) ),
-    diPhotonToken_( consumes<View<flashgg::DiPhotonCandidate> >( iConfig.getUntrackedParameter<InputTag> ( "DiPhotonTag", InputTag( "flashggDiPhotons" ) ) ) ),
-    vertexToken_( consumes<View<reco::Vertex> >( iConfig.getUntrackedParameter<InputTag> ( "VertexTag", InputTag( "offlineSlimmedPrimaryVertices" ) ) ) ),
-    usePUJetID( iConfig.getUntrackedParameter<bool>( "UsePUJetID", false ) )
+JetValidationTreeMaker::JetValidationTreeMaker(const edm::ParameterSet& iConfig):
+  genPartToken_ (consumes<View<reco::GenParticle> >(iConfig.getUntrackedParameter<InputTag> ("GenParticleTag", InputTag("prunedGenParticles")))),
+  genJetToken_  (consumes<View<reco::GenJet> >(iConfig.getUntrackedParameter<InputTag> ("GenJetTag", InputTag("slimmedGenJets")))),
+  jetDzToken_   (consumes<View<flashgg::Jet> >(iConfig.getParameter<InputTag>("JetTagDz"))),
+  diPhotonToken_(consumes<View<flashgg::DiPhotonCandidate> >(iConfig.getUntrackedParameter<InputTag> ("DiPhotonTag", InputTag("flashggDiPhotons")))),
+  vertexToken_  (consumes<View<reco::Vertex> >(iConfig.getUntrackedParameter<InputTag> ("VertexTag", InputTag("offlineSlimmedPrimaryVertices")))),
+  vertexCandidateMapToken_(consumes<VertexCandidateMap>(iConfig.getParameter<InputTag>("VertexCandidateMapTag"))),
+  usePUJetID    (iConfig.getUntrackedParameter<bool>("UsePUJetID"   ,false)),
+  photonJetVeto (iConfig.getUntrackedParameter<bool>("PhotonJetVeto",true)),
+  homeGenJetMatching_ (iConfig.getUntrackedParameter<bool>("homeGenJetMatching",false)),
+  debug_ (iConfig.getUntrackedParameter<bool>("debug",false))
 {
-    event_number = 0;
-    jetCollectionName = iConfig.getParameter<string>( "StringTag" );
+  event_number = 0;
+  jetCollectionName = iConfig.getParameter<string>("StringTag");
 }
+
+//double JetPtSorter(std::vector<>){
+
+//}
+
 
 JetValidationTreeMaker::~JetValidationTreeMaker()
 {
-    event_number = 0;
+  event_number = 0;
 }
 
+
 void
-JetValidationTreeMaker::analyze( const edm::Event &iEvent, const edm::EventSetup &iSetup )
+JetValidationTreeMaker::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
 {
+  
+  if(debug_){
+    std::cout << "\e[0;31m";
+    std::cout << setw(6)  << "========================= "     << std::endl;
+    std::cout << setw(12) << "Event" << setw(12) << event_number   << std::endl;
+    std::cout << setw(6)  << "------------------------- "     << std::endl;
+    std::cout <<"\e[0m"<< std::endl;
+  }
+  
 
+  Handle<View<reco::Vertex> > vtxs;
+  iEvent.getByToken(vertexToken_,vtxs);
+  //const PtrVector<reco::Vertex>& vtxs = primaryVertices->ptrVector();
+  
+  Handle<View<flashgg::DiPhotonCandidate> > diPhotons;
+  iEvent.getByToken(diPhotonToken_,diPhotons);
+  //const PtrVector<flashgg::DiPhotonCandidate>& diPhotons = diPhotons->ptrVector();
+  
+  Handle<View<reco::GenParticle> > gens;
+  iEvent.getByToken(genPartToken_,gens);
+  //const PtrVector<reco::GenParticle>& gens = genParticles->ptrVector();
+  
+  Handle<View<reco::GenJet> > genJets;
+  iEvent.getByToken(genJetToken_,genJets);
+  //const PtrVector<reco::GenJet>& genJets = genJet->ptrVector();
+  
+  Handle<View<flashgg::Jet> > jetsDz;
+  iEvent.getByToken(jetDzToken_,jetsDz);
+  //const PtrVector<flashgg::Jet>& jetsDzPointers = jetsDz->ptrVector();
 
+  Handle<VertexCandidateMap> vtxmap;
+  iEvent.getByToken(vertexCandidateMapToken_,vtxmap);
+  
+  
+  int legacyEqZeroth =0;
+  int nDiphotons =0;
+  
+  nDiphotons = diPhotons->size();
+  if(diPhotons->size()==0){
+    legacyEqZeroth =1; //if there is no diphoton, we use 0th vertex anyway.
+  } else {
+    if(fabs(diPhotons->ptrAt(0)->vtx()->z() - vtxs->ptrAt(0)->z())<0.01){
+      legacyEqZeroth =1;
+    }
+  }
+  eInfo.nDiphotons     = nDiphotons;
+  eInfo.legacyEqZeroth = legacyEqZeroth;
+  
+  initEventStructure();
+  
+  jInfo.nJets = jetsDz->size();
+  jInfo.nPV   = vtxs->size();
+  eInfo.nSV   = 0;
 
-    Handle<View<reco::Vertex> > primaryVertices;
-    iEvent.getByToken( vertexToken_, primaryVertices );
-//  const PtrVector<reco::Vertex>& vtxs = primaryVertices->ptrVector();
+  if(debug_){
+    std::cout << "\e[0;31m";
+    std::cout << setw(12) << "nJets"    << setw(12) << jetsDz->size()   << std::endl;
+    std::cout << setw(12) << "nVtxs"    << setw(12) << vtxs->size()     << std::endl;
+    std::cout << setw(12) << "nGenJet"  << setw(12) << genJets->size()  << std::endl;
+    std::cout << setw(12) << "PV0==Leg" << setw(12) << legacyEqZeroth   << std::endl;
+    std::cout << setw(6)  << "========================= "     << std::endl;
+    std::cout <<"\e[0m"<< std::endl;
+  }
+  // photon eoverlaping removal
+  std::vector<edm::Ptr<reco::GenParticle> > genPhoton;
+  std::vector<edm::Ptr<reco::GenParticle> > genParton;
+  
+  for( unsigned int genLoop =0 ; genLoop < gens->size(); genLoop++){
+    genInfo.pt     = gens->ptrAt( genLoop )->pt() ;
+    genInfo.eta    = gens->ptrAt( genLoop )->eta();
+    genInfo.phi    = gens->ptrAt( genLoop )->phi();
+    genInfo.status = gens->ptrAt( genLoop )->status();
+    genInfo.pdgid  = int(gens->ptrAt( genLoop )->pdgId());
+    
+    // be sure that the photons comes from the higgs
+    if (gens->ptrAt( genLoop )->pdgId() == 22 && gens->ptrAt( genLoop )-> mother(0)->pdgId() == 25){ 
+      genPhoton.push_back(gens->ptrAt( genLoop ));
+    }
+    
+    // select the quark and gluon 
+    if (std::abs(gens->ptrAt( genLoop )->pdgId()) == 21 || // gluons
+	std::abs(gens->ptrAt( genLoop )->pdgId()) <= 5  ){ // quarks
+      if(gens->ptrAt( genLoop )->status()==3){ // another condition about the status 3
+	genParton.push_back(gens->ptrAt( genLoop ));
+      }
+    }
+    // fill the tree
+    genPartTree->Fill();
+  }
+  // find tag the jets close to the photons
+  std::map<unsigned int, GenPhotonInfo> photonJet_id;
+  std::map<unsigned int, bool>             _isPhoton;
 
-    Handle<View<flashgg::DiPhotonCandidate> > diPhotons;
-    iEvent.getByToken( diPhotonToken_, diPhotons );
-//  const PtrVector<flashgg::DiPhotonCandidate>& diPhotonPointers = diPhotons->ptrVector();
+  for( unsigned int jetLoop =0 ; jetLoop < jetsDz->size(); jetLoop++){
+    float minDr = 1000;
+    std::map<float,unsigned int> minim;
+    GenPhotonInfo tmp_info;
+    if (genPhoton.size()!=0){
+      for( unsigned int ig=0; ig < genPhoton.size(); ig++){
+	float dphi  = deltaPhi(jetsDz->ptrAt( jetLoop )->phi(),genPhoton[ig]->phi());
+	float deta  = jetsDz->ptrAt( jetLoop )->eta() -  genPhoton[ig]->eta();
+	float dr    =  std::sqrt(deta*deta + dphi*dphi);
+	minDr = std::min(dr, minDr);
+	minim[dr] = ig; 
+      }
+      unsigned int close_gid = minim.find(minDr)->second;
+            
+      tmp_info.pt     = genPhoton[close_gid]->pt ();
+      tmp_info.eta    = genPhoton[close_gid]->eta();
+      tmp_info.phi    = genPhoton[close_gid]->phi();
+      tmp_info.DRmin  = minDr;
+      
+      _isPhoton[jetLoop] = false;
+      if(minDr < 0.3){
+	_isPhoton[jetLoop] = true;
+      }
+      photonJet_id[jetLoop] =  tmp_info;
+    }else{
+      tmp_info.pt     = -999.;
+      tmp_info.eta    = -999.;
+      tmp_info.phi    = -999.;
+      tmp_info.DRmin  = -999.;
+      
+      _isPhoton[jetLoop] = false;
+      photonJet_id[jetLoop] =  tmp_info;
+    }
+  }
 
-    Handle<View<reco::GenParticle> > genParticles;
-    iEvent.getByToken( genPartToken_, genParticles );
-//  const PtrVector<reco::GenParticle>& gens = genParticles->ptrVector();
+  if(debug_){
+    std::cout << "\e[0;31m";
+    std::cout << setw(12) << "PhoMatch"  << setw(12) << _isPhoton.size()  << std::endl;
+    std::cout <<"\e[0m"<< std::endl;
+  }
 
-    Handle<View<reco::GenJet> > genJet;
-    iEvent.getByToken( genJetToken_, genJet );
-//  const PtrVector<reco::GenJet>& genJets = genJet->ptrVector();
-
-    Handle<View<flashgg::Jet> > jetsDz;
-    iEvent.getByToken( jetDzToken_, jetsDz );
-//  const PtrVector<flashgg::Jet>& jetsDzPointers = jetsDz->ptrVector();
-
-    int legacyEqZeroth = 0;
-    int nDiphotons = 0;
-
-    //std::cout <<" DEBUG 1"<<std::endl;
-    nDiphotons = diPhotons->size();
-    if( diPhotons->size() == 0 ) {
-        legacyEqZeroth = 1; //if there is no diphoton, we use 0th vertex anyway.
+  //+++ GenJet Matcing
+  std::map<unsigned int, GenJetInfo>     genJet_id;
+  std::map<unsigned int, bool>          _isMatched;
+  std::map<unsigned int, unsigned int>   pairs;
+  
+  for( unsigned int jetLoop =0; jetLoop < jetsDz->size(); jetLoop++){
+    float minDr = 1000;
+    std::map<float,unsigned int> minim;
+    GenJetInfo tmp_info;
+    if (genJets->size()!=0){
+      for( unsigned int ig=0; ig < genJets->size(); ig++){
+	float dphi  = deltaPhi(jetsDz->ptrAt( jetLoop )->phi(),genJets->ptrAt( ig )->phi());
+	float deta  = jetsDz->ptrAt( jetLoop )->eta() - genJets->ptrAt( ig )->eta();
+	float dr    =  std::sqrt(deta*deta + dphi*dphi);
+	minDr = std::min(dr, minDr);
+	minim[dr] = ig; 
+      }
+      
+      unsigned int close_genjet_id = minim.find(minDr)->second;
+      tmp_info.pt     = genJets->ptrAt( close_genjet_id )->pt ();
+      tmp_info.eta    = genJets->ptrAt( close_genjet_id )->eta();
+      tmp_info.phi    = genJets->ptrAt( close_genjet_id )->phi();
+      tmp_info.dRmin  = minDr;
+      
+      _isMatched[jetLoop] = false;
+      if(minDr < 0.4 && pairs.find(close_genjet_id)==pairs.end()){
+	_isMatched[jetLoop] = true;
+	pairs[close_genjet_id] = jetLoop;
+	
+	//std ::cout << "DEBUG:: jet("<< jetLoop
+	//<<") == genJet(" << close_genjet_id
+	//<< ") pt = "     << tmp_info.pt 
+	//<< "DEBUG::  Dr min     == " << minDr 
+	//<< std::endl;
+	
+      }
+      genJet_id[jetLoop] =  tmp_info;
+    }else{
+      tmp_info.pt     = -999.;
+      tmp_info.eta    = -999.;//genJets->ptrAt( close_genjet_id )->eta();
+      tmp_info.phi    = -999.;//genJets->ptrAt( close_genjet_id )->phi();
+      tmp_info.dRmin  = -999.;//minDr;
+      genJet_id[jetLoop] =  tmp_info;
+    }
+  }
+  
+  //std::cout << " number of parton :: " << genParton.size() << std::endl;
+  //std::cout << " number of mathes :: " << _isMatched.size() << std::endl;
+  //std::cout << " number of genJet :: " << genJets->size() << std::endl;
+  
+  std::map<unsigned int, jetInfo> recojetmap;
+  
+  // +++ loop on the reconstructed jets
+  for (unsigned int jdz = 0 ; jdz < jetsDz->size() ; jdz++) {
+    jInfo.id            = jdz;
+    jInfo.photonMatch   = int(_isPhoton[jdz]); 
+    
+    GenPhotonInfo tmp_info = photonJet_id.find(jdz)->second; // call find ones
+    
+    jInfo.GenPhotonPt  = tmp_info.pt   ;
+    jInfo.GenPhotonEta = tmp_info.eta  ;
+    jInfo.GenPhotonPhi = tmp_info.phi  ;
+    jInfo.photondRmin  = tmp_info.DRmin;
+    
+    jInfo.pt            = jetsDz->ptrAt( jdz )->pt();
+    jInfo.rawPt         = jetsDz->ptrAt( jdz )->correctedJet("Uncorrected").pt() ;
+    
+    if(jetCollectionName.find("PPI")>1 && jetCollectionName.find("PPI")<jetCollectionName.size()){
+      jInfo.bestPt      = jetsDz->ptrAt( jdz )->correctedJet("Uncorrected").pt() ;
     } else {
-        if( fabs( diPhotons->ptrAt( 0 )->vtx()->z() - primaryVertices->ptrAt( 0 )->z() ) < 0.01 ) {
-            legacyEqZeroth = 1;
-        }
+      jInfo.bestPt      = jetsDz->ptrAt( jdz )->pt() ;
     }
-
-    eInfo.nDiphotons = nDiphotons;
-    eInfo.legacyEqZeroth = legacyEqZeroth;
-
-    initEventStructure();
-
-    eInfo.nJet = jetsDz->size();
-    eInfo.nPV  = primaryVertices->size();
-    eInfo.nSV  = 0;
-
-    // ++  finding the photon-jet overlaping
-    std::map<unsigned int, GenPhotonInfo> photonJet_id;
-
-    for( unsigned int genLoop = 0 ; genLoop < genParticles->size(); genLoop++ ) {
-        genInfo.pt     = genParticles->ptrAt( genLoop )->pt() ;
-        genInfo.eta    = genParticles->ptrAt( genLoop )->eta();
-        genInfo.phi    = genParticles->ptrAt( genLoop )->phi();
-        genInfo.status = genParticles->ptrAt( genLoop )->status();
-        genInfo.pdgid  = int( genParticles->ptrAt( genLoop )->pdgId() );
-
-        std::map<float, unsigned int> minim;
-        std::map<unsigned int, GenPhotonInfo> minim_info;
-        float DeltaRmin = 999.;
-
-        if( genParticles->ptrAt( genLoop )->pdgId() == 22  && genParticles->ptrAt( genLoop )->numberOfDaughters() == 0 ) {
-            for( unsigned int jetLoop = 0 ; jetLoop < jetsDz->size(); jetLoop++ ) {
-                GenPhotonInfo tmp_info;
-
-                float dphi  = deltaPhi( jetsDz->ptrAt( jetLoop )->phi(), genParticles->ptrAt( genLoop )->phi() );
-                float deta  = jetsDz->ptrAt( jetLoop )->eta() -  genParticles->ptrAt( genLoop )->eta();
-                float dr    =  std::sqrt( deta * deta + dphi * dphi );
-
-                DeltaRmin = std::min( dr, DeltaRmin );
-                minim[dr] = jetLoop;
-
-                // fill the info
-                tmp_info.pt     = genParticles->ptrAt( genLoop )->pt();
-                tmp_info.eta    = genParticles->ptrAt( genLoop )->eta();
-                tmp_info.phi    = genParticles->ptrAt( genLoop )->phi();
-                tmp_info.DRmin  = DeltaRmin;
-
-                minim_info[jetLoop] = tmp_info;
-            }
-            unsigned int bestjetid = minim.find( DeltaRmin )->second;
-            photonJet_id[bestjetid] = minim_info[bestjetid];
-        }
-        genPartTree->Fill();
+    
+    
+    if(homeGenJetMatching_){
+      jInfo.genJetMatch             = int(_isMatched[jdz]);
+      
+      GenJetInfo tmp_genjet_info    = genJet_id.find(jdz)->second;
+      jInfo.genJetPt                = tmp_genjet_info.pt ;
+      jInfo.genJetEta               = tmp_genjet_info.eta;
+      jInfo.genJetPhi               = tmp_genjet_info.phi;
+      jInfo.genJetdRmin             = tmp_genjet_info.dRmin;
+    }else{
+      if( jetsDz->ptrAt( jdz )->genJet()){
+	jInfo.genJetMatch           = 1;
+	jInfo.genJetPt              = jetsDz->ptrAt( jdz )->genJet()->pt();
+	jInfo.genJetEta             = jetsDz->ptrAt( jdz )->genJet()->eta();
+	jInfo.genJetEta             = jetsDz->ptrAt( jdz )->genJet()->eta();
+	jInfo.genJetdRmin           = delta_R(jetsDz->ptrAt( jdz )->genJet(), jetsDz->ptrAt( jdz ));
+      } else {
+	jInfo.genJetPt              = -9999.;
+	jInfo.genJetEta             = -9999.;
+	jInfo.genJetMatch           = 0;
+	jInfo.genJetdRmin           = -9999.;
+      }
     }
-
-    std::map<unsigned int, jetInfo> recojetmap;
-    for( unsigned int jdz = 0 ; jdz < jetsDz->size() ; jdz++ ) {
-
-        jInfo.photondRmin = 999.;
-        if( photonJet_id.find( jdz ) != photonJet_id.end() ) {
-            GenPhotonInfo tmp_info = photonJet_id.find( jdz )->second; // call find ones
-            jInfo.photondRmin  = tmp_info.DRmin;
-            jInfo.GenPhotonPt  = tmp_info.pt   ;
-            jInfo.GenPhotonEta = tmp_info.eta  ;
-            jInfo.GenPhotonPhi = tmp_info.phi  ;
-            jInfo.photonMatch  = 1;
-        } else {
-            jInfo.photondRmin  = -999.;
-            jInfo.GenPhotonPt  = -999.;
-            jInfo.GenPhotonEta = -999.;
-            jInfo.GenPhotonPhi = -999.;
-            jInfo.photonMatch  =  0   ;
-            jInfo.photondRmin  = -999.;
-        }
-
-        jInfo.pt            = jetsDz->ptrAt( jdz )->pt();
-        jInfo.rawPt         = jetsDz->ptrAt( jdz )->correctedJet( "Uncorrected" ).pt() ;
-
-        if( jetCollectionName.find( "PPI" ) > 1 && jetCollectionName.find( "PPI" ) < jetCollectionName.size() ) {
-            jInfo.bestPt      = jetsDz->ptrAt( jdz )->correctedJet( "Uncorrected" ).pt() ;
-        } else {
-            jInfo.bestPt      = jetsDz->ptrAt( jdz )->pt() ;
-        }
-
-        if( jetsDz->ptrAt( jdz )->genJet() ) {
-            jInfo.genJetMatch           = 1;
-            jInfo.genJetPt              = jetsDz->ptrAt( jdz )->genJet()->pt();
-            jInfo.genJetEta             = jetsDz->ptrAt( jdz )->genJet()->eta();
-
-        } else {
-            jInfo.genJetPt              = -9999.;
-            jInfo.genJetEta             = -9999.;
-            jInfo.genJetMatch           = 0;
-        }
-
-        if( jetsDz->ptrAt( jdz )->genParton() ) {
-            jInfo.genQuarkMatch           = 1;
-            jInfo.genQuarkPt              = jetsDz->ptrAt( jdz )->genParton()->pt();
-            jInfo.genQuarkEta             = jetsDz->ptrAt( jdz )->genParton()->eta();
-            jInfo.genQuarkPdgId           = jetsDz->ptrAt( jdz )->genParton()->pdgId();
-
-        } else {
-            jInfo.genQuarkPt              = -9999.;
-            jInfo.genQuarkEta             = -9999.;
-            jInfo.genQuarkMatch           = 0;
-            jInfo.genQuarkPdgId           = -9999;
-        }
-        //----------------------
-        jInfo.energy           = jetsDz->ptrAt( jdz )->energy() ;
-        jInfo.mass             = jetsDz->ptrAt( jdz )->mass() ;
-        jInfo.eta              = jetsDz->ptrAt( jdz )->eta();
-        jInfo.phi              = jetsDz->ptrAt( jdz )->phi();
-        jInfo.area             = jetsDz->ptrAt( jdz )->jetArea();
-
-        if( !( jetCollectionName.find( "PPI" ) > 1 && jetCollectionName.find( "PPI" ) < jetCollectionName.size() ) ) {
-            // use the di-photon vertex if the di-photon existe otherwise use the Vtx0
-
-            if( ( diPhotons->size() > 0 ) &&
-                    ( ( jetCollectionName.find( "Leg" ) > 1 && jetCollectionName.find( "Leg" ) < jetCollectionName.size() ) || ( jetCollectionName.length()   < 3 ) ) ) { // for PF
-
-                jInfo.PUJetID_betaStar        = jetsDz->ptrAt( jdz )->betaStar( diPhotons->ptrAt( 0 )->vtx() );
-                jInfo.PUJetID_rms             = jetsDz->ptrAt( jdz )->rms( diPhotons->ptrAt( 0 )->vtx() );
-                jInfo.passesPUJetID           = jetsDz->ptrAt( jdz )->passesPuJetId( diPhotons->ptrAt( 0 )->vtx() );
-
-            } else {
-
-                jInfo.PUJetID_betaStar        = jetsDz->ptrAt( jdz )->betaStar( primaryVertices->ptrAt( 0 ) );
-                jInfo.PUJetID_rms             = jetsDz->ptrAt( jdz )->rms( primaryVertices->ptrAt( 0 ) );
-                jInfo.passesPUJetID           = jetsDz->ptrAt( jdz )->passesPuJetId( primaryVertices->ptrAt( 0 ) );
-
-            }
-        } else {
-
-            jInfo.PUJetID_betaStar        = -999.;
-            jInfo.PUJetID_rms             = -999.;
-            jInfo.passesPUJetID           = -999;
-        }
-
-        jInfo.nDiphotons                = nDiphotons;
-        jInfo.legacyEqZeroth            = legacyEqZeroth;
-
-        // Get constituants information
-        jInfo.npart_0  = 0; //
-        jInfo.npart_5  = 0; //
-        jInfo.npart_10 = 0; //
-        jInfo.npart_20 = 0; //
-
-        jInfo.ncharged_0  = 0; //
-        jInfo.ncharged_5  = 0; //
-        jInfo.ncharged_10 = 0; //
-        jInfo.ncharged_20 = 0; //
-
-        jInfo.nphoton_0  = 0; //
-        jInfo.nphoton_5  = 0; //
-        jInfo.nphoton_10 = 0; //
-        jInfo.nphoton_20 = 0; //
-        // loop over consitutuants
-        //for (unsigned int i = 0 ; i < jetsDz->ptrAt(jdz)->jetConstituentsQuick().size() ; i++){
-        //
-        //  const reco::Candidate* icand = jetsDz->ptrAt(jdz)->jetConstituentsQuick()[i];
-        //  float candPt                 = icand->pt();
-        //  float candCharge             = icand->charge();
-        //
-        //  jInfo.npart_0++;
-        //  if(candCharge != 0) jInfo.ncharged_0++;
-        //  if(candCharge == 0 && icand->pdgId() == 22) jInfo.nphoton_0++;
-        //
-        //  if(candPt > 5){
-        //	jInfo.npart_5++;
-        //	if(candCharge != 0) jInfo.ncharged_5++;
-        //	if(candCharge == 0 && icand->pdgId() == 22) jInfo.nphoton_5++;
-        //  }
-        //  if(candPt > 10){
-        //	jInfo.npart_10++;
-        //	if(candCharge != 0) jInfo.ncharged_10++;
-        //	if(candCharge == 0 && icand->pdgId() == 22) jInfo.nphoton_10++;
-        //  }
-        //  if(candPt > 20){
-        //	jInfo.npart_20++;
-        //	if(candCharge != 0) jInfo.ncharged_20++;
-        //	if(candCharge == 0 && icand->pdgId() == 22) jInfo.nphoton_20++;
-        //  }
-        //}
-
-        recojetmap[jdz] = jInfo;
-        jetTree->Fill();
+    
+    if( jetsDz->ptrAt( jdz )->genParton()){
+      jInfo.genQuarkMatch           = 1;
+      jInfo.genQuarkPt              = jetsDz->ptrAt( jdz )->genParton()->pt();
+      jInfo.genQuarkEta             = jetsDz->ptrAt( jdz )->genParton()->eta();
+      jInfo.genQuarkPdgId           = jetsDz->ptrAt( jdz )->genParton()->pdgId();
+    } else {
+      jInfo.genQuarkPt              = -9999.;
+      jInfo.genQuarkEta             = -9999.;
+      jInfo.genQuarkMatch           = 0;
+      jInfo.genQuarkPdgId           = -9999;
     }
+    //----------------------
+    jInfo.energy           = jetsDz->ptrAt( jdz )->energy() ;
+    jInfo.mass             = jetsDz->ptrAt( jdz )->mass() ;
+    jInfo.eta              = jetsDz->ptrAt( jdz )->eta();
+    jInfo.phi              = jetsDz->ptrAt( jdz )->phi();
+    jInfo.area             = jetsDz->ptrAt( jdz )->jetArea();
 
-    for( unsigned int genLoop = 0 ; genLoop < genJet->size(); genLoop++ ) {
+    
+    if(!(jetCollectionName.find("PPI")>1 && jetCollectionName.find("PPI")<jetCollectionName.size()) )
+      {
 
-        genJetInfo.recoJetPt       = -999.;
-        genJetInfo.recoJetRawPt    = -999.;
-        genJetInfo.recoJetBestPt   = -999.;
-        genJetInfo.recoJetMatch    =  0   ;
-        genJetInfo.recoJetEta      = -999.;
-        genJetInfo.dR              = -999.;
-        genJetInfo.pt              = -999.;
-        genJetInfo.eta             = -999.;
-        genJetInfo.phi             = -999.;
-        genJetInfo.PUJetID_betaStar = -999.;
-        genJetInfo.PUJetID_rms     = -999.;
-        genJetInfo.passesPUJetID   = -999;
-        genJetInfo.nDiphotons      = nDiphotons;
-
-        if( genJet->ptrAt( genLoop )->pt() < 20 ) { continue;}
-
-        genJetInfo.pt     = genJet->ptrAt( genLoop )->pt() ;
-        genJetInfo.eta    = genJet->ptrAt( genLoop )->eta();
-        genJetInfo.phi    = genJet->ptrAt( genLoop )->phi();
-
-        float deta;
-        float dphi;
-        float dr  ;
-
-        for( unsigned int recoLoop = 0; recoLoop <  jetsDz->size(); recoLoop++ ) {
-
-
-            if( jetsDz->ptrAt( recoLoop )->pt() < 5 ) { continue; }
-
-            deta = jetsDz->ptrAt( recoLoop )->eta() - 	 genJet->ptrAt( genLoop )->eta();
-            dphi = deltaPhi( jetsDz->ptrAt( recoLoop )->phi(), genJet->ptrAt( genLoop )->phi() );
-            dr = std::sqrt( deta * deta + dphi * dphi );
-
-            if( dr < 0.4 ) {
-                genJetInfo.dR      =  dr;
-                genJetInfo.recoJetPt       = jetsDz->ptrAt( recoLoop )->pt() ;
-                genJetInfo.recoJetRawPt    = jetsDz->ptrAt( recoLoop )->correctedJet( "Uncorrected" ).pt()  ;
-
-                // add the photon overlaping info
-                jetInfo tmpjetinfo = recojetmap[recoLoop];
-                genJetInfo.photonMatch     = tmpjetinfo.photonMatch;
-                genJetInfo.GenPhotonPt     = tmpjetinfo.GenPhotonPt;//recojetmap[recojetmap].GenPhotonPt  ;
-                genJetInfo.photondRmin     = tmpjetinfo.photondRmin;//recojetmap[recojetmap].photondRmin  ;
-
-
-
-                if( !( jetCollectionName.find( "PPI" ) > 1 && jetCollectionName.find( "PPI" ) < jetCollectionName.size() ) ) {
-                    genJetInfo.recoJetBestPt   =  jetsDz->ptrAt( recoLoop )->correctedJet( "Uncorrected" ).pt() ;
-                    if( ( diPhotons->size() > 0 ) &&
-                            ( ( jetCollectionName.find( "Leg" ) > 1 && jetCollectionName.find( "Leg" ) < jetCollectionName.size() ) || ( jetCollectionName.length()   < 3 ) ) ) { // for PF
-
-                        genJetInfo.PUJetID_betaStar        = jetsDz->ptrAt( recoLoop )->betaStar( diPhotons->ptrAt( 0 )->vtx() );
-                        genJetInfo.PUJetID_rms             = jetsDz->ptrAt( recoLoop )->rms( diPhotons->ptrAt( 0 )->vtx() );
-                        genJetInfo.passesPUJetID           = jetsDz->ptrAt( recoLoop )->passesPuJetId( diPhotons->ptrAt( 0 )->vtx() );
-
-                    } else {
-
-                        genJetInfo.PUJetID_betaStar        = jetsDz->ptrAt( recoLoop )->betaStar( primaryVertices->ptrAt( 0 ) );
-                        genJetInfo.PUJetID_rms             = jetsDz->ptrAt( recoLoop )->rms( primaryVertices->ptrAt( 0 ) );
-                        genJetInfo.passesPUJetID           = jetsDz->ptrAt( recoLoop )->passesPuJetId( primaryVertices->ptrAt( 0 ) );
-
-                    }
-                } else {
-
-                    genJetInfo.recoJetBestPt   = jetsDz->ptrAt( recoLoop )->pt()  ;
-                    genJetInfo.PUJetID_betaStar  = -999.;
-                    genJetInfo.PUJetID_rms       = -999.;
-                    genJetInfo.passesPUJetID     = -999;
-
-                }
-
-                genJetInfo.recoJetMatch    = 1 ;
-                break;
-            }
-        }
-
-        genJetTree->Fill();
+	if((diPhotons->size() > 0 ) && (jetCollectionName.find("Leg")!=std::string::npos)){
+	  jInfo.PUJetID_betaStar   = jetsDz->ptrAt( jdz )->betaStar     (diPhotons->ptrAt(0)->vtx());
+	  jInfo.PUJetID_rms        = jetsDz->ptrAt( jdz )->rms          (diPhotons->ptrAt(0)->vtx());
+	  jInfo.passesPUJetID      = jetsDz->ptrAt( jdz )->passesPuJetId(diPhotons->ptrAt(0)->vtx());
+	  
+	  //jInfo.jet_W       = jetsDz->ptrAt( jdz )->pileupJetIdentifier(diPhotons->ptrAt(0)->vtx()).jetW();
+	  //jInfo.jet_dR2Mean = jetsDz->ptrAt( jdz )->pileupJetIdentifier(diPhotons->ptrAt(0)->vtx()).dR2Mean();
+	  //jInfo.jet_dRMean  = jetsDz->ptrAt( jdz )->pileupJetIdentifier(diPhotons->ptrAt(0)->vtx()).dRMean();
+	  //jInfo.jet_dZ      = jetsDz->ptrAt( jdz )->pileupJetIdentifier(diPhotons->ptrAt(0)->vtx()).dZ();
+	  //jInfo.jet_ptD     = jetsDz->ptrAt( jdz )->pileupJetIdentifier(diPhotons->ptrAt(0)->vtx()).ptD();
+	  
+	} else {
+	  //std::cout << " ------->> use 0 vtx !!" << std::endl;
+	  jInfo.PUJetID_betaStar   = jetsDz->ptrAt( jdz )->betaStar     (vtxs->ptrAt(0));
+	  jInfo.PUJetID_rms        = jetsDz->ptrAt( jdz )->rms          (vtxs->ptrAt(0));
+	  jInfo.passesPUJetID      = jetsDz->ptrAt( jdz )->passesPuJetId(vtxs->ptrAt(0));
+	  
+	  //jInfo.jet_W       = jetsDz->ptrAt( jdz )->pileupJetIdentifier(vtxs->ptrAt(0)).jetW();
+	  //jInfo.jet_dR2Mean = jetsDz->ptrAt( jdz )->pileupJetIdentifier(vtxs->ptrAt(0)).dR2Mean();
+	  //jInfo.jet_dRMean  = jetsDz->ptrAt( jdz )->pileupJetIdentifier(vtxs->ptrAt(0)).dRMean();
+	  //jInfo.jet_dZ        = jetsDz->ptrAt( jdz )->pileupJetIdentifier(vtxs->ptrAt(0)).dZ();
+	  //jInfo.jet_ptD     = jetsDz->ptrAt( jdz )->pileupJetIdentifier(vtxs->ptrAt(0)).ptD();
+	  
+	}
+      } else {
+      
+      jInfo.PUJetID_betaStar       = -999.;
+      jInfo.PUJetID_rms            = -999.;
+      jInfo.passesPUJetID          = -999;
     }
+    jInfo.nDiphotons = nDiphotons;
+    jInfo.LegIsPV0   = legacyEqZeroth;
+    
+    // Get constituants information
+    jInfo.nPart     = jetsDz->ptrAt( jdz )->numberOfDaughters  ();
+    jInfo.nCharged  = jetsDz->ptrAt( jdz )->chargedMultiplicity();
+    jInfo.nNeutral  = jetsDz->ptrAt( jdz )->neutralMultiplicity();
+    jInfo.chgEmFrac = jetsDz->ptrAt( jdz )->chargedEmEnergy()/jetsDz->ptrAt( jdz )->energy(); //
+    jInfo.neuEmFrac = jetsDz->ptrAt( jdz )->neutralEmEnergy()/jetsDz->ptrAt( jdz )->energy(); //
 
-    eventTree->Fill();
-    event_number++;
+    // study of the pile-up jet id
+    double sumTkPt  = 0;
+    double beta     = 0;
+    double betaStar = 0;
+    //if(debug_ && std::abs(jetsDz->ptrAt( jdz )->eta())<2.5){
+    if(debug_ && std::abs(jetsDz->ptrAt( jdz )->eta())<2.5 && jetsDz->ptrAt( jdz )->pt() > 20.0 ){
+      std::cout << setw(12)<<"jet["<< jdz
+		<<"] nPuJetId( "   << jetsDz->ptrAt( jdz )->nPuJetId() << " )"
+		<<" vtx0==vtxgg( " << jInfo.LegIsPV0 << " )"
+		<< std::endl ;
+      std::cout << setw(6) <<"";
+      std::cout << setw(6) <<"=======================================================" << std::endl;
+      
+      std::cout << setw(12) << "index";
+      std::cout << setw(12) << "PDG";
+      std::cout << setw(12) << "pt";
+      std::cout << setw(12) << "dZ0";
+      std::cout << setw(12) << "dZ";
+      std::cout << setw(12) << "inVtx0";
+      std::cout << setw(12) << "inOtherVtx";
+      std::cout << std::endl;
+    }
+    
+    const std::vector<std::pair<edm::Ptr<reco::Vertex>, edm::Ptr<pat::PackedCandidate> > >&  vtxmap_ = *vtxmap;
+    for (unsigned int i = 0 ; i < jetsDz->ptrAt( jdz )->numberOfDaughters()  ; i++){
+      edm::Ptr<pat::PackedCandidate> icand = edm::Ptr<pat::PackedCandidate> (jetsDz->ptrAt( jdz )->daughterPtr(i) );
+      if ( icand->charge() == 0 ) continue ;
+      
+      float tkpt = icand->pt();
+      sumTkPt   += tkpt;
+      
+      double dZ0 = std::abs(icand->dz(vtxs->ptrAt(0)->position()));
+      double dZ  = dZ0;
+      for (flashgg::VertexCandidateMap::const_iterator vi = vtxmap_.begin() ; vi != vtxmap_.end() ; vi++){
+	const edm::Ptr<reco::Vertex> iv = (vi->first);
+	if( iv->isFake() || iv->ndof() < 4 ) { continue; }
+	dZ = std::min<double>(dZ,std::abs(icand->dz(iv->position())));
+      }
+      
+      bool inVtx0       = false;
+      bool inAnotherVtx = false;
+      
+      if( dZ0 < 0.2 ) {
+	inVtx0 = true;
+	beta += tkpt;
+      } else if( dZ < 0.2 ) {
+	inAnotherVtx =true;
+	betaStar += tkpt;
+      } 
+
+      if(debug_ && std::abs(jetsDz->ptrAt( jdz )->eta())<2.5 && jetsDz->ptrAt( jdz )->pt() > 20.0 ){
+	std::cout << setw(12) << i;
+	std::cout << setw(12) << icand->pdgId();
+	std::cout << setw(12) << icand->pt();
+	std::cout << setw(12) << dZ0;
+	std::cout << setw(12) << dZ;
+	std::cout << setw(12) << inVtx0;
+	std::cout << setw(12) << inAnotherVtx;
+	std::cout << std::endl;
+      }
+    }
+    
+    if( sumTkPt != 0. ) {
+      beta     = beta    /sumTkPt;
+      betaStar = betaStar/sumTkPt;
+    }else{
+      beta     = -1;
+      betaStar = -1;
+    }
+    
+    
+    jInfo.mybetaStar = betaStar;
+    jInfo.mybeta     = beta;
+    
+    if(debug_ && std::abs(jetsDz->ptrAt( jdz )->eta())<2.5 && jetsDz->ptrAt( jdz )->pt() > 20.0 ){
+      std::cout << setw(6)  <<"";
+      std::cout << setw(6)  <<"-------------------------------------------------------" << std::endl;
+      std::cout << setw(12) << "id";
+      std::cout << setw(12) << "pt";
+      std::cout << setw(12) << "eta";
+      std::cout << setw(12) << "genMatch";
+      std::cout << setw(12) << "DrMatch";
+      std::cout << setw(12) << "betaStar";
+      std::cout << setw(12) << "newBetaStar";
+      std::cout << setw(12) << "isPhoton";
+      std::cout << setw(12) << "vtx_0";
+      std::cout << setw(12) << "vtx_gg";
+      std::cout << std::endl;
+      
+      std::cout << setw(12) << jdz;
+      std::cout << setw(12) << jetsDz->ptrAt( jdz )->pt();
+      std::cout << setw(12) << jetsDz->ptrAt( jdz )->eta();
+      std::cout << setw(12) << jInfo.genJetMatch;
+      std::cout << setw(12) << jInfo.genJetdRmin;
+      std::cout << setw(12) << jInfo.PUJetID_betaStar;
+      std::cout << setw(12) << jInfo.mybetaStar;
+      std::cout << setw(12) << jInfo.photonMatch;
+      std::cout << setw(12) << vtxs->ptrAt(0)->position().z();
+      
+      if(diPhotons->size()>0) std::cout << setw(12) << diPhotons->ptrAt(0)->vtx()->position().z();
+      else                    std::cout << setw(12) << "no gg";
+      
+      std::cout << std::endl;
+      std::cout << setw(6) <<"";
+      std::cout << setw(6) <<"=======================================================" << std::endl;
+    }
+    
+    recojetmap[jdz] = jInfo;
+    jetTree->Fill();
+  }// ++++ end loop reco jets
+  // loop over the GenJets
+  for( unsigned int genLoop =0 ; genLoop < genJets->size(); genLoop++){
+    
+    genJetInfo.recoJetPt       = -999.;
+    genJetInfo.recoJetRawPt    = -999.;
+    genJetInfo.recoJetBestPt   = -999.;
+    genJetInfo.recoJetMatch    =  0   ;
+    genJetInfo.recoJetEta      = -999.;
+    genJetInfo.dR              = -999.;
+    genJetInfo.pt              = -999.;
+    genJetInfo.eta             = -999.;
+    genJetInfo.phi             = -999.;
+    genJetInfo.PUJetID_betaStar= -999.;
+    genJetInfo.PUJetID_rms     = -999.;
+    genJetInfo.passesPUJetID   = -999;
+    genJetInfo.nDiphotons      = nDiphotons;
+    
+    if (genJets->ptrAt( genLoop )->pt() <20) { continue;}
+    
+    genJetInfo.pt     = genJets->ptrAt( genLoop )->pt() ;
+    genJetInfo.eta    = genJets->ptrAt( genLoop )->eta();
+    genJetInfo.phi    = genJets->ptrAt( genLoop )->phi();
+    
+    // ===========================
+    // +++ new code for the matching based on the minimum
+    // as the one I used for the photon overlaping
+    
+    std::map<float,unsigned int> minim;
+    //float DeltaRmin=999.;
+    // take only the jets without photons
+    /*
+    for( unsigned int jetLoop =0 ; jetLoop < jetsDz->size(); jetLoop++){
+      float dphi  = jetsDz[jetLoop]->phi() -  gens->ptrAt( genLoop )->phi();
+      float deta  = jetsDz[jetLoop]->eta() -  gens->ptrAt( genLoop )->eta();
+      float dr    =  std::sqrt(deta*deta + dphi*dphi);
+      
+      DeltaRmin = std::min (dr, DeltaRmin);
+      minim[dr] = jetLoop; 
+    }
+    
+    unsigned int bestjetid = minim.find(DeltaRmin)->second;
+    if(DeltaRmin < 100){
+      genJetInfo.dR              = DeltaRmin;
+      genJetInfo.recoJetPt       = jetsDz[bestjetid]->pt() ;
+      genJetInfo.recoJetRawPt    = jetsDz[bestjetid]->correctedJet("Uncorrected").pt()  ;
+      
+      
+      // ABOUT THE OVERLAPING PHOTON
+      genJetInfo.photonMatch       = _isPhoton[bestjetid];
+      if (_isPhoton[bestjetid]){ 
+	jetInfo tmpjetinfo          = recojetmap[bestjetid];
+	genJetInfo.GenPhotonPt     = tmpjetinfo.GenPhotonPt;
+	genJetInfo.photondRmin     = tmpjetinfo.photondRmin;
+      }else{
+	genJetInfo.GenPhotonPt     = -999;
+	genJetInfo.photondRmin     = -999;
+      }
+      
+      if(!(jetCollectionName.find("PPI")>1 && jetCollectionName.find("PPI")<jetCollectionName.size())){
+	genJetInfo.recoJetBestPt   =  jetsDz[bestjetid]->correctedJet("Uncorrected").pt() ;
+	if( (diPhotons.size() > 0 ) && 
+	    ((jetCollectionName.find("Leg")>1 && jetCollectionName.find("Leg")<jetCollectionName.size())||(jetCollectionName.length()   <3 )) ) { // for PF
+	  
+	  genJetInfo.PUJetID_betaStar        = jetsDz[bestjetid]->betaStar(diPhotons->ptrAt(0)->getvtx());
+	  genJetInfo.PUJetID_rms             = jetsDz[bestjetid]->RMS(diPhotons->ptrAt(0)->getvtx());
+	  genJetInfo.passesPUJetID           = jetsDz[bestjetid]->passesPuJetId(diPhotons->ptrAt(0)->getvtx());
+	} else {
+	  genJetInfo.PUJetID_betaStar        = jetsDz[bestjetid]->betaStar(vtxs->ptrAt(0));
+	  genJetInfo.PUJetID_rms             = jetsDz[bestjetid]->RMS(vtxs->ptrAt(0));
+	  genJetInfo.passesPUJetID           = jetsDz[bestjetid]->passesPuJetId(vtxs->ptrAt(0));
+	  
+	}
+      } else {
+	genJetInfo.recoJetBestPt   = jetsDz[bestjetid]->pt()  ;
+	genJetInfo.PUJetID_betaStar  = -999.;
+	genJetInfo.PUJetID_rms       = -999.;
+	genJetInfo.passesPUJetID     = -999;
+      }
+      
+      genJetInfo.recoJetMatch    = 1 ;
+    }
+    */
+    // ===========================
+    for (unsigned int recoLoop=0; recoLoop <  jetsDz->size(); recoLoop++){
+      if(jetsDz->ptrAt( recoLoop )->pt() < 5) continue;
+
+      double deta= jetsDz->ptrAt( recoLoop )->eta() - 	 genJets->ptrAt( genLoop )->eta();
+      double dphi= jetsDz->ptrAt( recoLoop )->phi() - 	 genJets->ptrAt( genLoop )->phi();
+      double dr = std::sqrt(deta*deta + dphi*dphi);
+      if (dr < 0.4 ) {
+	genJetInfo.dR      =  dr;
+	genJetInfo.recoJetPt       = jetsDz->ptrAt( recoLoop )->pt() ;
+	genJetInfo.recoJetRawPt    = jetsDz->ptrAt( recoLoop )->correctedJet("Uncorrected").pt()  ;
+
+	// add the photon overlaping info 
+	jetInfo tmpjetinfo = recojetmap[recoLoop];
+	genJetInfo.photonMatch     = tmpjetinfo.photonMatch;
+	genJetInfo.GenPhotonPt     = tmpjetinfo.GenPhotonPt;//recojetmap[recojetmap].GenPhotonPt  ;
+	genJetInfo.photondRmin     = tmpjetinfo.photondRmin;//recojetmap[recojetmap].photondRmin  ;
+	
+	if(!(jetCollectionName.find("PPI")>1 && jetCollectionName.find("PPI")<jetCollectionName.size())){
+	  genJetInfo.recoJetBestPt   =  jetsDz->ptrAt( recoLoop )->correctedJet("Uncorrected").pt() ;
+	  if( (diPhotons->size() > 0 ) && (jetCollectionName.find("Leg")!=std::string::npos)){
+	    //((jetCollectionName.find("Leg")>1 && jetCollectionName.find("Leg")<jetCollectionName.size())||(jetCollectionName.length()   <3 )) ) {
+	    
+	    genJetInfo.PUJetID_betaStar        = jetsDz->ptrAt( recoLoop )->betaStar(diPhotons->ptrAt(0)->vtx());
+	    genJetInfo.PUJetID_rms             = jetsDz->ptrAt( recoLoop )->rms(diPhotons->ptrAt(0)->vtx());
+	    genJetInfo.passesPUJetID           = jetsDz->ptrAt( recoLoop )->passesPuJetId(diPhotons->ptrAt(0)->vtx());
+	  } else {
+	    genJetInfo.PUJetID_betaStar        = jetsDz->ptrAt( recoLoop )->betaStar(vtxs->ptrAt(0));
+	    genJetInfo.PUJetID_rms             = jetsDz->ptrAt( recoLoop )->rms(vtxs->ptrAt(0));
+	    genJetInfo.passesPUJetID           = jetsDz->ptrAt( recoLoop )->passesPuJetId(vtxs->ptrAt(0));
+	  }
+	} else {
+	  genJetInfo.recoJetBestPt   = jetsDz->ptrAt( recoLoop )->pt()  ;
+	  genJetInfo.PUJetID_betaStar  = -999.;
+	  genJetInfo.PUJetID_rms       = -999.;
+	  genJetInfo.passesPUJetID     = -999;
+	}
+	
+	genJetInfo.recoJetMatch    = 1 ;
+	break;
+      }
+    }
+    genJetTree->Fill();
+  }
+
+  eventTree->Fill();
+  event_number++;
 }
 
-void
+void 
 JetValidationTreeMaker::beginJob()
 {
-    // +++ trees
-    std::string type( "eventTree_" );
-    type += jetCollectionName;
+  // +++ trees 
+  std::string type("eventTree_");
+  type += jetCollectionName;
 
-    eventTree = fs_->make<TTree>( type.c_str(), jetCollectionName.c_str() );
-    eventTree->Branch( "eventBranch", &eInfo.legacyEqZeroth, "legacyEqZeroth/I:nDiphotons/I" );
+  eventTree = fs_->make<TTree>(type.c_str(),jetCollectionName.c_str());
+  eventTree->Branch("eventBranch",&eInfo.legacyEqZeroth,"legacyEqZeroth/I:nDiphotons/I");
 
-    std::string typeJet( "jetTree_" );
-    typeJet += jetCollectionName;
-    jetTree = fs_->make<TTree>( typeJet.c_str(), jetCollectionName.c_str() );
-    jetTree->Branch( "pt"              , &jInfo.pt                , "pt/F" );
-    jetTree->Branch( "rawPt"           , &jInfo.rawPt             , "rawPt/F" );
-    jetTree->Branch( "bestPt"          , &jInfo.bestPt            , "bestPt/F" );
-    jetTree->Branch( "energy"          , &jInfo.energy            , "energy/F" );
-    jetTree->Branch( "mass"            , &jInfo.mass              , "mass/F" );
-    jetTree->Branch( "eta"             , &jInfo.eta               , "eta/F" );
-    jetTree->Branch( "phi"             , &jInfo.phi               , "phi/F" );
-    jetTree->Branch( "PUJetID_betaStar", &jInfo.PUJetID_betaStar  , "PUJetID_betaStar/F" );
-    jetTree->Branch( "PUJetID_rms"     , &jInfo.PUJetID_rms       , "PUJetID_rms/F" );
-    jetTree->Branch( "passesPUJetID"   , &jInfo.passesPUJetID     , "passesPUJetID/I" );
-    jetTree->Branch( "JetArea"         , &jInfo.area              , "area/F" );
-    jetTree->Branch( "nDiphotons"      , &jInfo.nDiphotons        , "nDiphotons/I" );
+  std::string typeJet("jetTree_");
+  typeJet += jetCollectionName;
+  jetTree = fs_->make<TTree>(typeJet.c_str(),jetCollectionName.c_str());
+  jetTree->Branch("pt"              ,&jInfo.pt                ,"pt/F" );
+  jetTree->Branch("rawPt"           ,&jInfo.rawPt             ,"rawPt/F" );
+  jetTree->Branch("bestPt"          ,&jInfo.bestPt            ,"bestPt/F" );
+  jetTree->Branch("energy"          ,&jInfo.energy            ,"energy/F" );
+  jetTree->Branch("mass"            ,&jInfo.mass              ,"mass/F" );
+  jetTree->Branch("eta"             ,&jInfo.eta               ,"eta/F");
+  jetTree->Branch("phi"             ,&jInfo.phi               ,"phi/F");
+  
+  jetTree->Branch("PlanarFlow"      ,&jInfo.PlanarFlow        ,"PlanarFlow/F");
+  jetTree->Branch("S"               ,&jInfo.S                 ,"S/F");
+  jetTree->Branch("Q"               ,&jInfo.Q                 ,"Q/F");
+  
+  jetTree->Branch("passesPUJetID"   ,&jInfo.passesPUJetID     ,"passesPUJetID/I");
+  jetTree->Branch("JetArea"         ,&jInfo.area              ,"area/F");
+  jetTree->Branch("nDiphotons"      ,&jInfo.nDiphotons        ,"nDiphotons/I");
+  jetTree->Branch("nPV"             ,&jInfo.nPV               ,"nPV/I");
+  jetTree->Branch("nJets"           ,&jInfo.nJets             ,"nJets/I");
+  jetTree->Branch("LegIsPV0"        ,&jInfo.LegIsPV0          ,"LegIsPV0/I");
+  
+  
+  // ===== PUJID variables
+  jetTree->Branch("betaStar" ,&jInfo.PUJetID_betaStar ,"betaStar/F");
+  jetTree->Branch("rms"      ,&jInfo.PUJetID_rms      ,"rms/F");
+  jetTree->Branch("W"        ,&jInfo.jet_W            ,"W/F");
+  jetTree->Branch("dR2Mean"  ,&jInfo.jet_dR2Mean      ,"dR2Mean/F");
+  jetTree->Branch("dRMean"   ,&jInfo.jet_dRMean       ,"dRMean/F");
+  jetTree->Branch("dZ"       ,&jInfo.jet_dZ           ,"dZ/F");
+  jetTree->Branch("ptD"      ,&jInfo.jet_ptD          ,"ptD/F");
+  // =====
+  
+  jetTree->Branch("id"        ,&jInfo.id        ,"id/I");
+  jetTree->Branch("nPart"     ,&jInfo.nPart     ,"nPart/I");
+  jetTree->Branch("nCharged"  ,&jInfo.nCharged  ,"nCharged/I");
+  jetTree->Branch("nNeutral"  ,&jInfo.nNeutral  ,"nNeutral/F");
+  jetTree->Branch("chgEmFrac" ,&jInfo.chgEmFrac ,"chgEmFrac/F");
+  jetTree->Branch("neuEmFrac" ,&jInfo.neuEmFrac ,"neuEmFrac/F");
+  
+  jetTree->Branch("genJetPt"       ,&jInfo.genJetPt     ,"genJetPt/F" );
+  jetTree->Branch("genJetEta"      ,&jInfo.genJetEta    ,"genJetEta/F" );
+  jetTree->Branch("genJetMatch"    ,&jInfo.genJetMatch  ,"genJetMatch/I" );
+  jetTree->Branch("genQuarkPt"     ,&jInfo.genQuarkPt   ,"genQuarkPt/F" );
+  jetTree->Branch("genQuarkEta"    ,&jInfo.genQuarkEta  ,"genQuarkEta/F" );
+  jetTree->Branch("genQuarkMatch"  ,&jInfo.genQuarkMatch,"genQuarkMatch/I" );
+  jetTree->Branch("genQuarkPdgId"  ,&jInfo.genQuarkPdgId,"genQuarkPdfId/I" );
+  
+  jetTree->Branch("photonMatch"    ,&jInfo.photonMatch  ,"photonMatch/I" );
+  jetTree->Branch("photondRmin"    ,&jInfo.photondRmin  ,"photondRmin/F" );
+  jetTree->Branch("GenPhotonPt"    ,&jInfo.GenPhotonPt   ,"GenPhotonPt/F" );
+  jetTree->Branch("GenPhotonEta"   ,&jInfo.GenPhotonEta  ,"GenPhotonEta/F" );
+  jetTree->Branch("GenPhotonPhi"   ,&jInfo.GenPhotonPhi  ,"GenPhotonPhi/F" );
+  
+  genPartTree = fs_->make<TTree>("genPartTree","Check per-jet tree");
+  genPartTree->Branch("pt"     ,&genInfo.pt      ,"pt/F" );
+  genPartTree->Branch("eta"    ,&genInfo.eta     ,"eta/F");
+  genPartTree->Branch("phi"    ,&genInfo.phi     ,"phi/F");
+  genPartTree->Branch("status" ,&genInfo.status  ,"status/I" );
+  genPartTree->Branch("pdgid"  ,&genInfo.pdgid   ,"pdgid/I");
+  genPartTree->Branch("y"      ,&genInfo.y       ,"y/F");   
+  
+  //genPartTree->SetBranchStatus( 'p4.*', 1 );
+  
+  std::string typeGenJet("genJetTree_");
+  typeGenJet += jetCollectionName;
+  genJetTree = fs_->make<TTree>(typeGenJet.c_str(),jetCollectionName.c_str());
+  genJetTree->Branch("pt"     ,&genJetInfo.pt      ,"pt/F" );
+  genJetTree->Branch("eta"    ,&genJetInfo.eta     ,"eta/F");
+  genJetTree->Branch("phi"    ,&genJetInfo.phi     ,"phi/F");
 
-    jetTree->Branch( "npart_0"        , &jInfo.npart_0      , "npart_0/I" );
-    jetTree->Branch( "npart_5"        , &jInfo.npart_5      , "npart_5/I" );
-    jetTree->Branch( "npart_10"       , &jInfo.npart_10     , "npart_10/I" );
-    jetTree->Branch( "npart_20"       , &jInfo.npart_20     , "npart_20/I" );
+  genJetTree->Branch("recoJetPt"        ,&genJetInfo.recoJetPt        ,"recoJetPt/F" );
+  genJetTree->Branch("recoJetRawPt"     ,&genJetInfo.recoJetRawPt     ,"recoJetRawPt/F" );
+  genJetTree->Branch("recoJetBestPt"    ,&genJetInfo.recoJetBestPt    ,"recoJetBestPt/F");
+  genJetTree->Branch("recoJetMatch"     ,&genJetInfo.recoJetMatch     ,"recoJetMatch/I");
+  genJetTree->Branch("recoJetEta"       ,&genJetInfo.recoJetEta       ,"recoJetEta/F" );
+  genJetTree->Branch("dR"               ,&genJetInfo.dR               ,"dR/F" );
+  genJetTree->Branch("PUJetID_betaStar" ,&genJetInfo.PUJetID_betaStar ,"PUJetID_betaStar/F");
+  genJetTree->Branch("PUJetID_rms"      ,&genJetInfo.PUJetID_rms      ,"PUJetID_rms/F");
+  genJetTree->Branch("passesPUJetID"    ,&genJetInfo.passesPUJetID    ,"passesPUJetID/I");
+  genJetTree->Branch("nDiphotons"       ,&genJetInfo.nDiphotons        ,"nDiphotons/I");
 
-    jetTree->Branch( "ncharged_0"     , &jInfo.ncharged_0   , "ncharged_0/I" );
-    jetTree->Branch( "ncharged_5"     , &jInfo.ncharged_5   , "ncharged_5/I" );
-    jetTree->Branch( "ncharged_10"    , &jInfo.ncharged_10  , "ncharged_10/I" );
-    jetTree->Branch( "ncharged_20"    , &jInfo.ncharged_20  , "ncharged_20/I" );
-
-    jetTree->Branch( "photon_0"       , &jInfo.nphoton_0    , "nphoton_0/I" );
-    jetTree->Branch( "photon_5"       , &jInfo.nphoton_5    , "nphoton_5/I" );
-    jetTree->Branch( "photon_10"      , &jInfo.nphoton_10   , "nphoton_10/I" );
-    jetTree->Branch( "photon_20"      , &jInfo.nphoton_20   , "nphoton_20/I" );
-
-    jetTree->Branch( "genJetPt"       , &jInfo.genJetPt     , "genJetPt/F" );
-    jetTree->Branch( "genJetEta"      , &jInfo.genJetEta    , "genJetEta/F" );
-    jetTree->Branch( "genJetMatch"    , &jInfo.genJetMatch  , "genJetMatch/I" );
-    jetTree->Branch( "genQuarkPt"     , &jInfo.genQuarkPt   , "genQuarkPt/F" );
-    jetTree->Branch( "genQuarkEta"    , &jInfo.genQuarkEta  , "genQuarkEta/F" );
-    jetTree->Branch( "genQuarkMatch"  , &jInfo.genQuarkMatch, "genQuarkMatch/I" );
-    jetTree->Branch( "genQuarkPdgId"  , &jInfo.genQuarkPdgId, "genQuarkPdfId/I" );
-
-    jetTree->Branch( "photonMatch"    , &jInfo.photonMatch  , "photonMatch/I" );
-    jetTree->Branch( "photondRmin"    , &jInfo.photondRmin  , "photondRmin/F" );
-
-    jetTree->Branch( "GenPhotonPt"    , &jInfo.GenPhotonPt   , "GenPhotonPt/F" );
-    jetTree->Branch( "GenPhotonEta"   , &jInfo.GenPhotonEta  , "GenPhotonEta/F" );
-    jetTree->Branch( "GenPhotonPhi"   , &jInfo.GenPhotonPhi  , "GenPhotonPhi/F" );
-
-    genPartTree = fs_->make<TTree>( "genPartTree", "Check per-jet tree" );
-    genPartTree->Branch( "pt"     , &genInfo.pt      , "pt/F" );
-    genPartTree->Branch( "eta"    , &genInfo.eta     , "eta/F" );
-    genPartTree->Branch( "phi"    , &genInfo.phi     , "phi/F" );
-    genPartTree->Branch( "status" , &genInfo.status  , "status/I" );
-    genPartTree->Branch( "pdgid"  , &genInfo.pdgid   , "pdgid/I" );
-
-    std::string typeGenJet( "genJetTree_" );
-    typeGenJet += jetCollectionName;
-    genJetTree = fs_->make<TTree>( typeGenJet.c_str(), jetCollectionName.c_str() );
-    genJetTree->Branch( "pt"     , &genJetInfo.pt      , "pt/F" );
-    genJetTree->Branch( "eta"    , &genJetInfo.eta     , "eta/F" );
-    genJetTree->Branch( "phi"    , &genJetInfo.phi     , "phi/F" );
-
-    genJetTree->Branch( "recoJetPt"        , &genJetInfo.recoJetPt        , "recoJetPt/F" );
-    genJetTree->Branch( "recoJetRawPt"     , &genJetInfo.recoJetRawPt     , "recoJetRawPt/F" );
-    genJetTree->Branch( "recoJetBestPt"    , &genJetInfo.recoJetBestPt    , "recoJetBestPt/F" );
-    genJetTree->Branch( "recoJetMatch"     , &genJetInfo.recoJetMatch     , "recoJetMatch/I" );
-    genJetTree->Branch( "recoJetEta"       , &genJetInfo.recoJetEta       , "recoJetEta/F" );
-    genJetTree->Branch( "dR"               , &genJetInfo.dR               , "dR/F" );
-    genJetTree->Branch( "PUJetID_betaStar" , &genJetInfo.PUJetID_betaStar , "PUJetID_betaStar/F" );
-    genJetTree->Branch( "PUJetID_rms"      , &genJetInfo.PUJetID_rms      , "PUJetID_rms/F" );
-    genJetTree->Branch( "passesPUJetID"    , &genJetInfo.passesPUJetID    , "passesPUJetID/I" );
-    genJetTree->Branch( "nDiphotons"       , &genJetInfo.nDiphotons        , "nDiphotons/I" );
-
-    genJetTree->Branch( "photonMatch"      , &genJetInfo.photonMatch  , "photonMatch/I" );
-    genJetTree->Branch( "photondRmin"      , &genJetInfo.photondRmin  , "photondRmin/F" );
-    genJetTree->Branch( "GenPhotonPt"      , &genJetInfo.GenPhotonPt  , "GenPhotonPt/F" );
+  genJetTree->Branch("photonMatch"      ,&genJetInfo.photonMatch  ,"photonMatch/I" );
+  genJetTree->Branch("photondRmin"      ,&genJetInfo.photondRmin  ,"photondRmin/F" );
+  genJetTree->Branch("GenPhotonPt"      ,&genJetInfo.GenPhotonPt  ,"GenPhotonPt/F" );
 
 }
 
-void JetValidationTreeMaker::endJob()
+void JetValidationTreeMaker::endJob() 
 {
 
 }
 
-void JetValidationTreeMaker::initEventStructure()
+void JetValidationTreeMaker::initEventStructure() 
 {
 
 }
 
 
-void JetValidationTreeMaker::fillDescriptions( edm::ConfigurationDescriptions &descriptions )
-{
-    // The following says we do not know what parameters are allowed so do no validation
-    // Please change this to state exactly what you do use, even if it is no parameters
-    edm::ParameterSetDescription desc;
-    desc.setUnknown();
-    descriptions.addDefault( desc );
+void JetValidationTreeMaker::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  // The following says we do not know what parameters are allowed so do no validation
+  // Please change this to state exactly what you do use, even if it is no parameters
+  edm::ParameterSetDescription desc;
+  desc.setUnknown();
+  descriptions.addDefault(desc);
 }
 
 typedef JetValidationTreeMaker FlashggJetValidationTreeMaker;
-DEFINE_FWK_MODULE( FlashggJetValidationTreeMaker );
-// Local Variables:
-// mode:c++
-// indent-tabs-mode:nil
-// tab-width:4
-// c-basic-offset:4
-// End:
-// vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4
-
+DEFINE_FWK_MODULE(FlashggJetValidationTreeMaker);

--- a/Validation/python/jets_producer_grid.py
+++ b/Validation/python/jets_producer_grid.py
@@ -1,0 +1,117 @@
+import FWCore.ParameterSet.Config as cms
+import FWCore.Utilities.FileUtils as FileUtils
+ 
+process = cms.Process("FLASHggMicroAOD")
+ 
+process.load("FWCore.MessageService.MessageLogger_cfi")
+process.load("Configuration.StandardSequences.GeometryDB_cff")
+process.load("Configuration.StandardSequences.MagneticField_cff")
+
+process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:run2_mc')
+
+process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32( -1 ) )
+process.MessageLogger.cerr.FwkReport.reportEvery = cms.untracked.int32( 100 )
+
+# PHYS14 Files
+process.source = cms.Source("PoolSource",fileNames=cms.untracked.vstring(
+    "/store/mc/Phys14DR/GluGluToHToGG_M-125_13TeV-powheg-pythia6/MINIAODSIM/PU20bx25_tsg_PHYS14_25_V1-v1/00000/3C2EFAB1-B16F-E411-AB34-7845C4FC39FB.root"
+))
+
+process.MessageLogger.cerr.threshold = 'ERROR' # can't get suppressWarning to work: disable all warnings for now
+# process.MessageLogger.suppressWarning.extend(['SimpleMemoryCheck','MemoryCheck']) # this would have been better...
+
+# Uncomment the following if you notice you have a memory leak
+# This is a lightweight tool to digg further
+#process.SimpleMemoryCheck = cms.Service("SimpleMemoryCheck",
+#                                        ignoreTotal = cms.untracked.int32(1),
+#                                        monitorPssAndPrivate = cms.untracked.bool(True)
+#                                       )
+
+process.load("flashgg/MicroAOD/flashggMicroAODSequence_cff")
+process.load("flashgg/MicroAOD/flashggMicroAODExtraJetsSequence_cff")
+process.load("flashgg/Validation/JetTreeMaker_cff")
+
+from flashgg.MicroAOD.flashggMicroAODOutputCommands_cff import microAODDefaultOutputCommand,microAODDebugOutputCommand
+process.out = cms.OutputModule("PoolOutputModule",
+                               fileName       = cms.untracked.string('myMicroAODOutputFile.root'),
+                               outputCommands = microAODDefaultOutputCommand
+                           )
+
+process.out.outputCommands += microAODDebugOutputCommand # extra items for debugging, CURRENTLY REQUIRED
+ 
+# need to allow unscheduled processes otherwise reclustering function will fail
+# this is because of the jet clustering tool, and we have to live with it for now.
+process.options = cms.untracked.PSet(
+    allowUnscheduled = cms.untracked.bool(True)
+)
+
+# ++++++++++++ PF +++++++++++++++++++
+# uses the vertex 0
+from flashgg.MicroAOD.flashggExtraJets_cfi import addFlashggPF
+addFlashggPF(process)
+# +++++++++++++++++++++++++++++++++++
+
+# ++++++++++++ PFCHS0 +++++++++++++++
+# uses the vertex 0
+from flashgg.MicroAOD.flashggExtraJets_cfi import addFlashggPFCHS0
+addFlashggPFCHS0(process)
+# +++++++++++++++++++++++++++++++++++
+
+# ++++++++++++ PFCHSLeg +++++++++++++
+# import function which takes care of reclustering the jets using legacy vertex     
+from flashgg.MicroAOD.flashggJets_cfi import addFlashggPFCHSLegJets 
+# call the function, it takes care of everything else.
+addFlashggPFCHSLegJets(process)
+# +++++++++++++++++++++++++++++++++++
+
+
+# ++++++++++++ JetTreeMaker +++++++++
+#process.TFileService = cms.Service("TFileService",
+#                                   fileName  = cms.string("JetValidationTrees_DYToMuMu_M-50.root"))
+
+#process.flashggJetValidationTreeMakerPF = cms.EDAnalyzer('FlashggJetValidationTreeMaker',
+#                                                         GenParticleTag        = cms.untracked.InputTag('prunedGenParticles'),
+#                                                         JetTagDz              = cms.InputTag("flashggJetsPF"),
+#                                                         StringTag	     = cms.string("PF"),
+#                                                         VertexCandidateMapTag = cms.InputTag("flashggVertexMapUnique"),
+#                                                     )
+#process.flashggJetValidationTreeMakerPFCHS0 = cms.EDAnalyzer('FlashggJetValidationTreeMaker',
+#                                                             GenParticleTag     = cms.untracked.InputTag('prunedGenParticles'),
+#                                                             JetTagDz           = cms.InputTag("flashggJetsPFCHS0"),
+#                                                             StringTag		= cms.string("PFCHS0"),
+#                                                             VertexCandidateMapTag = cms.InputTag("flashggVertexMapUnique"),
+#                                                         )
+#
+#process.flashggJetValidationTreeMakerPFCHSLeg = cms.EDAnalyzer('FlashggJetValidationTreeMaker',
+#                                                               GenParticleTag = cms.untracked.InputTag('prunedGenParticles'),
+#                                                               JetTagDz       = cms.InputTag("flashggJets"),                  
+#                                                               StringTag	= cms.string("PFCHSLeg"),
+#                                                               VertexCandidateMapTag = cms.InputTag("flashggVertexMapUnique"),
+#                                                           )
+# +++++++++++++++++++++++++++++++++
+
+process.p = cms.Path(process.flashggMicroAODSequence
+                     + process.flashggMicroAODExtraJetsSequence
+                     # tree producer ...
+                     #+ process.flashggJetValidationTreeMakerPF 
+                     #+ process.flashggJetValidationTreeMakerPFCHS0
+                     #+ process.flashggJetValidationTreeMakerPFCHSLeg
+                 )
+
+process.e = cms.EndPath(process.out)
+
+# Uncomment these lines to run the example commissioning module and send its output to root
+# process.commissioning = cms.EDAnalyzer('flashggCommissioning',
+#                                         PhotonTag=cms.untracked.InputTag('flashggPhotons'),
+#                                         DiPhotonTag = cms.untracked.InputTag('flashggDiPhotons'),
+#                                         VertexTag=cms.untracked.InputTag('offlineSlimmedPrimaryVertices')
+#)
+#process.TFileService = cms.Service("TFileService",
+#                                   fileName = cms.string("commissioningTree.root")
+#)
+#process.p *= process.commissioning
+
+from flashgg.MicroAOD.MicroAODCustomize import customize
+customize(process)

--- a/Validation/python/jets_producer_local.py
+++ b/Validation/python/jets_producer_local.py
@@ -12,11 +12,11 @@ process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
 from Configuration.AlCa.GlobalTag import GlobalTag
 process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:run2_mc')
 
-process.maxEvents  = cms.untracked.PSet( input = cms.untracked.int32( 500 ) )
+process.maxEvents  = cms.untracked.PSet( input = cms.untracked.int32( 100 ) )
 process.MessageLogger.cerr.FwkReport.reportEvery = cms.untracked.int32( 100 )
 
 
-jdebug=False
+jdebug=True
 
 # PHYS14 Files
 process.source = cms.Source("PoolSource",fileNames=cms.untracked.vstring(
@@ -46,7 +46,7 @@ process.load("flashgg/Validation/JetTreeMaker_cff")
 
 from flashgg.MicroAOD.flashggMicroAODOutputCommands_cff import microAODDefaultOutputCommand,microAODDebugOutputCommand
 process.out = cms.OutputModule("PoolOutputModule",
-                               fileName       = cms.untracked.string('myMicroAODOutputFile.root'),
+                               fileName       = cms.untracked.string('.workspace/myMicroAODOutputFile.root'),
                                outputCommands = microAODDefaultOutputCommand
                            )
 

--- a/Validation/python/jets_producer_local.py
+++ b/Validation/python/jets_producer_local.py
@@ -1,0 +1,134 @@
+import FWCore.ParameterSet.Config as cms
+import FWCore.Utilities.FileUtils as FileUtils
+ 
+process = cms.Process("FLASHggMicroAOD")
+ 
+process.load("FWCore.MessageService.MessageLogger_cfi")
+ 
+process.load("Configuration.StandardSequences.GeometryDB_cff")
+process.load("Configuration.StandardSequences.MagneticField_cff")
+
+#process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
+#process.GlobalTag.globaltag = 'PLS170_V7AN1::All'
+#process.GlobalTag.globaltag = 'auto:run2_mc'
+
+process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:run2_mc')
+
+process.maxEvents  = cms.untracked.PSet( input = cms.untracked.int32( 1000 ) )
+process.MessageLogger.cerr.FwkReport.reportEvery = cms.untracked.int32( 100 )
+
+
+# PHYS14 Files
+process.source = cms.Source("PoolSource",fileNames=cms.untracked.vstring(
+    #"/store/mc/Phys14DR/DYToMuMu_M-50_Tune4C_13TeV-pythia8/MINIAODSIM/PU40bx25_tsg_castor_PHYS14_25_V1-v2/00000/622CAFBA-BD9A-E411-BE11-002481E14FFC.root",
+    #"/store/mc/Phys14DR/DYToMuMu_M-50_Tune4C_13TeV-pythia8/MINIAODSIM/PU40bx25_tsg_castor_PHYS14_25_V1-v2/00000/FA4B46B9-8E9A-E411-A899-002590A3C954.root",
+    #"/store/mc/Phys14DR/DYToMuMu_M-50_Tune4C_13TeV-pythia8/MINIAODSIM/PU40bx25_tsg_castor_PHYS14_25_V1-v2/10000/8607F88E-F799-E411-A180-0025B3E063F0.root",
+    #"/store/mc/Phys14DR/DYToMuMu_M-50_Tune4C_13TeV-pythia8/MINIAODSIM/PU40bx25_tsg_castor_PHYS14_25_V1-v2/10000/F620A7C9-F799-E411-8DEF-002590A371AC.root"
+    #"/store/mc/Spring14miniaod/VBF_HToGG_M-125_13TeV-powheg-pythia6/MINIAODSIM/141029_PU40bx50_PLS170_V6AN2-v1/10000/5C3A5675-7C72-E411-AC85-003048D436EA.root"
+    "/store/mc/Phys14DR/GluGluToHToGG_M-125_13TeV-powheg-pythia6/MINIAODSIM/PU20bx25_tsg_PHYS14_25_V1-v1/00000/3C2EFAB1-B16F-E411-AB34-7845C4FC39FB.root"),
+    skipEvents=cms.untracked.uint32(2500)
+                       
+)
+
+process.MessageLogger.cerr.threshold = 'ERROR' # can't get suppressWarning to work: disable all warnings for now
+# process.MessageLogger.suppressWarning.extend(['SimpleMemoryCheck','MemoryCheck']) # this would have been better...
+ 
+# Uncomment the following if you notice you have a memory leak
+# This is a lightweight tool to digg further
+#process.SimpleMemoryCheck = cms.Service("SimpleMemoryCheck",
+#                                        ignoreTotal = cms.untracked.int32(1),
+#                                        monitorPssAndPrivate = cms.untracked.bool(True)
+#                                       )
+
+process.load("flashgg/MicroAOD/flashggMicroAODSequence_cff")
+process.load("flashgg/MicroAOD/flashggMicroAODExtraJetsSequence_cff")
+process.load("flashgg/Validation/JetTreeMaker_cff")
+
+from flashgg.MicroAOD.flashggMicroAODOutputCommands_cff import microAODDefaultOutputCommand,microAODDebugOutputCommand
+process.out = cms.OutputModule("PoolOutputModule",
+                               fileName       = cms.untracked.string('myMicroAODOutputFile.root'),
+                               outputCommands = microAODDefaultOutputCommand
+                           )
+
+process.out.outputCommands += microAODDebugOutputCommand # extra items for debugging, CURRENTLY REQUIRED
+
+# need to allow unscheduled processes otherwise reclustering function will fail
+# this is because of the jet clustering tool, and we have to live with it for now.
+
+process.options = cms.untracked.PSet(
+    allowUnscheduled = cms.untracked.bool(True)
+)
+
+# ++++++++++++ PF +++++++++++++++++++
+# uses the vertex 0
+from flashgg.MicroAOD.flashggExtraJets_cfi import addFlashggPF
+addFlashggPF(process)
+# +++++++++++++++++++++++++++++++++++
+
+# ++++++++++++ PFCHS0 +++++++++++++++
+# uses the vertex 0
+from flashgg.MicroAOD.flashggExtraJets_cfi import addFlashggPFCHS0
+addFlashggPFCHS0(process)
+# +++++++++++++++++++++++++++++++++++
+
+# ++++++++++++ PFCHSLeg +++++++++++++
+# import function which takes care of reclustering the jets using legacy vertex     
+from flashgg.MicroAOD.flashggJets_cfi import addFlashggPFCHSLegJets 
+# call the function, it takes care of everything else.
+addFlashggPFCHSLegJets(process)
+# +++++++++++++++++++++++++++++++++++
+
+
+# ++++++++++++ JetTreeMaker +++++++++
+process.TFileService = cms.Service("TFileService",
+                                   fileName  = cms.string("./workspace/GluGluToHToGG_M-125_13TeV_JetValTrees_NEW_0.root"))
+
+process.flashggJetValidationTreeMakerPF = cms.EDAnalyzer('FlashggJetValidationTreeMaker',
+                                                         GenParticleTag        = cms.untracked.InputTag('prunedGenParticles'),
+                                                         JetTagDz              = cms.InputTag("flashggJetsPF"),
+                                                         StringTag	       = cms.string("PF"),
+                                                         VertexCandidateMapTag = cms.InputTag("flashggVertexMapUnique"),
+                                                         debug                 = cms.untracked.bool(True),
+                                                     )
+
+#process.flashggJetValidationTreeMakerPFCHS0 = cms.EDAnalyzer('FlashggJetValidationTreeMaker',
+#                                                             GenParticleTag     = cms.untracked.InputTag('prunedGenParticles'),
+#                                                             JetTagDz           = cms.InputTag("flashggJetsPFCHS0"),
+#                                                             StringTag		= cms.string("PFCHS0"),
+#                                                             VertexCandidateMapTag = cms.InputTag("flashggVertexMapUnique"),
+#                                                         )
+#
+#process.flashggJetValidationTreeMakerPFCHSLeg = cms.EDAnalyzer('FlashggJetValidationTreeMaker',
+#                                                               GenParticleTag = cms.untracked.InputTag('prunedGenParticles'),
+#                                                               JetTagDz       = cms.InputTag("flashggJets"),                  
+#                                                               StringTag	= cms.string("PFCHSLeg"),
+#                                                               VertexCandidateMapTag = cms.InputTag("flashggVertexMapUnique"),
+#                                                           )
+# +++++++++++++++++++++++++++++++++
+
+process.p = cms.Path(process.flashggMicroAODSequence
+                     + process.flashggMicroAODExtraJetsSequence
+                     # tree producer ...
+                     + process.flashggJetValidationTreeMakerPF 
+                     #+ process.flashggJetValidationTreeMakerPFCHS0
+                     #+ process.flashggJetValidationTreeMakerPFCHSLeg
+                 )
+
+process.e = cms.EndPath(process.out)
+
+# Uncomment these lines to run the example commissioning module and send its output to root
+# process.commissioning = cms.EDAnalyzer('flashggCommissioning',
+#                                         PhotonTag   = cms.untracked.InputTag('flashggPhotons'),
+#                                         DiPhotonTag = cms.untracked.InputTag('flashggDiPhotons'),
+#                                         VertexTag   = cms.untracked.InputTag('offlineSlimmedPrimaryVertices')
+#)
+#process.TFileService = cms.Service("TFileService",
+#                                   fileName = cms.string("commissioningTree.root")
+#)
+#process.p *= process.commissioning
+ 
+ 
+from flashgg.MicroAOD.MicroAODCustomize import customize
+customize(process)


### PR DESCRIPTION
* Modification of `JetValidationTreeMaker.cc` following the 74X recipe. 
* Allow the jet producer to save PuJetIdenfiyer for vtx0 
* PFCHS0 and PF Jet collections are produced with `addFlashggPF(process)` and `addFlashggPFCHS0(process)` implemented in a new file : `MicroAOD/python/flashggExtraJets_cfi.py`
* An example of how to run the extra-Jets producer is in `Validation/python/jets_producer_local.py`
 