### PR TITLE
SinglePhotonView as component of DiPhoton

### DIFF
--- a/DataFormats/interface/DiPhotonCandidate.h
+++ b/DataFormats/interface/DiPhotonCandidate.h
@@ -11,9 +11,7 @@
 
 
 namespace flashgg {
-//    class SinglePhotonView;
 
-//    class DiPhotonCandidate : public math::XYZTLorentzVector //reco::LeafCandidate
     class DiPhotonCandidate : public reco::LeafCandidate
     {
     public:
@@ -23,18 +21,17 @@ namespace flashgg {
 
         const edm::Ptr<reco::Vertex> vtx() const { return vertex_; }
 
-        const flashgg::Photon *leadingPhoton() const; // { return viewPho1_->photonPtr(); }
-        const flashgg::Photon *subLeadingPhoton() const; // { return viewPho1_->photonPtr(); }
+        const flashgg::Photon *leadingPhoton() const { return viewPho1_.photon(); };
+        const flashgg::Photon *subLeadingPhoton() const { return viewPho2_.photon(); }
 
-        flashgg::Photon &getLeadingPhoton(); // { return viewPho1_->photon(); }
-        flashgg::Photon &getSubLeadingPhoton(); // { return viewPho2_->photon(); }
+        flashgg::Photon &getLeadingPhoton() { return viewPho1_.getPhoton(); }
+        flashgg::Photon &getSubLeadingPhoton() { return viewPho2_.getPhoton(); };
 
-        flashgg::SinglePhotonView &leadingView() {return viewPho1_; }
-        flashgg::SinglePhotonView &subLeadingView() {return viewPho2_; }
+        flashgg::SinglePhotonView &getLeadingView() { return viewPho1_; }
+        flashgg::SinglePhotonView &getSubLeadingView() { return viewPho2_; }
 
-        const flashgg::SinglePhotonView &leadingView() const { return viewPho1_; }
-        const flashgg::SinglePhotonView &subLeadingView() const { return viewPho2_; }
-
+        const flashgg::SinglePhotonView *leadingView() const { return &viewPho1_; }
+        const flashgg::SinglePhotonView *subLeadingView() const { return &viewPho2_; }
 
         void setLogSumPt2( float val ) { logsumpt2_ = val; }
         void setPtBal( float val ) { ptbal_ = val; }
@@ -73,8 +70,7 @@ namespace flashgg {
         float vtxProbMVA() const { return vtxprobmva_; }
         float sumPt() const
         {
-//            return ( this->daughter( 0 )->pt() + this->daughter( 1 )->pt() );
-            return ( corrPho1_.pt() + corrPho2_.pt() );
+            return ( leadingPhoton()->pt() + subLeadingPhoton()->pt() );
         }
         int vertexIndex() const { return vertex_index_; }
 
@@ -96,7 +92,14 @@ namespace flashgg {
 
         bool operator <( const DiPhotonCandidate &b ) const;
 
-        math::XYZTLorentzVector PhoP4Corr( edm::Ptr<flashgg::Photon> ) const;
+        //        math::XYZTLorentzVector PhoP4Corr( edm::Ptr<flashgg::Photon> ) const;
+
+        void computeP4AndOrder();
+        void makePhotonsPersistent()
+        {
+            viewPho1_.MakePersistent();
+            viewPho2_.MakePersistent();
+        }
 
     private:
 
@@ -127,10 +130,9 @@ namespace flashgg {
 
         std::string systLabel_;
 
-        math::XYZTLorentzVector corrPho1_;
-        math::XYZTLorentzVector corrPho2_;
+        //        math::XYZTLorentzVector corrPho1_;
+        //        math::XYZTLorentzVector corrPho2_;
 
-//		SPView viewPho1_;
         flashgg::SinglePhotonView viewPho1_;
         flashgg::SinglePhotonView viewPho2_;
     };

--- a/DataFormats/interface/DiPhotonCandidate.h
+++ b/DataFormats/interface/DiPhotonCandidate.h
@@ -2,29 +2,39 @@
 #define FLASHgg_DiPhotonCandidate_h
 
 #include "DataFormats/Candidate/interface/CompositeCandidate.h"
+#include "DataFormats/Candidate/interface/ShallowCloneCandidate.h"
+#include "DataFormats/Candidate/interface/LeafCandidate.h"
 #include "flashgg/DataFormats/interface/Photon.h"
+#include "flashgg/DataFormats/interface/SinglePhotonView.h"
 #include "DataFormats/VertexReco/interface/Vertex.h"
 
-namespace flashgg {
-    class SinglePhotonView;
 
-    class DiPhotonCandidate : public reco::CompositeCandidate
+
+namespace flashgg {
+//    class SinglePhotonView;
+
+//    class DiPhotonCandidate : public math::XYZTLorentzVector //reco::LeafCandidate
+    class DiPhotonCandidate : public reco::LeafCandidate
     {
     public:
         DiPhotonCandidate();
         DiPhotonCandidate( edm::Ptr<flashgg::Photon>, edm::Ptr<flashgg::Photon>, edm::Ptr<reco::Vertex> );
-        DiPhotonCandidate( const flashgg::Photon &, const flashgg::Photon &, edm::Ptr<reco::Vertex> );
         ~DiPhotonCandidate();
 
         const edm::Ptr<reco::Vertex> vtx() const { return vertex_; }
-        const flashgg::Photon *leadingPhoton() const;
-        const flashgg::Photon *subLeadingPhoton() const;
 
-        flashgg::Photon &getLeadingPhoton();
-        flashgg::Photon &getSubLeadingPhoton();
+        const flashgg::Photon *leadingPhoton() const; // { return viewPho1_->photonPtr(); }
+        const flashgg::Photon *subLeadingPhoton() const; // { return viewPho1_->photonPtr(); }
 
-        flashgg::SinglePhotonView leadingView() const;
-        flashgg::SinglePhotonView subLeadingView() const;
+        flashgg::Photon &getLeadingPhoton(); // { return viewPho1_->photon(); }
+        flashgg::Photon &getSubLeadingPhoton(); // { return viewPho2_->photon(); }
+
+        flashgg::SinglePhotonView &leadingView() {return viewPho1_; }
+        flashgg::SinglePhotonView &subLeadingView() {return viewPho2_; }
+
+        const flashgg::SinglePhotonView &leadingView() const { return viewPho1_; }
+        const flashgg::SinglePhotonView &subLeadingView() const { return viewPho2_; }
+
 
         void setLogSumPt2( float val ) { logsumpt2_ = val; }
         void setPtBal( float val ) { ptbal_ = val; }
@@ -63,7 +73,8 @@ namespace flashgg {
         float vtxProbMVA() const { return vtxprobmva_; }
         float sumPt() const
         {
-            return ( this->daughter( 0 )->pt() + this->daughter( 1 )->pt() );
+//            return ( this->daughter( 0 )->pt() + this->daughter( 1 )->pt() );
+            return ( corrPho1_.pt() + corrPho2_.pt() );
         }
         int vertexIndex() const { return vertex_index_; }
 
@@ -84,6 +95,8 @@ namespace flashgg {
         std::string systLabel() const { return systLabel_; }
 
         bool operator <( const DiPhotonCandidate &b ) const;
+
+        math::XYZTLorentzVector PhoP4Corr( edm::Ptr<flashgg::Photon> ) const;
 
     private:
 
@@ -111,9 +124,17 @@ namespace flashgg {
         std::vector<float> vmva_value_;
         std::vector<unsigned int> vmva_sortedindex_;
         std::vector<edm::Ptr<reco::Vertex> > vVtxPtr_;
+
         std::string systLabel_;
 
+        math::XYZTLorentzVector corrPho1_;
+        math::XYZTLorentzVector corrPho2_;
+
+//		SPView viewPho1_;
+        flashgg::SinglePhotonView viewPho1_;
+        flashgg::SinglePhotonView viewPho2_;
     };
+
 
 
 }

--- a/DataFormats/interface/Photon.h
+++ b/DataFormats/interface/Photon.h
@@ -16,8 +16,11 @@ namespace flashgg {
     public:
         Photon();
         Photon( const pat::Photon & );
+        Photon( const flashgg::Photon & );
         ~Photon();
         virtual Photon *clone() const;
+
+        void ZeroVariables();
 
         enum mcMatch_t { kUnkown = 0, kPrompt, kFake  };
 
@@ -145,8 +148,8 @@ namespace flashgg {
 
         float sipip_;
         float sieip_;
-        float zernike20_;
-        float zernike42_;
+        //        float zernike20_;
+        //        float zernike42_;
         float e2nd_;
         float e2x5right_;
         float e2x5left_;

--- a/DataFormats/interface/SinglePhotonView.h
+++ b/DataFormats/interface/SinglePhotonView.h
@@ -2,44 +2,70 @@
 #define FLASHgg_SinglePhotonView_h
 
 #include "flashgg/DataFormats/interface/Photon.h"
-#include "flashgg/DataFormats/interface/DiPhotonCandidate.h"
+//#include "flashgg/DataFormats/interface/DiPhotonCandidate.h"
 #include "DataFormats/Common/interface/Ptr.h"
 
 #include <string>
+#include <vector>
 
 namespace flashgg {
+
+//    class DiPhotonCandidate;
 
     class SinglePhotonView
     {
 
     public:
-        typedef edm::Ptr<DiPhotonCandidate> dipho_ptr_type;
+//        typedef edm::Ptr<flashgg::DiPhotonCandidate> dipho_ptr_type;
+        typedef edm::Ptr<flashgg::Photon> pho_ptr_type;
+        typedef edm::Ptr<reco::Vertex> vtx_ptr_type;
         typedef Photon cand_type;
 
-        SinglePhotonView() : pho_( 0 ), dipho_( 0 ) {}
-        SinglePhotonView( dipho_ptr_type dipho, int daughter ) : edmdipho_( dipho ), daughter_( daughter ), pho_( 0 ), dipho_( 0 ) {}
-        SinglePhotonView( const DiPhotonCandidate *dipho, int daughter ) : daughter_( daughter ), pho_( 0 ), dipho_( dipho ) {}
+//		SinglePhotonView( const DiPhotonCandidate *dipho, int daughter );
+//		SinglePhotonView( dipho_ptr_type dipho, int daughter );
+        SinglePhotonView() : hasPhoton_( 0 ) {}
+        SinglePhotonView( edm::Ptr<flashgg::Photon> pho, edm::Ptr<reco::Vertex> vtx ) : phoRef_( pho ), vtxRef_( vtx ), hasPhoton_( 0 ), hasVtx_( 1 ) {}
+        SinglePhotonView( edm::Ptr<flashgg::Photon> pho ) : phoRef_( pho ), hasPhoton_( 0 ), hasVtx_( 0 ) {}
 
-        const cand_type &photon() const { daughterMaybe(); return *pho_; }
 
-        const cand_type *operator->() const { daughterMaybe(); return pho_; }
+//        const cand_type &photon() const { MakePhoton(); return ( (persistVec_.size() > 0) ? persistVec_[0] : pho_  );}
+        const cand_type &photon() const { if( persistVec_.size() ) { return persistVec_[0]; } else { MakePhoton(); return pho_; } }
 
-        float pfChIso02WrtChosenVtx() const { return photon().pfChgIso02WrtVtx( dipho_->vtx() ); }
-        float pfChIso03WrtChosenVtx() const { return photon().pfChgIso03WrtVtx( dipho_->vtx() ); }
-        float pfChIso04WrtChosenVtx() const { return photon().pfChgIso04WrtVtx( dipho_->vtx() ); }
+//		const cand_type * photonPtr() const  { MakePhoton(); return ( (persistVec_.size() > 0) ? &persistVec_[0] : &pho_  ); }
+        const cand_type *photonPtr() const  { if( persistVec_.size() ) { return &persistVec_[0]; } else { MakePhoton(); return &pho_; } }
 
-        float phoIdMvaWrtChosenVtx() const { return photon().phoIdMvaDWrtVtx( dipho_->vtx() ); }
+//        const cand_type *operator->() const { MakePhoton(); return ( (persistVec_.size() > 0) ? &persistVec_[0] : &pho_  ); }
+        const cand_type *operator->() const { if( persistVec_.size() ) { return &persistVec_[0]; } else { MakePhoton(); return &pho_; } }
 
-        float extraChIsoWrtChoosenVtx( const std::string &key ) const { return photon().extraChgIsoWrtVtx( key, dipho_->vtx() ); }
+        const pho_ptr_type photonRef() const { return phoRef_; }
+
+        float pfChIso02WrtChosenVtx() const { MakePhoton(); return ( pho_.pfChgIso02WrtVtx( vtxRef_ ) ); }
+        float pfChIso03WrtChosenVtx() const { MakePhoton(); return ( pho_.pfChgIso03WrtVtx( vtxRef_ ) ); }
+        float pfChIso04WrtChosenVtx() const { MakePhoton(); return ( pho_.pfChgIso04WrtVtx( vtxRef_ ) ); }
+
+        float phoIdMvaWrtChosenVtx() const { MakePhoton(); return ( pho_.phoIdMvaDWrtVtx( vtxRef_ ) ); }
+
+        float extraChIsoWrtChoosenVtx( const std::string &key ) const { MakePhoton(); return ( pho_.extraChgIsoWrtVtx( key, vtxRef_ ) ); }
+
+        bool hasPhoton() const { return hasPhoton_; }
+
+        void MakePersistent();
+//        void MakePersistent()  { MakePhoton(); flashgg::Photon tempPho = pho_;  persistVec_.push_back(tempPho); std::cout << "size of persistent vector: " << persistVec_.size() << std::endl;}
+//        void AddPersistent( flashgg::Photon PersPho_) { persistVec_.push_back(PersPho_); }
+//        flashgg::Photon getPersistent() { flashgg::Photon Pho; if (persistVec_.size() > 0 ) Pho = persistVec_[0]; return Pho ;}
+
+//		flashgg::Photon pho4MomCorrection( edm::Ptr<flashgg::Photon> photon, edm::Ptr<reco::Vertex> vtx ) const;
+
+
 
     private:
-        void daughterMaybe() const;
-
-        dipho_ptr_type edmdipho_;
-        int daughter_;
-        mutable const Photon *pho_;
-        mutable const DiPhotonCandidate *dipho_;
-
+        mutable flashgg::Photon pho_;
+        edm::Ptr<flashgg::Photon> phoRef_;
+        edm::Ptr<reco::Vertex> vtxRef_;
+        mutable bool hasPhoton_;
+        bool hasVtx_;
+        bool MakePhoton() const;
+        std::vector<flashgg::Photon> persistVec_;
     };
 }
 

--- a/DataFormats/interface/SinglePhotonView.h
+++ b/DataFormats/interface/SinglePhotonView.h
@@ -2,7 +2,6 @@
 #define FLASHgg_SinglePhotonView_h
 
 #include "flashgg/DataFormats/interface/Photon.h"
-//#include "flashgg/DataFormats/interface/DiPhotonCandidate.h"
 #include "DataFormats/Common/interface/Ptr.h"
 
 #include <string>
@@ -10,57 +9,35 @@
 
 namespace flashgg {
 
-//    class DiPhotonCandidate;
-
     class SinglePhotonView
     {
 
     public:
-//        typedef edm::Ptr<flashgg::DiPhotonCandidate> dipho_ptr_type;
         typedef edm::Ptr<flashgg::Photon> pho_ptr_type;
         typedef edm::Ptr<reco::Vertex> vtx_ptr_type;
         typedef Photon cand_type;
 
-//		SinglePhotonView( const DiPhotonCandidate *dipho, int daughter );
-//		SinglePhotonView( dipho_ptr_type dipho, int daughter );
         SinglePhotonView() : hasPhoton_( 0 ) {}
-        SinglePhotonView( edm::Ptr<flashgg::Photon> pho, edm::Ptr<reco::Vertex> vtx ) : phoRef_( pho ), vtxRef_( vtx ), hasPhoton_( 0 ), hasVtx_( 1 ) {}
-        SinglePhotonView( edm::Ptr<flashgg::Photon> pho ) : phoRef_( pho ), hasPhoton_( 0 ), hasVtx_( 0 ) {}
+        SinglePhotonView( edm::Ptr<flashgg::Photon> pho, edm::Ptr<reco::Vertex> vtx ) : phoPtr_( pho ), vtxRef_( vtx ), hasPhoton_( 0 ), hasVtx_( 1 ) {}
+        SinglePhotonView( edm::Ptr<flashgg::Photon> pho ) : phoPtr_( pho ), hasPhoton_( 0 ), hasVtx_( 0 ) {}
 
+        const cand_type *photon() const;
+        cand_type &getPhoton(); // You can only have a non-const pointer if you call makePersistent() first
+        edm::Ptr<flashgg::Photon> originalPhoton() const { return phoPtr_; }
 
-//        const cand_type &photon() const { MakePhoton(); return ( (persistVec_.size() > 0) ? persistVec_[0] : pho_  );}
-        const cand_type &photon() const { if( persistVec_.size() ) { return persistVec_[0]; } else { MakePhoton(); return pho_; } }
+        float pfChIso02WrtChosenVtx() const { MakePhoton(); return ( photon()->pfChgIso02WrtVtx( vtxRef_ ) ); }
+        float pfChIso03WrtChosenVtx() const { MakePhoton(); return ( photon()->pfChgIso03WrtVtx( vtxRef_ ) ); }
+        float pfChIso04WrtChosenVtx() const { MakePhoton(); return ( photon()->pfChgIso04WrtVtx( vtxRef_ ) ); }
 
-//		const cand_type * photonPtr() const  { MakePhoton(); return ( (persistVec_.size() > 0) ? &persistVec_[0] : &pho_  ); }
-        const cand_type *photonPtr() const  { if( persistVec_.size() ) { return &persistVec_[0]; } else { MakePhoton(); return &pho_; } }
+        float phoIdMvaWrtChosenVtx() const { MakePhoton(); return ( photon()->phoIdMvaDWrtVtx( vtxRef_ ) ); }
 
-//        const cand_type *operator->() const { MakePhoton(); return ( (persistVec_.size() > 0) ? &persistVec_[0] : &pho_  ); }
-        const cand_type *operator->() const { if( persistVec_.size() ) { return &persistVec_[0]; } else { MakePhoton(); return &pho_; } }
-
-        const pho_ptr_type photonRef() const { return phoRef_; }
-
-        float pfChIso02WrtChosenVtx() const { MakePhoton(); return ( pho_.pfChgIso02WrtVtx( vtxRef_ ) ); }
-        float pfChIso03WrtChosenVtx() const { MakePhoton(); return ( pho_.pfChgIso03WrtVtx( vtxRef_ ) ); }
-        float pfChIso04WrtChosenVtx() const { MakePhoton(); return ( pho_.pfChgIso04WrtVtx( vtxRef_ ) ); }
-
-        float phoIdMvaWrtChosenVtx() const { MakePhoton(); return ( pho_.phoIdMvaDWrtVtx( vtxRef_ ) ); }
-
-        float extraChIsoWrtChoosenVtx( const std::string &key ) const { MakePhoton(); return ( pho_.extraChgIsoWrtVtx( key, vtxRef_ ) ); }
-
-        bool hasPhoton() const { return hasPhoton_; }
+        float extraChIsoWrtChoosenVtx( const std::string &key ) const { MakePhoton(); return ( photon()->extraChgIsoWrtVtx( key, vtxRef_ ) ); }
 
         void MakePersistent();
-//        void MakePersistent()  { MakePhoton(); flashgg::Photon tempPho = pho_;  persistVec_.push_back(tempPho); std::cout << "size of persistent vector: " << persistVec_.size() << std::endl;}
-//        void AddPersistent( flashgg::Photon PersPho_) { persistVec_.push_back(PersPho_); }
-//        flashgg::Photon getPersistent() { flashgg::Photon Pho; if (persistVec_.size() > 0 ) Pho = persistVec_[0]; return Pho ;}
-
-//		flashgg::Photon pho4MomCorrection( edm::Ptr<flashgg::Photon> photon, edm::Ptr<reco::Vertex> vtx ) const;
-
-
 
     private:
         mutable flashgg::Photon pho_;
-        edm::Ptr<flashgg::Photon> phoRef_;
+        edm::Ptr<flashgg::Photon> phoPtr_;
         edm::Ptr<reco::Vertex> vtxRef_;
         mutable bool hasPhoton_;
         bool hasVtx_;

--- a/DataFormats/src/DiPhotonCandidate.cc
+++ b/DataFormats/src/DiPhotonCandidate.cc
@@ -1,7 +1,7 @@
 #include "flashgg/DataFormats/interface/DiPhotonCandidate.h"
 #include "flashgg/DataFormats/interface/Photon.h"
-#include "flashgg/DataFormats/interface/SinglePhotonView.h"
 #include "CommonTools/CandUtils/interface/AddFourMomenta.h"
+
 
 using namespace flashgg;
 
@@ -11,88 +11,118 @@ DiPhotonCandidate::~DiPhotonCandidate() {}
 
 DiPhotonCandidate::DiPhotonCandidate( edm::Ptr<flashgg::Photon> photon1, edm::Ptr<flashgg::Photon> photon2, edm::Ptr<reco::Vertex> vertex )
 {
-    addDaughter( *photon1 );
-    addDaughter( *photon2 );
     vertex_ = vertex;
+    if( DiPhotonCandidate::PhoP4Corr( photon1 ).pt() > DiPhotonCandidate::PhoP4Corr( photon2 ).pt() ) {
+//		viewPho1_ = new flashgg::SinglePhotonView(photon1, vertex);
+//		viewPho2_ = new flashgg::SinglePhotonView(photon2, vertex);
+        viewPho1_ = flashgg::SinglePhotonView( photon1, vertex );
+        viewPho2_ = flashgg::SinglePhotonView( photon2, vertex );
+        corrPho1_ = DiPhotonCandidate::PhoP4Corr( photon1 );
+        corrPho2_ = DiPhotonCandidate::PhoP4Corr( photon2 );
+    } else {
+//		viewPho1_ = new flashgg::SinglePhotonView(photon2, vertex);
+//		viewPho2_ = new flashgg::SinglePhotonView(photon1, vertex);
+        viewPho1_ = flashgg::SinglePhotonView( photon2, vertex );
+        viewPho2_ = flashgg::SinglePhotonView( photon1, vertex );
+        corrPho1_ = DiPhotonCandidate::PhoP4Corr( photon2 );
+        corrPho2_ = DiPhotonCandidate::PhoP4Corr( photon1 );
+    }
+
+//    std::cout << "SETTING VIEWS: \t VIEW1 pt " << viewPho1_->photonPtr()->pt() << " \t VIEW 2 pt " << viewPho2_->photonPtr()->pt() << std::endl;
+
+//	math::XYZTLorentzVector pho1corr = DiPhotonCandidate::PhoP4Corr(photon1);
+//	math::XYZTLorentzVector pho2corr = DiPhotonCandidate::PhoP4Corr(photon2);
+//	corrPho1_ = DiPhotonCandidate::PhoP4Corr(photon1);
+//	corrPho2_ = DiPhotonCandidate::PhoP4Corr(photon2);
+//
+
+//	double thisX = corrPho1_.px() + corrPho2_.Px();
+//	double thisY = corrPho1_.py() + corrPho2_.Py();
+//	double thisZ = corrPho1_.pz() + corrPho2_.Pz();
+//	double thisE = corrPho1_.energy() + corrPho2_.energy();
+//	this->SetPxPyPzE(thisX, thisY, thisZ, thisE);
+
+    this->setP4( corrPho1_ + corrPho2_ );
 
     // Adding momenta
     // Needs its own object - but why?
     // Copied from example
-    AddFourMomenta addP4;
-    addP4.set( *this );
+//    AddFourMomenta addP4;
+//    addP4.set( *this );
 }
 
-DiPhotonCandidate::DiPhotonCandidate( const flashgg::Photon &photon1, const flashgg::Photon &photon2, edm::Ptr<reco::Vertex> vertex )
-{
-    addDaughter( photon1 );
-    addDaughter( photon2 );
-    vertex_ = vertex;
-
-    // Adding momenta
-    // Needs its own object - but why?
-    // Copied from example
-    AddFourMomenta addP4;
-    addP4.set( *this );
-}
-
-flashgg::Photon &DiPhotonCandidate::getLeadingPhoton()
-{
-    if( daughter( 0 )->pt() > daughter( 1 )->pt() ) {
-        return dynamic_cast<flashgg::Photon &>( *daughter( 0 ) );
-    } else {
-        return dynamic_cast<flashgg::Photon &>( *daughter( 1 ) );
-    }
-}
-
-flashgg::Photon &DiPhotonCandidate::getSubLeadingPhoton()
-{
-    if( daughter( 0 )->pt() > daughter( 1 )->pt() ) {
-        return dynamic_cast<flashgg::Photon &>( *daughter( 1 ) );
-    } else {
-        return dynamic_cast<flashgg::Photon &>( *daughter( 0 ) );
-    }
-}
 
 const flashgg::Photon *DiPhotonCandidate::leadingPhoton() const
 {
-    if( daughter( 0 )->pt() > daughter( 1 )->pt() ) {
-        return dynamic_cast<const flashgg::Photon *>( daughter( 0 ) );
-    } else {
-        return dynamic_cast<const flashgg::Photon *>( daughter( 1 ) );
-    }
+//	return viewPho1_->photonPtr();
+    return viewPho1_.photonPtr();
 }
 
 const flashgg::Photon *DiPhotonCandidate::subLeadingPhoton() const
 {
-    if( daughter( 0 )->pt() > daughter( 1 )->pt() ) {
-        return dynamic_cast<const flashgg::Photon *>( daughter( 1 ) );
-    } else {
-        return dynamic_cast<const flashgg::Photon *>( daughter( 0 ) );
-    }
+//	return viewPho2_->photonPtr();
+    return viewPho2_.photonPtr();
 }
 
-SinglePhotonView DiPhotonCandidate::leadingView() const
+flashgg::Photon &DiPhotonCandidate::getLeadingPhoton()
 {
-    if( daughter( 0 )->pt() > daughter( 1 )->pt() ) {
-        return SinglePhotonView( this, 0 );
-    } else {
-        return SinglePhotonView( this, 1 );
-    }
+//	return const_cast<flashgg::Photon &>(*viewPho1_->photonPtr());
+    return const_cast<flashgg::Photon &>( *viewPho1_.photonPtr() );
+//	return remove_const<flashgg::Photon>(viewPho1_->photon());
 }
 
-SinglePhotonView DiPhotonCandidate::subLeadingView() const
+flashgg::Photon &DiPhotonCandidate::getSubLeadingPhoton()
 {
-    if( daughter( 0 )->pt() > daughter( 1 )->pt() ) {
-        return SinglePhotonView( this, 1 );
-    } else {
-        return SinglePhotonView( this, 0 );
-    }
+//	return const_cast<flashgg::Photon &>(*viewPho2_->photonPtr());
+    return const_cast<flashgg::Photon &>( *viewPho2_.photonPtr() );
+//	return const_cast<flashgg::Photon>(viewPho2_->photon());
 }
 
 bool DiPhotonCandidate::operator <( const DiPhotonCandidate &b ) const
 {
     return ( sumPt() < b.sumPt() );
 }
+
+// SinglePhotonView DiPhotonCandidate::leadingView() const
+// {
+//     // if( daughter( 0 )->pt() > daughter( 1 )->pt() ) {
+//     //     return SinglePhotonView( this, 0 );
+//     // } else {
+//     //     return SinglePhotonView( this, 1 );
+//     // }
+// 	return 0;
+// }
+//
+// SinglePhotonView DiPhotonCandidate::subLeadingView() const
+// {
+//     // if( daughter( 0 )->pt() > daughter( 1 )->pt() ) {
+//     //     return SinglePhotonView( this, 1 );
+//     // } else {
+//     //     return SinglePhotonView( this, 0 );
+//     // }
+// 	return 0;
+// }
+
+math::XYZTLorentzVector DiPhotonCandidate::PhoP4Corr( edm::Ptr<flashgg::Photon> photon1 ) const
+{
+    /// vtx should be the chosen vtx, not primary vtx ///
+    float vtx_X = vertex_->x();
+    float vtx_Y = vertex_->y();
+    float vtx_Z = vertex_->z();
+
+    float sc_X = photon1->superCluster()->x();
+    float sc_Y = photon1->superCluster()->y();
+    float sc_Z = photon1->superCluster()->z();
+
+    math::XYZVector vtx_Pos( vtx_X, vtx_Y, vtx_Z );
+    math::XYZVector sc_Pos( sc_X, sc_Y, sc_Z );
+
+    math::XYZVector direction = sc_Pos - vtx_Pos;
+    math::XYZVector p = ( direction.Unit() ) * ( photon1->energy() );
+    math::XYZTLorentzVector corrected_p4( p.x(), p.y(), p.z(), photon1->energy() );
+    return corrected_p4;
+}
+
 // Local Variables:
 // mode:c++
 // indent-tabs-mode:nil

--- a/DataFormats/src/Photon.cc
+++ b/DataFormats/src/Photon.cc
@@ -4,12 +4,17 @@
 
 using namespace flashgg;
 
-Photon::Photon()
+Photon::Photon() : pat::Photon::Photon()
+{
+    ZeroVariables();
+}
+
+void Photon::ZeroVariables()
 {
     sipip_ = 0.;
     sieip_ = 0.;
-    zernike20_ = 0.;
-    zernike42_ = 0.;
+    //    zernike20_ = 0.;
+    //    zernike42_ = 0.;
     e2nd_ = 0.;
     e2x5right_ = 0.;
     e2x5left_ = 0.;
@@ -34,7 +39,42 @@ Photon::Photon()
     phoIdMvaD_.clear();
     passElecVeto_ = false;
 }
-Photon::Photon( const pat::Photon &aPhoton ) : pat::Photon( aPhoton ) {}
+
+Photon::Photon( const pat::Photon &aPhoton ) : pat::Photon::Photon( aPhoton )
+{
+    ZeroVariables();
+}
+
+Photon::Photon( const Photon &aPhoton ) : pat::Photon::Photon( aPhoton )
+{
+    sipip_ = aPhoton.sipip();
+    sieip_ = aPhoton.sieip();
+    e2nd_ = aPhoton.e2nd();
+    e2x5right_ = aPhoton.e2x5right();
+    e2x5left_ = aPhoton.e2x5left();
+    e2x5top_ = aPhoton.e2x5top();
+    e2x5bottom_ = aPhoton.e2x5bottom();
+    e2x5max_ = aPhoton.e2x5max();
+    eright_ = aPhoton.eright();
+    eleft_ = aPhoton.eleft();
+    etop_ = aPhoton.etop();
+    ebottom_ = aPhoton.ebottom();
+    e1x3_ = aPhoton.e1x3();
+    S4_ = aPhoton.s4();
+    pfPhoIso04_ = aPhoton.pfPhoIso04();
+    pfPhoIso03_ = aPhoton.pfPhoIso03();
+    pfChgIsoWrtWorstVtx04_ = aPhoton.pfChgIsoWrtWorstVtx04();
+    pfChgIsoWrtWorstVtx03_ = aPhoton.pfChgIsoWrtWorstVtx03();
+    pfChgIsoWrtChosenVtx02_ = aPhoton.pfChgIsoWrtChosenVtx02();
+    ESEffSigmaRR_ = aPhoton.esEffSigmaRR();
+    sigEOverE_ = aPhoton.sigEOverE();
+    pfChgIso04_ = aPhoton.pfChgIso04();
+    pfChgIso03_ = aPhoton.pfChgIso03();
+    pfChgIso02_ = aPhoton.pfChgIso02();
+    phoIdMvaD_ = aPhoton.phoIdMvaD();
+    passElecVeto_ = aPhoton.passElectronVeto();
+}
+
 Photon::~Photon() {}
 
 Photon *Photon::clone() const { return new Photon( *this ); }

--- a/DataFormats/src/SinglePhotonView.cc
+++ b/DataFormats/src/SinglePhotonView.cc
@@ -1,58 +1,32 @@
 #include "flashgg/DataFormats/interface/SinglePhotonView.h"
 
 namespace flashgg {
-    /*
-    SinglePhotonView::SinglePhotonView( const DiPhotonCandidate *dipho, int daughter )
-    {
-    	hasPhoton_ = 1;
-    	hasVtx_ = 1;
-    	vtxRef_ = dipho->vtx(); //const_cast< edm::Ptr<reco::Vertex> >(dipho->vtx());
-    	if(daughter == 0){
-    		phoRef_ = dipho->leadingView()->photonRef();
-    	} else  if (daughter == 1){
-    		phoRef_ = dipho->subLeadingView()->photonRef();
-    	}
-    }
 
-    SinglePhotonView::SinglePhotonView( dipho_ptr_type dipho, int daughter )
-    {
-    	hasPhoton_ = 1;
-    	hasVtx_ = 1;
-    	vtxRef_ = dipho->vtx();
-    	if(daughter == 0){
-    		phoRef_ = dipho->leadingView()->photonRef();
-    	} else  if (daughter == 1){
-    		phoRef_ = dipho->subLeadingView()->photonRef();
-    	}
-    }
-    */
     bool SinglePhotonView::MakePhoton() const
     {
-        if( hasPhoton_ ) { return false; }
-        else if( hasVtx_ ) {
+        if( hasPhoton_ ) {
+            return false;
+        } else if( hasVtx_ ) {
             float vtx_X = vtxRef_->x();
             float vtx_Y = vtxRef_->y();
             float vtx_Z = vtxRef_->z();
 
-            float sc_X = phoRef_->superCluster()->x();
-            float sc_Y = phoRef_->superCluster()->y();
-            float sc_Z = phoRef_->superCluster()->z();
+            float sc_X = phoPtr_->superCluster()->x();
+            float sc_Y = phoPtr_->superCluster()->y();
+            float sc_Z = phoPtr_->superCluster()->z();
 
             math::XYZVector vtx_Pos( vtx_X, vtx_Y, vtx_Z );
             math::XYZVector sc_Pos( sc_X, sc_Y, sc_Z );
 
             math::XYZVector direction = sc_Pos - vtx_Pos;
-            math::XYZVector p = ( direction.Unit() ) * ( phoRef_->energy() );
-            math::XYZTLorentzVector corrected_p4( p.x(), p.y(), p.z(), phoRef_->energy() );
+            math::XYZVector p = ( direction.Unit() ) * ( phoPtr_->energy() );
+            math::XYZTLorentzVector corrected_p4( p.x(), p.y(), p.z(), phoPtr_->energy() );
 
-            pho_ =  flashgg::Photon( *phoRef_ );
-//            pho_ = new flashgg::Photon(*phoRef_);
-//			pho_ = const_cast<flashgg::Photon *>(phoRef_.get());
+            pho_ =  flashgg::Photon( *phoPtr_ );
             pho_.setP4( corrected_p4 );
             hasPhoton_ = true;
         } else {
-            pho_ = flashgg::Photon( *phoRef_ );
-//			pho_ = const_cast<flashgg::Photon *>(phoRef_.get());
+            pho_ = flashgg::Photon( *phoPtr_ );
             hasPhoton_ = true;
         }
         return true;
@@ -61,39 +35,32 @@ namespace flashgg {
 
     void SinglePhotonView::MakePersistent()
     {
-        if( persistVec_.size() > 0 ) { std::cout << "There is already one persistified photon in the SinglePhotonView" << std::endl; }
-        else {
+        if( !persistVec_.size() ) {
             MakePhoton();
             persistVec_.push_back( pho_ );
         }
     }
 
+    const Photon *SinglePhotonView::photon() const
+    {
+        if( persistVec_.size() ) {
+            return &persistVec_[0];
+        } else {
+            MakePhoton();
+            return &pho_;
+        }
+    }
+
+    Photon &SinglePhotonView::getPhoton()
+    {
+        if( !persistVec_.size() ) {
+            throw cms::Exception( "IncorrectUsage" ) << "SinglePhotonView not persistified. If you really want a non-const photon, call MakePersistent()";
+        }
+        return persistVec_[0];
+    }
+
+
 }
-
-/*
-flashgg::Photon SinglePhotonView::pho4MomCorrection( edm::Ptr<flashgg::Photon> photon, edm::Ptr<reco::Vertex> vtx ) const
-{
-
-    /// vtx should be the chosen vtx, not primary vtx ///
-    float vtx_X = vtx->x();
-    float vtx_Y = vtx->y();
-    float vtx_Z = vtx->z();
-
-    float sc_X = photon->superCluster()->x();
-    float sc_Y = photon->superCluster()->y();
-    float sc_Z = photon->superCluster()->z();
-
-    math::XYZVector vtx_Pos( vtx_X, vtx_Y, vtx_Z );
-    math::XYZVector sc_Pos( sc_X, sc_Y, sc_Z );
-
-    math::XYZVector direction = sc_Pos - vtx_Pos;
-    math::XYZVector p = ( direction.Unit() ) * ( photon->energy() );
-    math::XYZTLorentzVector corrected_p4( p.x(), p.y(), p.z(), photon->energy() );
-    flashgg::Photon p4CorrPho = *photon;
-    p4CorrPho.setP4( corrected_p4 );
-    return p4CorrPho;
-}
-*/
 
 // Local Variables:
 // mode:c++

--- a/DataFormats/src/SinglePhotonView.cc
+++ b/DataFormats/src/SinglePhotonView.cc
@@ -1,17 +1,100 @@
 #include "flashgg/DataFormats/interface/SinglePhotonView.h"
 
 namespace flashgg {
-
-    void SinglePhotonView::daughterMaybe() const
+    /*
+    SinglePhotonView::SinglePhotonView( const DiPhotonCandidate *dipho, int daughter )
     {
-        if( pho_ == 0 ) {
-            if( dipho_ == 0 ) { dipho_ = &( *edmdipho_ ); }
-            if( dipho_ == 0 ) { throw; }
-            pho_ = dynamic_cast<const Photon *>( dipho_->daughter( daughter_ ) );
-            if( pho_ == 0 ) { throw; }
+    	hasPhoton_ = 1;
+    	hasVtx_ = 1;
+    	vtxRef_ = dipho->vtx(); //const_cast< edm::Ptr<reco::Vertex> >(dipho->vtx());
+    	if(daughter == 0){
+    		phoRef_ = dipho->leadingView()->photonRef();
+    	} else  if (daughter == 1){
+    		phoRef_ = dipho->subLeadingView()->photonRef();
+    	}
+    }
+
+    SinglePhotonView::SinglePhotonView( dipho_ptr_type dipho, int daughter )
+    {
+    	hasPhoton_ = 1;
+    	hasVtx_ = 1;
+    	vtxRef_ = dipho->vtx();
+    	if(daughter == 0){
+    		phoRef_ = dipho->leadingView()->photonRef();
+    	} else  if (daughter == 1){
+    		phoRef_ = dipho->subLeadingView()->photonRef();
+    	}
+    }
+    */
+    bool SinglePhotonView::MakePhoton() const
+    {
+        if( hasPhoton_ ) { return false; }
+        else if( hasVtx_ ) {
+            float vtx_X = vtxRef_->x();
+            float vtx_Y = vtxRef_->y();
+            float vtx_Z = vtxRef_->z();
+
+            float sc_X = phoRef_->superCluster()->x();
+            float sc_Y = phoRef_->superCluster()->y();
+            float sc_Z = phoRef_->superCluster()->z();
+
+            math::XYZVector vtx_Pos( vtx_X, vtx_Y, vtx_Z );
+            math::XYZVector sc_Pos( sc_X, sc_Y, sc_Z );
+
+            math::XYZVector direction = sc_Pos - vtx_Pos;
+            math::XYZVector p = ( direction.Unit() ) * ( phoRef_->energy() );
+            math::XYZTLorentzVector corrected_p4( p.x(), p.y(), p.z(), phoRef_->energy() );
+
+            pho_ =  flashgg::Photon( *phoRef_ );
+//            pho_ = new flashgg::Photon(*phoRef_);
+//			pho_ = const_cast<flashgg::Photon *>(phoRef_.get());
+            pho_.setP4( corrected_p4 );
+            hasPhoton_ = true;
+        } else {
+            pho_ = flashgg::Photon( *phoRef_ );
+//			pho_ = const_cast<flashgg::Photon *>(phoRef_.get());
+            hasPhoton_ = true;
+        }
+        return true;
+    }
+
+
+    void SinglePhotonView::MakePersistent()
+    {
+        if( persistVec_.size() > 0 ) { std::cout << "There is already one persistified photon in the SinglePhotonView" << std::endl; }
+        else {
+            MakePhoton();
+            persistVec_.push_back( pho_ );
         }
     }
+
 }
+
+/*
+flashgg::Photon SinglePhotonView::pho4MomCorrection( edm::Ptr<flashgg::Photon> photon, edm::Ptr<reco::Vertex> vtx ) const
+{
+
+    /// vtx should be the chosen vtx, not primary vtx ///
+    float vtx_X = vtx->x();
+    float vtx_Y = vtx->y();
+    float vtx_Z = vtx->z();
+
+    float sc_X = photon->superCluster()->x();
+    float sc_Y = photon->superCluster()->y();
+    float sc_Z = photon->superCluster()->z();
+
+    math::XYZVector vtx_Pos( vtx_X, vtx_Y, vtx_Z );
+    math::XYZVector sc_Pos( sc_X, sc_Y, sc_Z );
+
+    math::XYZVector direction = sc_Pos - vtx_Pos;
+    math::XYZVector p = ( direction.Unit() ) * ( photon->energy() );
+    math::XYZTLorentzVector corrected_p4( p.x(), p.y(), p.z(), photon->energy() );
+    flashgg::Photon p4CorrPho = *photon;
+    p4CorrPho.setP4( corrected_p4 );
+    return p4CorrPho;
+}
+*/
+
 // Local Variables:
 // mode:c++
 // indent-tabs-mode:nil

--- a/DataFormats/src/classes.h
+++ b/DataFormats/src/classes.h
@@ -204,6 +204,8 @@ namespace  {
 
         std::vector<edm::Ptr<pat::MET> >        vec_ptr_pat_met;
         edm::Wrapper<std::vector<edm::Ptr<pat::MET> > >   wrp_vec_ptr_pat_met;
+
+
     };
 }
 // Local Variables:

--- a/DataFormats/src/classes_def.xml
+++ b/DataFormats/src/classes_def.xml
@@ -67,7 +67,12 @@
 <class name="edm::Wrapper<edm::Ptr<flashgg::DiPhotonCandidate> >"/>
 <class name="std::vector<edm::Ptr<flashgg::DiPhotonCandidate> >"/>
 <class name="edm::Wrapper<std::vector<edm::Ptr<flashgg::DiPhotonCandidate> > >"/>
-<class name="flashgg::SinglePhotonView"/>
+<!-- <class name="flashgg::SinglePhotonView"></class> -->
+<class name="flashgg::SinglePhotonView"><field name="pho_" transient="true"/></class>
+<ioread sourceClass = "flashgg::SinglePhotonView" version="[1-]" targetClass="flashgg::SinglePhotonView" source="" target="hasPhoton_">
+	<![CDATA[ hasPhoton_ = false;
+	]]>
+</ioread>
 <class name="edm::Ptr<flashgg::SinglePhotonView>"/>
 <class name="std::vector<flashgg::SinglePhotonView>"/>
 <class name="edm::Wrapper<std::vector<flashgg::SinglePhotonView> >"/>
@@ -85,8 +90,6 @@
 <class name="std::pair<edm::Ptr<reco::Vertex>,float>"/>
 <class name="std::map<std::string,std::map<edm::Ptr<reco::Vertex>,float>>"/>
 <class name="std::pair<std::string,std::map<edm::Ptr<reco::Vertex>,float>>"/>
-<!-- <class name="edm::Wrapper<std::map<edm::Ptr<reco::Vertex>,edm::PtrVector<pat::PackedCandidate> > >"/>
-<class name="edm::Wrapper<std::pair<edm::Ptr<reco::Vertex>,edm::PtrVector<pat::PackedCandidate> > >"/> -->
 <class name="edm::Wrapper<std::vector<flashgg::Jet> >"/>
 <class name="flashgg::Electron"/>
 <class name="edm::Ptr<flashgg::Electron>"/>

--- a/MicroAOD/interface/PerPhotonMVADiPhotonPostProcess.h
+++ b/MicroAOD/interface/PerPhotonMVADiPhotonPostProcess.h
@@ -24,8 +24,8 @@ namespace flashgg {
         {
             computer_.update( event );
             for( auto &dipho : *output ) {
-                computer_.fill( dipho.getLeadingPhoton() );
-                computer_.fill( dipho.getSubLeadingPhoton() );
+                computer_.fill( dipho.leadingPhoton() );
+                computer_.fill( dipho.subLeadingPhoton() );
             }
         };
     private:

--- a/MicroAOD/interface/PhotonIdUtils.h
+++ b/MicroAOD/interface/PhotonIdUtils.h
@@ -62,6 +62,8 @@ namespace flashgg {
 
         static flashgg::Photon     pho4MomCorrection( edm::Ptr<flashgg::Photon> &, edm::Ptr<reco::Vertex> );
 
+        math::XYZTLorentzVector     pho4MomCorrectionTLVector( edm::Ptr<flashgg::Photon> &, edm::Ptr<reco::Vertex> );
+
         static bool vetoPackedCand( const pat::Photon &photon, const edm::Ptr<pat::PackedCandidate> &pfcand );
 
         std::map<edm::Ptr<reco::Vertex>, float> computeMVAWrtAllVtx( flashgg::Photon &, const std::vector<edm::Ptr<reco::Vertex> > &, const double );

--- a/MicroAOD/plugins/CHSLegacyVertexCandidateProducer.cc
+++ b/MicroAOD/plugins/CHSLegacyVertexCandidateProducer.cc
@@ -102,6 +102,7 @@ namespace flashgg {
             }
         }
 
+
         std::auto_ptr<vector<pat::PackedCandidate> > result( new vector<pat::PackedCandidate>() );
 
         for( unsigned int pfCandLoop = 0 ; pfCandLoop < pfCandidates->size() ; pfCandLoop++ ) {
@@ -121,6 +122,8 @@ namespace flashgg {
                 if( flashVertex == currentVertex ) { result->push_back( *cand ); }
             }
         }
+
+
 
         evt.put( result );
     }

--- a/MicroAOD/plugins/DiPhotonProducer.cc
+++ b/MicroAOD/plugins/DiPhotonProducer.cc
@@ -57,7 +57,6 @@ namespace flashgg {
 
     void DiPhotonProducer::produce( Event &evt, const EventSetup & )
     {
-
         Handle<View<reco::Vertex> > primaryVertices;
         evt.getByToken( vertexToken_, primaryVertices );
         // const PtrVector<reco::Vertex>& pvPointers = primaryVertices->ptrVector();
@@ -90,6 +89,7 @@ namespace flashgg {
 //    cout << "evt.id().event()= " << evt.id().event() << "\tevt.isRealData()= " << evt.isRealData() << "\tphotons->size()= " << photons->size() << "\tprimaryVertices->size()= " << primaryVertices->size() << endl;
 
         for( unsigned int i = 0 ; i < photons->size() ; i++ ) {
+
             Ptr<flashgg::Photon> pp1 = photons->ptrAt( i );
             for( unsigned int j = i + 1 ; j < photons->size() ; j++ ) {
                 Ptr<flashgg::Photon> pp2 = photons->ptrAt( j );
@@ -114,19 +114,23 @@ namespace flashgg {
                 photon1_corr.setpfChgIsoWrtChosenVtx03( photon1_corr.pfChgIso03WrtVtx( pvx ) );
                 photon2_corr.setpfChgIsoWrtChosenVtx03( photon2_corr.pfChgIso03WrtVtx( pvx ) );
 
-                DiPhotonCandidate dipho( photon1_corr, photon2_corr, pvx );
+                DiPhotonCandidate dipho( pp1, pp2, pvx );
                 dipho.setVertexIndex( ivtx );
 
+                cout << "DiPhoton pt: " << dipho.pt();
+                cout << "Pho1 pt: " << dipho.leadingPhoton()->pt() << endl;
                 // Obviously the last selection has to be for this diphoton or this is wrong
                 vertexSelector_->writeInfoFromLastSelectionTo( dipho );
 
+                dipho.leadingView().MakePersistent();
+
                 // store the diphoton into the collection
                 diPhotonColl->push_back( dipho );
-
             }
         }
         // Sort the final collection (descending) and put it in the event
         std::sort( diPhotonColl->begin(), diPhotonColl->end(), []( const DiPhotonCandidate & a, const DiPhotonCandidate & b ) { return b < a; } );
+
         evt.put( diPhotonColl );
     }
 }

--- a/MicroAOD/plugins/DiPhotonProducer.cc
+++ b/MicroAOD/plugins/DiPhotonProducer.cc
@@ -117,12 +117,8 @@ namespace flashgg {
                 DiPhotonCandidate dipho( pp1, pp2, pvx );
                 dipho.setVertexIndex( ivtx );
 
-                cout << "DiPhoton pt: " << dipho.pt();
-                cout << "Pho1 pt: " << dipho.leadingPhoton()->pt() << endl;
                 // Obviously the last selection has to be for this diphoton or this is wrong
                 vertexSelector_->writeInfoFromLastSelectionTo( dipho );
-
-                dipho.leadingView().MakePersistent();
 
                 // store the diphoton into the collection
                 diPhotonColl->push_back( dipho );

--- a/MicroAOD/plugins/SinglePhotonViewProducer.cc
+++ b/MicroAOD/plugins/SinglePhotonViewProducer.cc
@@ -8,6 +8,7 @@
 #include "FWCore/Utilities/interface/EDMException.h"
 
 #include "flashgg/DataFormats/interface/SinglePhotonView.h"
+#include "flashgg/DataFormats/interface/DiPhotonCandidate.h"
 
 #include <vector>
 #include <algorithm>
@@ -49,8 +50,10 @@ namespace flashgg {
         int nCand = maxCandidates_;
         //for(auto & dipho : diPhotons) {
         for( unsigned int i = 0 ; i < diPhotons->size(); i++ ) {
-            SinglePhotonView leg0( diPhotons->ptrAt( i ), 0 );
-            SinglePhotonView leg1( diPhotons->ptrAt( i ), 1 );
+            SinglePhotonView leg0( diPhotons->ptrAt( i )->leadingView().photonRef(), diPhotons->ptrAt( i )->vtx() );
+            SinglePhotonView leg1( diPhotons->ptrAt( i )->subLeadingView().photonRef(), diPhotons->ptrAt( i )->vtx() );
+//            SinglePhotonView leg0( diPhotons->ptrAt( i ), 0 );
+//          SinglePhotonView leg1( diPhotons->ptrAt( i ), 1 );
 
             if( leg0->pt() < leg1->pt() ) { std::swap( leg0, leg1 ); }
 

--- a/MicroAOD/plugins/SinglePhotonViewProducer.cc
+++ b/MicroAOD/plugins/SinglePhotonViewProducer.cc
@@ -43,22 +43,15 @@ namespace flashgg {
 
         Handle<View<flashgg::DiPhotonCandidate> > diPhotons;
         evt.getByToken( diPhotonToken_, diPhotons );
-        //	const PtrVector<flashgg::DiPhotonCandidate>& diPhotonPointers = diPhotons->ptrVector();
 
         std::auto_ptr<vector<SinglePhotonView> > photonViews( new vector<SinglePhotonView> );
 
         int nCand = maxCandidates_;
         //for(auto & dipho : diPhotons) {
         for( unsigned int i = 0 ; i < diPhotons->size(); i++ ) {
-            SinglePhotonView leg0( diPhotons->ptrAt( i )->leadingView().photonRef(), diPhotons->ptrAt( i )->vtx() );
-            SinglePhotonView leg1( diPhotons->ptrAt( i )->subLeadingView().photonRef(), diPhotons->ptrAt( i )->vtx() );
-//            SinglePhotonView leg0( diPhotons->ptrAt( i ), 0 );
-//          SinglePhotonView leg1( diPhotons->ptrAt( i ), 1 );
 
-            if( leg0->pt() < leg1->pt() ) { std::swap( leg0, leg1 ); }
-
-            photonViews->push_back( leg0 );
-            photonViews->push_back( leg1 );
+            photonViews->push_back( *diPhotons->ptrAt( i )->leadingView() );
+            photonViews->push_back( *diPhotons->ptrAt( i )->subLeadingView() );
 
             if( --nCand == 0 ) { break; }
         }

--- a/MicroAOD/src/CutBasedPhotonViewSelector.cc
+++ b/MicroAOD/src/CutBasedPhotonViewSelector.cc
@@ -12,7 +12,7 @@ namespace flashgg {
 
     bool CutBasedPhotonViewSelector::operator()( const SinglePhotonView &cand, const EventBase &ev ) const
     {
-        return CutBasedPhotonObjectSelector::operator()( cand.photon(), ev );
+        return CutBasedPhotonObjectSelector::operator()( *cand.photon(), ev );
     }
 
 }

--- a/Systematics/interface/DiPhotonFromPhotonBase.h
+++ b/Systematics/interface/DiPhotonFromPhotonBase.h
@@ -53,13 +53,21 @@ namespace flashgg {
     template<class param_var>
     void DiPhotonFromPhotonBase<param_var>::applyCorrection( DiPhotonCandidate &y, param_var syst_shift )
     {
-        if( debug_ ) { std::cout << "START OF DiPhotonFromPhoton::applyCorrection M PT E1 E2 " << y.mass() << " " << y.pt() << " " << y.leadingPhoton()->energy() << " " << y.subLeadingPhoton()->energy() << std::endl; }
+        if( debug_ ) {
+            std::cout << "START OF DiPhotonFromPhoton::applyCorrection M PT E1 E2 ETA1 ETA2 "
+                      << y.mass() << " " << y.pt() << " " << y.leadingPhoton()->energy() << " " << y.subLeadingPhoton()->energy() << " "
+                      << y.leadingPhoton()->eta() << " " << y.subLeadingPhoton()->eta() << std::endl;
+        }
+        y.makePhotonsPersistent();
         photon_corr_->applyCorrection( y.getLeadingPhoton(), syst_shift );
         photon_corr_->applyCorrection( y.getSubLeadingPhoton(), syst_shift );
-        AddFourMomenta addP4;
-        addP4.set( y );
+        y.computeP4AndOrder();
         y.setSystLabel( shiftLabel( syst_shift ) );
-        if( debug_ ) { std::cout << "END OF DiPhotonFromPhoton::applyCorrection M PT E1 E2 " << y.mass() << " " << y.pt() << " " << y.leadingPhoton()->energy() << " " << y.subLeadingPhoton()->energy() << std::endl; }
+        if( debug_ ) {
+            std::cout << "END OF DiPhotonFromPhoton::applyCorrection M PT E1 E2 ETA1 ETA2 "
+                      << y.mass() << " " << y.pt() << " " << y.leadingPhoton()->energy() << " " << y.subLeadingPhoton()->energy() << " "
+                      << y.leadingPhoton()->eta() << " " << y.subLeadingPhoton()->eta() << std::endl;
+        }
     }
 }
 

--- a/Systematics/interface/ObjectSystematicProducer.h
+++ b/Systematics/interface/ObjectSystematicProducer.h
@@ -130,6 +130,7 @@ namespace flashgg {
             param_var syst_shift )
     {
         //        std::cout << " 1d before 1d " << std::endl;
+        //        std::cout << " In ObjectSystematicProducer::ApplyCorrections pt m " << y.pt() << " " << y.mass() << std::endl;
         for( unsigned int shift = 0; shift < Corrections_.size(); shift++ ) {
             if( CorrToShift == Corrections_.at( shift ) ) {
                 Corrections_.at( shift )->applyCorrection( y, syst_shift );
@@ -150,6 +151,7 @@ namespace flashgg {
             shared_ptr<BaseSystMethod<flashgg_object, pair<param_var, param_var> > > CorrToShift,
             pair<param_var, param_var>  syst_shift )
     {
+        //        std::cout << " In ObjectSystematicProducer::ApplyCorrections pt m " << y.pt() << " " << y.mass() << std::endl;
         //        std::cout << "2d before 1d" << std::endl;
         for( unsigned int shift = 0; shift < Corrections_.size(); shift++ ) {
             Corrections_.at( shift )->applyCorrection( y, param_var( 0 ) );

--- a/Taggers/plugins/DiPhotonMVAProducer.cc
+++ b/Taggers/plugins/DiPhotonMVAProducer.cc
@@ -91,11 +91,9 @@ namespace flashgg {
 
     void DiPhotonMVAProducer::produce( Event &evt, const EventSetup & )
     {
-        cout << "test1" << endl;
         Handle<View<flashgg::DiPhotonCandidate> > diPhotons;
         evt.getByToken( diPhotonToken_, diPhotons );
         // const PtrVector<flashgg::DiPhotonCandidate>& diPhotonPointers = diPhotons->ptrVector();
-        cout << "DIPHOTONS SIZE " << diPhotons->size() << endl;
 
         Handle<reco::BeamSpot> recoBeamSpotHandle;
         evt.getByToken( beamSpotToken_, recoBeamSpotHandle );
@@ -110,17 +108,8 @@ namespace flashgg {
         std::auto_ptr<vector<DiPhotonMVAResult> > results( new vector<DiPhotonMVAResult> ); // one per diphoton, always in same order, vector is more efficient than map
 
         for( unsigned int candIndex = 0; candIndex < diPhotons->size() ; candIndex++ ) {
-            cout << "DIPHO m " << diPhotons->ptrAt( candIndex )->mass() << endl;
             flashgg::DiPhotonMVAResult mvares;
-            cout << "GETTING VTX PTR" << endl;
             edm::Ptr<reco::Vertex> vtx = diPhotons->ptrAt( candIndex )->vtx();
-            cout << "GETTING pho1 PTR" << endl;
-            const flashgg::SinglePhotonView v1 = diPhotons->ptrAt( candIndex )->leadingView();
-            cout << "GETTING pho2 PTR" << endl;
-            const flashgg::SinglePhotonView v2 = diPhotons->ptrAt( candIndex )->subLeadingView();
-            cout << "PT "  << endl;
-            cout << "Pho1 pt " << v1.photonRef()->pt() << " \t Pho2 pt " << v2->pt() << endl;
-
 
             const flashgg::Photon *g1 = diPhotons->ptrAt( candIndex )->leadingPhoton();
             const flashgg::Photon *g2 = diPhotons->ptrAt( candIndex )->subLeadingPhoton();

--- a/Taggers/plugins/DiPhotonMVAProducer.cc
+++ b/Taggers/plugins/DiPhotonMVAProducer.cc
@@ -10,6 +10,8 @@
 #include "flashgg/DataFormats/interface/DiPhotonCandidate.h"
 #include "flashgg/DataFormats/interface/DiPhotonMVAResult.h"
 
+#include "flashgg/DataFormats/interface/SinglePhotonView.h"
+
 #include "TMVA/Reader.h"
 #include "TMath.h"
 #include "TVector3.h"
@@ -89,9 +91,11 @@ namespace flashgg {
 
     void DiPhotonMVAProducer::produce( Event &evt, const EventSetup & )
     {
+        cout << "test1" << endl;
         Handle<View<flashgg::DiPhotonCandidate> > diPhotons;
         evt.getByToken( diPhotonToken_, diPhotons );
         // const PtrVector<flashgg::DiPhotonCandidate>& diPhotonPointers = diPhotons->ptrVector();
+        cout << "DIPHOTONS SIZE " << diPhotons->size() << endl;
 
         Handle<reco::BeamSpot> recoBeamSpotHandle;
         evt.getByToken( beamSpotToken_, recoBeamSpotHandle );
@@ -106,9 +110,18 @@ namespace flashgg {
         std::auto_ptr<vector<DiPhotonMVAResult> > results( new vector<DiPhotonMVAResult> ); // one per diphoton, always in same order, vector is more efficient than map
 
         for( unsigned int candIndex = 0; candIndex < diPhotons->size() ; candIndex++ ) {
+            cout << "DIPHO m " << diPhotons->ptrAt( candIndex )->mass() << endl;
             flashgg::DiPhotonMVAResult mvares;
-
+            cout << "GETTING VTX PTR" << endl;
             edm::Ptr<reco::Vertex> vtx = diPhotons->ptrAt( candIndex )->vtx();
+            cout << "GETTING pho1 PTR" << endl;
+            const flashgg::SinglePhotonView v1 = diPhotons->ptrAt( candIndex )->leadingView();
+            cout << "GETTING pho2 PTR" << endl;
+            const flashgg::SinglePhotonView v2 = diPhotons->ptrAt( candIndex )->subLeadingView();
+            cout << "PT "  << endl;
+            cout << "Pho1 pt " << v1.photonRef()->pt() << " \t Pho2 pt " << v2->pt() << endl;
+
+
             const flashgg::Photon *g1 = diPhotons->ptrAt( candIndex )->leadingPhoton();
             const flashgg::Photon *g2 = diPhotons->ptrAt( candIndex )->subLeadingPhoton();
 

--- a/Taggers/python/flashggTagSequence_cfi.py
+++ b/Taggers/python/flashggTagSequence_cfi.py
@@ -9,14 +9,15 @@ flashggTagSequence = cms.Sequence(flashggDiPhotonMVA
                                   * flashggVBFMVANew
                                   * flashggVBFDiPhoDiJetMVA
                                   * flashggVBFDiPhoDiJetMVANew
-                                  * (flashggUntaggedCategory
-                                     + flashggVBFTag
+                                  * ( flashggUntaggedCategory
+                                      + flashggVBFTag
                                      + flashggTTHLeptonicTag
                                      + flashggVHEtTag
                                      + flashggTTHHadronicTag
                                      + flashggVHLooseTag
                                      + flashggVHTightTag
-                                     + flashggVHHadronicTag)
-                                  * flashggTagSorter
+                                     + flashggVHHadronicTag
+					)
+                                 * flashggTagSorter
                                   )
 


### PR DESCRIPTION
Work by @rateixei with some interface tweaks by me.  Wraps each photon in a SinglePhotonView inside the diphoton, which provides a link to the original photon (addressing #27 ) and builds a cached photon with corrected P4 based on the diphoton vertex.  When saved, the cached photon is not included to save space in MicroAOD; it's rebuilt from the link to the original when next required.  However, for systematics it can be "made persistent", i.e. the changed photon is stored separately as part of a copied DiPhoton.  

In most cases, DiPhotons can be used exactly as they were before.  Methods like leadingPhoton(), subLeadingPhoton(), leadingView(), subLeadingView() are const pointers.  

Accessors with get in front return non-const references.  In order to protect the user from making objects larger when not intended, attempting to get a non-const reference before MakePersistent() is called causes a run-time exception; if photons are changed, computeP4AndOrder() must be called on the DiPhoton so that it returns correct information for its own momentum.  The MakePersistent and computeP4AndOrder methods are currently needed in only one place: Systematics/interface/DiPhotonFromPhotonBase.h    

At MicroAOD level, the impact is the following savings of space (collection, compressed size, uncompressed size):

Old: flashggDiPhotonCandidates_flashggDiPhotons__FLASHggMicroAOD. 9162.08 1679.16
New: flashggDiPhotonCandidates_flashggDiPhotons__FLASHggMicroAOD. 837.327 436.969