### PR TITLE
Implementation of PUPPI for `flashgg` 

### DIFF
--- a/MicroAOD/python/flashggMicroAODOutputCommands_cff.py
+++ b/MicroAOD/python/flashggMicroAODOutputCommands_cff.py
@@ -4,6 +4,10 @@ microAODDefaultOutputCommand = cms.untracked.vstring("drop *",
                                                      "keep *_flashgg*_*_*",
                                                      "drop *_flashggVertexMap*_*_*", 
                                                      "drop *_flashggDiPhotons_*_*", # keep preselected only
+                                                     ## this part drop all the tools used to build puppi jets
+                                                     "drop *_flashggPuppi*_*_*",
+                                                     #
+                                                     ""
                                                      "drop patPackedCandidates_*_*_*", # for intermediate PFCHSLeg jet constituents
                                                      "drop *_flashggPrunedGenParticles_*_*",   
                                                      "keep recoGenParticles_flashggPrunedGenParticles_*_*", # this line, and preceding, drop unneded association object

--- a/Validation/python/multi_jets_producer_test.py
+++ b/Validation/python/multi_jets_producer_test.py
@@ -59,21 +59,26 @@ process.TFileService = cms.Service("TFileService",
 
 
 from flashgg.MicroAOD.flashggExtraJets_cfi import addFlashggPF
-from flashgg.MicroAOD.flashggJets_cfi      import addFlashggPFCHSLegJets
+from flashgg.MicroAOD.flashggJets_cfi      import addFlashggPFCHSJets, addFlashggPuppiJets
 
 print ':: process ==', process
 addFlashggPF           (process = process, doQGTagging = True, label = '')
 
 
 for vtx in range(0,5):
-    addFlashggPFCHSLegJets (process = process,
-                            vertexIndex =vtx,
-                            doQGTagging = True,
-                            label = '' + str(vtx))
+    # chs
+    addFlashggPFCHSJets (process = process,
+                         vertexIndex =vtx,
+                         doQGTagging = True,
+                         debug       = True,
+                         label = '' + str(vtx))
+    # puppi 
+    addFlashggPuppiJets (process     = process,
+                         vertexIndex = vtx,
+                         debug       = True,
+                         label = '' + str(vtx)) 
     
-
-
-
+    
 #newseq = cloneProcessingSnippet(process,process.currentMicroAODExtraJetsSequence,'flashggJetsPF')
 #currentMicroAODExtraJetsSequence = cms.Sequence( )# addFlashggPF + addFlashggPFCHS0)
 
@@ -89,9 +94,7 @@ for vtx in range(0,5):
 #                                                           )
 #
 
-
 process.p = cms.Path(  process.flashggMicroAODSequence )
-
 process.e = cms.EndPath(process.out)
 
 from flashgg.MicroAOD.MicroAODCustomize import customize

--- a/setup.sh
+++ b/setup.sh
@@ -83,16 +83,16 @@ git cms-addpkg RecoJets/JetProducers
 git cms-merge-topic sethzenz:topic-pujid-74X
 echo
 
-#echo "Setting up PUPPI..."
-#git clone -b flashgg https://github.com/ldcorpe/Dummy
-
-echo
 echo "Setting up weight counter..."
 git cms-addpkg CommonTools/UtilAlgos 
 git cms-addpkg DataFormats/Common
 git cms-merge-topic sethzenz:topic-weights-count-74X
 
+echo "Setting up PUPPI..."
+git cms-addpkg CommonTools/PileupAlgos
+git cms-merge-topic yhaddad:topic-puppi-for-flashgg-74X
 echo
+
 echo "Setting up Conversion tools for pat electron..."
 git cms-addpkg RecoEgamma/EgammaTools
 git cms-merge-topic -u sethzenz:topic-conversion-tools-for-pat-ele-74X

--- a/setup.sh
+++ b/setup.sh
@@ -90,7 +90,7 @@ git cms-merge-topic sethzenz:topic-weights-count-74X
 
 echo "Setting up PUPPI..."
 git cms-addpkg CommonTools/PileupAlgos
-git cms-merge-topic yhaddad:topic-puppi-for-flashgg-74X
+git cms-merge-topic yhaddad:topic-puppi-flashgg-74X
 echo
 
 echo "Setting up Conversion tools for pat electron..."


### PR DESCRIPTION
This PR contains the implementation of PUPPI for ```flashgg``` using  a non standard vertex (ref [PUPPI twiki page](https://twiki.cern.ch/twiki/bin/viewauth/CMS/PUPPI)) 

To add `flashggPuppiJet` collections :

``` python
from flashgg.MicroAOD.flashggJets_cfi      import addFlashggPuppiJets
for vtx in range(0,5):
    addFlashggPuppiJets (process     = process,
                         vertexIndex = vtx,
                         debug       = True,
                         label = '' + str(vtx)) 

```
This will create 5 jet collections following the scheme described  in [#286](https://github.com/cms-analysis/flashgg/pull/286) and [here](https://indico.cern.ch/event/435396/#preview:1624154)

