### PR TITLE
Topic minimized egamma

### DIFF
--- a/MicroAOD/plugins/EGammaMinimizer.cc
+++ b/MicroAOD/plugins/EGammaMinimizer.cc
@@ -26,18 +26,18 @@ using namespace std;
 
 namespace flashgg {
 
-    class PhotonCollectionFromDiPhotons : public EDProducer
+    class EGammaMinimizer : public EDProducer
     {
 
     public:
-        PhotonCollectionFromDiPhotons( const ParameterSet & );
+        EGammaMinimizer( const ParameterSet & );
     private:
         void produce( Event &, const EventSetup & ) override;
         EDGetTokenT<View<flashgg::DiPhotonCandidate> > diPhotonToken_;
         bool debug_;
     };
 
-    PhotonCollectionFromDiPhotons::PhotonCollectionFromDiPhotons( const ParameterSet &iConfig ) :
+    EGammaMinimizer::EGammaMinimizer( const ParameterSet &iConfig ) :
         diPhotonToken_( consumes<View<flashgg::DiPhotonCandidate> >( iConfig.getParameter<InputTag> ( "DiPhotonTag" ) ) ),
         debug_( iConfig.getUntrackedParameter( "Debug", false ) )
     {
@@ -52,7 +52,7 @@ namespace flashgg {
         produces<vector<reco::PhotonCore> >();
     }
 
-    void PhotonCollectionFromDiPhotons::produce( Event &evt, const EventSetup & )
+    void EGammaMinimizer::produce( Event &evt, const EventSetup & )
     {
         Handle<View<flashgg::DiPhotonCandidate> > diPhotons;
         evt.getByToken( diPhotonToken_, diPhotons );
@@ -167,8 +167,8 @@ namespace flashgg {
     }
 }
 
-typedef flashgg::PhotonCollectionFromDiPhotons FlashggPhotonCollectionFromDiPhotons;
-DEFINE_FWK_MODULE( FlashggPhotonCollectionFromDiPhotons );
+typedef flashgg::EGammaMinimizer FlashggEGammaMinimizer;
+DEFINE_FWK_MODULE( FlashggEGammaMinimizer );
 // Local Variables:
 // mode:c++
 // indent-tabs-mode:nil

--- a/MicroAOD/python/flashggFinalEGamma_cfi.py
+++ b/MicroAOD/python/flashggFinalEGamma_cfi.py
@@ -1,4 +1,12 @@
 import FWCore.ParameterSet.Config as cms
 
 flashggFinalEGamma = cms.EDProducer("FlashggEGammaMinimizer",
-                                    DiPhotonTag=cms.InputTag("flashggPreselectedDiPhotons"))
+                                    DiPhotonTag=cms.InputTag("flashggPreselectedDiPhotons"),
+                                    ElectronTag=cms.InputTag("selectedFlashggElectrons"),
+                                    ElectronCollectionName=cms.string("finalElectrons"),
+                                    ElectronCoreCollectionName=cms.string("finalElectronCores"),
+                                    PhotonCollectionName=cms.string("finalPhotons"),
+                                    PhotonCoreCollectionName=cms.string("finalPhotonCores"),
+                                    DiPhotonCollectionName=cms.string("finalDiPhotons"),
+                                    SuperClusterCollectionName=cms.string("finalSuperClusters"),
+                                    )

--- a/MicroAOD/python/flashggFinalEGamma_cfi.py
+++ b/MicroAOD/python/flashggFinalEGamma_cfi.py
@@ -1,0 +1,4 @@
+import FWCore.ParameterSet.Config as cms
+
+flashggFinalEGamma = cms.EDProducer("FlashggEGammaMinimizer",
+                                    DiPhotonTag=cms.InputTag("flashggPreselectedDiPhotons"))

--- a/MicroAOD/python/flashggMicroAODSequence_cff.py
+++ b/MicroAOD/python/flashggMicroAODSequence_cff.py
@@ -7,7 +7,7 @@ from flashgg.MicroAOD.flashggJets_cfi import flashggJets
 from flashgg.MicroAOD.flashggElectrons_cfi import flashggElectrons
 from flashgg.MicroAOD.flashggMuons_cfi import flashggMuons
 from flashgg.MicroAOD.flashggObjectSelectors_cff import selectedFlashggJets,selectedFlashggMuons,selectedFlashggElectrons,selectedFlashggPhotons
-from flashgg.MicroAOD.flashggSlimmedPhotonAndDiPhoton_cfi import flashggSlimmedPhotonAndDiPhoton
+from flashgg.MicroAOD.flashggFinalEGamma_cfi import flashggFinalEGamma
 from flashgg.MicroAOD.flashggMicroAODGenSequence_cff import *
 
 eventCount = cms.EDProducer("EventCountProducer")
@@ -28,5 +28,5 @@ flashggMicroAODSequence = cms.Sequence((eventCount+weightsCount
                                         )
                                        *flashggPhotons*selectedFlashggPhotons*flashggDiPhotons
                                        *(flashggPreselectedDiPhotons+flashggVertexMapForCHS*flashggJets*selectedFlashggJets)
-                                       *flashggSlimmedPhotonAndDiPhoton
+                                       *flashggFinalEGamma
                                        )

--- a/MicroAOD/python/flashggSlimmedPhotonAndDiPhoton_cfi.py
+++ b/MicroAOD/python/flashggSlimmedPhotonAndDiPhoton_cfi.py
@@ -1,4 +1,0 @@
-import FWCore.ParameterSet.Config as cms
-
-flashggSlimmedPhotonAndDiPhoton = cms.EDProducer("FlashggPhotonCollectionFromDiPhotons",
-                                                 DiPhotonTag=cms.InputTag("flashggPreselectedDiPhotons"))

--- a/Taggers/test/simple_Tag_test.py
+++ b/Taggers/test/simple_Tag_test.py
@@ -27,6 +27,20 @@ process.source = cms.Source ("PoolSource",fileNames = cms.untracked.vstring("fil
 process.load("flashgg/Taggers/flashggTagSequence_cfi")
 process.load("flashgg/Taggers/flashggTagTester_cfi")
 
+# For debugging
+switchToPreselected = False
+switchToFinal = False
+assert(not switchToPreselected or not switchToFinal)
+
+if switchToPreselected:
+    from PhysicsTools.PatAlgos.tools.helpers import massSearchReplaceAnyInputTag
+    massSearchReplaceAnyInputTag(process.flashggTagSequence,cms.InputTag("flashggDiPhotons"),cms.InputTag("flashggPreselectedDiPhotons"))
+
+if switchToFinal:
+    from flashgg.MicroAOD.flashggFinalEGamma_cfi import flashggFinalEGamma
+    from PhysicsTools.PatAlgos.tools.helpers import massSearchReplaceAnyInputTag
+    massSearchReplaceAnyInputTag(process.flashggTagSequence,cms.InputTag("flashggDiPhotons"),cms.InputTag("flashggFinalEGamma",flashggFinalEGamma.DiPhotonCollectionName.value()))
+
 from flashgg.Taggers.flashggTagOutputCommands_cff import tagDefaultOutputCommand
 
 process.out = cms.OutputModule("PoolOutputModule", fileName = cms.untracked.string('myTagOutputFile.root'),


### PR DESCRIPTION
Expand function of PhotonCollectionFromDiPhotons module (now renamed to EGammaMinimizer).  Starting from diphotons and electrons, this module produces 6 new collections (DiPhoton, Photon, PhotonCore, Electron, ElectronCore, SuperCluster) in order to self-consistently remove any objects that are not needed for the next step.  Note that electrons are not expected to shrink from this module, but new collections must be built so that the photon and electron superClusters point into the same collection - we also can save some space on the cores and superClusters because of the electron selection at an earlier step.  After these changes - once the preselection is finalized - we will use approximately 11.5 kB / evt for ttH (target 9.6 kB/evt).  Some interesting comparisons of collection sizes (uncompressed/compressed):

 flashggDiPhotonCandidates_flashggDiPhotons__FLASHggMicroAOD. 1748.04 562.644
 flashggDiPhotonCandidates_flashggPreselectedDiPhotons__FLASHggMicroAOD. 623.99 220.959
 flashggDiPhotonCandidates_flashggFinalEGamma_finalDiPhotons_FLASHggMicroAOD. 625.35 222.298

 flashggPhotons_selectedFlashggPhotons__FLASHggMicroAOD. 10014.7 2878.16
 flashggPhotons_flashggFinalEGamma_finalPhotons_FLASHggMicroAOD. 2813.98 1155.63

 recoPhotonCores_reducedEgamma_reducedGedPhotonCores_PAT. 265.606 55.832
 recoPhotonCores_flashggFinalEGamma_finalPhotonCores_FLASHggMicroAOD. 151.645 38.37

 recoSuperClusters_reducedEgamma_reducedSuperClusters_PAT. 3021.95 1028.47
 recoSuperClusters_flashggFinalEGamma_finalSuperClusters_FLASHggMicroAOD. 1898.96 648.036

 flashggElectrons_flashggFinalEGamma_finalElectrons_FLASHggMicroAOD. 4450.56 1667.76
 flashggElectrons_selectedFlashggElectrons__FLASHggMicroAOD. 4440.14 1657.91

 recoGsfElectronCores_reducedEgamma_reducedGedGsfElectronCores_PAT. 230.342 60.435
 recoGsfElectronCores_flashggFinalEGamma_finalElectronCores_FLASHggMicroAOD. 164.65 49.157