### PR TITLE
Store SuperClusters, not other clusters - unneeded

### DIFF
--- a/MicroAOD/python/flashggMicroAODOutputCommands_cff.py
+++ b/MicroAOD/python/flashggMicroAODOutputCommands_cff.py
@@ -8,7 +8,7 @@ microAODDefaultOutputCommand = cms.untracked.vstring("drop *",
                                                      "drop *_flashggPrunedGenParticles_*_*",   
                                                      "keep recoGenParticles_flashggPrunedGenParticles_*_*", # this line, and preceding, drop unneded association object
                                                      "keep *_offlineSlimmedPrimaryVertices_*_*",
-                                                     "keep *_reducedEgamma_reduced*Clusters_*",
+                                                     "keep *_reducedEgamma_reducedSuperClusters_*",
                                                      "keep *_reducedEgamma_*PhotonCores_*",
                                                      "keep *_slimmedMETs_*_*",
                                                      "keep *_fixedGridRhoAll_*_*",


### PR DESCRIPTION
Refine the reducedEGamma collections we keep.  Clusters appear not to be needed, only superclusters.  After changing this, we get (ignoring collections that ultimately won't be saved) 12 kB/evt.  Full list of collections here:

    flashggJets_selectedFlashggJets__FLASHggMicroAOD. 11386.4 1767.89
    flashggElectrons_selectedFlashggElectrons__FLASHggMicroAOD. 4440.14 1657.91
    PileupSummaryInfos_addPileupInfo__HLT. 4602.5 1640.32
    flashggMuons_selectedFlashggMuons__FLASHggMicroAOD. 2974.24 1345.57
    flashggPhotons_flashggSlimmedPhotonAndDiPhoton__FLASHggMicroAOD. 2995.14 1258.06
    recoSuperClusters_reducedEgamma_reducedSuperClusters_PAT. 3021.95 1028.47
    recoGenJets_slimmedGenJets__PAT. 3463.25 815.546
    recoVertexs_offlineSlimmedPrimaryVertices__PAT. 1276.1 700.128
    recoGenParticles_flashggPrunedGenParticles__FLASHggMicroAOD. 2332.33 500.446 
    patMETs_slimmedMETs__PAT. 1064.44 384.924
    flashggDiPhotonCandidates_flashggSlimmedPhotonAndDiPhoton__FLASHggMicroAOD. 664.507 239.071
    edmTriggerResults_TriggerResults__HLT. 936.161 179.263
    patPackedGenParticles_flashggGenPhotons__FLASHggMicroAOD. 687.339 129.964
    GenEventInfoProduct_generator__SIM. 239.593 95.891
    floatedmValueMap_offlineSlimmedPrimaryVertices__PAT. 122.997 74.975
    recoGsfElectronCores_reducedEgamma_reducedGedGsfElectronCores_PAT. 230.342 60.435
    flashggGenPhotonExtras_flashggGenPhotonsExtra__FLASHggMicroAOD. 213.593 57.131
    recoPhotonCores_reducedEgamma_reducedGedPhotonCores_PAT. 265.606 55.832
    recoBeamSpot_offlineBeamSpot__RECO. 314.321 31.347
    EventAuxiliary 133.696 11.498
    edmTriggerResults_TriggerResults__PAT. 103.025 6.6
    double_fixedGridRhoAll__RECO. 11.131 6.445
    EventProductProvenance 321.041 6.371
    edmTriggerResults_TriggerResults__FLASHggMicroAOD. 79.005 5.967
    EventSelections 124.702 3.221
    BranchListIndexes 26.62 2.389

 Uncompressed subtotal: 42030.169
 Compressed subtotal: 12065.664

