### PR TITLE
update tagger for running over data; updates to microAODcustomize.py for globaltags and local filenames

### DIFF
--- a/MicroAOD/python/MicroAODCustomize.py
+++ b/MicroAOD/python/MicroAODCustomize.py
@@ -10,7 +10,7 @@ class MicroAODCustomize(object):
         
         self.options.register ('fileNames',
                                 "", # default value
-                               VarParsing.VarParsing.multiplicity.singleton, # singleton or list
+                               VarParsing.VarParsing.multiplicity.list, # singleton or list
                                VarParsing.VarParsing.varType.string,          # string, int, or float
                                "fileNames")
         self.options.register ('datasetName',

--- a/Taggers/plugins/TTHHadronicTagProducer.cc
+++ b/Taggers/plugins/TTHHadronicTagProducer.cc
@@ -195,8 +195,7 @@ namespace flashgg {
             }
         }
         evt.put( tthhtags );
-        if( ! evt.isRealData() )
-        { evt.put( truths ); }
+        evt.put( truths ); 
         // cout << "tagged events = " << count << endl;
     }
 }

--- a/Taggers/plugins/TTHHadronicTagProducer.cc
+++ b/Taggers/plugins/TTHHadronicTagProducer.cc
@@ -111,14 +111,14 @@ namespace flashgg {
         std::auto_ptr<vector<TagTruthBase> > truths( new vector<TagTruthBase> );
 
         Point higgsVtx;
-
-        for( unsigned int genLoop = 0 ; genLoop < genParticles->size(); genLoop++ ) {
-            int pdgid = genParticles->ptrAt( genLoop )->pdgId();
-            if( pdgid == 25 || pdgid == 22 ) {
-                higgsVtx = genParticles->ptrAt( genLoop )->vertex();
-                break;
+        if( ! evt.isRealData() )
+            for( unsigned int genLoop = 0 ; genLoop < genParticles->size(); genLoop++ ) {
+                int pdgid = genParticles->ptrAt( genLoop )->pdgId();
+                if( pdgid == 25 || pdgid == 22 ) {
+                    higgsVtx = genParticles->ptrAt( genLoop )->vertex();
+                    break;
+                }
             }
-        }
 
         edm::RefProd<vector<TagTruthBase> > rTagTruth = evt.getRefBeforePut<vector<TagTruthBase> >();
         unsigned int idx = 0;
@@ -186,14 +186,17 @@ namespace flashgg {
                 tthhtags_obj.setDiPhotonIndex( diphoIndex );
                 tthhtags->push_back( tthhtags_obj );
                 TagTruthBase truth_obj;
-                truth_obj.setGenPV( higgsVtx );
-                truths->push_back( truth_obj );
-                tthhtags->back().setTagTruth( edm::refToPtr( edm::Ref<vector<TagTruthBase> >( rTagTruth, idx++ ) ) );
+                if( ! evt.isRealData() ) {
+                    truth_obj.setGenPV( higgsVtx );
+                    truths->push_back( truth_obj );
+                    tthhtags->back().setTagTruth( edm::refToPtr( edm::Ref<vector<TagTruthBase> >( rTagTruth, idx++ ) ) );
+                }
                 // count++;
             }
         }
         evt.put( tthhtags );
-        evt.put( truths );
+        if( ! evt.isRealData() )
+        { evt.put( truths ); }
         // cout << "tagged events = " << count << endl;
     }
 }

--- a/Taggers/plugins/TTHLeptonicTagProducer.cc
+++ b/Taggers/plugins/TTHLeptonicTagProducer.cc
@@ -481,8 +481,7 @@ namespace flashgg {
 
         }//diPho loop end !
         evt.put( tthltags );
-        if( ! evt.isRealData() )
-        { evt.put( truths ); }
+        evt.put( truths ); 
     }
 
 }

--- a/Taggers/plugins/TTHLeptonicTagProducer.cc
+++ b/Taggers/plugins/TTHLeptonicTagProducer.cc
@@ -242,13 +242,14 @@ namespace flashgg {
 
         Point higgsVtx;
 
-        for( unsigned int genLoop = 0 ; genLoop < genParticles->size(); genLoop++ ) {
-            int pdgid = genParticles->ptrAt( genLoop )->pdgId();
-            if( pdgid == 25 || pdgid == 22 ) {
-                higgsVtx = genParticles->ptrAt( genLoop )->vertex();
-                break;
+        if( ! evt.isRealData() )
+            for( unsigned int genLoop = 0 ; genLoop < genParticles->size(); genLoop++ ) {
+                int pdgid = genParticles->ptrAt( genLoop )->pdgId();
+                if( pdgid == 25 || pdgid == 22 ) {
+                    higgsVtx = genParticles->ptrAt( genLoop )->vertex();
+                    break;
+                }
             }
-        }
 
         edm::RefProd<vector<TagTruthBase> > rTagTruth = evt.getRefBeforePut<vector<TagTruthBase> >();
         unsigned int idx = 0;
@@ -471,14 +472,17 @@ namespace flashgg {
                 tthltags_obj.setDiPhotonIndex( diphoIndex );
                 tthltags->push_back( tthltags_obj );
                 TagTruthBase truth_obj;
-                truth_obj.setGenPV( higgsVtx );
-                truths->push_back( truth_obj );
-                tthltags->back().setTagTruth( edm::refToPtr( edm::Ref<vector<TagTruthBase> >( rTagTruth, idx++ ) ) );
+                if( ! evt.isRealData() ) {
+                    truth_obj.setGenPV( higgsVtx );
+                    truths->push_back( truth_obj );
+                    tthltags->back().setTagTruth( edm::refToPtr( edm::Ref<vector<TagTruthBase> >( rTagTruth, idx++ ) ) );
+                }
             }
 
         }//diPho loop end !
         evt.put( tthltags );
-        evt.put( truths );
+        if( ! evt.isRealData() )
+        { evt.put( truths ); }
     }
 
 }

--- a/Taggers/plugins/UntaggedTagProducer.cc
+++ b/Taggers/plugins/UntaggedTagProducer.cc
@@ -129,8 +129,7 @@ namespace flashgg {
             }
         }
         evt.put( tags );
-        if( ! evt.isRealData() )
-        { evt.put( truths ); }
+        evt.put( truths );
     }
 }
 

--- a/Taggers/plugins/UntaggedTagProducer.cc
+++ b/Taggers/plugins/UntaggedTagProducer.cc
@@ -56,7 +56,7 @@ namespace flashgg {
         // getUntrackedParameter<vector<float> > has no library, so we use double transiently
         boundaries = iConfig.getUntrackedParameter<vector<double > >( "Boundaries", default_boundaries );
 
-        assert( is_sorted( boundaries.begin(), boundaries.end() ) ); // we are counting on ascending order - update this to give an error message or exception        
+        assert( is_sorted( boundaries.begin(), boundaries.end() ) ); // we are counting on ascending order - update this to give an error message or exception
         produces<vector<UntaggedTag> >();
         produces<vector<TagTruthBase> >();
     }
@@ -89,17 +89,17 @@ namespace flashgg {
         std::auto_ptr<vector<TagTruthBase> > truths( new vector<TagTruthBase> );
 
         Point higgsVtx;
-
-        for( unsigned int genLoop = 0 ; genLoop < genParticles->size(); genLoop++ ) {
-            int pdgid = genParticles->ptrAt( genLoop )->pdgId();
-            if( pdgid == 25 || pdgid == 22 ) {
-                higgsVtx = genParticles->ptrAt( genLoop )->vertex();
-                break;
+        if( ! evt.isRealData() )
+            for( unsigned int genLoop = 0 ; genLoop < genParticles->size(); genLoop++ ) {
+                int pdgid = genParticles->ptrAt( genLoop )->pdgId();
+                if( pdgid == 25 || pdgid == 22 ) {
+                    higgsVtx = genParticles->ptrAt( genLoop )->vertex();
+                    break;
+                }
             }
-        }
 
         assert( diPhotons->size() == mvaResults->size() ); // We are relying on corresponding sets - update this to give an error/exception
-        
+
         unsigned int idx = 0;
 
         // Je ne comprends pas ces RefProds, mais je le fais
@@ -122,12 +122,15 @@ namespace flashgg {
             // std::cout << "[UNTAGGED] MVA is "<< mvares->result << " and category is " << tag_obj.categoryNumber() << std::endl;
             if( tag_obj.categoryNumber() >= 0 ) {
                 tags->push_back( tag_obj );
-                truths->push_back( truth_obj );
-                tags->back().setTagTruth( edm::refToPtr( edm::Ref<vector<TagTruthBase> >( rTagTruth, idx++ ) ) );
+                if( ! evt.isRealData() ) {
+                    truths->push_back( truth_obj );
+                    tags->back().setTagTruth( edm::refToPtr( edm::Ref<vector<TagTruthBase> >( rTagTruth, idx++ ) ) );
+                }
             }
         }
         evt.put( tags );
-        evt.put( truths );
+        if( ! evt.isRealData() )
+        { evt.put( truths ); }
     }
 }
 

--- a/Taggers/plugins/VBFTagProducer.cc
+++ b/Taggers/plugins/VBFTagProducer.cc
@@ -109,31 +109,31 @@ namespace flashgg {
         float pt_leadq = 0., pt_subleadq = 0.;
         Point higgsVtx;
 
-        for( unsigned int genLoop = 0 ; genLoop < genParticles->size(); genLoop++ ) {
-            int pdgid = genParticles->ptrAt( genLoop )->pdgId();
-            if( pdgid == 25 || pdgid == 22 ) {
-                higgsVtx = genParticles->ptrAt( genLoop )->vertex();
-                break;
+        if( ! evt.isRealData() ) {
+            for( unsigned int genLoop = 0 ; genLoop < genParticles->size(); genLoop++ ) {
+                int pdgid = genParticles->ptrAt( genLoop )->pdgId();
+                if( pdgid == 25 || pdgid == 22 ) {
+                    higgsVtx = genParticles->ptrAt( genLoop )->vertex();
+                    break;
+                }
             }
-        }
-
-        for( unsigned int genLoop = 0 ; genLoop < genParticles->size(); genLoop++ ) {
-            edm::Ptr<reco::GenParticle> part = genParticles->ptrAt( genLoop );
-            if( part->status() == 3 ) {
-                if( abs( part->pdgId() ) <= 5 ) {
-                    if( part->pt() > pt_leadq ) {
-                        index_subleadq = index_leadq;
-                        pt_subleadq = pt_leadq;
-                        index_leadq = genLoop;
-                        pt_leadq = part->pt();
-                    } else if( part->pt() > pt_subleadq ) {
-                        index_subleadq = genLoop;
-                        pt_subleadq = part->pt();
+            for( unsigned int genLoop = 0 ; genLoop < genParticles->size(); genLoop++ ) {
+                edm::Ptr<reco::GenParticle> part = genParticles->ptrAt( genLoop );
+                if( part->status() == 3 ) {
+                    if( abs( part->pdgId() ) <= 5 ) {
+                        if( part->pt() > pt_leadq ) {
+                            index_subleadq = index_leadq;
+                            pt_subleadq = pt_leadq;
+                            index_leadq = genLoop;
+                            pt_leadq = part->pt();
+                        } else if( part->pt() > pt_subleadq ) {
+                            index_subleadq = genLoop;
+                            pt_subleadq = part->pt();
+                        }
                     }
                 }
             }
         }
-
         assert( diPhotons->size() == vbfDiPhoDiJetMvaResults->size() ); // We are relying on corresponding sets - update this to give an error/exception
         assert( diPhotons->size() ==
                 mvaResults->size() ); // We are relying on corresponding sets - update this to give an error/exception
@@ -148,7 +148,6 @@ namespace flashgg {
 
             int catnum = chooseCategory( vbfdipho_mvares->vbfDiPhoDiJetMvaResult );
             tag_obj.setCategoryNumber( catnum );
-
             unsigned int index_gp_leadjet = std::numeric_limits<unsigned int>::max();
             unsigned int index_gp_subleadjet = std::numeric_limits<unsigned int>::max();
             unsigned int index_gp_leadphoton = std::numeric_limits<unsigned int>::max();
@@ -162,67 +161,69 @@ namespace flashgg {
             float dr_gj_leadjet = 999.;
             float dr_gj_subleadjet = 999.;
             VBFTagTruth truth_obj;
-
-            for( unsigned int genLoop = 0 ; genLoop < genParticles->size(); genLoop++ ) {
-                edm::Ptr<reco::GenParticle> part = genParticles->ptrAt( genLoop );
-                if( part->status() == 3 ) {
-                    float dr = deltaR( tag_obj.leadingJet().eta(), tag_obj.leadingJet().phi(), part->eta(), part->phi() );
-                    if( dr < dr_gp_leadjet ) {
-                        dr_gp_leadjet = dr;
-                        index_gp_leadjet = genLoop;
-                    }
-                    dr = deltaR( tag_obj.subLeadingJet().eta(), tag_obj.subLeadingJet().phi(), part->eta(), part->phi() );
-                    if( dr < dr_gp_subleadjet ) {
-                        dr_gp_subleadjet = dr;
-                        index_gp_subleadjet = genLoop;
-                    }
-                    dr = deltaR( tag_obj.diPhoton()->leadingPhoton()->eta(), tag_obj.diPhoton()->leadingPhoton()->phi(), part->eta(), part->phi() );
-                    if( dr < dr_gp_leadphoton ) {
-                        dr_gp_leadphoton = dr;
-                        index_gp_leadphoton = genLoop;
-                    }
-                    dr = deltaR( tag_obj.diPhoton()->subLeadingPhoton()->eta(), tag_obj.diPhoton()->subLeadingPhoton()->phi(), part->eta(), part->phi() );
-                    if( dr < dr_gp_subleadphoton ) {
-                        dr_gp_subleadphoton = dr;
-                        index_gp_subleadphoton = genLoop;
+            if( ! evt.isRealData() ) {
+                for( unsigned int genLoop = 0 ; genLoop < genParticles->size(); genLoop++ ) {
+                    edm::Ptr<reco::GenParticle> part = genParticles->ptrAt( genLoop );
+                    if( part->status() == 3 ) {
+                        float dr = deltaR( tag_obj.leadingJet().eta(), tag_obj.leadingJet().phi(), part->eta(), part->phi() );
+                        if( dr < dr_gp_leadjet ) {
+                            dr_gp_leadjet = dr;
+                            index_gp_leadjet = genLoop;
+                        }
+                        dr = deltaR( tag_obj.subLeadingJet().eta(), tag_obj.subLeadingJet().phi(), part->eta(), part->phi() );
+                        if( dr < dr_gp_subleadjet ) {
+                            dr_gp_subleadjet = dr;
+                            index_gp_subleadjet = genLoop;
+                        }
+                        dr = deltaR( tag_obj.diPhoton()->leadingPhoton()->eta(), tag_obj.diPhoton()->leadingPhoton()->phi(), part->eta(), part->phi() );
+                        if( dr < dr_gp_leadphoton ) {
+                            dr_gp_leadphoton = dr;
+                            index_gp_leadphoton = genLoop;
+                        }
+                        dr = deltaR( tag_obj.diPhoton()->subLeadingPhoton()->eta(), tag_obj.diPhoton()->subLeadingPhoton()->phi(), part->eta(), part->phi() );
+                        if( dr < dr_gp_subleadphoton ) {
+                            dr_gp_subleadphoton = dr;
+                            index_gp_subleadphoton = genLoop;
+                        }
                     }
                 }
+
+                if( index_gp_leadjet < std::numeric_limits<unsigned int>::max() ) { truth_obj.setClosestParticleToLeadingJet( genParticles->ptrAt( index_gp_leadjet ) ); }
+                if( index_gp_subleadjet < std::numeric_limits<unsigned int>::max() ) { truth_obj.setClosestParticleToSubLeadingJet( genParticles->ptrAt( index_gp_subleadjet ) ); }
+                if( index_gp_leadphoton < std::numeric_limits<unsigned int>::max() ) { truth_obj.setClosestParticleToLeadingPhoton( genParticles->ptrAt( index_gp_leadphoton ) ); }
+                if( index_gp_subleadphoton < std::numeric_limits<unsigned int>::max() ) { truth_obj.setClosestParticleToSubLeadingPhoton( genParticles->ptrAt( index_gp_subleadphoton ) ); }
+                for( unsigned int gjLoop = 0 ; gjLoop < genJets->size() ; gjLoop++ ) {
+                    edm::Ptr<reco::GenJet> gj = genJets->ptrAt( gjLoop );
+                    float dr = deltaR( tag_obj.leadingJet().eta(), tag_obj.leadingJet().phi(), gj->eta(), gj->phi() );
+                    if( dr < dr_gj_leadjet ) {
+                        dr_gj_leadjet = dr;
+                        index_gj_leadjet = gjLoop;
+                    }
+                    dr = deltaR( tag_obj.subLeadingJet().eta(), tag_obj.subLeadingJet().phi(), gj->eta(), gj->phi() );
+                    if( dr < dr_gj_subleadjet ) {
+                        dr_gj_subleadjet = dr;
+                        index_gj_subleadjet = gjLoop;
+                    }
+                }
+                if( index_gj_leadjet < std::numeric_limits<unsigned int>::max() ) { truth_obj.setClosestGenJetToLeadingJet( genJets->ptrAt( index_gj_leadjet ) ); }
+                if( index_gj_subleadjet < std::numeric_limits<unsigned int>::max() ) { truth_obj.setClosestGenJetToSubLeadingJet( genJets->ptrAt( index_gj_subleadjet ) ); }
+
+                if( index_leadq < std::numeric_limits<unsigned int>::max() ) { truth_obj.setLeadingQuark( genParticles->ptrAt( index_leadq ) ); }
+                if( index_subleadq < std::numeric_limits<unsigned int>::max() ) { truth_obj.setSubLeadingQuark( genParticles->ptrAt( index_subleadq ) ); }
             }
-
-            if( index_gp_leadjet < std::numeric_limits<unsigned int>::max() ) { truth_obj.setClosestParticleToLeadingJet( genParticles->ptrAt( index_gp_leadjet ) ); }
-            if( index_gp_subleadjet < std::numeric_limits<unsigned int>::max() ) { truth_obj.setClosestParticleToSubLeadingJet( genParticles->ptrAt( index_gp_subleadjet ) ); }
-            if( index_gp_leadphoton < std::numeric_limits<unsigned int>::max() ) { truth_obj.setClosestParticleToLeadingPhoton( genParticles->ptrAt( index_gp_leadphoton ) ); }
-            if( index_gp_subleadphoton < std::numeric_limits<unsigned int>::max() ) { truth_obj.setClosestParticleToSubLeadingPhoton( genParticles->ptrAt( index_gp_subleadphoton ) ); }
-            for( unsigned int gjLoop = 0 ; gjLoop < genJets->size() ; gjLoop++ ) {
-                edm::Ptr<reco::GenJet> gj = genJets->ptrAt( gjLoop );
-                float dr = deltaR( tag_obj.leadingJet().eta(), tag_obj.leadingJet().phi(), gj->eta(), gj->phi() );
-                if( dr < dr_gj_leadjet ) {
-                    dr_gj_leadjet = dr;
-                    index_gj_leadjet = gjLoop;
-                }
-                dr = deltaR( tag_obj.subLeadingJet().eta(), tag_obj.subLeadingJet().phi(), gj->eta(), gj->phi() );
-                if( dr < dr_gj_subleadjet ) {
-                    dr_gj_subleadjet = dr;
-                    index_gj_subleadjet = gjLoop;
-                }
-            }
-            if( index_gj_leadjet < std::numeric_limits<unsigned int>::max() ) { truth_obj.setClosestGenJetToLeadingJet( genJets->ptrAt( index_gj_leadjet ) ); }
-            if( index_gj_subleadjet < std::numeric_limits<unsigned int>::max() ) { truth_obj.setClosestGenJetToSubLeadingJet( genJets->ptrAt( index_gj_subleadjet ) ); }
-
-            if( index_leadq < std::numeric_limits<unsigned int>::max() ) { truth_obj.setLeadingQuark( genParticles->ptrAt( index_leadq ) ); }
-            if( index_subleadq < std::numeric_limits<unsigned int>::max() ) { truth_obj.setSubLeadingQuark( genParticles->ptrAt( index_subleadq ) ); }
-
             truth_obj.setGenPV( higgsVtx );
-
             if( tag_obj.categoryNumber() >= 0 ) {
                 tags->push_back( tag_obj );
-                truths->push_back( truth_obj );
-                tags->back().setTagTruth( edm::refToPtr( edm::Ref<vector<VBFTagTruth> >( rTagTruth, idx++ ) ) );
+                if( ! evt.isRealData() ) {
+                    truths->push_back( truth_obj );
+                    tags->back().setTagTruth( edm::refToPtr( edm::Ref<vector<VBFTagTruth> >( rTagTruth, idx++ ) ) );
+                }
             }
         }
 
         evt.put( tags );
-        evt.put( truths );
+        if( ! evt.isRealData() )
+        { evt.put( truths ); }
     }
 }
 

--- a/Taggers/plugins/VBFTagProducer.cc
+++ b/Taggers/plugins/VBFTagProducer.cc
@@ -222,8 +222,7 @@ namespace flashgg {
         }
 
         evt.put( tags );
-        if( ! evt.isRealData() )
-        { evt.put( truths ); }
+        evt.put( truths );
     }
 }
 

--- a/Taggers/plugins/VHEtTagProducer.cc
+++ b/Taggers/plugins/VHEtTagProducer.cc
@@ -148,8 +148,7 @@ namespace flashgg {
             }
         }
         evt.put( vhettags );
-        if( ! evt.isRealData() )
-        { evt.put( truths ); }
+        evt.put( truths );
     }
 }
 

--- a/Taggers/plugins/VHEtTagProducer.cc
+++ b/Taggers/plugins/VHEtTagProducer.cc
@@ -87,13 +87,14 @@ namespace flashgg {
 
         Point higgsVtx;
 
-        for( unsigned int genLoop = 0 ; genLoop < genParticles->size(); genLoop++ ) {
-            int pdgid = genParticles->ptrAt( genLoop )->pdgId();
-            if( pdgid == 25 || pdgid == 22 ) {
-                higgsVtx = genParticles->ptrAt( genLoop )->vertex();
-                break;
+        if( ! evt.isRealData() )
+            for( unsigned int genLoop = 0 ; genLoop < genParticles->size(); genLoop++ ) {
+                int pdgid = genParticles->ptrAt( genLoop )->pdgId();
+                if( pdgid == 25 || pdgid == 22 ) {
+                    higgsVtx = genParticles->ptrAt( genLoop )->vertex();
+                    break;
+                }
             }
-        }
 
         edm::RefProd<vector<TagTruthBase> > rTagTruth = evt.getRefBeforePut<vector<TagTruthBase> >();
         unsigned int idx = 0;
@@ -140,12 +141,15 @@ namespace flashgg {
                 //setdiphotonindex
                 //setMET
                 vhettags->push_back( tag_obj );
-                truths->push_back( truth_obj );
-                vhettags->back().setTagTruth( edm::refToPtr( edm::Ref<vector<TagTruthBase> >( rTagTruth, idx++ ) ) );
+                if( ! evt.isRealData() ) {
+                    truths->push_back( truth_obj );
+                    vhettags->back().setTagTruth( edm::refToPtr( edm::Ref<vector<TagTruthBase> >( rTagTruth, idx++ ) ) );
+                }
             }
         }
         evt.put( vhettags );
-        evt.put( truths );
+        if( ! evt.isRealData() )
+        { evt.put( truths ); }
     }
 }
 

--- a/Taggers/plugins/VHHadronicTagProducer.cc
+++ b/Taggers/plugins/VHHadronicTagProducer.cc
@@ -130,14 +130,14 @@ namespace flashgg {
         std::auto_ptr<vector<TagTruthBase> > truths( new vector<TagTruthBase> );
 
         Point higgsVtx;
-
-        for( unsigned int genLoop = 0 ; genLoop < genParticles->size(); genLoop++ ) {
-            int pdgid = genParticles->ptrAt( genLoop )->pdgId();
-            if( pdgid == 25 || pdgid == 22 ) {
-                higgsVtx = genParticles->ptrAt( genLoop )->vertex();
-                break;
+        if( ! evt.isRealData() )
+            for( unsigned int genLoop = 0 ; genLoop < genParticles->size(); genLoop++ ) {
+                int pdgid = genParticles->ptrAt( genLoop )->pdgId();
+                if( pdgid == 25 || pdgid == 22 ) {
+                    higgsVtx = genParticles->ptrAt( genLoop )->vertex();
+                    break;
+                }
             }
-        }
 
         edm::RefProd<vector<TagTruthBase> > rTagTruth = evt.getRefBeforePut<vector<TagTruthBase> >();
         unsigned int idx = 0;
@@ -217,11 +217,14 @@ namespace flashgg {
 
             TagTruthBase truth_obj;
             truth_obj.setGenPV( higgsVtx );
-            truths->push_back( truth_obj );
-            vhhadtags->back().setTagTruth( edm::refToPtr( edm::Ref<vector<TagTruthBase> >( rTagTruth, idx++ ) ) );
+            if( ! evt.isRealData() ) {
+                truths->push_back( truth_obj );
+                vhhadtags->back().setTagTruth( edm::refToPtr( edm::Ref<vector<TagTruthBase> >( rTagTruth, idx++ ) ) );
+            }
         }
         evt.put( vhhadtags );
-        evt.put( truths );
+        if( ! evt.isRealData() )
+        { evt.put( truths ); }
     }
 
 

--- a/Taggers/plugins/VHHadronicTagProducer.cc
+++ b/Taggers/plugins/VHHadronicTagProducer.cc
@@ -223,8 +223,7 @@ namespace flashgg {
             }
         }
         evt.put( vhhadtags );
-        if( ! evt.isRealData() )
-        { evt.put( truths ); }
+        evt.put( truths );
     }
 
 

--- a/Taggers/plugins/VHLooseTagProducer.cc
+++ b/Taggers/plugins/VHLooseTagProducer.cc
@@ -387,8 +387,7 @@ namespace flashgg {
             }
         }
         evt.put( vhloosetags );
-        if( ! evt.isRealData() )
-        { evt.put( truths ); }
+        evt.put( truths );
     }
 
 }

--- a/Taggers/plugins/VHLooseTagProducer.cc
+++ b/Taggers/plugins/VHLooseTagProducer.cc
@@ -223,14 +223,14 @@ namespace flashgg {
         std::auto_ptr<vector<TagTruthBase> > truths( new vector<TagTruthBase> );
 
         Point higgsVtx;
-
-        for( unsigned int genLoop = 0 ; genLoop < genParticles->size(); genLoop++ ) {
-            int pdgid = genParticles->ptrAt( genLoop )->pdgId();
-            if( pdgid == 25 || pdgid == 22 ) {
-                higgsVtx = genParticles->ptrAt( genLoop )->vertex();
-                break;
+        if( ! evt.isRealData() )
+            for( unsigned int genLoop = 0 ; genLoop < genParticles->size(); genLoop++ ) {
+                int pdgid = genParticles->ptrAt( genLoop )->pdgId();
+                if( pdgid == 25 || pdgid == 22 ) {
+                    higgsVtx = genParticles->ptrAt( genLoop )->vertex();
+                    break;
+                }
             }
-        }
 
         edm::RefProd<vector<TagTruthBase> > rTagTruth = evt.getRefBeforePut<vector<TagTruthBase> >();
         unsigned int idx = 0;
@@ -379,13 +379,16 @@ namespace flashgg {
                 vhloosetags_obj.setDiPhotonIndex( diphoIndex );
                 vhloosetags->push_back( vhloosetags_obj );
                 TagTruthBase truth_obj;
-                truth_obj.setGenPV( higgsVtx );
-                truths->push_back( truth_obj );
-                vhloosetags->back().setTagTruth( edm::refToPtr( edm::Ref<vector<TagTruthBase> >( rTagTruth, idx++ ) ) );
+                if( ! evt.isRealData() ) {
+                    truth_obj.setGenPV( higgsVtx );
+                    truths->push_back( truth_obj );
+                    vhloosetags->back().setTagTruth( edm::refToPtr( edm::Ref<vector<TagTruthBase> >( rTagTruth, idx++ ) ) );
+                }
             }
         }
         evt.put( vhloosetags );
-        evt.put( truths );
+        if( ! evt.isRealData() )
+        { evt.put( truths ); }
     }
 
 }

--- a/Taggers/plugins/VHTightTagProducer.cc
+++ b/Taggers/plugins/VHTightTagProducer.cc
@@ -484,8 +484,7 @@ namespace flashgg {
             }
         }
         evt.put( VHTightTags );
-        if( ! evt.isRealData() )
-        { evt.put( truths ); }
+        evt.put( truths );
     }
 
 }

--- a/Taggers/plugins/VHTightTagProducer.cc
+++ b/Taggers/plugins/VHTightTagProducer.cc
@@ -240,14 +240,14 @@ namespace flashgg {
         std::auto_ptr<vector<TagTruthBase> > truths( new vector<TagTruthBase> );
 
         Point higgsVtx;
-
-        for( unsigned int genLoop = 0 ; genLoop < genParticles->size(); genLoop++ ) {
-            int pdgid = genParticles->ptrAt( genLoop )->pdgId();
-            if( pdgid == 25 || pdgid == 22 ) {
-                higgsVtx = genParticles->ptrAt( genLoop )->vertex();
-                break;
+        if( ! evt.isRealData() )
+            for( unsigned int genLoop = 0 ; genLoop < genParticles->size(); genLoop++ ) {
+                int pdgid = genParticles->ptrAt( genLoop )->pdgId();
+                if( pdgid == 25 || pdgid == 22 ) {
+                    higgsVtx = genParticles->ptrAt( genLoop )->vertex();
+                    break;
+                }
             }
-        }
 
         edm::RefProd<vector<TagTruthBase> > rTagTruth = evt.getRefBeforePut<vector<TagTruthBase> >();
         unsigned int idx = 0;
@@ -303,6 +303,7 @@ namespace flashgg {
 
             VHTightTag VHTightTags_obj( dipho, mvares );
             if( dipho->leadingPhoton()->pt() < ( dipho->mass() )*leadPhoOverMassThreshold_ ) { continue; }
+
             if( dipho->subLeadingPhoton()->pt() < ( dipho->mass() )*subleadPhoOverMassThreshold_ ) { continue; }
             if( ( fabs( dipho->leadingPhoton()->superCluster()->eta() ) > LowPtEtaPhoThreshold_ &&
                     fabs( dipho->leadingPhoton()->superCluster()->eta() ) < MidPtEtaPhoThreshold_ ) ||
@@ -476,13 +477,15 @@ namespace flashgg {
                 VHTightTags->push_back( VHTightTags_obj );
                 TagTruthBase truth_obj;
                 truth_obj.setGenPV( higgsVtx );
-                truths->push_back( truth_obj );
-                VHTightTags->back().setTagTruth( edm::refToPtr( edm::Ref<vector<TagTruthBase> >( rTagTruth, idx++ ) ) );
+                if( ! evt.isRealData() ) {
+                    truths->push_back( truth_obj );
+                    VHTightTags->back().setTagTruth( edm::refToPtr( edm::Ref<vector<TagTruthBase> >( rTagTruth, idx++ ) ) );
+                }
             }
         }
         evt.put( VHTightTags );
-        evt.put( truths );
-
+        if( ! evt.isRealData() )
+        { evt.put( truths ); }
     }
 
 }


### PR DESCRIPTION
Here's the actual update to the Taggers to not conflict with real data (GEN requirements check the realData flag).

Also included is an update to customize.  It automatically assigns a globaltag based on signal/background/mc and also can be overwritten via a command line argument.  The update also allows for setting the input filename from the command line during cmsRun.