### PR TITLE
Store jetCollectionIndex in diphoton for forthcoming PFCHS tools

### DIFF
--- a/DataFormats/interface/DiPhotonCandidate.h
+++ b/DataFormats/interface/DiPhotonCandidate.h
@@ -91,6 +91,7 @@ namespace flashgg {
         std::string systLabel() const { return systLabel_; }
 
         bool operator <( const DiPhotonCandidate &b ) const;
+        bool operator >( const DiPhotonCandidate &b ) const;
 
         //        math::XYZTLorentzVector PhoP4Corr( edm::Ptr<flashgg::Photon> ) const;
 
@@ -100,6 +101,9 @@ namespace flashgg {
             viewPho1_.MakePersistent();
             viewPho2_.MakePersistent();
         }
+
+        void setJetCollectionIndex( unsigned int val ) { jetCollectionIndex_ = val; }
+        unsigned int jetCollectionIndex() const { return jetCollectionIndex_; }
 
     private:
 
@@ -135,6 +139,8 @@ namespace flashgg {
 
         flashgg::SinglePhotonView viewPho1_;
         flashgg::SinglePhotonView viewPho2_;
+
+        unsigned int jetCollectionIndex_; // index for which jet collection corresponds to the vertex choice in this diphoton
     };
 
 

--- a/DataFormats/src/DiPhotonCandidate.cc
+++ b/DataFormats/src/DiPhotonCandidate.cc
@@ -23,6 +23,11 @@ bool DiPhotonCandidate::operator <( const DiPhotonCandidate &b ) const
     return ( sumPt() < b.sumPt() );
 }
 
+bool DiPhotonCandidate::operator >( const DiPhotonCandidate &b ) const
+{
+    return ( sumPt() > b.sumPt() );
+}
+
 void DiPhotonCandidate::computeP4AndOrder()
 {
     //    std::cout << " START of DiPhotonCandidate::computeP4AndOrder PT M PT1 PT2 " << this->pt() << " " << this->mass() << " " << leadingPhoton()->pt() << " " <<


### PR DESCRIPTION
Add jet collection index to diphoton:
0 - always the standard CMS 0th vertex
1 - first non-0th vertex found used by diphoton collection (if any)
N - next non-PV vertex found used by diphoton collection (if any)

The idea is that the jet tools being finalized by @yhaddad will look at this index (and the vertices linked from the diphotons) and produce the minimal number of PFCHS collections, and that the collections other than the 0th will be filled only if there exists a diphoton using them.  The number will then be used in tags to figure out which jet collection is correct for each diphoton.