### PR TITLE
PUPPI requires different logic for map than PFCHS

### DIFF
--- a/DataFormats/src/Photon.cc
+++ b/DataFormats/src/Photon.cc
@@ -230,7 +230,7 @@ float const Photon::findVertexFloat( const edm::Ptr<reco::Vertex> &vtx, const st
     }
 
     throw cms::Exception( "Missing Data" ) << "could not find value for vertex " << vtx.key() << " " << vtx.id() << " lazy search: " << lazy <<  "\n";;
-    
+
     return 0.;
 }
 

--- a/MicroAOD/python/flashggJets_cfi.py
+++ b/MicroAOD/python/flashggJets_cfi.py
@@ -123,7 +123,7 @@ def addFlashggPuppiJets(process,
           flashggPuppi.clone( candName              = cms.InputTag('packedPFCandidates'),
                               vertexName            = cms.InputTag('offlineSlimmedPrimaryVertices'),
                               diPhotonTag           = cms.InputTag('flashggDiPhotons'),
-                              VertexCandidateMapTag = cms.InputTag('flashggVertexMapForCHS'),
+                              VertexCandidateMapTag = cms.InputTag('flashggVertexMapForPUPPI'),
                               vertexIndex           = cms.untracked.uint32(vertexIndex),
                               debug                 = cms.untracked.bool(debug)
                             )
@@ -155,7 +155,7 @@ def addFlashggPuppiJets(process,
                           DiPhotonTag           = cms.InputTag('flashggDiPhotons'),
                           VertexTag             = cms.InputTag('offlineSlimmedPrimaryVertices'),
                           JetTag                = cms.InputTag('patJetsAK4PUPPI' + label),
-                          VertexCandidateMapTag = cms.InputTag("flashggVertexMapForCHS"),
+                          VertexCandidateMapTag = cms.InputTag("flashggVertexMapForPUPPI"),
                           UsePuppi              = cms.untracked.bool(True),
                           PileupJetIdParameters = cms.PSet(pu_jetid)
                         ))

--- a/MicroAOD/python/flashggMicroAODSequence_cff.py
+++ b/MicroAOD/python/flashggMicroAODSequence_cff.py
@@ -1,5 +1,5 @@
 import FWCore.ParameterSet.Config as cms
-from flashgg.MicroAOD.flashggTkVtxMap_cfi import flashggVertexMapUnique,flashggVertexMapNonUnique,flashggVertexMapForCHS
+from flashgg.MicroAOD.flashggTkVtxMap_cfi import flashggVertexMapUnique,flashggVertexMapNonUnique,flashggVertexMapForCHS,flashggVertexMapForPUPPI
 from flashgg.MicroAOD.flashggPhotons_cfi import flashggPhotons
 from flashgg.MicroAOD.flashggDiPhotons_cfi import flashggDiPhotons
 from flashgg.MicroAOD.flashggPreselectedDiPhotons_cfi import flashggPreselectedDiPhotons
@@ -28,5 +28,6 @@ flashggMicroAODSequence = cms.Sequence(eventCount+weightsCount
                                        +flashggMicroAODGenSequence
                                        +flashggPhotons*flashggDiPhotons*flashggPreselectedDiPhotons
                                        +flashggFinalEGamma
-                                       +flashggVertexMapForCHS*flashggFinalJets*flashggFinalPuppiJets
+                                       +flashggVertexMapForCHS*flashggFinalJets
+                                       +flashggVertexMapForPUPPI*flashggFinalPuppiJets
                                        )

--- a/MicroAOD/python/flashggTkVtxMap_cfi.py
+++ b/MicroAOD/python/flashggTkVtxMap_cfi.py
@@ -20,8 +20,20 @@ flashggVertexMapNonUnique = cms.EDProducer('FlashggDzVertexMapProducer',
 #                                        )
 
 flashggVertexMapForCHS = cms.EDProducer('FlashggVertexMapFromCandidateProducer', # https://twiki.cern.ch/twiki/bin/view/CMSPublic/WorkBookMiniAOD2015#PV_Assignment
-                                                   PFCandidatesTag=cms.InputTag('packedPFCandidates'),
-                                                   VertexTag=cms.InputTag('offlineSlimmedPrimaryVertices'),
-                                                   FromPVCut=cms.uint32(0)) # "The definition normally used for isolation calculations is fromPV() > 1; 
-                                                                            # the definition used for CHS subtraction in jets is fromPV() > 0."
+                                        PFCandidatesTag=cms.InputTag('packedPFCandidates'),
+                                        VertexTag=cms.InputTag('offlineSlimmedPrimaryVertices'),
+                                        FromPVCut=cms.uint32(0), # "The definition normally used for isolation calculations is fromPV() > 1; 
+                                                                 # the definition used for CHS subtraction in jets is fromPV() > 0."
+                                        FromPVCutIfPassDz=cms.uint32(0),
+                                        DzCut=cms.double(999999.))
+
+
                                                    
+flashggVertexMapForPUPPI = cms.EDProducer('FlashggVertexMapFromCandidateProducer',
+                                          PFCandidatesTag=cms.InputTag('packedPFCandidates'),
+                                          VertexTag=cms.InputTag('offlineSlimmedPrimaryVertices'),
+                                          FromPVCut=cms.uint32(2), # if used in fit, keep it
+                                          FromPVCutIfPassDz=cms.uint32(0), # if loose or tight, check dz cut
+                                          DzCut=cms.double(0.3))
+
+                                          


### PR DESCRIPTION
It turns out PUPPI vertex association logic is different than PFCHS vertex association logic.  Add features to the PackedCandidate::FromPV map builder to emulate puppi logic:

   * Accept a track if it has `fromPV() == PVUsedInFit`
   * Otherwise if it's PVLoose or PVTight, accept if `absdz < 0.3`

N.B. the enum for fromPV is this, which should magic the logic and configurations clearer:

        enum PVAssoc { NoPV=0, PVLoose=1, PVTight=2, PVUsedInFit=3 } ;