### PR TITLE
String-based photon energy scale adjustment module + example

### DIFF
--- a/Systematics/BuildFile.xml
+++ b/Systematics/BuildFile.xml
@@ -1,4 +1,5 @@
 <use name="FWCore/PluginManager"/>
+<use name="CommonTools/Utils"/>
 <use name="flashgg/DataFormats"/>
 <use name="rootrflx"/>
 <export>

--- a/Systematics/plugins/PhotonScaleString.cc
+++ b/Systematics/plugins/PhotonScaleString.cc
@@ -1,0 +1,80 @@
+#include "flashgg/Systematics/interface/BaseSystMethods.h"
+#include "DataFormats/Common/interface/Handle.h"
+#include "DataFormats/Common/interface/PtrVector.h"
+#include "flashgg/DataFormats/interface/Photon.h"
+#include "CommonTools/Utils/interface/StringCutObjectSelector.h"
+
+
+namespace flashgg {
+
+    class PhotonScaleString: public BaseSystMethods<flashgg::Photon, int>
+    {
+
+    public:
+        PhotonScaleString( const edm::ParameterSet &conf );
+
+        void applyCorrection( flashgg::Photon &y, int syst_shift ) override;
+        std::string shiftLabel( int ) override;
+
+    private:
+        std::vector<std::pair<StringCutObjectSelector<Photon, true>, double> > bins_;
+        StringCutObjectSelector<Photon, true> overall_range_;
+        bool debug_;
+    };
+
+    PhotonScaleString::PhotonScaleString( const edm::ParameterSet &conf ) :
+        BaseSystMethods( conf ),
+        overall_range_( conf.getParameter<std::string>( "OverallRange" ) ),
+        debug_( conf.getUntrackedParameter<bool>( "Debug", false ) )
+    {
+        const auto &vpset = conf.getParameterSetVector( "Bins" );
+        for( const auto &pset : vpset ) {
+            std::string range = pset.getParameter<std::string>( "Range" );
+            double scale = pset.getParameter<double>( "Scale" );
+            bins_.emplace_back( StringCutObjectSelector<Photon, true>( range ), scale );
+        }
+    }
+
+    std::string PhotonScaleString::shiftLabel( int syst_value )
+    {
+        std::string result;
+        if( syst_value == 0 ) {
+            result = Form( "%sCentral", label().c_str() );
+        } else if( syst_value > 0 ) {
+            result = Form( "%sUp%.2dsigma", label().c_str(), syst_value );
+        } else {
+            result = Form( "%sDown%.2dsigma", label().c_str(), -1 * syst_value );
+        }
+        return result;
+    }
+
+    void PhotonScaleString::applyCorrection( flashgg::Photon &y, int syst_shift )
+    {
+        if( syst_shift == 0 || !overall_range_( y ) ) {
+            // Nominal correction or this corrector does not apply to this object
+        } else {
+            for( auto binit = bins_.begin() ; binit != bins_.end() ; binit++ ) {
+                if( ( binit->first )( y ) ) {
+                    if( debug_ ) {
+                        std::cout << "  " << label() << ": Photon has pt= " << y.pt() << " eta=" << y.eta()
+                                  << " and we a apply a " << syst_shift << " sigma shift with sigma=" << binit->second << std::endl;
+                    }
+                    y.updateEnergy( shiftLabel( syst_shift ), y.energy() + binit->second * syst_shift );
+                    break;
+                }
+            }
+        }
+    }
+}
+
+DEFINE_EDM_PLUGIN( FlashggSystematicPhotonMethodsFactory,
+                   flashgg::PhotonScaleString,
+                   "FlashggPhotonScaleString" );
+// Local Variables:
+// mode:c++
+// indent-tabs-mode:nil
+// tab-width:4
+// c-basic-offset:4
+// End:
+// vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4
+

--- a/Systematics/python/flashggPhotonSmear_cfi.py
+++ b/Systematics/python/flashggPhotonSmear_cfi.py
@@ -1,5 +1,10 @@
 import FWCore.ParameterSet.Config as cms
 
+scaleBins = cms.VPSet(cms.PSet( Range = cms.string("pt>10.&&pt<15."), Scale = cms.double(0.5) ),
+                      cms.PSet( Range = cms.string("pt>15.&&pt<20."), Scale = cms.double(1.0) ),
+                      cms.PSet( Range = cms.string("pt>20."), Scale = cms.double(2.0) )
+                      )
+
 flashggSmearPhoton = cms.EDProducer('FlashggPhotonSystematicProducer',
 		PhotonTag = cms.untracked.InputTag('flashggPhotons'),
 		SystMethods = cms.VPSet(cms.PSet( MethodName = cms.string("FlashggSimplePhotonSmear"),
@@ -9,6 +14,20 @@ flashggSmearPhoton = cms.EDProducer('FlashggPhotonSystematicProducer',
                                         cms.PSet( MethodName = cms.string("FlashggSimplePhotonSmear"),
                                                   Label = cms.string("exampleSystBravo"),
                                                   Sigma = cms.double(1.0),
-                                                  NSigmas = cms.vint32(-2,-1,4,7))
+                                                  NSigmas = cms.vint32(-2,-1,4,7)),
+                                        cms.PSet( MethodName = cms.string("FlashggPhotonScaleString"),
+                                                  Label = cms.string("exampleSystCharlieBarrel"),
+                                                  NSigmas = cms.vint32(-1,1),
+                                                  OverallRange = cms.string("pt > 10.&&abs(eta)<1.479"),
+                                                  Bins = scaleBins,
+                                                  Debug = cms.untracked.bool(True)
+                                                  ),
+                                        cms.PSet( MethodName = cms.string("FlashggPhotonScaleString"),
+                                                  Label = cms.string("exampleSystCharlieEndcap"),
+                                                  NSigmas = cms.vint32(-1,1),
+                                                  OverallRange = cms.string("pt > 10.&&abs(eta)>1.653"),
+                                                  Bins = scaleBins,
+                                                  Debug = cms.untracked.bool(True)
+                                                  )
                                         )
                                     )

--- a/Systematics/python/flashggPhotonSmear_cfi.py
+++ b/Systematics/python/flashggPhotonSmear_cfi.py
@@ -1,8 +1,8 @@
 import FWCore.ParameterSet.Config as cms
 
-scaleBins = cms.VPSet(cms.PSet( Range = cms.string("pt>10.&&pt<15."), Scale = cms.double(0.5) ),
-                      cms.PSet( Range = cms.string("pt>15.&&pt<20."), Scale = cms.double(1.0) ),
-                      cms.PSet( Range = cms.string("pt>20."), Scale = cms.double(2.0) )
+scaleBins = cms.VPSet(cms.PSet( Range = cms.string("pt>10.&&pt<15."), Shift = cms.double(0.003), Uncertainty = cms.double(0.001) ),
+                      cms.PSet( Range = cms.string("pt>15.&&pt<20."), Shift = cms.double(-0.001), Uncertainty = cms.double(0.0005) ),
+                      cms.PSet( Range = cms.string("pt>20."), Shift = cms.double(0.002), Uncertainty = cms.double(0.0004) )
                       )
 
 flashggSmearPhoton = cms.EDProducer('FlashggPhotonSystematicProducer',


### PR DESCRIPTION
Create a tool that uses string parsing to create arbitrary photon systematic shifts in arbitrary bins.  Common binning can be given for many copies of the tool, which are each given their own range of applicability, so that different ranges can be correlated or uncorrelated as needed.  A simple example of this with uncorrelated barrel/endcap is implemented in Systematics/python/flashggPhotonSmear_cfi.py