### PR TITLE
changes to produce puppi by default in miniaod, and to make it readab…

### DIFF
--- a/MicroAOD/plugins/JetProducer.cc
+++ b/MicroAOD/plugins/JetProducer.cc
@@ -83,7 +83,19 @@ namespace flashgg {
                 if( !usePuppi ) {
                     if( !fjet.hasPuJetId( vtx ) ) {
                         PileupJetIdentifier lPUJetId = pileupJetIdAlgo_->computeIdVariables( pjet.get(), vtx, *vertexCandidateMap, true );
-                        fjet.setPuJetId( vtx, lPUJetId ); //temporarily make all jets pass
+                        fjet.setPuJetId( vtx, lPUJetId );
+                    }
+                } else {
+                    if( !fjet.hasPuJetId( vtx ) ) {
+                        PileupJetIdentifier lPUJetId;
+                        lPUJetId.RMS( 0 );
+                        lPUJetId.betaStar( 0 );
+                        int idFlag( 0 );
+                        idFlag += 1 <<  PileupJetIdentifier::kTight;
+                        idFlag += 1 <<  PileupJetIdentifier::kMedium;
+                        idFlag += 1 <<  PileupJetIdentifier::kLoose;
+                        lPUJetId.idFlag( idFlag );
+                        fjet.setPuJetId( vtx, lPUJetId ); //temporarily make puppi jets pass
                     }
                 }
             }
@@ -91,6 +103,18 @@ namespace flashgg {
                 if( primaryVertices->size() > 0 && !fjet.hasPuJetId( primaryVertices->ptrAt( 0 ) ) ) {
                     PileupJetIdentifier lPUJetId = pileupJetIdAlgo_->computeIdVariables( pjet.get(), primaryVertices->ptrAt( 0 ), *vertexCandidateMap, true );
                     fjet.setPuJetId( primaryVertices->ptrAt( 0 ), lPUJetId );
+                }
+            } else {
+                if( !fjet.hasPuJetId( primaryVertices->ptrAt( 0 ) ) ) {
+                    PileupJetIdentifier lPUJetId;
+                    lPUJetId.RMS( 0 );
+                    lPUJetId.betaStar( 0 );
+                    int idFlag( 0 );
+                    idFlag += 1 <<  PileupJetIdentifier::kTight;
+                    idFlag += 1 <<  PileupJetIdentifier::kMedium;
+                    idFlag += 1 <<  PileupJetIdentifier::kLoose;
+                    lPUJetId.idFlag( idFlag );
+                    fjet.setPuJetId( primaryVertices->ptrAt( 0 ), lPUJetId ); //temporarily make puppi jets pass
                 }
             }
             jetColl->push_back( fjet );

--- a/MicroAOD/python/flashggJets_cfi.py
+++ b/MicroAOD/python/flashggJets_cfi.py
@@ -181,7 +181,7 @@ flashggFinalJets = cms.EDProducer("FlashggVectorVectorJetCollector",
                                   inputTagJets= JetCollectionVInputTag
 )
 
-flashggFinalPuppiJets = cms.EDProducer("FlashggVectorVectorPuppiJetCollector",
+flashggFinalPuppiJets = cms.EDProducer("FlashggVectorVectorJetCollector",
                                   inputTagJets= PuppiJetCollectionVInputTag
 )
 

--- a/MicroAOD/python/flashggMicroAODOutputCommands_cff.py
+++ b/MicroAOD/python/flashggMicroAODOutputCommands_cff.py
@@ -33,7 +33,8 @@ microAODDefaultOutputCommand = cms.untracked.vstring("drop *",
                                                      "drop *_flashggMuons_*_*",
                                                      "drop *_flashggElectrons_*_*",
 
-                                                     "keep *_flashggFinalJets_*_*"
+                                                     "keep *_flashggFinalJets_*_*",
+                                                     "keep *_flashggFinalPuppiJets_*_*"
 
                                                      )
 

--- a/MicroAOD/python/flashggMicroAODSequence_cff.py
+++ b/MicroAOD/python/flashggMicroAODSequence_cff.py
@@ -3,7 +3,7 @@ from flashgg.MicroAOD.flashggTkVtxMap_cfi import flashggVertexMapUnique,flashggV
 from flashgg.MicroAOD.flashggPhotons_cfi import flashggPhotons
 from flashgg.MicroAOD.flashggDiPhotons_cfi import flashggDiPhotons
 from flashgg.MicroAOD.flashggPreselectedDiPhotons_cfi import flashggPreselectedDiPhotons
-from flashgg.MicroAOD.flashggJets_cfi import flashggFinalJets
+from flashgg.MicroAOD.flashggJets_cfi import flashggFinalJets,flashggFinalPuppiJets
 from flashgg.MicroAOD.flashggElectrons_cfi import flashggElectrons
 from flashgg.MicroAOD.flashggMuons_cfi import flashggMuons
 from flashgg.MicroAOD.flashggFinalEGamma_cfi import flashggFinalEGamma
@@ -28,5 +28,5 @@ flashggMicroAODSequence = cms.Sequence(eventCount+weightsCount
                                        +flashggMicroAODGenSequence
                                        +flashggPhotons*flashggDiPhotons*flashggPreselectedDiPhotons
                                        +flashggFinalEGamma
-                                       +flashggVertexMapForCHS*flashggFinalJets
+                                       +flashggVertexMapForCHS*flashggFinalJets*flashggFinalPuppiJets
                                        )

--- a/MicroAOD/test/microAODstd.py
+++ b/MicroAOD/test/microAODstd.py
@@ -80,6 +80,7 @@ process.options = cms.untracked.PSet(
     )
 # import function which takes care of reclustering the jets using legacy vertex		
 from flashgg.MicroAOD.flashggJets_cfi import addFlashggPFCHSJets 
+from flashgg.MicroAOD.flashggJets_cfi import addFlashggPuppiJets
 from flashgg.MicroAOD.flashggJets_cfi import maxJetCollections
 # call the function, it takes care of everything else.
 for vtx in range(0,maxJetCollections):
@@ -87,6 +88,10 @@ for vtx in range(0,maxJetCollections):
                          vertexIndex =vtx,
                          doQGTagging = True,
                          label = '' + str(vtx))    
+    addFlashggPuppiJets (process     = process,
+                         vertexIndex = vtx,
+                         debug       = False,
+                         label = '' + str(vtx))
 
 process.p = cms.Path(process.flashggMicroAODSequence)
 process.e = cms.EndPath(process.out)

--- a/Taggers/plugins/VectorVectorJetUnpacker.cc
+++ b/Taggers/plugins/VectorVectorJetUnpacker.cc
@@ -55,10 +55,12 @@ namespace flashgg {
             throw cms::Exception( "Configuration" ) << " Too many collections in input vector - inconsistency with MicroAOD";
         }
 
-        for( unsigned int i = 0 ; i < theJets->size() ; i++ ) {
+        for( unsigned int i = 0 ; i < nCollections_ ; i++ ) {
             auto_ptr<vector<Jet> > result( new vector<Jet> );
-            for( unsigned int j = 0 ; j < theJets->at( i ).size() ; j++ ) {
-                result->push_back( theJets->at( i )[j] );
+            if( theJets->size() > i ) {
+                for( unsigned int j = 0 ; j < theJets->at( i ).size() ; j++ ) {
+                    result->push_back( theJets->at( i )[j] );
+                }
             }
             char number[2];
             sprintf( number, "%u", i );

--- a/Taggers/test/simple_Tag_test.py
+++ b/Taggers/test/simple_Tag_test.py
@@ -30,6 +30,7 @@ process.load("flashgg/Taggers/flashggTagTester_cfi")
 # For debugging
 switchToPreselected = False
 switchToFinal = False
+switchToPuppi = False
 assert(not switchToPreselected or not switchToFinal)
 
 if switchToPreselected:
@@ -40,6 +41,9 @@ if switchToFinal:
     from flashgg.MicroAOD.flashggFinalEGamma_cfi import flashggFinalEGamma
     from PhysicsTools.PatAlgos.tools.helpers import massSearchReplaceAnyInputTag
     massSearchReplaceAnyInputTag(process.flashggTagSequence,cms.InputTag("flashggDiPhotons"),cms.InputTag("flashggFinalEGamma",flashggFinalEGamma.DiPhotonCollectionName.value()))
+
+if switchToPuppi:
+    process.flashggUnpackedJets.JetsTag = cms.InputTag("flashggFinalPuppiJets")
 
 from flashgg.Taggers.flashggTagOutputCommands_cff import tagDefaultOutputCommand
 


### PR DESCRIPTION
Changes to produce puppi by default in miniaod, and to make it readable from tag with a switch:

* Run puppi in MicroAOD and produce default output
* Save dummy "pass" for pujetid for puppi.  (Can be fixed later, but space cost is not high.)
* Fix bug in VectorVectorJetUnpacker that causes missing output collections if there were 0 jets.
* Flag to read puppi instead of PFCHS jets in simple_Tag_test.py