### PR TITLE
updated the 2015B globaltag based on CMS conditions twiki

### DIFF
--- a/MetaData/work/campaigns/globalTagsLookup.json
+++ b/MetaData/work/campaigns/globalTagsLookup.json
@@ -1,5 +1,5 @@
 {
-    "Run2015B-PromptReco"                          : ["GR_P_V56"],
+    "Run2015B-PromptReco"                          : ["74X_dataRun2_Prompt_v0"],
     "RunIISpring15DR74-Asympt50ns_MCRUN2_74_V9A"   : ["MCRUN2_74_V9A"],
     "RunIISpring15DR74-Asympt25ns_MCRUN2_74_V9"	   : ["MCRUN2_74_V9"]
 }


### PR DESCRIPTION
Basically right after Mauro's initial commit and production run the globaltag for 2015B data was updated.  From: https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuideFrontierConditions?redirectedfrom=CMS.SWGuideFrontierConditions#Prompt_reconstruction_Global_Tag

"same as GR_P_V56
- changing name of tag for EcalClusterLocalContCorrParameters to decouple it from MC
upgrade tag for DTT0Rcd to FEB corrected one "