### PR TITLE
change setup to protect from pushing to upstream/master

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 SETUP_REMOTES=false
+SETUP_ORIGIN=true
 
 echo
 echo "Welcome to the FLASHgg automagic setup script!"
@@ -25,12 +26,15 @@ echo
 echo "You should have checked out from cms-analysis/flashgg. Renaming this to upstream for convenience of existing developers..."
 cd $CMSSW_BASE/src/flashgg
 git remote rename origin upstream
+git remote set-url --push upstream DISALLOWED
 GITHUBUSERNAME=`git config user.github`
+echo "Setting up a new origin repo, assuming your fork name is ${GITHUBUSERNAME} - check this!"
+git remote add origin git@github.com:${GITHUBUSERNAME}/flashgg.git
+git config branch.master.remote origin
 
 if ${SETUP_REMOTES} ; then
   echo "Setting up remotes listed in setup script..."
   cd $CMSSW_BASE/src/flashgg
-  git remote add origin git@github.com:${GITHUBUSERNAME}/flashgg.git
   git remote add ArnabPurohit https://github.com/ArnabPurohit/flashgg
   git remote add bcourbon https://github.com/bcourbon/flashgg
   git remote add bmarzocc https://github.com/bmarzocc/flashgg
@@ -67,12 +71,6 @@ if ${SETUP_REMOTES} ; then
   git remote add upstream-writable git@github.com:cms-analysis/flashgg.git
 else
   echo "Not setting up additional remote names (default)"
-  echo
-  echo "Remember that:"
-  echo "  * To get a branch you can commit to, do: git checkout -b my-informative-branchname"
-  echo "  * YOU will need to add your own repo as a remote to push anything, e.g. with this command (check your GitHub username!):"
-  echo "      cd ${CMSSW_BASE}/src/flashgg ; git remote add origin git@github.com:${GITHUBUSERNAME}/flashgg.git"
-  echo
 fi
 
 cd $CMSSW_BASE/src

--- a/setup.sh
+++ b/setup.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 SETUP_REMOTES=false
-SETUP_ORIGIN=true
 
 echo
 echo "Welcome to the FLASHgg automagic setup script!"


### PR DESCRIPTION
With the current setup it's easy for people with admin access to push branches to cms-analysis rather than their own fork.  (It seems to have happened twice in fact.)  This changes setup.sh to do the following:

   * Mangle the push-url for `upstream` to make pushing impossible
   * Always create `origin` and set the remote for the master branch (originally from cms-analysis) to it

If you have access and want to push to cms-analysis, you can create the remote I like to call `upstream-writable`; this is done automagically if SETUP_REMOTES is turned on in setup.sh