### PR TITLE
Produce a vector<vector<Jet> > collection for multi-PFCHS

### DIFF
--- a/DataFormats/src/classes.h
+++ b/DataFormats/src/classes.h
@@ -89,10 +89,13 @@ namespace  {
         std::pair<edm::Ptr<reco::Vertex>, flashgg::MinimalPileupJetIdentifier>                    pair_ptr_vtx_pujetid;
         std::map<edm::Ptr<reco::Vertex>, flashgg::MinimalPileupJetIdentifier>                    map_ptr_vtx_pujetid;
 
-        flashgg::Jet                                                      fgg_jet;
-        edm::Wrapper<flashgg::Jet>                                    wrp_fgg_jet;
-        std::vector<flashgg::Jet>                                     vec_fgg_jet;
-        edm::Ptr<flashgg::Jet>                                        ptr_fgg_jet;
+        flashgg::Jet                                                       fgg_jet;
+        edm::Wrapper<flashgg::Jet>                                     wrp_fgg_jet;
+        std::vector<flashgg::Jet>                                      vec_fgg_jet;
+        edm::Ptr<flashgg::Jet>                                         ptr_fgg_jet;
+        std::vector<std::vector<flashgg::Jet> >                    vec_vec_fgg_jet;
+        edm::Wrapper<std::vector<flashgg::Jet> >                   wrp_vec_fgg_jet;
+        edm::Wrapper<std::vector<std::vector<flashgg::Jet> > > wrp_vec_vec_fgg_jet;
         std::vector<pat::Muon>                                        vec_fgg_muon;
         flashgg::Muon						                                fgg_mu;
         edm::Ptr<flashgg::Muon> 					                    ptr_fgg_mu;
@@ -100,7 +103,6 @@ namespace  {
         std::vector<flashgg::Muon>				                        vec_fgg_mu;
         edm::Wrapper<std::vector<flashgg::Muon> >                   wrp_vec_fgg_mu;
 
-        edm::Wrapper<std::vector<flashgg::Jet> >                  wrp_vec_fgg_jet;
         std::map<edm::Ptr<reco::Vertex>, float>                    map_ptr_vtx_flo;
         std::pair<edm::Ptr<reco::Vertex>, float>                   pai_ptr_vtx_flo;
         std::map<std::string, std::map<edm::Ptr<reco::Vertex>, float> >  map_str_ptr_vtx_flo;

--- a/DataFormats/src/classes_def.xml
+++ b/DataFormats/src/classes_def.xml
@@ -90,6 +90,8 @@
 <class name="std::map<std::string,std::map<edm::Ptr<reco::Vertex>,float>>"/>
 <class name="std::pair<std::string,std::map<edm::Ptr<reco::Vertex>,float>>"/>
 <class name="edm::Wrapper<std::vector<flashgg::Jet> >"/>
+<class name="std::vector<std::vector<flashgg::Jet> >"/>
+<class name="edm::Wrapper<std::vector<std::vector<flashgg::Jet> > >"/>
 <class name="flashgg::Electron"/>
 <class name="edm::Ptr<flashgg::Electron>"/>
 <class name="std::vector<flashgg::Electron>"/>

--- a/MicroAOD/plugins/VectorVectorJetCollector.cc
+++ b/MicroAOD/plugins/VectorVectorJetCollector.cc
@@ -1,0 +1,79 @@
+// VectorVectorJetCollector.cc
+// S. Zenz, July 2015
+// Because sometimes internal rhyme is more important than consistent collection naming
+
+#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "DataFormats/Common/interface/Handle.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/EDMException.h"
+
+#include "flashgg/DataFormats/interface/Jet.h"
+
+using namespace std;
+using namespace edm;
+
+namespace flashgg {
+    class VectorVectorJetCollector : public EDProducer
+    {
+
+    public:
+        VectorVectorJetCollector( const ParameterSet & );
+    private:
+        void produce( Event &, const EventSetup & ) override;
+
+        typedef std::vector<edm::Handle<edm::View<flashgg::Jet> > > JetViewVector;
+
+        std::vector<edm::InputTag> inputTagJets_;
+    };
+
+    VectorVectorJetCollector::VectorVectorJetCollector( const ParameterSet &iConfig ) :
+        inputTagJets_( iConfig.getParameter<std::vector<edm::InputTag> >( "inputTagJets" ) )
+    {
+        produces<vector<vector<Jet> > >();
+    }
+
+    void VectorVectorJetCollector::produce( Event &evt, const EventSetup & )
+    {
+        auto_ptr<vector<vector<Jet> > > result( new vector<vector<Jet> > );
+
+        size_t output_size = 0;
+        JetViewVector Jets( inputTagJets_.size() );
+        for( size_t j = 0; j < inputTagJets_.size(); ++j ) {
+            std::cout << " before getByLabel " << j << std::endl;
+            evt.getByLabel( inputTagJets_[j], Jets[j] );
+            if( Jets[j]->size() > 0 ) { output_size = j + 1; }
+            std::cout << " Jets[j]->size()=" << Jets[j]->size() << std::endl;
+        }
+
+        std::cout << " output_size=" << output_size << std::endl;
+
+        result->resize( output_size );
+
+        std::cout << " Resized!" << std::endl;
+
+        for( size_t j = 0 ; j < result->size() ; ++j ) {
+            std::cout << "  j=" << j << std::endl;
+            for( size_t k = 0 ; k < Jets[j]->size() ; ++k ) {
+                std::cout << "   j=" << j << " k=" << k << std::endl;
+                result->at( j ).push_back( *( Jets[j]->ptrAt( k ) ) );
+            }
+        }
+
+        std::cout << " Before put" << std::endl;
+
+        evt.put( result );
+    }
+}
+typedef flashgg::VectorVectorJetCollector FlashggVectorVectorJetCollector;
+DEFINE_FWK_MODULE( FlashggVectorVectorJetCollector );
+// Local Variables:
+// mode:c++
+// indent-tabs-mode:nil
+// tab-width:4
+// c-basic-offset:4
+// End:
+// vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4

--- a/MicroAOD/plugins/VertexMapFromCandidateProducer.cc
+++ b/MicroAOD/plugins/VertexMapFromCandidateProducer.cc
@@ -12,10 +12,11 @@
 using namespace edm;
 using namespace std;
 
-// if the track did not attach to any vertex, attach it to ALL vertices!
-// This probably mimics better how PFCHS works
-// We want to keep all the tracks for the vertex that's ultimately selected,
-// unless they're clearly close to another vertex
+// use PackedCandidate::fromPV to produce a flashgg vertex map
+// Require fromPV(int) > FromPVCut
+// From https://twiki.cern.ch/twiki/bin/view/CMSPublic/WorkBookMiniAOD2015#PV_Assignment
+//   "The definition normally used for isolation calculations is fromPV() > 1;
+//    the definition used for CHS subtraction in jets is fromPV() > 0."
 
 namespace flashgg {
 

--- a/MicroAOD/python/flashggJets_cfi.py
+++ b/MicroAOD/python/flashggJets_cfi.py
@@ -114,4 +114,6 @@ JetCollectionVInputTag = cms.VInputTag()
 for i in range(0,maxJetCollections):
   JetCollectionVInputTag.append(cms.InputTag('selectedFlashggPFCHSJets' + str(i)))
 
-    
+flashggFinalJets = cms.EDProducer("FlashggVectorVectorJetCollector",
+                                  inputTagJets= JetCollectionVInputTag
+                                  )

--- a/MicroAOD/python/flashggMicroAODOutputCommands_cff.py
+++ b/MicroAOD/python/flashggMicroAODOutputCommands_cff.py
@@ -29,6 +29,8 @@ microAODDefaultOutputCommand = cms.untracked.vstring("drop *",
                                                      "drop *_flashggMuons_*_*",
                                                      "drop *_flashggElectrons_*_*",
                                                      "drop *_flashggPhotons_*_*",
+
+                                                     "keep *_flashggFinalJets_*_*"
                                                      )
 
 # Should be included for now for ongoing studies, but to be removed some day

--- a/MicroAOD/python/flashggMicroAODSequence_cff.py
+++ b/MicroAOD/python/flashggMicroAODSequence_cff.py
@@ -3,7 +3,7 @@ from flashgg.MicroAOD.flashggTkVtxMap_cfi import flashggVertexMapUnique,flashggV
 from flashgg.MicroAOD.flashggPhotons_cfi import flashggPhotons
 from flashgg.MicroAOD.flashggDiPhotons_cfi import flashggDiPhotons
 from flashgg.MicroAOD.flashggPreselectedDiPhotons_cfi import flashggPreselectedDiPhotons
-#from flashgg.MicroAOD.flashggJets_cfi import flashggJets
+from flashgg.MicroAOD.flashggJets_cfi import flashggFinalJets
 from flashgg.MicroAOD.flashggElectrons_cfi import flashggElectrons
 from flashgg.MicroAOD.flashggMuons_cfi import flashggMuons
 from flashgg.MicroAOD.flashggFinalEGamma_cfi import flashggFinalEGamma
@@ -30,4 +30,5 @@ flashggMicroAODSequence = cms.Sequence((eventCount+weightsCount
                                        *flashggPhotons*selectedFlashggPhotons*flashggDiPhotons
                                        *(flashggPreselectedDiPhotons+flashggVertexMapForCHS)
                                        *flashggFinalEGamma
+                                       *flashggFinalJets
                                        )

--- a/Taggers/plugins/VectorVectorJetUnpacker.cc
+++ b/Taggers/plugins/VectorVectorJetUnpacker.cc
@@ -1,0 +1,77 @@
+// VectorVectorJetUnpacker.cc
+// S. Zenz, July 2015
+
+#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "DataFormats/Common/interface/Handle.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/EDMException.h"
+
+#include "flashgg/DataFormats/interface/Jet.h"
+
+#include <stdio.h>
+
+using namespace std;
+using namespace edm;
+
+namespace flashgg {
+    class VectorVectorJetUnpacker : public EDProducer
+    {
+
+    public:
+        VectorVectorJetUnpacker( const ParameterSet & );
+    private:
+        void produce( Event &, const EventSetup & ) override;
+
+        EDGetTokenT<View<vector<Jet> > > jetsToken_;
+        unsigned int nCollections_;
+    };
+
+    VectorVectorJetUnpacker::VectorVectorJetUnpacker( const ParameterSet &iConfig ) :
+        jetsToken_( consumes<View<vector<flashgg::Jet> > >( iConfig.getParameter<InputTag>( "JetsTag" ) ) ),
+        nCollections_( iConfig.getParameter<unsigned int>( "NCollections" ) )
+    {
+        if( nCollections_ > 9 ) {
+            throw cms::Exception( "Configuration" ) << " Number of jet collections more than 1 digit long is unreasonable";
+            // We never needed more than 3 in tests; 5 should be safe. 10 would be bonkers
+        }
+        for( unsigned int i = 0 ; i < nCollections_ ; i++ ) {
+            char number[2];
+            sprintf( number, "%u", i );
+            produces<vector<Jet> >( number );
+        }
+    }
+
+    void VectorVectorJetUnpacker::produce( Event &evt, const EventSetup & )
+    {
+
+        Handle<View<vector<flashgg::Jet> > > theJets;
+        evt.getByToken( jetsToken_, theJets );
+
+        if( theJets->size() > nCollections_ ) {
+            throw cms::Exception( "Configuration" ) << " Too many collections in input vector - inconsistency with MicroAOD";
+        }
+
+        for( unsigned int i = 0 ; i < theJets->size() ; i++ ) {
+            auto_ptr<vector<Jet> > result( new vector<Jet> );
+            for( unsigned int j = 0 ; j < theJets->at( i ).size() ; j++ ) {
+                result->push_back( theJets->at( i )[j] );
+            }
+            char number[2];
+            sprintf( number, "%u", i );
+            evt.put( result, number );
+        }
+    }
+}
+typedef flashgg::VectorVectorJetUnpacker FlashggVectorVectorJetUnpacker;
+DEFINE_FWK_MODULE( FlashggVectorVectorJetUnpacker );
+// Local Variables:
+// mode:c++
+// indent-tabs-mode:nil
+// tab-width:4
+// c-basic-offset:4
+// End:
+// vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4

--- a/Taggers/python/flashggTagSequence_cfi.py
+++ b/Taggers/python/flashggTagSequence_cfi.py
@@ -6,6 +6,7 @@ from flashgg.Taggers.flashggTagSorter_cfi import flashggTagSorter
 
 flashggTagSequence = cms.Sequence(flashggDiPhotonMVA
 				  * flashggDiPhotonMVANew
+                                  * flashggUnpackedJets
                                   * flashggVBFMVA
                                   * flashggVBFMVANew
                                   * flashggVBFDiPhoDiJetMVA

--- a/Taggers/python/flashggTags_cff.py
+++ b/Taggers/python/flashggTags_cff.py
@@ -1,8 +1,16 @@
 import FWCore.ParameterSet.Config as cms
-from flashgg.MicroAOD.flashggJets_cfi import flashggBTag, JetCollectionVInputTag
+from flashgg.MicroAOD.flashggJets_cfi import flashggBTag, maxJetCollections
+
+flashggUnpackedJets = cms.EDProducer("FlashggVectorVectorJetUnpacker",
+                                     JetsTag = cms.InputTag("flashggFinalJets"),
+                                     NCollections = cms.uint32(maxJetCollections)
+                                     )
+
+UnpackedJetCollectionVInputTag = cms.VInputTag()
+for i in range(0,maxJetCollections):
+    UnpackedJetCollectionVInputTag.append(cms.InputTag('flashggUnpackedJets',str(i)))
 
 flashggUntagged = cms.EDProducer("FlashggUntaggedTagProducer",
-                                 #                                         DiPhotonTag=cms.InputTag('flashggPreselectedDiPhotons'), # why doesn't this work?
                                  DiPhotonTag=cms.InputTag('flashggDiPhotons'),
                                  MVAResultTag=cms.InputTag('flashggDiPhotonMVA'),
                                  GenParticleTag=cms.InputTag( "flashggPrunedGenParticles" ),
@@ -13,7 +21,7 @@ flashggTTHHadronicTag = cms.EDProducer("FlashggTTHHadronicTagProducer",
                                        DiPhotonTag=cms.InputTag('flashggDiPhotons'),
                                        MVAResultTag=cms.InputTag('flashggDiPhotonMVA'),
                                        #JetTag=cms.InputTag('selectedFlashggJets'),
-                                       inputTagJets= JetCollectionVInputTag,
+                                       inputTagJets= UnpackedJetCollectionVInputTag,
                                        bDiscriminatorLoose = cms.untracked.double(0.275),
                                        bDiscriminatorMedium = cms.untracked.double(0.545),
                                        jetsNumberThreshold = cms.untracked.int32(4),
@@ -23,7 +31,6 @@ flashggTTHHadronicTag = cms.EDProducer("FlashggTTHHadronicTagProducer",
 )
 
 flashggVBFTag = cms.EDProducer("FlashggVBFTagProducer",
-                               #                                         DiPhotonTag=cms.InputTag('flashggPreselectedDiPhotons'), # why doesn't this work?
                                DiPhotonTag=cms.InputTag('flashggDiPhotons'),
                                MVAResultTag=cms.InputTag('flashggDiPhotonMVA'),
                                VBFDiPhoDiJetMVAResultTag=cms.InputTag('flashggVBFDiPhoDiJetMVA'),
@@ -47,7 +54,7 @@ flashggTTHLeptonicTag = cms.EDProducer("FlashggTTHLeptonicTagProducer",
                                        DiPhotonTag=cms.InputTag('flashggDiPhotons'),
                                        MVAResultTag=cms.InputTag('flashggDiPhotonMVA'),
                                        #JetTag=cms.InputTag('selectedFlashggJets'),
-                                       inputTagJets= JetCollectionVInputTag,
+                                       inputTagJets= UnpackedJetCollectionVInputTag,
                                        ElectronTag=cms.InputTag('selectedFlashggElectrons'),
                                        MuonTag=cms.InputTag('selectedFlashggMuons'),
                                        VertexTag=cms.InputTag('offlineSlimmedPrimaryVertices'),
@@ -89,7 +96,7 @@ flashggTTHLeptonicTag = cms.EDProducer("FlashggTTHLeptonicTagProducer",
 flashggVHLooseTag = cms.EDProducer("FlashggVHLooseTagProducer",
                                    DiPhotonTag=cms.InputTag('flashggDiPhotons'),
                                    #JetTag=cms.InputTag('selectedFlashggJets'),
-                                   inputTagJets= JetCollectionVInputTag,
+                                   inputTagJets= UnpackedJetCollectionVInputTag,
                                    ElectronTag=cms.InputTag('selectedFlashggElectrons'),
                                    MuonTag=cms.InputTag('selectedFlashggMuons'),
                                    VertexTag=cms.InputTag('offlineSlimmedPrimaryVertices'),
@@ -128,7 +135,7 @@ flashggVHLooseTag = cms.EDProducer("FlashggVHLooseTagProducer",
 flashggVHTightTag = cms.EDProducer("FlashggVHTightTagProducer",
                                    DiPhotonTag=cms.InputTag('flashggDiPhotons'),
                                    #JetTag=cms.InputTag('selectedFlashggJets'),
-                                   inputTagJets= JetCollectionVInputTag,
+                                   inputTagJets= UnpackedJetCollectionVInputTag,
                                    ElectronTag=cms.InputTag('selectedFlashggElectrons'),
                                    MuonTag=cms.InputTag('selectedFlashggMuons'),
                                    VertexTag=cms.InputTag('offlineSlimmedPrimaryVertices'),
@@ -178,7 +185,7 @@ flashggVHHadronicTag = cms.EDProducer("FlashggVHHadronicTagProducer",
                                       DiPhotonTag = cms.InputTag('flashggDiPhotons'),
                                       MVAResultTag=cms.InputTag('flashggDiPhotonMVA'),
                                       #JetTag = cms.InputTag('selectedFlashggJets'),
-                                      inputTagJets= JetCollectionVInputTag,
+                                      inputTagJets= UnpackedJetCollectionVInputTag,
                                       GenParticleTag=cms.InputTag( "flashggPrunedGenParticles" ),
                                       leadPhoOverMassThreshold = cms.untracked.double(0.375),
                                       subleadPhoOverMassThreshold = cms.untracked.double(0.25),

--- a/Taggers/python/flashggVBFMVA_cff.py
+++ b/Taggers/python/flashggVBFMVA_cff.py
@@ -1,12 +1,12 @@
 import FWCore.ParameterSet.Config as cms
 
-from flashgg.MicroAOD.flashggJets_cfi import JetCollectionVInputTag
+from flashgg.Taggers.flashggTags_cff import UnpackedJetCollectionVInputTag
 
 # legacy VBF MVA
 flashggVBFMVA = cms.EDProducer('FlashggVBFMVAProducer',
                                DiPhotonTag=cms.InputTag('flashggDiPhotons'),
                                #JetTag=cms.InputTag('selectedFlashggJets'),
-                               inputTagJets= JetCollectionVInputTag,
+                               inputTagJets= UnpackedJetCollectionVInputTag,
                                UseLegacyMVA = cms.untracked.bool(True),
                                MinDijetMinv = cms.double(0.0),
                                vbfMVAweightfile = cms.FileInPath("flashgg/Taggers/data/TMVA_dijet_sherpa_scalewt50_2evenb_powheg200_maxdPhi_oct9_Gradient.weights.xml"),
@@ -26,7 +26,7 @@ flashggVBFDiPhoDiJetMVA = cms.EDProducer('FlashggVBFDiPhoDiJetMVAProducer',
 flashggVBFMVANew = cms.EDProducer('FlashggVBFMVAProducer',
                                   DiPhotonTag = cms.InputTag('flashggDiPhotons'),
                                   #JetTag = cms.InputTag('selectedFlashggJets'),
-                                  inputTagJets= JetCollectionVInputTag,
+                                  inputTagJets= UnpackedJetCollectionVInputTag,
                                   UseLegacyMVA = cms.untracked.bool(False),
                                   MinDijetMinv = cms.double(0.0),
                                   vbfMVAweightfile = cms.FileInPath("flashgg/Taggers/data/Flashgg_VBF_BDT.weights.xml"),


### PR DESCRIPTION
Build a single `vector<vector<Jet> >` collection instead of 5 collections as in  #290 + #291.  This turns out to save a lot of space (when compressed, last column):

    flashggJetss_flashggFinalJets__FLASHggMicroAOD. 10049.7 1334.43
    flashggJets_selectedFlashggPFCHSJets0__FLASHggMicroAOD. 5818.09 1017.54
    flashggJets_selectedFlashggPFCHSJets1__FLASHggMicroAOD. 2126.48 441.002
    flashggJets_selectedFlashggPFCHSJets2__FLASHggMicroAOD. 825.617 204.615
    flashggJets_selectedFlashggPFCHSJets3__FLASHggMicroAOD. 795.759 191.256
    flashggJets_selectedFlashggPFCHSJets4__FLASHggMicroAOD. 795.759 191.256

Also included is a tool for the Tag Produces to "unpack" back to 5 separate collections.  This is necessary because many tags rely on `vector<Ptr<Jet> >` and a Ptr into `vector<vector<Jet> >` is not persistifiable.  (To make it persistifiable, we'd have to write a new Ptr supporting 2 indices.)  So we'll end up with Tags pointing into the reconstituted collections, raising some questions as to what exactly we'll save as output of the Tags once we're in steady state - I'll make some slides on that for Monday.