### PR TITLE
Global tags

### DIFF
--- a/MetaData/work/campaigns/RunIISpring15-50ns.json
+++ b/MetaData/work/campaigns/RunIISpring15-50ns.json
@@ -1,0 +1,16 @@
+{
+    "data" : ["/DoubleEG/Run2015B-PromptReco-v1/MINIAOD",
+       	      "/EGamma/Run2015B-PromptReco-v1/MINIAOD",
+       	      "/SinglePhoton/Run2015B-PromptReco-v1/MINIAOD"
+	      ],
+    "sig"  : ["/ttHJetToGG_M120_13TeV_amcatnloFXFX_madspin_pythia8/RunIISpring15DR74-Asympt50ns_MCRUN2_74_V9A-v1/MINIAODSIM",
+              "/ttHJetToGG_M125_13TeV_amcatnloFXFX_madspin_pythia8/RunIISpring15DR74-Asympt50ns_MCRUN2_74_V9A-v1/MINIAODSIM",
+    	      "/ttHJetToGG_M130_13TeV_amcatnloFXFX_madspin_pythia8/RunIISpring15DR74-Asympt50ns_MCRUN2_74_V9A-v1/MINIAODSIM"
+	      ],
+    "bkg"  : ["/GJet_Pt-20to40_DoubleEMEnriched_MGG-80toInf_TuneCUETP8M1_13TeV_Pythia8/RunIISpring15DR74-Asympt50ns_MCRUN2_74_V9A-v2/MINIAODSIM",
+    	      "/GJet_Pt-40toInf_DoubleEMEnriched_MGG-80toInf_TuneCUETP8M1_13TeV_Pythia8/RunIISpring15DR74-Asympt50ns_MCRUN2_74_V9A-v1/MINIAODSIM",	      
+    	      "/QCD_Pt-30to40_DoubleEMEnriched_MGG-80toInf_TuneCUETP8M1_13TeV_Pythia8/RunIISpring15DR74-Asympt50ns_MCRUN2_74_V9A-v2/MINIAODSIM",
+	      "/QCD_Pt-40toInf_DoubleEMEnriched_MGG-80toInf_TuneCUETP8M1_13TeV_Pythia8/RunIISpring15DR74-Asympt50ns_MCRUN2_74_V9A-v1/MINIAODSIM",
+	      "/QCD_Pt-30toInf_DoubleEMEnriched_MGG-40to80_TuneCUETP8M1_13TeV_Pythia8/RunIISpring15DR74-Asympt50ns_MCRUN2_74_V9A-v1/MINIAODSIM"
+	      ]
+}

--- a/MetaData/work/campaigns/globalTagsLookup.json
+++ b/MetaData/work/campaigns/globalTagsLookup.json
@@ -1,0 +1,4 @@
+{
+    "Run2015B-PromptReco"                          : ["GR_P_V56"],
+    "RunIISpring15DR74-Asympt50ns_MCRUN2_74_V9A"   : ["MCRUN2_74_V9A"]
+}

--- a/MetaData/work/campaigns/globalTagsLookup.json
+++ b/MetaData/work/campaigns/globalTagsLookup.json
@@ -1,4 +1,5 @@
 {
     "Run2015B-PromptReco"                          : ["GR_P_V56"],
-    "RunIISpring15DR74-Asympt50ns_MCRUN2_74_V9A"   : ["MCRUN2_74_V9A"]
+    "RunIISpring15DR74-Asympt50ns_MCRUN2_74_V9A"   : ["MCRUN2_74_V9A"],
+    "RunIISpring15DR74-Asympt25ns_MCRUN2_74_V9"	   : ["MCRUN2_74_V9"]
 }

--- a/MetaData/work/crabConfig_TEMPLATE.py
+++ b/MetaData/work/crabConfig_TEMPLATE.py
@@ -29,7 +29,7 @@ config.Data.publishDataName = 'FLASHGG_VERSION-PROCESSED_DSET'
 config.Data.outLFNDirBase = "OUTLFN"
 
 config.section_("Site")
-config.Site.storageSite = "OUTSITE"
+config.Site.storageSite = "T2_CH_CERN"
 #config.Site.blacklist = ["T2_CH_CERN"]
-config.Site.blacklist = ["T2_UK_London_Brunel","T1_US_FNAL","T2_US_MIT"]
+#config.Site.blacklist = ["T2_UK_London_Brunel","T1_US_FNAL","T2_US_MIT"]
 

--- a/MetaData/work/crabConfig_TEMPLATE.py
+++ b/MetaData/work/crabConfig_TEMPLATE.py
@@ -29,7 +29,7 @@ config.Data.publishDataName = 'FLASHGG_VERSION-PROCESSED_DSET'
 config.Data.outLFNDirBase = "OUTLFN"
 
 config.section_("Site")
-config.Site.storageSite = "T2_CH_CERN"
+config.Site.storageSite = "OUTSITE"
 #config.Site.blacklist = ["T2_CH_CERN"]
 #config.Site.blacklist = ["T2_UK_London_Brunel","T1_US_FNAL","T2_US_MIT"]
 

--- a/MetaData/work/prepareCrabJobs.py
+++ b/MetaData/work/prepareCrabJobs.py
@@ -100,11 +100,6 @@ parser = OptionParser(option_list=[
                     action="store_true", dest="verbose",
                     default=False,
                     help="default: %default"),
-#        make_option("--gt","--globalTags",
-#                    dest="globalTags",
-#                    action="callback",callback=Load(),type="string",
-#                    default={},
-#                    help="List of global tags to be used for data and MC. Default: %default"),
         make_option("--gt","--globalTags",
                     dest="globalTags",
                     action="store",type="string",
@@ -250,22 +245,20 @@ if options.createCrabConfig:
         # associate the processedLabel to the globaltag from the json filex
         globalTag = gtJson[processedLabel]
         # print ProcessedDataset, globalTag
+        replacements["PYCFG_PARAMS"].append(str("globalTag=%s" % globalTag[0])) 
 
         # specific replacements for data and MC
         if sample in data:
             replacements["SPLITTING"]   = "LumiBased"
             replacements["UNITSPERJOB"] = str(options.lumisPerJob)
             replacements["PYCFG_PARAMS"].append("processType=data")
-            replacements["PYCFG_PARAMS"].append(str("globalTag=%s" % globalTag[0]))  #MDDB
             ## FIXME: lumi mask, run ranges, etc.
         if sample in sig:
             ## Extra options for signal samples
             replacements["PYCFG_PARAMS"].append("processType=signal")
-            replacements["PYCFG_PARAMS"].append(str("globalTag=%s" % globalTag[0]))  #MDDB
         if sample in bkg:
             ## Extra options for background samples
             replacements["PYCFG_PARAMS"].append("processType=background")
-            replacements["PYCFG_PARAMS"].append(str("globalTag=%s" % globalTag[0]))  #MDDB
 
         replacements["PYCFG_PARAMS"] = str(replacements["PYCFG_PARAMS"])
         

--- a/MetaData/work/prepareCrabJobs.py
+++ b/MetaData/work/prepareCrabJobs.py
@@ -248,29 +248,24 @@ if options.createCrabConfig:
         # print processedLabel
 
         # associate the processedLabel to the globaltag from the json filex
-        gtData = ''
-        gtMc   = ''
-        if ProcessedDataset.count("201"): #check if data or mc
-            gtData = gtJson[processedLabel]
-        else:
-            gtMc   = gtJson[processedLabel]
-        # print ProcessedDataset, gtData, gtMc
+        globalTag = gtJson[processedLabel]
+        # print ProcessedDataset, globalTag
 
         # specific replacements for data and MC
         if sample in data:
             replacements["SPLITTING"]   = "LumiBased"
             replacements["UNITSPERJOB"] = str(options.lumisPerJob)
             replacements["PYCFG_PARAMS"].append("processType=data")
-            replacements["PYCFG_PARAMS"].append(str("globalTag=%s" % gtData[0]))  #MDDB
+            replacements["PYCFG_PARAMS"].append(str("globalTag=%s" % globalTag[0]))  #MDDB
             ## FIXME: lumi mask, run ranges, etc.
         if sample in sig:
             ## Extra options for signal samples
             replacements["PYCFG_PARAMS"].append("processType=signal")
-            replacements["PYCFG_PARAMS"].append(str("globalTag=%s" % gtMc[0]))  #MDDB
+            replacements["PYCFG_PARAMS"].append(str("globalTag=%s" % globalTag[0]))  #MDDB
         if sample in bkg:
             ## Extra options for background samples
             replacements["PYCFG_PARAMS"].append("processType=background")
-            replacements["PYCFG_PARAMS"].append(str("globalTag=%s" % gtMc[0]))  #MDDB
+            replacements["PYCFG_PARAMS"].append(str("globalTag=%s" % globalTag[0]))  #MDDB
 
         replacements["PYCFG_PARAMS"] = str(replacements["PYCFG_PARAMS"])
         

--- a/MicroAOD/python/MicroAODCustomize.py
+++ b/MicroAOD/python/MicroAODCustomize.py
@@ -1,3 +1,4 @@
+
 import FWCore.ParameterSet.Config as cms
 import FWCore.ParameterSet.VarParsing as VarParsing
 class MicroAODCustomize(object):
@@ -23,11 +24,6 @@ class MicroAODCustomize(object):
                                VarParsing.VarParsing.multiplicity.singleton, # singleton or list
                                VarParsing.VarParsing.varType.string,          # string, int, or float
                                "processType")
-        self.options.register ('globalTag',
-                               "", # default value
-                               VarParsing.VarParsing.multiplicity.singleton, # singleton or list
-                               VarParsing.VarParsing.varType.string,          # string, int, or float
-                               "globalTag")
         self.options.register('debug',
                               1, # default value
                               VarParsing.VarParsing.multiplicity.singleton, # singleton or list
@@ -69,8 +65,6 @@ class MicroAODCustomize(object):
             self.customizeDebug(process)
         if self.muMuGamma == 1:
             self.customizeMuMuGamma(process)
-        if len(self.globalTag) >0:
-            self.customizeGlobalTag(process)
         if len(self.fileNames) >0:
             self.customizeFileNames(process)
 
@@ -78,19 +72,16 @@ class MicroAODCustomize(object):
     # signal specific customization
     def customizeSignal(self,process):
         process.flashggGenPhotonsExtra.defaultType = 1
-        process.GlobalTag.globaltag = "GR_R_74_V8::All"
         
     # background specific customization
     def customizeBackground(self,process):
         if "sherpa" in self.datasetName:
             process.flashggGenPhotonsExtra.defaultType = 1
-            process.GlobalTag.globaltag = "GR_R_74_V8::All"
 
             
     # data specific customization
     def customizeData(self,process):
         ## remove MC-specific modules
-        process.GlobalTag.globaltag = "GR_R_74_V13A::All"
         modules = process.flashggMicroAODGenSequence.moduleNames()
         for pathName in process.paths:
             path = getattr(process,pathName)
@@ -109,9 +100,6 @@ class MicroAODCustomize(object):
         process.load("flashgg/MicroAOD/flashggDiMuons_cfi")
         process.load("flashgg/MicroAOD/flashggMuMuGamma_cfi")
         process.p *= process.flashggDiMuons*process.flashggMuMuGamma
-
-    def customizeGlobalTag(self,process):
-        process.GlobalTag.globaltag = self.globalTag
 
     def customizeFileNames(self,process):
         process.source.fileNames = cms.untracked.vstring(self.fileNames)

--- a/MicroAOD/python/MicroAODCustomize.py
+++ b/MicroAOD/python/MicroAODCustomize.py
@@ -101,6 +101,9 @@ class MicroAODCustomize(object):
         process.load("flashgg/MicroAOD/flashggMuMuGamma_cfi")
         process.p *= process.flashggDiMuons*process.flashggMuMuGamma
 
+    def customizeGlobalTag(self,process):
+        process.GlobalTag.globaltag = self.globalTag
+
     def customizeFileNames(self,process):
         process.source.fileNames = cms.untracked.vstring(self.fileNames)
 

--- a/MicroAOD/python/MicroAODCustomize.py
+++ b/MicroAOD/python/MicroAODCustomize.py
@@ -34,6 +34,11 @@ class MicroAODCustomize(object):
                               VarParsing.VarParsing.multiplicity.singleton, # singleton or list
                               VarParsing.VarParsing.varType.int,          # string, int, or float
                               "muMuGamma")
+        self.options.register ('globalTag',
+                               "", # default value
+                               VarParsing.VarParsing.multiplicity.singleton, # singleton or list
+                               VarParsing.VarParsing.varType.string,          # string, int, or float
+                               "globalTag")
 
     def __getattr__(self,name):
         ## did not manage to inherit from VarParsing, because of some issues in __init__
@@ -65,6 +70,8 @@ class MicroAODCustomize(object):
             self.customizeDebug(process)
         if self.muMuGamma == 1:
             self.customizeMuMuGamma(process)
+        if len(self.globalTag) >0:
+            self.customizeGlobalTag(process)
         if len(self.fileNames) >0:
             self.customizeFileNames(process)
 


### PR DESCRIPTION
This allows to have the global tags set by accessing a lookup table in MetaData/work/campaigns/globalTagsLookup.json.
All defaults set in MicroAOD/python/MicroAODCustomize.py has been surfaced to MetaData/work/prepareCrabJobs.py.