### PR TITLE
require full cluster info for selectedFlashggPhotons

### DIFF
--- a/MicroAOD/python/flashggObjectSelectors_cff.py
+++ b/MicroAOD/python/flashggObjectSelectors_cff.py
@@ -12,5 +12,6 @@ selectedFlashggMuons = cms.EDFilter("FLASHggMuonSelector",
 
 selectedFlashggPhotons = cms.EDFilter("FLASHggPhotonSelector",
     src = cms.InputTag("flashggPhotons"),
-    cut = cms.string("pt > 14 && hadTowOverEm()<0.15") # same as MiniAOD, so not doing anything
+#    cut = cms.string("pt > 14 && hadTowOverEm()<0.15") # same as MiniAOD, so not doing anything
+    cut = cms.string("pt > 14 && hadTowOverEm()<0.15 && (r9()>0.8 || chargedHadronIso()<20 || chargedHadronIso()<0.3*pt())") # full clusters in MiniAOD for these only
 )

--- a/MicroAOD/test/microAODstd.py
+++ b/MicroAOD/test/microAODstd.py
@@ -55,6 +55,7 @@ if current_gt.count("::All"):
 # Spring15
 #process.source = cms.Source("PoolSource",fileNames=cms.untracked.vstring("/store/mc/RunIISpring15DR74/ttHJetToGG_M125_13TeV_amcatnloFXFX_madspin_pythia8/MINIAODSIM/Asympt50ns_MCRUN2_74_V9A-v1/70000/0232BC3C-01FF-E411-8779-0025907B4FC2.root"))
 process.source = cms.Source("PoolSource",fileNames=cms.untracked.vstring("/store/mc/RunIISpring15DR74/GluGluHToGG_M-125_13TeV_powheg_pythia8/MINIAODSIM/Asympt50ns_MCRUN2_74_V9A-v1/30000/54ECB9A4-912E-E511-BB7D-002590A831CA.root"))
+#process.source = cms.Source("PoolSource",fileNames=cms.untracked.vstring("/store/mc/RunIISpring15DR74/VBFHToGG_M-125_13TeV_powheg_pythia8/MINIAODSIM/Asympt50ns_MCRUN2_74_V9A-v1/50000/049AAFAA-CA2D-E511-93E8-02163E00F402.root"))
 
 process.MessageLogger.cerr.threshold = 'ERROR' # can't get suppressWarning to work: disable all warnings for now
 # process.MessageLogger.suppressWarning.extend(['SimpleMemoryCheck','MemoryCheck']) # this would have been better...


### PR DESCRIPTION
selectedFlashggPhoton now requires the full cuts from MiniAOD that are on both of these lines:

https://github.com/cms-sw/cmssw/blob/68b4ccfc9d6f7b0ae0980969622686957e61fc9a/RecoEgamma/EgammaPhotonProducers/python/reducedEgamma_cfi.py#L5-L6

Therefore starting with this collection we won't have photons with incomplete information.  Note that, for conceptual reasons and ease of remembering things, we might want to repeat these cuts in the preselection module once it's finalized.