### PR TITLE
new producer to build minimal photon collection from preselected dipho

### DIFF
--- a/DataFormats/interface/Photon.h
+++ b/DataFormats/interface/Photon.h
@@ -8,6 +8,7 @@
 
 #include <map>
 #include <string>
+#include <set>
 
 namespace flashgg {
 
@@ -22,6 +23,7 @@ namespace flashgg {
         virtual Photon *clone() const;
 
         void ZeroVariables();
+        void removeVerticesExcept( const std::set<edm::Ptr<reco::Vertex> > & );
 
         enum mcMatch_t { kUnkown = 0, kPrompt, kFake  };
 

--- a/DataFormats/interface/SinglePhotonView.h
+++ b/DataFormats/interface/SinglePhotonView.h
@@ -35,6 +35,9 @@ namespace flashgg {
 
         void MakePersistent();
 
+        // DO NOT USE THIS FUNCTION UNLESS YOU HAVE A GOOD REASON AND KNOW IT WON'T CAUSE INTERNAL INCONSISTENCIES
+        void replacePtr( edm::Ptr<flashgg::Photon> replacement ) { phoPtr_ = replacement; }
+
     private:
         mutable flashgg::Photon pho_;
         edm::Ptr<flashgg::Photon> phoPtr_;

--- a/DataFormats/src/Photon.cc
+++ b/DataFormats/src/Photon.cc
@@ -79,6 +79,112 @@ Photon::~Photon() {}
 
 Photon *Photon::clone() const { return new Photon( *this ); }
 
+void Photon::removeVerticesExcept( const std::set<edm::Ptr<reco::Vertex> > &vtxPtrList )
+{
+    /*
+        std::map<edm::Ptr<reco::Vertex>, float> pfChgIso04_;
+        std::map<edm::Ptr<reco::Vertex>, float> pfChgIso03_;
+        std::map<edm::Ptr<reco::Vertex>, float> pfChgIso02_;
+        std::map<edm::Ptr<reco::Vertex>, float> phoIdMvaD_;
+        bool passElecVeto_;
+        std::map<std::string, std::map<edm::Ptr<reco::Vertex>, float> > extraChargedIsolations_;
+    */
+
+    //    std::cout << "Running removeVerticesExcept" << std::endl;
+    //    std::cout << "  Size of pfChgIso04_: " << pfChgIso04_.size() << std::endl;
+    //    std::cout << "  Size of vtxPtrList: " << vtxPtrList.size() << std::endl;
+
+    std::map<edm::Ptr<reco::Vertex>, float>::iterator map_it;
+
+    for( auto extra_map_it = extraChargedIsolations_.begin() ; extra_map_it != extraChargedIsolations_.end() ; extra_map_it++ ) {
+        map_it = extra_map_it->second.begin();
+        while( map_it != extra_map_it->second.end() ) {
+            bool deleteMe = true;
+            for( auto list_it = vtxPtrList.begin() ; list_it != vtxPtrList.end() ; list_it++ ) {
+                if( *list_it == map_it->first ) {
+                    deleteMe = false;
+                    break;
+                }
+            }
+            if( deleteMe ) {
+                map_it = extra_map_it->second.erase( map_it );
+            } else {
+                map_it++;
+            }
+        }
+    }
+
+    map_it = phoIdMvaD_.begin();
+    while( map_it != phoIdMvaD_.end() ) {
+        bool deleteMe = true;
+        for( auto list_it = vtxPtrList.begin() ; list_it != vtxPtrList.end() ; list_it++ ) {
+            if( *list_it == map_it->first ) {
+                deleteMe = false;
+                break;
+            }
+        }
+        if( deleteMe ) {
+            map_it = phoIdMvaD_.erase( map_it );
+        } else {
+            map_it++;
+        }
+    }
+
+    map_it = pfChgIso04_.begin();
+    while( map_it != pfChgIso04_.end() ) {
+        bool deleteMe = true;
+        for( auto list_it = vtxPtrList.begin() ; list_it != vtxPtrList.end() ; list_it++ ) {
+            if( *list_it == map_it->first ) {
+                deleteMe = false;
+                break;
+            }
+        }
+        if( deleteMe ) {
+            map_it = pfChgIso04_.erase( map_it );
+        } else {
+            map_it++;
+        }
+    }
+
+    map_it = pfChgIso03_.begin();
+    while( map_it != pfChgIso03_.end() ) {
+        bool deleteMe = true;
+        for( auto list_it = vtxPtrList.begin() ; list_it != vtxPtrList.end() ; list_it++ ) {
+            if( *list_it == map_it->first ) {
+                deleteMe = false;
+                break;
+            }
+        }
+        if( deleteMe ) {
+            map_it = pfChgIso03_.erase( map_it );
+        } else {
+            map_it++;
+        }
+    }
+
+    map_it = pfChgIso02_.begin();
+    while( map_it != pfChgIso02_.end() ) {
+        bool deleteMe = true;
+        for( auto list_it = vtxPtrList.begin() ; list_it != vtxPtrList.end() ; list_it++ ) {
+            if( *list_it == map_it->first ) {
+                deleteMe = false;
+                break;
+            }
+        }
+        if( deleteMe ) {
+            map_it = pfChgIso02_.erase( map_it );
+        } else {
+            map_it++;
+        }
+    }
+
+
+    //    std::cout << "  Size of pfChgIso04_: " << pfChgIso04_.size() << std::endl;
+    //    std::cout << "  Size of vtxPtrList: " << vtxPtrList.size() << std::endl;
+    //    std::cout << "End of removeVerticesExcept"<< std::endl;
+}
+
+
 // Very simple functions now, but we want to be smarter about them later
 void Photon::setEnergyAtStep( std::string key, float val )
 {

--- a/MicroAOD/plugins/DiPhotonProducer.cc
+++ b/MicroAOD/plugins/DiPhotonProducer.cc
@@ -103,15 +103,6 @@ namespace flashgg {
                         ivtx = k;
                         break;
                     }
-                // A number of things need to be done once the vertex is chosen
-                // recomputing photon 4-momenta accordingly
-                flashgg::Photon photon1_corr = PhotonIdUtils::pho4MomCorrection( pp1, pvx );
-                flashgg::Photon photon2_corr = PhotonIdUtils::pho4MomCorrection( pp2, pvx );
-                // - compute isolations with respect to chosen vertex needed for preselection
-                photon1_corr.setpfChgIsoWrtChosenVtx02( photon1_corr.pfChgIso02WrtVtx( pvx ) );
-                photon2_corr.setpfChgIsoWrtChosenVtx02( photon2_corr.pfChgIso02WrtVtx( pvx ) );
-                photon1_corr.setpfChgIsoWrtChosenVtx03( photon1_corr.pfChgIso03WrtVtx( pvx ) );
-                photon2_corr.setpfChgIsoWrtChosenVtx03( photon2_corr.pfChgIso03WrtVtx( pvx ) );
 
                 DiPhotonCandidate dipho( pp1, pp2, pvx );
                 dipho.setVertexIndex( ivtx );

--- a/MicroAOD/plugins/PhotonCollectionFromDiPhotons.cc
+++ b/MicroAOD/plugins/PhotonCollectionFromDiPhotons.cc
@@ -1,0 +1,139 @@
+#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "DataFormats/Common/interface/Handle.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/EDMException.h"
+#include "CommonTools/UtilAlgos/interface/TFileService.h"
+#include "flashgg/DataFormats/interface/DiPhotonCandidate.h"
+#include "flashgg/MicroAOD/interface/PhotonIdUtils.h"
+#include "DataFormats/VertexReco/interface/Vertex.h"
+#include "flashgg/MicroAOD/interface/VertexSelectorBase.h"
+#include "DataFormats/PatCandidates/interface/PackedCandidate.h"
+#include "flashgg/DataFormats/interface/VertexCandidateMap.h"
+#include "DataFormats/EgammaCandidates/interface/Conversion.h"
+#include "DataFormats/BeamSpot/interface/BeamSpot.h"
+#include "DataFormats/PatCandidates/interface/PackedGenParticle.h"
+
+using namespace edm;
+using namespace std;
+
+namespace flashgg {
+
+    class PhotonCollectionFromDiPhotons : public EDProducer
+    {
+
+    public:
+        PhotonCollectionFromDiPhotons( const ParameterSet & );
+    private:
+        void produce( Event &, const EventSetup & ) override;
+        EDGetTokenT<View<flashgg::DiPhotonCandidate> > diPhotonToken_;
+        bool debug_;
+    };
+
+    PhotonCollectionFromDiPhotons::PhotonCollectionFromDiPhotons( const ParameterSet &iConfig ) :
+        diPhotonToken_( consumes<View<flashgg::DiPhotonCandidate> >( iConfig.getParameter<InputTag> ( "DiPhotonTag" ) ) ),
+        debug_( iConfig.getUntrackedParameter( "Debug", false ) )
+    {
+        produces<vector<flashgg::DiPhotonCandidate> >();
+        produces<vector<flashgg::Photon> >();
+    }
+
+    void PhotonCollectionFromDiPhotons::produce( Event &evt, const EventSetup & )
+    {
+        Handle<View<flashgg::DiPhotonCandidate> > diPhotons;
+        evt.getByToken( diPhotonToken_, diPhotons );
+
+        auto_ptr<vector<DiPhotonCandidate> > diPhotonColl( new vector<DiPhotonCandidate> );
+        auto_ptr<vector<Photon> > photonColl( new vector<Photon> );
+        edm::RefProd<vector<Photon> > rPhoton = evt.getRefBeforePut<vector<Photon> >();
+
+        // Same order as output photon collection to keep track of what's copied already
+        vector<Ptr<Photon> > usedPhotonPtrs;
+
+        if( debug_ ) {
+            std::cout << std::cout << " Input DiPhoton collection size: " << diPhotons->size() << std::endl;
+        }
+
+        for( unsigned int i = 0 ; i < diPhotons->size() ; i++ ) {
+            //            std::cout << "  DiPhoton " << i << std::endl;
+            Ptr<DiPhotonCandidate> oldpdp = diPhotons->ptrAt( i );
+            Ptr<Photon> oldpp1 = oldpdp->leadingView()->originalPhoton();
+            Ptr<Photon> oldpp2 = oldpdp->subLeadingView()->originalPhoton();
+            Ptr<Photon> pp1;
+            Ptr<Photon> pp2;
+
+            bool donepp1 = false;
+            bool donepp2 = false;
+            for( unsigned int j = 0 ; j < usedPhotonPtrs.size() ; j++ ) {
+                // If photon already copied into new collection, point to same one
+                if( oldpp1 == usedPhotonPtrs[j] ) {
+                    donepp1 = true;
+                    pp1 = edm::refToPtr( edm::Ref<vector<Photon> >( rPhoton, j ) );
+                    if( debug_ ) { std::cout << "   Leading photon with pt " << oldpp1->pt() << " already in collection at place " << j << std::endl; }
+                }
+                if( oldpp2 == usedPhotonPtrs[j] ) {
+                    donepp2 = true;
+                    pp2 = edm::refToPtr( edm::Ref<vector<Photon> >( rPhoton, j ) );
+                    if( debug_ ) { std::cout << "   Subleading photon with pt " << oldpp2->pt() << " already in collection at place " << j << std::endl; }
+                }
+            }
+
+            // If photon not yet copied: copy photon, create pointers into new collection
+            if( !donepp1 ) {
+                Photon p1( *oldpp1 );
+                pp1 = edm::refToPtr( edm::Ref<vector<Photon> >( rPhoton, usedPhotonPtrs.size() ) );
+                if( debug_ ) { std::cout << "   Putting copy of Leading photon with pt " << oldpp1->pt() << " in at place " << usedPhotonPtrs.size() << std::endl; }
+                photonColl->push_back( p1 );
+                usedPhotonPtrs.push_back( oldpp1 );
+            }
+            if( !donepp2 ) {
+                Photon p2( *oldpp2 ); // copy Photon
+                pp2 = edm::refToPtr( edm::Ref<vector<Photon> >( rPhoton, usedPhotonPtrs.size() ) );
+                if( debug_ ) { std::cout << "   Putting copy of Subleading photon with pt " << oldpp2->pt() << " in at place " << usedPhotonPtrs.size() << std::endl; }
+                photonColl->push_back( p2 );
+                usedPhotonPtrs.push_back( oldpp2 );
+            }
+
+            // Can't use ordinary DiPhoton constructor with Ptrs because pp1 and pp2 are pointing into a collection that's not saved yet
+            // But all the old values are still valid, so swapping in pp1 and pp2 after won't break anything
+            // But be very very very careful emulating this!
+            DiPhotonCandidate dipho( *oldpdp );
+            dipho.getLeadingView().replacePtr( pp1 );
+            dipho.getSubLeadingView().replacePtr( pp2 );
+
+            diPhotonColl->push_back( dipho );
+        }
+
+        if( debug_ ) {
+            std::cout << " Final diphoton collection size: " << diPhotonColl->size() << std::endl;
+            std::cout << " Final photon collection size: " << photonColl->size() << std::endl;
+        }
+
+        evt.put( photonColl );
+
+        if( debug_ ) {
+            std::cout << " We put the photons in, now we check diphoton pt before and after recomputation: " << std::endl;
+            for( unsigned int i = 0 ; i < diPhotonColl->size() ; i++ ) {
+                std::cout << "   DiPhoton " << i << " pt before recomputation: " << diPhotonColl->at( i ).pt() << std::endl;
+                diPhotonColl->at( i ).computeP4AndOrder();
+                std::cout << "   DiPhoton " << i << " pt after recomputation: " << diPhotonColl->at( i ).pt() << std::endl;
+            }
+        }
+
+        evt.put( diPhotonColl );
+    }
+}
+
+typedef flashgg::PhotonCollectionFromDiPhotons FlashggPhotonCollectionFromDiPhotons;
+DEFINE_FWK_MODULE( FlashggPhotonCollectionFromDiPhotons );
+// Local Variables:
+// mode:c++
+// indent-tabs-mode:nil
+// tab-width:4
+// c-basic-offset:4
+// End:
+// vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4
+

--- a/MicroAOD/plugins/PhotonCollectionFromDiPhotons.cc
+++ b/MicroAOD/plugins/PhotonCollectionFromDiPhotons.cc
@@ -17,6 +17,8 @@
 #include "DataFormats/BeamSpot/interface/BeamSpot.h"
 #include "DataFormats/PatCandidates/interface/PackedGenParticle.h"
 
+#include <set>
+
 using namespace edm;
 using namespace std;
 
@@ -57,6 +59,11 @@ namespace flashgg {
             std::cout << std::cout << " Input DiPhoton collection size: " << diPhotons->size() << std::endl;
         }
 
+        std::set<edm::Ptr<reco::Vertex> > usedVertices;
+        for( unsigned int i = 0 ; i < diPhotons->size() ; i++ ) {
+            usedVertices.insert( diPhotons->ptrAt( i )->vtx() );
+        }
+
         for( unsigned int i = 0 ; i < diPhotons->size() ; i++ ) {
             //            std::cout << "  DiPhoton " << i << std::endl;
             Ptr<DiPhotonCandidate> oldpdp = diPhotons->ptrAt( i );
@@ -84,6 +91,7 @@ namespace flashgg {
             // If photon not yet copied: copy photon, create pointers into new collection
             if( !donepp1 ) {
                 Photon p1( *oldpp1 );
+                p1.removeVerticesExcept( usedVertices );
                 pp1 = edm::refToPtr( edm::Ref<vector<Photon> >( rPhoton, usedPhotonPtrs.size() ) );
                 if( debug_ ) { std::cout << "   Putting copy of Leading photon with pt " << oldpp1->pt() << " in at place " << usedPhotonPtrs.size() << std::endl; }
                 photonColl->push_back( p1 );
@@ -91,6 +99,7 @@ namespace flashgg {
             }
             if( !donepp2 ) {
                 Photon p2( *oldpp2 ); // copy Photon
+                p2.removeVerticesExcept( usedVertices );
                 pp2 = edm::refToPtr( edm::Ref<vector<Photon> >( rPhoton, usedPhotonPtrs.size() ) );
                 if( debug_ ) { std::cout << "   Putting copy of Subleading photon with pt " << oldpp2->pt() << " in at place " << usedPhotonPtrs.size() << std::endl; }
                 photonColl->push_back( p2 );

--- a/MicroAOD/python/flashggMicroAODSequence_cff.py
+++ b/MicroAOD/python/flashggMicroAODSequence_cff.py
@@ -7,7 +7,7 @@ from flashgg.MicroAOD.flashggJets_cfi import flashggJets
 from flashgg.MicroAOD.flashggElectrons_cfi import flashggElectrons
 from flashgg.MicroAOD.flashggMuons_cfi import flashggMuons
 from flashgg.MicroAOD.flashggObjectSelectors_cff import selectedFlashggJets,selectedFlashggMuons,selectedFlashggElectrons,selectedFlashggPhotons
-
+from flashgg.MicroAOD.flashggSlimmedPhotonAndDiPhoton_cfi import flashggSlimmedPhotonAndDiPhoton
 from flashgg.MicroAOD.flashggMicroAODGenSequence_cff import *
 
 eventCount = cms.EDProducer("EventCountProducer")
@@ -28,4 +28,5 @@ flashggMicroAODSequence = cms.Sequence((eventCount+weightsCount
                                         )
                                        *flashggPhotons*selectedFlashggPhotons*flashggDiPhotons
                                        *(flashggPreselectedDiPhotons+flashggVertexMapForCHS*flashggJets*selectedFlashggJets)
+                                       *flashggSlimmedPhotonAndDiPhoton
                                        )

--- a/MicroAOD/python/flashggSlimmedPhotonAndDiPhoton_cfi.py
+++ b/MicroAOD/python/flashggSlimmedPhotonAndDiPhoton_cfi.py
@@ -1,0 +1,4 @@
+import FWCore.ParameterSet.Config as cms
+
+flashggSlimmedPhotonAndDiPhoton = cms.EDProducer("FlashggPhotonCollectionFromDiPhotons",
+                                                 DiPhotonTag=cms.InputTag("flashggPreselectedDiPhotons"))


### PR DESCRIPTION
This is a (slightly tricksy) producer that takes in a diphoton collection and builds:
   * A new photon collection using only the photons pointed to by the diphotons
   * A new diphoton collection pointing to those photons
So the diphoton collection is the same size, but the photons can be smaller, for example after a preselection.

New collection is produced and saved, but no change is made in this PR to which collections are kept or which are read by the tag sequence.  We need the real preselection before we can finalize a switchover. 

Assuming a preselection with roughly the same "efficiency" as the current dummy, this reduces the file size from 16.1 kb / evt to 14.1 kb / evt.  Target is 9.6 kb / evt for the ttH(gg) sample I'm getting these numbers from.