### PR TITLE
preselection with rho correction

### DIFF
--- a/MicroAOD/interface/GlobalVariablesComputer.h
+++ b/MicroAOD/interface/GlobalVariablesComputer.h
@@ -23,9 +23,9 @@ namespace flashgg {
         void update( const edm::EventBase &event );
 
         float *addressOf( const std::string &varName );
-        int indexOf(const std::string &varName );
-        float valueOf(const std::string &varName );
-        float valueOf(int varIndex );
+        int indexOf( const std::string &varName );
+        float valueOf( const std::string &varName );
+        float valueOf( int varIndex );
 
     protected:
         edm::InputTag rhoTag_, vtxTag_;

--- a/MicroAOD/python/flashggPreselectedDiPhotons_cfi.py
+++ b/MicroAOD/python/flashggPreselectedDiPhotons_cfi.py
@@ -1,82 +1,72 @@
 import FWCore.ParameterSet.Config as cms
 
-phoEffArea=cms.PSet( var=cms.string("abs(superCluster.eta)"), bins=cms.vdouble(0.,0.9,1.5,2,2.2,3), vals=cms.vdouble(0.21,0.2,0.14,0.22,0.31) )
-neuEffArea=cms.PSet( var=cms.string("abs(superCluster.eta)"), bins=cms.vdouble(0.,0.9,1.5,2,2.2,3), vals=cms.vdouble(0.04,0.059,0.05,0.05,0.15) )
+phoEffArea=cms.PSet( var=cms.string("abs(superCluster.eta)"), bins=cms.vdouble(0.,0.9,1.5,2,2.2,3), vals=cms.vdouble(0.16544,0.16544,0.13212,0.13212,0.13212) )
+#phoEffArea=cms.PSet( var=cms.string("abs(superCluster.eta)"), bins=cms.vdouble(0.,0.9,1.5,2,2.2,3), vals=cms.vdouble(1.,1.,1.,1.,1.) )
+#neuEffArea=cms.PSet( var=cms.string("abs(superCluster.eta)"), bins=cms.vdouble(0.,0.9,1.5,2,2.2,3), vals=cms.vdouble(0.04,0.059,0.05,0.05,0.15) )
 
-PreselectionVariables = cms.vstring(
-    "egChargedHadronIso", 
-    "egPhotonIso", 
-    "egNeutralHadronIso",
-    "hadTowOverEm",
-    "(?r9>0.8||egChargedHadronIso<20||egChargedHadronIso/pt<0.3?full5x5_sigmaIetaIeta:sigmaIetaIeta)",
-    "passElectronVeto"
+rediscoveryHLTvariables = cms.vstring(
+    "pfPhoIso03", 
+    "trkSumPtHollowConeDR03",
+    "sigmaIetaIeta",
+    "full5x5_r9"
     )
 
-rediscoveryPreselection = cms.VPSet(
-    cms.PSet(cut=cms.string("abs(superCluster.eta)<1.5 && r9>0.94"),
+rediscoveryHLTcutsV1 = cms.VPSet(
+    cms.PSet(cut=cms.string("isEB && full5x5_r9>0.85"), ##EB high R9
              selection = cms.VPSet(
-            cms.PSet(max=cms.string("5.95")),
-            cms.PSet(max=cms.string("2.87"), 
+            cms.PSet(max=cms.string("100000.0"), 
                      rhocorr=phoEffArea,
                      ),
-            cms.PSet(# no neutra iso cut
-                ),
-            cms.PSet(max=cms.string("4.53e-1")),
-            cms.PSet(min=cms.string("0.001"), max=cms.string("1.05e-2")),
+            cms.PSet(max=cms.string("100000.0")),
+            cms.PSet(max=cms.string("100000.0")),
             cms.PSet(min=cms.string("0.5"))
             ),
              ),
-    cms.PSet(cut=cms.string("abs(superCluster.eta)<1.5 && r9<=0.94"),
+    
+    cms.PSet(cut=cms.string("isEE && full5x5_r9>0.90"),  ##EE high R9
              selection = cms.VPSet(
-            cms.PSet(max=cms.string("7.08")),
-            cms.PSet(max=cms.string("5.47"), 
-                     rhocorr=phoEffArea
+            cms.PSet(max=cms.string("100000.0"), 
+                     rhocorr=phoEffArea,
                      ),
-            cms.PSet(# no neutra iso cut
-                ),
-            cms.PSet(max=cms.string("2.12e-1")),
-            cms.PSet(min=cms.string("0.001"), max=cms.string("1.05e-2")),
-            cms.PSet(min=cms.string("0.5"))
+            cms.PSet(max=cms.string("100000.0")),
+            cms.PSet(max=cms.string("100000.0")),
+            cms.PSet(min=cms.string("0.8"))
             ),
              ),
-    cms.PSet(cut=cms.string("abs(superCluster.eta)>=1.5 && r9>0.94"),
+    cms.PSet(cut=cms.string("isEB && full5x5_r9<=0.85"),  #EB low R9
              selection = cms.VPSet(
-            cms.PSet(max=cms.string("6.10")),
-            cms.PSet(max=cms.string("5.98"), 
-                     rhocorr=phoEffArea),
-            cms.PSet(# no neutra iso cut
-                ),
-            cms.PSet(max=cms.string("6.3e-2")),
-            cms.PSet(min=cms.string("0.001"), max=cms.string("2.82e-2")),
+            cms.PSet(max=cms.string("4.0"), 
+                     rhocorr=phoEffArea,
+                     ),
+            cms.PSet(max=cms.string("6.0")),
+            cms.PSet(max=cms.string("0.015")),
             cms.PSet(min=cms.string("0.5"))
-            ),
-             ),
-    cms.PSet(cut=cms.string("abs(superCluster.eta)>=1.5 && r9<=0.94"),
+            ),       
+             ),       
+    cms.PSet(cut=cms.string("isEE && full5x5_r9<=0.90"),  ##EE low R9
              selection = cms.VPSet(
-            cms.PSet(max=cms.string("5.07")),
-            cms.PSet(max=cms.string("3.44"), 
-                     rhocorr=phoEffArea),
-            cms.PSet(# no neutra iso cut
-                ),
-            cms.PSet(max=cms.string("7.8e-2")),
-            cms.PSet(min=cms.string("0.001"), max=cms.string("2.80e-2")),
-            cms.PSet(min=cms.string("0.5"))
+            cms.PSet(max=cms.string("4.0"), 
+                     rhocorr=phoEffArea,
+                     ),
+            cms.PSet(max=cms.string("6.0")),
+            cms.PSet(max=cms.string("0.015")),
+            cms.PSet(min=cms.string("0.8"))
             ),
              )
     )
-
-selectedPreselection = rediscoveryPreselection
+rediscoveryHLTcuts = rediscoveryHLTcutsV1
 
 flashggPreselectedDiPhotons = cms.EDFilter(
-    "DiPhotonCandidateSelector",
+    "GenericDiPhotonCandidateSelector",
     src = cms.InputTag("flashggDiPhotons"),
     rho = cms.InputTag("fixedGridRhoAll"),
     cut = cms.string(
-        "    (leadingPhoton.r9>0.8||leadingPhoton.egChargedHadronIso<20||leadingPhoton.egChargedHadronIso/leadingPhoton.pt<0.3)"
-        " && (subLeadingPhoton.r9>0.8||subLeadingPhoton.egChargedHadronIso<20||subLeadingPhoton.egChargedHadronIso/subLeadingPhoton.pt<0.3)" 
-        )
-    ,
-    variables = PreselectionVariables,
-    categories = selectedPreselection,
+        "    (leadingPhoton.full5x5_r9>0.8||leadingPhoton.egChargedHadronIso<20||leadingPhoton.egChargedHadronIso/leadingPhoton.pt<0.3)"
+        " && (subLeadingPhoton.full5x5_r9>0.8||subLeadingPhoton.egChargedHadronIso<20||subLeadingPhoton.egChargedHadronIso/subLeadingPhoton.pt<0.3)"
+        " && (leadingPhoton.hadronicOverEm < 0.08 && subLeadingPhoton.hadronicOverEm < 0.08)"
+        " && (leadingPhoton.pt >30.0 && subLeadingPhoton.pt > 20.0)"
+        " && (abs(leadingPhoton.superCluster.eta) < 2.5 && abs(subLeadingPhoton.superCluster.eta) < 2.5)"
+        ),
+    variables = rediscoveryHLTvariables,
+    categories = rediscoveryHLTcuts, 
     )
-

--- a/MicroAOD/python/flashggPreselectedDiPhotons_cfi.py
+++ b/MicroAOD/python/flashggPreselectedDiPhotons_cfi.py
@@ -1,47 +1,82 @@
 import FWCore.ParameterSet.Config as cms
 
-#changed to match trigger logic
-#uses objects which don't quite match HLT objects
-#needs to be updated with final preselection
-flashggPreselectedDiPhotons = cms.EDFilter("DiPhotonCandidateSelector",
-                                   src = cms.InputTag("flashggDiPhotons"),
-                                   cut = cms.string("""(leadingPhoton.pt > 30. && subLeadingPhoton.pt>18) &&
-                                                    (abs(leadingPhoton.superCluster.eta) < 2.5 && abs(subLeadingPhoton.superCluster.eta) < 2.5) &&
-                                    (  leadingPhoton.hadronicOverEm < 0.1 && subLeadingPhoton.hadronicOverEm < 0.1) &&
-                                    (( leadingPhoton.r9 > 0.5 && leadingPhoton.isEB) || (leadingPhoton.r9 > 0.8 && leadingPhoton.isEE)) &&
-                                    (( subLeadingPhoton.r9 > 0.5 && subLeadingPhoton.isEB) || (subLeadingPhoton.r9 > 0.8 && subLeadingPhoton.isEE)) &&
-                                    (
-                                        ( leadingPhoton.isEB &&
-                                        (leadingPhoton.r9>0.85 || 
-                                        (leadingPhoton.sigmaIetaIeta < 0.015 && 
-                                         leadingPhoton.pfChgIsoWrtChosenVtx02 < 6.0 && 
-                                         leadingPhoton.trkSumPtHollowConeDR03 < 6.0 )))  ||
-                                        ( leadingPhoton.isEE &&
-                                        (leadingPhoton.r9>0.9 || 
-                                        (leadingPhoton.sigmaIetaIeta < 0.035 && 
-                                         leadingPhoton.pfChgIsoWrtChosenVtx02 < 6.0 && 
-                                         leadingPhoton.trkSumPtHollowConeDR03 < 6.0 ))) 
-                                     )
-                                     &&
-                                    (
-                                        ( subLeadingPhoton.isEB &&
-                                        (subLeadingPhoton.r9>0.85 || 
-                                        (subLeadingPhoton.sigmaIetaIeta < 0.015 && 
-                                         subLeadingPhoton.pfChgIsoWrtChosenVtx02 < 6.0 && 
-                                         subLeadingPhoton.trkSumPtHollowConeDR03 < 6.0 )))  ||
-                                        ( subLeadingPhoton.isEE &&
-                                        (subLeadingPhoton.r9>0.9 || 
-                                        (subLeadingPhoton.sigmaIetaIeta < 0.035 && 
-                                         subLeadingPhoton.pfChgIsoWrtChosenVtx02 < 6.0 && 
-                                         subLeadingPhoton.trkSumPtHollowConeDR03 < 6.0 ))) 
-                                     )
-                                        &&
-                                     (leadingPhoton.pt > 14 && leadingPhoton.hadTowOverEm()<0.15 && 
-                                     (leadingPhoton.r9()>0.8 || leadingPhoton.chargedHadronIso()<20 
-                                      || leadingPhoton.chargedHadronIso()<0.3*leadingPhoton.pt())) &&
-                                     (subLeadingPhoton.pt > 14 && subLeadingPhoton.hadTowOverEm()<0.15 &&
-                                     (subLeadingPhoton.r9()>0.8 || subLeadingPhoton.chargedHadronIso()<20 
-                                      || subLeadingPhoton.chargedHadronIso()<0.3*subLeadingPhoton.pt()))               
+phoEffArea=cms.PSet( var=cms.string("abs(superCluster.eta)"), bins=cms.vdouble(0.,0.9,1.5,2,2.2,3), vals=cms.vdouble(0.21,0.2,0.14,0.22,0.31) )
+neuEffArea=cms.PSet( var=cms.string("abs(superCluster.eta)"), bins=cms.vdouble(0.,0.9,1.5,2,2.2,3), vals=cms.vdouble(0.04,0.059,0.05,0.05,0.15) )
 
-                                     """)
-                                   )
+PreselectionVariables = cms.vstring(
+    "egChargedHadronIso", 
+    "egPhotonIso", 
+    "egNeutralHadronIso",
+    "hadTowOverEm",
+    "(?r9>0.8||egChargedHadronIso<20||egChargedHadronIso/pt<0.3?full5x5_sigmaIetaIeta:sigmaIetaIeta)",
+    "passElectronVeto"
+    )
+
+rediscoveryPreselection = cms.VPSet(
+    cms.PSet(cut=cms.string("abs(superCluster.eta)<1.5 && r9>0.94"),
+             selection = cms.VPSet(
+            cms.PSet(max=cms.string("5.95")),
+            cms.PSet(max=cms.string("2.87"), 
+                     rhocorr=phoEffArea,
+                     ),
+            cms.PSet(# no neutra iso cut
+                ),
+            cms.PSet(max=cms.string("4.53e-1")),
+            cms.PSet(min=cms.string("0.001"), max=cms.string("1.05e-2")),
+            cms.PSet(min=cms.string("0.5"))
+            ),
+             ),
+    cms.PSet(cut=cms.string("abs(superCluster.eta)<1.5 && r9<=0.94"),
+             selection = cms.VPSet(
+            cms.PSet(max=cms.string("7.08")),
+            cms.PSet(max=cms.string("5.47"), 
+                     rhocorr=phoEffArea
+                     ),
+            cms.PSet(# no neutra iso cut
+                ),
+            cms.PSet(max=cms.string("2.12e-1")),
+            cms.PSet(min=cms.string("0.001"), max=cms.string("1.05e-2")),
+            cms.PSet(min=cms.string("0.5"))
+            ),
+             ),
+    cms.PSet(cut=cms.string("abs(superCluster.eta)>=1.5 && r9>0.94"),
+             selection = cms.VPSet(
+            cms.PSet(max=cms.string("6.10")),
+            cms.PSet(max=cms.string("5.98"), 
+                     rhocorr=phoEffArea),
+            cms.PSet(# no neutra iso cut
+                ),
+            cms.PSet(max=cms.string("6.3e-2")),
+            cms.PSet(min=cms.string("0.001"), max=cms.string("2.82e-2")),
+            cms.PSet(min=cms.string("0.5"))
+            ),
+             ),
+    cms.PSet(cut=cms.string("abs(superCluster.eta)>=1.5 && r9<=0.94"),
+             selection = cms.VPSet(
+            cms.PSet(max=cms.string("5.07")),
+            cms.PSet(max=cms.string("3.44"), 
+                     rhocorr=phoEffArea),
+            cms.PSet(# no neutra iso cut
+                ),
+            cms.PSet(max=cms.string("7.8e-2")),
+            cms.PSet(min=cms.string("0.001"), max=cms.string("2.80e-2")),
+            cms.PSet(min=cms.string("0.5"))
+            ),
+             )
+    )
+
+selectedPreselection = rediscoveryPreselection
+
+flashggPreselectedDiPhotons = cms.EDFilter(
+    "DiPhotonCandidateSelector",
+    src = cms.InputTag("flashggDiPhotons"),
+    rho = cms.InputTag("fixedGridRhoAll"),
+    cut = cms.string(
+        "    (leadingPhoton.r9>0.8||leadingPhoton.egChargedHadronIso<20||leadingPhoton.egChargedHadronIso/leadingPhoton.pt<0.3)"
+        " && (subLeadingPhoton.r9>0.8||subLeadingPhoton.egChargedHadronIso<20||subLeadingPhoton.egChargedHadronIso/subLeadingPhoton.pt<0.3)" 
+        )
+    ,
+    variables = PreselectionVariables,
+    categories = selectedPreselection,
+    )
+

--- a/MicroAOD/src/GlobalVariablesComputer.cc
+++ b/MicroAOD/src/GlobalVariablesComputer.cc
@@ -21,7 +21,7 @@ namespace flashgg {
         return 0;
     }
 
-    int GlobalVariablesComputer::indexOf(const std::string &varName )
+    int GlobalVariablesComputer::indexOf( const std::string &varName )
     {
         if( varName == "rho" ) { return 0; }
         else if( varName == "nvtx" ) { return 1; }
@@ -30,21 +30,21 @@ namespace flashgg {
         else if( varName == "lumi" ) { return 4; }
         return -1;
     }
-    
-    float GlobalVariablesComputer::valueOf(const std::string &varName )
+
+    float GlobalVariablesComputer::valueOf( const std::string &varName )
     {
-        return valueOf( indexOf(varName) );
+        return valueOf( indexOf( varName ) );
     }
-    
-    float GlobalVariablesComputer::valueOf(int varIndex )
+
+    float GlobalVariablesComputer::valueOf( int varIndex )
     {
         if( varIndex == 0 ) { return cache_.rho; }
-        else if( varIndex == 1 ) { return (float)cache_.nvtx; }
-        else if( varIndex == 2 ) { return (float)cache_.run; }
-        else if( varIndex == 3 ) { return (float)cache_.event; }
-        else if( varIndex == 4 ) { return (float)cache_.lumi; }
+        else if( varIndex == 1 ) { return ( float )cache_.nvtx; }
+        else if( varIndex == 2 ) { return ( float )cache_.run; }
+        else if( varIndex == 3 ) { return ( float )cache_.event; }
+        else if( varIndex == 4 ) { return ( float )cache_.lumi; }
         return -1e+6;
-    
+
     }
 
     void GlobalVariablesComputer::update( const EventBase &evt )

--- a/Taggers/interface/CategoryDumper.h
+++ b/Taggers/interface/CategoryDumper.h
@@ -55,7 +55,7 @@ namespace flashgg {
     };
 
     typedef std::tuple<std::string, int, std::vector<double>, int, std::vector<double>, TH1 *> histo_info;
-    
+
     template<class FunctorT, class ObjectT>
     class CategoryDumper
     {
@@ -159,21 +159,21 @@ namespace flashgg {
             vector<double> xbins, ybins;
             auto pos = xname.find( "global." );
             int xindex = -1;
-            if( pos == 0 ) { 
-                xindex = -globalVarsDumper_->indexOf(xname.substr(7))-2;
-            } else { 
+            if( pos == 0 ) {
+                xindex = -globalVarsDumper_->indexOf( xname.substr( 7 ) ) - 2;
+            } else {
                 xindex = find( names_.begin(), names_.end(), xname ) - names_.begin(); // FIXME: check validity
             }
             int yindex = -1;
             if( ! yname.empty() ) {
                 pos = yname.find( "global." );
-                if( pos == 0 ) { 
-                    yindex = -globalVarsDumper_->indexOf(yname.substr(7))-2;
-                } else { 
+                if( pos == 0 ) {
+                    yindex = -globalVarsDumper_->indexOf( yname.substr( 7 ) ) - 2;
+                } else {
                     yindex = find( names_.begin(), names_.end(), yname ) - names_.begin(); // FIXME: check validity
                 }
             }
-            if( find(histograms_.begin(), histograms_.end(), name ) != histograms_.end() ) {
+            if( find( histograms_.begin(), histograms_.end(), name ) != histograms_.end() ) {
                 histograms_.push_back( make_tuple( name, xindex, xbins, yindex, ybins, ( TH1 * )0 ) );
                 continue;
             }
@@ -181,7 +181,7 @@ namespace flashgg {
                 xbins = histo.getUntrackedParameter<vector<double> >( "xbins" );
             } else {
                 auto xmin = histo.getUntrackedParameter<double>( "xmin" );
-                auto xmax = histo.getUntrackedParameter<double>( "xmax" ); 
+                auto xmax = histo.getUntrackedParameter<double>( "xmax" );
                 auto step = ( xmax - xmin ) / ( double )nxbins;
                 for( auto bound = xmin; bound <= xmax; bound += step ) {
                     xbins.push_back( bound );
@@ -215,9 +215,9 @@ namespace flashgg {
             auto name = formatString( name_ + get<0>( histo ), replacements );
             auto &xbins = get<2>( histo );
             auto &th1 = get<5>( histo );
-            try { 
-                th1 = fs.getObject<TH1>(name);
-            } catch(...) {
+            try {
+                th1 = fs.getObject<TH1>( name );
+            } catch( ... ) {
                 if( get<3>( histo ) >= 0 ) {
                     auto &ybins = get<4>( histo );
                     th1 = fs.make<TH2F>( name.c_str(), name.c_str(), xbins.size() - 1, &xbins[0], ybins.size() - 1, &ybins[0] );
@@ -301,9 +301,9 @@ namespace flashgg {
                 auto &th1 = *std::get<5>( histo );
                 auto xv = std::get<1>( histo );
                 auto yv = std::get<3>( histo );
-                float xval = ( xv >= 0 ? get<0>(variables_[xv]) : globalVarsDumper_->valueOf(-xv-2) );
-                if( yv != -1) {
-                    float yval = ( yv >= 0 ? get<0>(variables_[yv]) : globalVarsDumper_->valueOf(-yv-2) );
+                float xval = ( xv >= 0 ? get<0>( variables_[xv] ) : globalVarsDumper_->valueOf( -xv - 2 ) );
+                if( yv != -1 ) {
+                    float yval = ( yv >= 0 ? get<0>( variables_[yv] ) : globalVarsDumper_->valueOf( -yv - 2 ) );
                     // dynamic_cast<TH2 &>( th1 ).Fill( std::get<0>( variables_[xv] ), std::get<0>( variables_[yv] ), weight_ );
                     dynamic_cast<TH2 &>( th1 ).Fill( xval, yval, weight_ );
                 } else {
@@ -316,8 +316,8 @@ namespace flashgg {
 
 }
 
-inline bool operator==(const flashgg::histo_info& lh, const std::string & rh) { return get<0>(lh) == rh; };
-inline bool operator==(const std::string & lh, const flashgg::histo_info& rh) { return lh == get<0>(rh); };
+inline bool operator==( const flashgg::histo_info &lh, const std::string &rh ) { return get<0>( lh ) == rh; };
+inline bool operator==( const std::string &lh, const flashgg::histo_info &rh ) { return lh == get<0>( rh ); };
 
 
 #endif  // flashgg_CategoryDumper_h

--- a/Taggers/interface/GlobalVariablesDumper.h
+++ b/Taggers/interface/GlobalVariablesDumper.h
@@ -20,10 +20,10 @@ namespace flashgg {
         void bookTreeVariables( TTree *target, const std::map<std::string, std::string> &replacements );
 
         void fill( const edm::EventBase &event );
-        
+
     private:
         edm::InputTag triggerTag_;
-        std::vector<std::pair<std::string,bool>> bits_;
+        std::vector<std::pair<std::string, bool>> bits_;
 
     };
 

--- a/Taggers/src/GlobalVariablesDumper.cc
+++ b/Taggers/src/GlobalVariablesDumper.cc
@@ -17,13 +17,13 @@ namespace flashgg {
     GlobalVariablesDumper::GlobalVariablesDumper( const ParameterSet &cfg ) :
         GlobalVariablesComputer( cfg )
     {
-        if( cfg.exists("addTriggerBits") ) {
-            const auto &trg = cfg.getParameter<ParameterSet>("addTriggerBits");
-            triggerTag_ = trg.getParameter<InputTag>("tag");
-            auto bitNames   = trg.getParameter<std::vector<std::string> >("bits");
-            for(auto & bit : bitNames) {
+        if( cfg.exists( "addTriggerBits" ) ) {
+            const auto &trg = cfg.getParameter<ParameterSet>( "addTriggerBits" );
+            triggerTag_ = trg.getParameter<InputTag>( "tag" );
+            auto bitNames   = trg.getParameter<std::vector<std::string> >( "bits" );
+            for( auto &bit : bitNames ) {
                 std::cout << bit << std::endl;
-                bits_.push_back(std::make_pair(bit,false));
+                bits_.push_back( std::make_pair( bit, false ) );
             }
         }
     }
@@ -40,8 +40,8 @@ namespace flashgg {
         tree->Branch( "lumi", &cache_.lumi, "lumi/b" );
         tree->Branch( "run", &cache_.run, "run/i" );
         tree->Branch( "nvtx", &cache_.nvtx );
-        for(auto & bit : bits_ ) {
-            tree->Branch(bit.first.c_str(),&bit.second, (bit.first+"/O").c_str());
+        for( auto &bit : bits_ ) {
+            tree->Branch( bit.first.c_str(), &bit.second, ( bit.first + "/O" ).c_str() );
         }
     }
 
@@ -50,15 +50,15 @@ namespace flashgg {
         update( evt );
         if( ! bits_.empty() ) {
             Handle<TriggerResults> trigResults; //our trigger result object
-            evt.getByLabel(triggerTag_,trigResults);
-            
-            for(auto & bit : bits_ ) { bit.second = false; }
-            auto & trigNames = evt.triggerNames(*trigResults);
-            for(size_t itrg=0; itrg<trigNames.size(); ++itrg) {
-                if( ! trigResults->accept(itrg) ) { continue; }
-                auto pathName = trigNames.triggerName(itrg);
-                for(auto & bit : bits_ ) {
-                    if( pathName.find(bit.first) != std::string::npos ) {
+            evt.getByLabel( triggerTag_, trigResults );
+
+            for( auto &bit : bits_ ) { bit.second = false; }
+            auto &trigNames = evt.triggerNames( *trigResults );
+            for( size_t itrg = 0; itrg < trigNames.size(); ++itrg ) {
+                if( ! trigResults->accept( itrg ) ) { continue; }
+                auto pathName = trigNames.triggerName( itrg );
+                for( auto &bit : bits_ ) {
+                    if( pathName.find( bit.first ) != std::string::npos ) {
                         bit.second = true;
                         break;
                     }

--- a/Validation/plugins/DiphotonPreselectionValidation.cc
+++ b/Validation/plugins/DiphotonPreselectionValidation.cc
@@ -1,0 +1,370 @@
+// By O. Bondu
+// Adapted from S. Senz VertexValidation, base code from the flashggCommissioning tree maker code  by C. Favaro et al.
+
+#include <memory>
+
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "CommonTools/UtilAlgos/interface/TFileService.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "DataFormats/Common/interface/Handle.h"
+#include "DataFormats/Common/interface/Ptr.h"
+//#include "DataFormats/Common/interface/PtrVector.h"
+
+#include "DataFormats/VertexReco/interface/Vertex.h"
+
+#include "flashgg/MicroAOD/interface/VertexSelectorBase.h"
+#include "DataFormats/EgammaCandidates/interface/PhotonCore.h"
+#include "DataFormats/EgammaCandidates/interface/Photon.h"
+#include "DataFormats/PatCandidates/interface/Photon.h"
+#include "flashgg/DataFormats/interface/Photon.h"
+#include "flashgg/DataFormats/interface/DiPhotonCandidate.h"
+
+#include "flashgg/MicroAOD/interface/PhotonIdUtils.h"
+
+#include "flashgg/DataFormats/interface/VertexCandidateMap.h"
+#include "TTree.h"
+#include "TFile.h"
+#include "TH2F.h"
+#include "TH1F.h"
+
+// **********************************************************************
+
+// define the structures used to create tree branches and fill the trees
+
+// per-event tree:
+struct eventInfo {
+
+    int ndiphoton;
+
+};
+
+using namespace std;
+using namespace edm;
+using namespace flashgg;
+
+// **********************************************************************
+
+class DiphotonPreselectionValidation : public edm::EDAnalyzer
+{
+public:
+    explicit DiphotonPreselectionValidation( const edm::ParameterSet & );
+    ~DiphotonPreselectionValidation();
+
+private:
+
+    edm::Service<TFileService> fs_;
+
+    virtual void beginJob() override;
+    virtual void analyze( const edm::Event &, const edm::EventSetup & ) override;
+    virtual void endJob() override;
+
+    eventInfo evInfo;
+
+    TH1F *ptLead[9  ];
+    TH1F *ptTrail[9  ];
+    TH1F *ptLeadNorm[9  ];
+    TH1F *ptTrailNorm[9  ];
+    TH1F *massDiphotonhisto[9  ];
+    TH1F *massHiggshisto[9  ];
+    TH1F *higgsEta[9  ];
+    TH1F *higgsPhi[9  ];
+    TH1F *higgsP[9  ];
+    TH1F *higgsPt[9  ];
+    TH2F *phi1phi2[9  ];
+    TH2F *eta1eta2[9  ];
+    TH2F *pt1pt2[9  ];
+    TH2F *pt1pt2Norm[9  ];
+    TH2F *pt1pt2Zoom[9  ];
+    TH2F *wide_pt1pt2[9  ];
+
+    TH1F *diphoton_LeadR9[9  ];
+    TH1F *diphoton_SubLeadR9[9  ];
+
+    TH1F *diphoton_LeadHoE[9  ];
+    TH1F *diphoton_SubLeadHoE[9  ];
+
+    TH1F *diphoton_LeadTrkIso03[9  ];
+    TH1F *diphoton_SubLeadTrkIso03[9  ];
+
+    TH1F *diphoton_LeadHcalIso03[9  ];
+    TH1F *diphoton_SubLeadHcalIso03[9  ];
+
+    TH1F *diphoton_Leadpfiso02[9  ];
+    TH1F *diphoton_SubLeadpfiso02[9  ];
+
+    const Double_t bins[19] = {5, 10, 15, 20, 25, 30, 35, 40, 45, 50, 55, 60, 65, 70, 75, 80, 90, 100, 110};
+    bool cut[9  ];
+    int cut_index;
+
+    TH1F *cutflow;
+    TFile *theFileOut;
+    TString name;
+
+    edm::EDGetTokenT<edm::View<flashgg::DiPhotonCandidate> > diphotonToken_;
+    edm::EDGetTokenT<edm::View<flashgg::DiPhotonCandidate> > diphotonToken_1;
+    edm::EDGetTokenT<edm::View<flashgg::DiPhotonCandidate> > diphotonToken_2;
+
+};
+
+// ******************************************************************************************
+// ******************************************************************************************
+
+//
+// constants, enums and typedefs
+//
+
+//
+// static data member definitions
+//
+
+// data to compute preselection efficiencies per lead/sublead photon category
+
+//
+// constructors and destructor
+//
+DiphotonPreselectionValidation::DiphotonPreselectionValidation( const edm::ParameterSet &iConfig ):
+    diphotonToken_( consumes<View<flashgg::DiPhotonCandidate> >( iConfig.getParameter<InputTag> ( "DiPhotonTag" ) ) ),
+    diphotonToken_1( consumes<View<flashgg::DiPhotonCandidate> >( iConfig.getParameter<InputTag> ( "DiPhotonTag1" ) ) ), 
+    diphotonToken_2( consumes<View<flashgg::DiPhotonCandidate> >( iConfig.getParameter<InputTag> ( "DiPhotonTag2" ) ) )
+{
+
+}
+
+
+DiphotonPreselectionValidation::~DiphotonPreselectionValidation()
+{
+
+
+}
+
+
+
+void
+DiphotonPreselectionValidation::analyze( const edm::Event &iEvent, const edm::EventSetup &iSetup )
+{
+
+    // ********************************************************************************
+
+    // access edm objects
+
+    Handle<View<flashgg::DiPhotonCandidate> > diphotons;
+    iEvent.getByToken( diphotonToken_, diphotons );
+
+    Handle<View<flashgg::DiPhotonCandidate> > diphotons1;
+    iEvent.getByToken( diphotonToken_1, diphotons1 );
+
+    Handle<View<flashgg::DiPhotonCandidate> > diphotons2;
+    iEvent.getByToken( diphotonToken_2, diphotons2 );
+
+
+    std::cout<<"sizes:"<<diphotons->size()<<","<<diphotons1->size()<<","<<diphotons2->size()<<std::endl;
+
+    for( size_t idipho = 0; idipho < diphotons->size(); idipho++ ) {
+
+        Ptr<flashgg::DiPhotonCandidate> dipho = diphotons->ptrAt( idipho );
+        
+        //checking if preselected in 1
+        bool preselected_in_1=false;
+        for( size_t idipho1 = 0; idipho1 < diphotons1->size(); idipho1++ ) {
+            if(dipho->eta()==diphotons->ptrAt( idipho1 )->eta()
+               &&dipho->phi()==diphotons->ptrAt( idipho1 )->phi()
+               &&dipho->mass()==diphotons->ptrAt( idipho1 )->mass()){
+                preselected_in_1=true;
+            }
+        }
+
+
+        //checking if preselected in 2
+        bool preselected_in_2=false;
+        for( size_t idipho2 = 0; idipho2 < diphotons2->size(); idipho2++ ) {
+            if(dipho->eta()==diphotons->ptrAt( idipho2 )->eta()
+               &&dipho->phi()==diphotons->ptrAt( idipho2 )->phi()
+               &&dipho->mass()==diphotons->ptrAt( idipho2 )->mass()){
+                preselected_in_2=true;
+            }
+        }
+
+        
+        cut[0] = true; //all minitree level plots for reference, no cuts
+        
+        cut[1] = true;
+        cut[2] = preselected_in_1;
+        
+        cut[3] = true;
+        cut[4] = preselected_in_2;
+        
+        cut[5] = true;
+        cut[6] = true;
+        
+        cut[7] = true;
+        cut[8] = true;
+        
+        for( cut_index = 0; cut_index < 9  ; cut_index++ ) { //Loop over the different histograms
+            if( cut[cut_index] ) { //all hitograms below will be filled up if the boolean is true.
+                cutflow->Fill( cut_index );
+                phi1phi2[cut_index]->Fill( dipho->leadingPhoton()->phi(), dipho->subLeadingPhoton()->phi() );
+                eta1eta2[cut_index]->Fill( dipho->leadingPhoton()->eta(), dipho->subLeadingPhoton()->eta() );
+                pt1pt2[cut_index]->Fill( dipho->leadingPhoton()->pt(), dipho->subLeadingPhoton()->pt() );
+                pt1pt2Norm[cut_index]->Fill( dipho->leadingPhoton()->pt() / dipho->mass(), dipho->subLeadingPhoton()->pt() / dipho->mass() );
+                pt1pt2Zoom[cut_index]->Fill( dipho->leadingPhoton()->pt() / dipho->mass(), dipho->subLeadingPhoton()->pt() / dipho->mass() );
+                wide_pt1pt2[cut_index]->Fill( dipho->leadingPhoton()->pt(), dipho->subLeadingPhoton()->pt() );
+                higgsEta[cut_index]->Fill( dipho->eta() );
+                higgsPhi[cut_index]->Fill( dipho->phi() );
+                higgsP[cut_index]->Fill( dipho->p() );
+                higgsPt[cut_index]->Fill( dipho->pt() );
+                ptLead[cut_index]->Fill( dipho->leadingPhoton()->pt() );
+                ptTrail[cut_index]->Fill( dipho->subLeadingPhoton()->pt() );
+                ptLeadNorm[cut_index]->Fill( dipho->leadingPhoton()->pt() / dipho->mass() );
+                ptTrailNorm[cut_index]->Fill( dipho->subLeadingPhoton()->pt() / dipho->mass() );
+                massHiggshisto[cut_index]->Fill( dipho->mass() );
+                massDiphotonhisto[cut_index]->Fill( dipho->mass() );
+                
+                diphoton_LeadR9[cut_index]->Fill( dipho->leadingPhoton()->r9() );
+                diphoton_SubLeadR9[cut_index]->Fill( dipho->subLeadingPhoton()->r9() );
+                
+                /*
+                diphoton_LeadTrkIso03[cut_index]->Fill(dipho->leadingPhoton()->TrkIso03);
+                diphotonsubLeadTrkIso03[cut_index]->Fill(dipho->subLeadingPhoton()->SubLeadTrkIso03);
+                
+                diphoton_LeadHcalIso03[cut_index]->Fill(dipho->leadingPhoton()->HcalIso03);
+                diphotonsubLeadHcalIso03[cut_index]->Fill(dipho->subLeadingPhoton()->HcalIso03);
+                
+                diphoton_Leadpfiso02[cut_index]->Fill(dipho->leadingPhoton()->pfiso02);
+                diphotonsubLeadpfiso02[cut_index]->Fill(dipho->subLeadingPhoton()->pfiso02);
+                */
+            }
+        }
+        
+    }        
+}
+
+
+void
+DiphotonPreselectionValidation::beginJob()
+{
+    theFileOut = new TFile( "output_hlt.root", "RECREATE" );
+
+    cutflow = new TH1F( "cutflow", "cutflow", 9  , -0.5, 8.5 );
+
+    for( cut_index = 0; cut_index < 9  ; cut_index++ ) //Loop over the different histograms
+        {
+            name = Form( "ptLead_%d", cut_index );
+            ptLead[cut_index]            = new TH1F( name, name, 100, 0., 120. );
+            name = Form( "ptTrail_%d", cut_index );
+            ptTrail[cut_index]           = new TH1F( name, name, 100, 0., 120. );
+            name = Form( "ptLeadNorm_%d", cut_index );
+            ptLeadNorm[cut_index]        = new TH1F( name, name, 100, 0., 1. );
+            name = Form( "ptTrailNorm_%d", cut_index );
+            ptTrailNorm[cut_index]       = new TH1F( name, name, 100, 0., 1. );
+            name = Form( "massDiphoton_%d", cut_index );
+            massDiphotonhisto[cut_index] = new TH1F( name, name, 100, 60., 180. );
+            name = Form( "massHiggs_%d", cut_index );
+            massHiggshisto[cut_index]    = new TH1F( name, name, 100, 60., 180. );
+            name = Form( "higgsEta_%d", cut_index );
+            higgsEta[cut_index]          = new TH1F( name, name, 100, -5, 5 );
+            name = Form( "higgsPhi_%d", cut_index );
+            higgsPhi[cut_index]          = new TH1F( name, name, 180, -3.15, 3.15 );
+            name = Form( "higgsP_%d", cut_index );
+            higgsP[cut_index]            = new TH1F( name, name, 500, 0, 1200 );
+            name = Form( "higgsPt_%d", cut_index );
+            higgsPt[cut_index]           = new TH1F( name, name, 500, 0, 1200 );
+            name = Form( "phi1phi2_%d", cut_index );
+            phi1phi2[cut_index]          = new TH2F( name, name, 180, -3.15, 3.15, 180, -3.15, 3.15 );
+            name = Form( "eta1eta2_%d", cut_index );
+            eta1eta2[cut_index]          = new TH2F( name, name, 100, -5, 5, 100, -5, 5 );
+            name = Form( "pt1pt2_%d", cut_index );
+            pt1pt2[cut_index]            = new TH2F( name, name, 100, 0., 110., 100, 0., 110. );
+            name = Form( "pt1pt2Norm_%d", cut_index );
+            pt1pt2Norm[cut_index]        = new TH2F( name, name, 100, 0., 1., 100, 0., 1. );
+            name = Form( "pt1pt2Zoom_%d", cut_index );
+            pt1pt2Zoom[cut_index]        = new TH2F( name, name, 20, 0.3, 0.5, 20, 0.2, 0.4 );
+            name = Form( "wide_pt1pt2_%d", cut_index );
+            wide_pt1pt2[cut_index]       = new TH2F( name, name, 19 - 1, bins, 19 - 1, bins );
+
+            name = Form( "diphoton_LeadR9_%d", cut_index );
+            diphoton_LeadR9[cut_index]       = new TH1F( name, name, 100, 0., 1. );
+            name = Form( "diphoton_SubLeadR9_%d", cut_index );
+            diphoton_SubLeadR9[cut_index]       = new TH1F( name, name, 100, 0., 1. );
+
+            name = Form( "diphoton_LeadHoE_%d", cut_index );
+            diphoton_LeadHoE[cut_index]       = new TH1F( name, name, 100, 0., 0.01 );
+            name = Form( "diphoton_SubLeadHoE_%d", cut_index );
+            diphoton_SubLeadHoE[cut_index]       = new TH1F( name, name, 100, 0., 0.01 );
+
+            name = Form( "diphoton_LeadTrkIso03_%d", cut_index );
+            diphoton_LeadTrkIso03[cut_index]       = new TH1F( name, name, 100, 0., 0.01 );
+            name = Form( "diphoton_SubLeadTrkIso03_%d", cut_index );
+            diphoton_SubLeadTrkIso03[cut_index]       = new TH1F( name, name, 100, 0., 0.01 );
+
+            name = Form( "diphoton_LeadHcalIso03_%d", cut_index );
+            diphoton_LeadHcalIso03[cut_index]       = new TH1F( name, name, 100, 0., 0.01 );
+            name = Form( "diphoton_SubLeadHcalIso03_%d", cut_index );
+            diphoton_SubLeadHcalIso03[cut_index]       = new TH1F( name, name, 100, 0., 0.01 );
+
+            name = Form( "diphoton_Leadpfiso02_%d", cut_index );
+            diphoton_Leadpfiso02[cut_index]       = new TH1F( name, name, 100, 0., 0.01 );
+            name = Form( "diphoton_SubLeadpfiso02_%d", cut_index );
+            diphoton_SubLeadpfiso02[cut_index]       = new TH1F( name, name, 100, 0., 0.01 );
+        }    
+
+
+
+}
+
+void
+DiphotonPreselectionValidation::endJob()
+{
+    theFileOut->cd();
+    cutflow->Write();
+    for( cut_index = 0; cut_index < 9  ; cut_index++ ) //Loop over the different histograms
+        {
+            cout << "index=" << cut_index << endl;
+            ptLead[cut_index]->Write();
+            ptTrail[cut_index]->Write();
+            ptLeadNorm[cut_index]->Write();
+            ptTrailNorm[cut_index]->Write();
+            massDiphotonhisto[cut_index]->Write();
+            massHiggshisto[cut_index]->Write();
+            higgsEta[cut_index]->Write();
+            higgsPhi[cut_index]->Write();
+            higgsP[cut_index]->Write();
+            higgsPt[cut_index]->Write();
+            phi1phi2[cut_index]->Write();
+            eta1eta2[cut_index]->Write();
+            pt1pt2[cut_index]->Write();
+            pt1pt2Norm[cut_index]->Write();
+            pt1pt2Zoom[cut_index]->Write();
+            wide_pt1pt2[cut_index]->Write();
+            diphoton_LeadR9[cut_index]->Write();
+            diphoton_SubLeadR9[cut_index]->Write();
+            diphoton_LeadHoE[cut_index]->Write();
+            diphoton_SubLeadHoE[cut_index]->Write();
+            diphoton_LeadTrkIso03[cut_index]->Write();
+            diphoton_SubLeadTrkIso03[cut_index]->Write();
+            diphoton_LeadHcalIso03[cut_index]->Write();
+            diphoton_SubLeadHcalIso03[cut_index]->Write();
+            diphoton_Leadpfiso02[cut_index]->Write();
+            diphoton_SubLeadpfiso02[cut_index]->Write();
+        }
+    theFileOut->Close();
+
+} // end of endJob
+
+
+typedef DiphotonPreselectionValidation FlashggDiphotonPreselectionValidation;
+DEFINE_FWK_MODULE( FlashggDiphotonPreselectionValidation );
+// Local Variables:
+// mode:c++
+// indent-tabs-mode:nil
+// tab-width:4
+// c-basic-offset:4
+// End:
+// vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4
+

--- a/Validation/plugins/DiphotonPreselectionValidation.cc
+++ b/Validation/plugins/DiphotonPreselectionValidation.cc
@@ -131,7 +131,7 @@ private:
 //
 DiphotonPreselectionValidation::DiphotonPreselectionValidation( const edm::ParameterSet &iConfig ):
     diphotonToken_( consumes<View<flashgg::DiPhotonCandidate> >( iConfig.getParameter<InputTag> ( "DiPhotonTag" ) ) ),
-    diphotonToken_1( consumes<View<flashgg::DiPhotonCandidate> >( iConfig.getParameter<InputTag> ( "DiPhotonTag1" ) ) ), 
+    diphotonToken_1( consumes<View<flashgg::DiPhotonCandidate> >( iConfig.getParameter<InputTag> ( "DiPhotonTag1" ) ) ),
     diphotonToken_2( consumes<View<flashgg::DiPhotonCandidate> >( iConfig.getParameter<InputTag> ( "DiPhotonTag2" ) ) )
 {
 
@@ -164,48 +164,48 @@ DiphotonPreselectionValidation::analyze( const edm::Event &iEvent, const edm::Ev
     iEvent.getByToken( diphotonToken_2, diphotons2 );
 
 
-    std::cout<<"sizes:"<<diphotons->size()<<","<<diphotons1->size()<<","<<diphotons2->size()<<std::endl;
+    std::cout << "sizes:" << diphotons->size() << "," << diphotons1->size() << "," << diphotons2->size() << std::endl;
 
     for( size_t idipho = 0; idipho < diphotons->size(); idipho++ ) {
 
         Ptr<flashgg::DiPhotonCandidate> dipho = diphotons->ptrAt( idipho );
-        
+
         //checking if preselected in 1
-        bool preselected_in_1=false;
+        bool preselected_in_1 = false;
         for( size_t idipho1 = 0; idipho1 < diphotons1->size(); idipho1++ ) {
-            if(dipho->eta()==diphotons->ptrAt( idipho1 )->eta()
-               &&dipho->phi()==diphotons->ptrAt( idipho1 )->phi()
-               &&dipho->mass()==diphotons->ptrAt( idipho1 )->mass()){
-                preselected_in_1=true;
+            if( dipho->eta() == diphotons->ptrAt( idipho1 )->eta()
+                    && dipho->phi() == diphotons->ptrAt( idipho1 )->phi()
+                    && dipho->mass() == diphotons->ptrAt( idipho1 )->mass() ) {
+                preselected_in_1 = true;
             }
         }
 
 
         //checking if preselected in 2
-        bool preselected_in_2=false;
+        bool preselected_in_2 = false;
         for( size_t idipho2 = 0; idipho2 < diphotons2->size(); idipho2++ ) {
-            if(dipho->eta()==diphotons->ptrAt( idipho2 )->eta()
-               &&dipho->phi()==diphotons->ptrAt( idipho2 )->phi()
-               &&dipho->mass()==diphotons->ptrAt( idipho2 )->mass()){
-                preselected_in_2=true;
+            if( dipho->eta() == diphotons->ptrAt( idipho2 )->eta()
+                    && dipho->phi() == diphotons->ptrAt( idipho2 )->phi()
+                    && dipho->mass() == diphotons->ptrAt( idipho2 )->mass() ) {
+                preselected_in_2 = true;
             }
         }
 
-        
+
         cut[0] = true; //all minitree level plots for reference, no cuts
-        
+
         cut[1] = true;
         cut[2] = preselected_in_1;
-        
+
         cut[3] = true;
         cut[4] = preselected_in_2;
-        
+
         cut[5] = true;
         cut[6] = true;
-        
+
         cut[7] = true;
         cut[8] = true;
-        
+
         for( cut_index = 0; cut_index < 9  ; cut_index++ ) { //Loop over the different histograms
             if( cut[cut_index] ) { //all hitograms below will be filled up if the boolean is true.
                 cutflow->Fill( cut_index );
@@ -225,24 +225,24 @@ DiphotonPreselectionValidation::analyze( const edm::Event &iEvent, const edm::Ev
                 ptTrailNorm[cut_index]->Fill( dipho->subLeadingPhoton()->pt() / dipho->mass() );
                 massHiggshisto[cut_index]->Fill( dipho->mass() );
                 massDiphotonhisto[cut_index]->Fill( dipho->mass() );
-                
+
                 diphoton_LeadR9[cut_index]->Fill( dipho->leadingPhoton()->r9() );
                 diphoton_SubLeadR9[cut_index]->Fill( dipho->subLeadingPhoton()->r9() );
-                
+
                 /*
                 diphoton_LeadTrkIso03[cut_index]->Fill(dipho->leadingPhoton()->TrkIso03);
                 diphotonsubLeadTrkIso03[cut_index]->Fill(dipho->subLeadingPhoton()->SubLeadTrkIso03);
-                
+
                 diphoton_LeadHcalIso03[cut_index]->Fill(dipho->leadingPhoton()->HcalIso03);
                 diphotonsubLeadHcalIso03[cut_index]->Fill(dipho->subLeadingPhoton()->HcalIso03);
-                
+
                 diphoton_Leadpfiso02[cut_index]->Fill(dipho->leadingPhoton()->pfiso02);
                 diphotonsubLeadpfiso02[cut_index]->Fill(dipho->subLeadingPhoton()->pfiso02);
                 */
             }
         }
-        
-    }        
+
+    }
 }
 
 
@@ -253,66 +253,65 @@ DiphotonPreselectionValidation::beginJob()
 
     cutflow = new TH1F( "cutflow", "cutflow", 9  , -0.5, 8.5 );
 
-    for( cut_index = 0; cut_index < 9  ; cut_index++ ) //Loop over the different histograms
-        {
-            name = Form( "ptLead_%d", cut_index );
-            ptLead[cut_index]            = new TH1F( name, name, 100, 0., 120. );
-            name = Form( "ptTrail_%d", cut_index );
-            ptTrail[cut_index]           = new TH1F( name, name, 100, 0., 120. );
-            name = Form( "ptLeadNorm_%d", cut_index );
-            ptLeadNorm[cut_index]        = new TH1F( name, name, 100, 0., 1. );
-            name = Form( "ptTrailNorm_%d", cut_index );
-            ptTrailNorm[cut_index]       = new TH1F( name, name, 100, 0., 1. );
-            name = Form( "massDiphoton_%d", cut_index );
-            massDiphotonhisto[cut_index] = new TH1F( name, name, 100, 60., 180. );
-            name = Form( "massHiggs_%d", cut_index );
-            massHiggshisto[cut_index]    = new TH1F( name, name, 100, 60., 180. );
-            name = Form( "higgsEta_%d", cut_index );
-            higgsEta[cut_index]          = new TH1F( name, name, 100, -5, 5 );
-            name = Form( "higgsPhi_%d", cut_index );
-            higgsPhi[cut_index]          = new TH1F( name, name, 180, -3.15, 3.15 );
-            name = Form( "higgsP_%d", cut_index );
-            higgsP[cut_index]            = new TH1F( name, name, 500, 0, 1200 );
-            name = Form( "higgsPt_%d", cut_index );
-            higgsPt[cut_index]           = new TH1F( name, name, 500, 0, 1200 );
-            name = Form( "phi1phi2_%d", cut_index );
-            phi1phi2[cut_index]          = new TH2F( name, name, 180, -3.15, 3.15, 180, -3.15, 3.15 );
-            name = Form( "eta1eta2_%d", cut_index );
-            eta1eta2[cut_index]          = new TH2F( name, name, 100, -5, 5, 100, -5, 5 );
-            name = Form( "pt1pt2_%d", cut_index );
-            pt1pt2[cut_index]            = new TH2F( name, name, 100, 0., 110., 100, 0., 110. );
-            name = Form( "pt1pt2Norm_%d", cut_index );
-            pt1pt2Norm[cut_index]        = new TH2F( name, name, 100, 0., 1., 100, 0., 1. );
-            name = Form( "pt1pt2Zoom_%d", cut_index );
-            pt1pt2Zoom[cut_index]        = new TH2F( name, name, 20, 0.3, 0.5, 20, 0.2, 0.4 );
-            name = Form( "wide_pt1pt2_%d", cut_index );
-            wide_pt1pt2[cut_index]       = new TH2F( name, name, 19 - 1, bins, 19 - 1, bins );
+    for( cut_index = 0; cut_index < 9  ; cut_index++ ) { //Loop over the different histograms
+        name = Form( "ptLead_%d", cut_index );
+        ptLead[cut_index]            = new TH1F( name, name, 100, 0., 120. );
+        name = Form( "ptTrail_%d", cut_index );
+        ptTrail[cut_index]           = new TH1F( name, name, 100, 0., 120. );
+        name = Form( "ptLeadNorm_%d", cut_index );
+        ptLeadNorm[cut_index]        = new TH1F( name, name, 100, 0., 1. );
+        name = Form( "ptTrailNorm_%d", cut_index );
+        ptTrailNorm[cut_index]       = new TH1F( name, name, 100, 0., 1. );
+        name = Form( "massDiphoton_%d", cut_index );
+        massDiphotonhisto[cut_index] = new TH1F( name, name, 100, 60., 180. );
+        name = Form( "massHiggs_%d", cut_index );
+        massHiggshisto[cut_index]    = new TH1F( name, name, 100, 60., 180. );
+        name = Form( "higgsEta_%d", cut_index );
+        higgsEta[cut_index]          = new TH1F( name, name, 100, -5, 5 );
+        name = Form( "higgsPhi_%d", cut_index );
+        higgsPhi[cut_index]          = new TH1F( name, name, 180, -3.15, 3.15 );
+        name = Form( "higgsP_%d", cut_index );
+        higgsP[cut_index]            = new TH1F( name, name, 500, 0, 1200 );
+        name = Form( "higgsPt_%d", cut_index );
+        higgsPt[cut_index]           = new TH1F( name, name, 500, 0, 1200 );
+        name = Form( "phi1phi2_%d", cut_index );
+        phi1phi2[cut_index]          = new TH2F( name, name, 180, -3.15, 3.15, 180, -3.15, 3.15 );
+        name = Form( "eta1eta2_%d", cut_index );
+        eta1eta2[cut_index]          = new TH2F( name, name, 100, -5, 5, 100, -5, 5 );
+        name = Form( "pt1pt2_%d", cut_index );
+        pt1pt2[cut_index]            = new TH2F( name, name, 100, 0., 110., 100, 0., 110. );
+        name = Form( "pt1pt2Norm_%d", cut_index );
+        pt1pt2Norm[cut_index]        = new TH2F( name, name, 100, 0., 1., 100, 0., 1. );
+        name = Form( "pt1pt2Zoom_%d", cut_index );
+        pt1pt2Zoom[cut_index]        = new TH2F( name, name, 20, 0.3, 0.5, 20, 0.2, 0.4 );
+        name = Form( "wide_pt1pt2_%d", cut_index );
+        wide_pt1pt2[cut_index]       = new TH2F( name, name, 19 - 1, bins, 19 - 1, bins );
 
-            name = Form( "diphoton_LeadR9_%d", cut_index );
-            diphoton_LeadR9[cut_index]       = new TH1F( name, name, 100, 0., 1. );
-            name = Form( "diphoton_SubLeadR9_%d", cut_index );
-            diphoton_SubLeadR9[cut_index]       = new TH1F( name, name, 100, 0., 1. );
+        name = Form( "diphoton_LeadR9_%d", cut_index );
+        diphoton_LeadR9[cut_index]       = new TH1F( name, name, 100, 0., 1. );
+        name = Form( "diphoton_SubLeadR9_%d", cut_index );
+        diphoton_SubLeadR9[cut_index]       = new TH1F( name, name, 100, 0., 1. );
 
-            name = Form( "diphoton_LeadHoE_%d", cut_index );
-            diphoton_LeadHoE[cut_index]       = new TH1F( name, name, 100, 0., 0.01 );
-            name = Form( "diphoton_SubLeadHoE_%d", cut_index );
-            diphoton_SubLeadHoE[cut_index]       = new TH1F( name, name, 100, 0., 0.01 );
+        name = Form( "diphoton_LeadHoE_%d", cut_index );
+        diphoton_LeadHoE[cut_index]       = new TH1F( name, name, 100, 0., 0.01 );
+        name = Form( "diphoton_SubLeadHoE_%d", cut_index );
+        diphoton_SubLeadHoE[cut_index]       = new TH1F( name, name, 100, 0., 0.01 );
 
-            name = Form( "diphoton_LeadTrkIso03_%d", cut_index );
-            diphoton_LeadTrkIso03[cut_index]       = new TH1F( name, name, 100, 0., 0.01 );
-            name = Form( "diphoton_SubLeadTrkIso03_%d", cut_index );
-            diphoton_SubLeadTrkIso03[cut_index]       = new TH1F( name, name, 100, 0., 0.01 );
+        name = Form( "diphoton_LeadTrkIso03_%d", cut_index );
+        diphoton_LeadTrkIso03[cut_index]       = new TH1F( name, name, 100, 0., 0.01 );
+        name = Form( "diphoton_SubLeadTrkIso03_%d", cut_index );
+        diphoton_SubLeadTrkIso03[cut_index]       = new TH1F( name, name, 100, 0., 0.01 );
 
-            name = Form( "diphoton_LeadHcalIso03_%d", cut_index );
-            diphoton_LeadHcalIso03[cut_index]       = new TH1F( name, name, 100, 0., 0.01 );
-            name = Form( "diphoton_SubLeadHcalIso03_%d", cut_index );
-            diphoton_SubLeadHcalIso03[cut_index]       = new TH1F( name, name, 100, 0., 0.01 );
+        name = Form( "diphoton_LeadHcalIso03_%d", cut_index );
+        diphoton_LeadHcalIso03[cut_index]       = new TH1F( name, name, 100, 0., 0.01 );
+        name = Form( "diphoton_SubLeadHcalIso03_%d", cut_index );
+        diphoton_SubLeadHcalIso03[cut_index]       = new TH1F( name, name, 100, 0., 0.01 );
 
-            name = Form( "diphoton_Leadpfiso02_%d", cut_index );
-            diphoton_Leadpfiso02[cut_index]       = new TH1F( name, name, 100, 0., 0.01 );
-            name = Form( "diphoton_SubLeadpfiso02_%d", cut_index );
-            diphoton_SubLeadpfiso02[cut_index]       = new TH1F( name, name, 100, 0., 0.01 );
-        }    
+        name = Form( "diphoton_Leadpfiso02_%d", cut_index );
+        diphoton_Leadpfiso02[cut_index]       = new TH1F( name, name, 100, 0., 0.01 );
+        name = Form( "diphoton_SubLeadpfiso02_%d", cut_index );
+        diphoton_SubLeadpfiso02[cut_index]       = new TH1F( name, name, 100, 0., 0.01 );
+    }
 
 
 
@@ -323,36 +322,35 @@ DiphotonPreselectionValidation::endJob()
 {
     theFileOut->cd();
     cutflow->Write();
-    for( cut_index = 0; cut_index < 9  ; cut_index++ ) //Loop over the different histograms
-        {
-            cout << "index=" << cut_index << endl;
-            ptLead[cut_index]->Write();
-            ptTrail[cut_index]->Write();
-            ptLeadNorm[cut_index]->Write();
-            ptTrailNorm[cut_index]->Write();
-            massDiphotonhisto[cut_index]->Write();
-            massHiggshisto[cut_index]->Write();
-            higgsEta[cut_index]->Write();
-            higgsPhi[cut_index]->Write();
-            higgsP[cut_index]->Write();
-            higgsPt[cut_index]->Write();
-            phi1phi2[cut_index]->Write();
-            eta1eta2[cut_index]->Write();
-            pt1pt2[cut_index]->Write();
-            pt1pt2Norm[cut_index]->Write();
-            pt1pt2Zoom[cut_index]->Write();
-            wide_pt1pt2[cut_index]->Write();
-            diphoton_LeadR9[cut_index]->Write();
-            diphoton_SubLeadR9[cut_index]->Write();
-            diphoton_LeadHoE[cut_index]->Write();
-            diphoton_SubLeadHoE[cut_index]->Write();
-            diphoton_LeadTrkIso03[cut_index]->Write();
-            diphoton_SubLeadTrkIso03[cut_index]->Write();
-            diphoton_LeadHcalIso03[cut_index]->Write();
-            diphoton_SubLeadHcalIso03[cut_index]->Write();
-            diphoton_Leadpfiso02[cut_index]->Write();
-            diphoton_SubLeadpfiso02[cut_index]->Write();
-        }
+    for( cut_index = 0; cut_index < 9  ; cut_index++ ) { //Loop over the different histograms
+        cout << "index=" << cut_index << endl;
+        ptLead[cut_index]->Write();
+        ptTrail[cut_index]->Write();
+        ptLeadNorm[cut_index]->Write();
+        ptTrailNorm[cut_index]->Write();
+        massDiphotonhisto[cut_index]->Write();
+        massHiggshisto[cut_index]->Write();
+        higgsEta[cut_index]->Write();
+        higgsPhi[cut_index]->Write();
+        higgsP[cut_index]->Write();
+        higgsPt[cut_index]->Write();
+        phi1phi2[cut_index]->Write();
+        eta1eta2[cut_index]->Write();
+        pt1pt2[cut_index]->Write();
+        pt1pt2Norm[cut_index]->Write();
+        pt1pt2Zoom[cut_index]->Write();
+        wide_pt1pt2[cut_index]->Write();
+        diphoton_LeadR9[cut_index]->Write();
+        diphoton_SubLeadR9[cut_index]->Write();
+        diphoton_LeadHoE[cut_index]->Write();
+        diphoton_SubLeadHoE[cut_index]->Write();
+        diphoton_LeadTrkIso03[cut_index]->Write();
+        diphoton_SubLeadTrkIso03[cut_index]->Write();
+        diphoton_LeadHcalIso03[cut_index]->Write();
+        diphoton_SubLeadHcalIso03[cut_index]->Write();
+        diphoton_Leadpfiso02[cut_index]->Write();
+        diphoton_SubLeadpfiso02[cut_index]->Write();
+    }
     theFileOut->Close();
 
 } // end of endJob

--- a/Validation/python/DiphotonPreselection_Validator.py
+++ b/Validation/python/DiphotonPreselection_Validator.py
@@ -1,0 +1,25 @@
+import FWCore.ParameterSet.Config as cms
+import FWCore.Utilities.FileUtils as FileUtils
+
+process = cms.Process("FLASHggDiphotonValidation")
+
+process.load("FWCore.MessageService.MessageLogger_cfi")
+process.load("Configuration.StandardSequences.GeometryDB_cff")
+process.load("Configuration.StandardSequences.MagneticField_cff")
+process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
+process.GlobalTag.globaltag = 'POSTLS170_V5::All'
+
+process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32( -1 ) )
+
+process.source = cms.Source("PoolSource",fileNames=cms.untracked.vstring("file:/afs/cern.ch/user/c/carrillo/flashgg/CMSSW_7_4_6_patch2/src/myMicroAODOutputFile.root"))
+
+#process.TFileService = cms.Service("TFileService",fileName = cms.string("DiphotonValidationTree.root"))
+process.flashggDiphotonPreselectionValidation = cms.EDAnalyzer('FlashggDiphotonPreselectionValidation',
+    DiPhotonTag  = cms.InputTag('flashggDiPhotons'),
+    DiPhotonTag1  = cms.InputTag('flashggPreselectedDiPhotons'),
+    DiPhotonTag2  = cms.InputTag('flashggPreselectedDiPhotons')
+)
+
+process.p = cms.Path(
+    process.flashggDiphotonPreselectionValidation
+)

--- a/Validation/test/fwlite_preselection/index.html
+++ b/Validation/test/fwlite_preselection/index.html
@@ -1,0 +1,956 @@
+<html>
+<head>
+<style type="text/css">
+<!--
+A:link {text-decoration: none;}
+A:visited {text-decoration: none;}
+A:active {text-decoration: none;}
+A:hover {text-decoration: none; color: #66ccff;}
+//-->
+</style>
+<title>Higgs HLT studies</title>
+</head>
+<body>
+<font size="8">Flashgg Higgs HLT studies<br></font><br>
+
+<table width="40%" border="1" cellpadding="0" cellspacing="0">
+    <tr>
+    <td align="center">
+      <font size="8">Cut flow</font>
+    </td>
+  <tr>
+  <tr>
+    <td align="center">
+      <a href='./plots/cutflow.png'>
+	<img width="600" border='0' src='./plots/cutflow.png'>
+      </a>
+    </td>
+  </tr>
+</table>
+
+<table width="20%" border="1" cellpadding="0" cellspacing="0">
+  <tr>
+    <td align="center">
+      <font size="8">cut[0] cut[1]</font>
+    </td>
+    <td align="center">
+      <font size="8">eff [1]/[0]</font>
+    </td>
+    <td align="center">
+      <font size="8">cut[0] cut[1] cut[2]</font>
+    </td>
+    <td align="center">
+      <font size="8">eff [2]/[1] </font>
+    </td>
+    <td align="center">
+      <font size="8">cut[0] cut[3] cut[4]</font>
+    </td>
+    <td align="center">
+      <font size="8">eff [4]/[3] </font>
+    </td>
+    <td align="center">
+      <font size="8">cut[0] cut[5] cut[6]</font>
+    </td>
+    <td align="center">
+      <font size="8">eff [6]/[5] </font>
+    </td>
+    <td align="center">
+      <font size="8">cut[0] cut[7] cut[8]</font>
+    </td>
+    <td align="center">
+      <font size="8">eff [8]/[7] </font>
+    </td>
+  </tr> 
+  <tr>
+    <td align="center">
+      <a href='./plots/10higgsEta.png'>
+	<img width="600" border='0' src='./plots/10higgsEta.png'>
+      </a>
+    </td>
+    <td align="center">
+      <a href='./plots/eff10_higgsEta.png'>
+	<img width="600" border='0' src='./plots/eff10_higgsEta.png'>
+      </a>
+    </td>
+    <td align="center">
+      <a href='./plots/21higgsEta.png'>
+	<img width="600" border='0' src='./plots/21higgsEta.png'>
+      </a>
+    </td>
+    <td align="center">
+      <a href='./plots/eff21_higgsEta.png'>
+	<img width="600" border='0' src='./plots/eff21_higgsEta.png'>
+      </a>
+    </td>
+    <td align="center">
+      <a href='./plots/43higgsEta.png'>
+	<img width="600" border='0' src='./plots/43higgsEta.png'>
+      </a>
+    </td>
+    <td align="center">
+      <a href='./plots/eff43_higgsEta.png'>
+	<img width="600" border='0' src='./plots/eff43_higgsEta.png'>
+      </a>
+    </td>
+    <td align="center">
+      <a href='./plots/65higgsEta.png'>
+	<img width="600" border='0' src='./plots/65higgsEta.png'>
+      </a>
+    </td>
+    <td align="center">
+      <a href='./plots/eff65_higgsEta.png'>
+	<img width="600" border='0' src='./plots/eff65_higgsEta.png'>
+      </a>
+    </td>
+    <td align="center">
+      <a href='./plots/87higgsEta.png'>
+	<img width="600" border='0' src='./plots/87higgsEta.png'>
+      </a>
+    </td>
+    <td align="center">
+      <a href='./plots/eff87_higgsEta.png'>
+	<img width="600" border='0' src='./plots/eff87_higgsEta.png'>
+      </a>
+    </td>
+  </tr>
+  <tr>
+    <td align="center">
+      <a href='./plots/10higgsPhi.png'>
+	<img width="600" border='0' src='./plots/10higgsPhi.png'>
+      </a>
+    </td>
+    <td align="center">
+      <a href='./plots/eff10_higgsPhi.png'>
+	<img width="600" border='0' src='./plots/eff10_higgsPhi.png'>
+      </a>
+    </td>
+    <td align="center">
+      <a href='./plots/21higgsPhi.png'>
+	<img width="600" border='0' src='./plots/21higgsPhi.png'>
+      </a>
+    </td>
+    <td align="center">
+      <a href='./plots/eff21_higgsPhi.png'>
+	<img width="600" border='0' src='./plots/eff21_higgsPhi.png'>
+      </a>
+    </td>
+    <td align="center">
+      <a href='./plots/43higgsPhi.png'>
+	<img width="600" border='0' src='./plots/43higgsPhi.png'>
+      </a>
+    </td>
+    <td align="center">
+      <a href='./plots/eff43_higgsPhi.png'>
+	<img width="600" border='0' src='./plots/eff43_higgsPhi.png'>
+      </a>
+    </td>
+    <td align="center">
+      <a href='./plots/65higgsPhi.png'>
+	<img width="600" border='0' src='./plots/65higgsPhi.png'>
+      </a>
+    </td>
+    <td align="center">
+      <a href='./plots/eff65_higgsPhi.png'>
+	<img width="600" border='0' src='./plots/eff65_higgsPhi.png'>
+      </a>
+    </td>
+    <td align="center">
+      <a href='./plots/87higgsPhi.png'>
+	<img width="600" border='0' src='./plots/87higgsPhi.png'>
+      </a>
+    </td>
+    <td align="center">
+      <a href='./plots/eff87_higgsPhi.png'>
+	<img width="600" border='0' src='./plots/eff87_higgsPhi.png'>
+      </a>
+    </td>
+  </tr>
+  <tr>
+    <td align="center">
+      <a href='./plots/10massDiphoton.png'>
+	<img width="600" border='0' src='./plots/10massDiphoton.png'>
+      </a>
+    </td>
+    <td align="center">
+      <a href='./plots/eff10_massDiphoton.png'>
+	<img width="600" border='0' src='./plots/eff10_massDiphoton.png'>
+      </a>
+    </td>
+    <td align="center">
+      <a href='./plots/21massDiphoton.png'>
+	<img width="600" border='0' src='./plots/21massDiphoton.png'>
+      </a>
+    </td>
+    <td align="center">
+      <a href='./plots/eff21_massDiphoton.png'>
+	<img width="600" border='0' src='./plots/eff21_massDiphoton.png'>
+      </a>
+    </td>
+    <td align="center">
+      <a href='./plots/43massDiphoton.png'>
+	<img width="600" border='0' src='./plots/43massDiphoton.png'>
+      </a>
+    </td>
+    <td align="center">
+      <a href='./plots/eff43_massDiphoton.png'>
+	<img width="600" border='0' src='./plots/eff43_massDiphoton.png'>
+      </a>
+    </td>
+    <td align="center">
+      <a href='./plots/65massDiphoton.png'>
+	<img width="600" border='0' src='./plots/65massDiphoton.png'>
+      </a>
+    </td>
+    <td align="center">
+      <a href='./plots/eff65_massDiphoton.png'>
+	<img width="600" border='0' src='./plots/eff65_massDiphoton.png'>
+      </a>
+    </td>
+    <td align="center">
+      <a href='./plots/87massDiphoton.png'>
+	<img width="600" border='0' src='./plots/87massDiphoton.png'>
+      </a>
+    </td>
+    <td align="center">
+      <a href='./plots/eff87_massDiphoton.png'>
+	<img width="600" border='0' src='./plots/eff87_massDiphoton.png'>
+      </a>
+    </td>
+  </tr>
+  <tr>
+    <td align="center">
+      <a href='./plots/10ptLead.png'>
+	<img width="600" border='0' src='./plots/10ptLead.png'>
+      </a>
+    </td>
+    <td align="center">
+      <a href='./plots/eff10_ptLead.png'>
+	<img width="600" border='0' src='./plots/eff10_ptLead.png'>
+      </a>
+    </td>
+    <td align="center">
+      <a href='./plots/21ptLead.png'>
+	<img width="600" border='0' src='./plots/21ptLead.png'>
+      </a>
+    </td>
+    <td align="center">
+      <a href='./plots/eff21_ptLead.png'>
+	<img width="600" border='0' src='./plots/eff21_ptLead.png'>
+      </a>
+    </td>
+    <td align="center">
+      <a href='./plots/43ptLead.png'>
+	<img width="600" border='0' src='./plots/43ptLead.png'>
+      </a>
+    </td>
+    <td align="center">
+      <a href='./plots/eff43_ptLead.png'>
+	<img width="600" border='0' src='./plots/eff43_ptLead.png'>
+      </a>
+    </td>
+    <td align="center">
+      <a href='./plots/65ptLead.png'>
+	<img width="600" border='0' src='./plots/65ptLead.png'>
+      </a>
+    </td>
+    <td align="center">
+      <a href='./plots/eff65_ptLead.png'>
+	<img width="600" border='0' src='./plots/eff65_ptLead.png'>
+      </a>
+    </td>
+    <td align="center">
+      <a href='./plots/87ptLead.png'>
+	<img width="600" border='0' src='./plots/87ptLead.png'>
+      </a>
+    </td>
+    <td align="center">
+      <a href='./plots/eff87_ptLead.png'>
+	<img width="600" border='0' src='./plots/eff87_ptLead.png'>
+      </a>
+    </td>
+  </tr>
+  <tr>
+    <td align="center">
+      <a href='./plots/10ptTrail.png'>
+	<img width="600" border='0' src='./plots/10ptTrail.png'>
+      </a>
+    </td>
+    <td align="center">
+      <a href='./plots/eff10_ptTrail.png'>
+	<img width="600" border='0' src='./plots/eff10_ptTrail.png'>
+      </a>
+    </td>
+    <td align="center">
+      <a href='./plots/21ptTrail.png'>
+	<img width="600" border='0' src='./plots/21ptTrail.png'>
+      </a>
+    </td>
+    <td align="center">
+      <a href='./plots/eff21_ptTrail.png'>
+	<img width="600" border='0' src='./plots/eff21_ptTrail.png'>
+      </a>
+    </td>
+    <td align="center">
+      <a href='./plots/43ptTrail.png'>
+	<img width="600" border='0' src='./plots/43ptTrail.png'>
+      </a>
+    </td>
+    <td align="center">
+      <a href='./plots/eff43_ptTrail.png'>
+	<img width="600" border='0' src='./plots/eff43_ptTrail.png'>
+      </a>
+    </td>
+    <td align="center">
+      <a href='./plots/65ptTrail.png'>
+	<img width="600" border='0' src='./plots/65ptTrail.png'>
+      </a>
+    </td>
+    <td align="center">
+      <a href='./plots/eff65_ptTrail.png'>
+	<img width="600" border='0' src='./plots/eff65_ptTrail.png'>
+      </a>
+    </td>
+    <td align="center">
+      <a href='./plots/87ptTrail.png'>
+	<img width="600" border='0' src='./plots/87ptTrail.png'>
+      </a>
+    </td>
+    <td align="center">
+      <a href='./plots/eff87_ptTrail.png'>
+	<img width="600" border='0' src='./plots/eff87_ptTrail.png'>
+      </a>
+    </td>
+  </tr>
+  <tr>
+    <td align="center">
+      <a href='./plots/10ptLeadNorm.png'>
+	<img width="600" border='0' src='./plots/10ptLeadNorm.png'>
+      </a>
+    </td>
+    <td align="center">
+      <a href='./plots/eff10_ptLeadNorm.png'>
+	<img width="600" border='0' src='./plots/eff10_ptLeadNorm.png'>
+      </a>
+    </td>
+    <td align="center">
+      <a href='./plots/21ptLeadNorm.png'>
+	<img width="600" border='0' src='./plots/21ptLeadNorm.png'>
+      </a>
+    </td>
+    <td align="center">
+      <a href='./plots/eff21_ptLeadNorm.png'>
+	<img width="600" border='0' src='./plots/eff21_ptLeadNorm.png'>
+      </a>
+    </td>
+    <td align="center">
+      <a href='./plots/43ptLeadNorm.png'>
+	<img width="600" border='0' src='./plots/43ptLeadNorm.png'>
+      </a>
+    </td>
+    <td align="center">
+      <a href='./plots/eff43_ptLeadNorm.png'>
+	<img width="600" border='0' src='./plots/eff43_ptLeadNorm.png'>
+      </a>
+    </td>
+    <td align="center">
+      <a href='./plots/65ptLeadNorm.png'>
+	<img width="600" border='0' src='./plots/65ptLeadNorm.png'>
+      </a>
+    </td>
+    <td align="center">
+      <a href='./plots/eff65_ptLeadNorm.png'>
+	<img width="600" border='0' src='./plots/eff65_ptLeadNorm.png'>
+      </a>
+    </td>
+    <td align="center">
+      <a href='./plots/87ptLeadNorm.png'>
+	<img width="600" border='0' src='./plots/87ptLeadNorm.png'>
+      </a>
+    </td>
+    <td align="center">
+      <a href='./plots/eff87_ptLeadNorm.png'>
+	<img width="600" border='0' src='./plots/eff87_ptLeadNorm.png'>
+      </a>
+    </td>
+  </tr>
+  <tr>
+    <td align="center">
+      <a href='./plots/10ptTrailNorm.png'>
+	<img width="600" border='0' src='./plots/10ptTrailNorm.png'>
+      </a>
+    </td>
+    <td align="center">
+      <a href='./plots/eff10_ptTrailNorm.png'>
+	<img width="600" border='0' src='./plots/eff10_ptTrailNorm.png'>
+      </a>
+    </td>
+    <td align="center">
+      <a href='./plots/21ptTrailNorm.png'>
+	<img width="600" border='0' src='./plots/21ptTrailNorm.png'>
+      </a>
+    </td>
+    <td align="center">
+      <a href='./plots/eff21_ptTrailNorm.png'>
+	<img width="600" border='0' src='./plots/eff21_ptTrailNorm.png'>
+      </a>
+    </td>
+    <td align="center">
+      <a href='./plots/43ptTrailNorm.png'>
+	<img width="600" border='0' src='./plots/43ptTrailNorm.png'>
+      </a>
+    </td>
+    <td align="center">
+      <a href='./plots/eff43_ptTrailNorm.png'>
+	<img width="600" border='0' src='./plots/eff43_ptTrailNorm.png'>
+      </a>
+    </td>
+    <td align="center">
+      <a href='./plots/65ptTrailNorm.png'>
+	<img width="600" border='0' src='./plots/65ptTrailNorm.png'>
+      </a>
+    </td>
+    <td align="center">
+      <a href='./plots/eff65_ptTrailNorm.png'>
+	<img width="600" border='0' src='./plots/eff65_ptTrailNorm.png'>
+      </a>
+    </td>
+    <td align="center">
+      <a href='./plots/87ptTrailNorm.png'>
+	<img width="600" border='0' src='./plots/87ptTrailNorm.png'>
+      </a>
+    </td>
+    <td align="center">
+      <a href='./plots/eff87_ptTrailNorm.png'>
+	<img width="600" border='0' src='./plots/eff87_ptTrailNorm.png'>
+      </a>
+    </td>
+  </tr>
+  <tr>
+    <td align="center">
+      <a href='./plots/10diphoton_LeadR9.png'>
+	<img width="600" border='0' src='./plots/10diphoton_LeadR9.png'>
+      </a>
+    </td>
+    <td align="center">
+      <a href='./plots/eff10_diphoton_LeadR9.png'>
+	<img width="600" border='0' src='./plots/eff10_diphoton_LeadR9.png'>
+      </a>
+    </td>
+    <td align="center">
+      <a href='./plots/21diphoton_LeadR9.png'>
+	<img width="600" border='0' src='./plots/21diphoton_LeadR9.png'>
+      </a>
+    </td>
+    <td align="center">
+      <a href='./plots/eff21_diphoton_LeadR9.png'>
+	<img width="600" border='0' src='./plots/eff21_diphoton_LeadR9.png'>
+      </a>
+    </td>
+    <td align="center">
+      <a href='./plots/43diphoton_LeadR9.png'>
+	<img width="600" border='0' src='./plots/43diphoton_LeadR9.png'>
+      </a>
+    </td>
+    <td align="center">
+      <a href='./plots/eff43_diphoton_LeadR9.png'>
+	<img width="600" border='0' src='./plots/eff43_diphoton_LeadR9.png'>
+      </a>
+    </td>
+    <td align="center">
+      <a href='./plots/65diphoton_LeadR9.png'>
+	<img width="600" border='0' src='./plots/65diphoton_LeadR9.png'>
+      </a>
+    </td>
+    <td align="center">
+      <a href='./plots/eff65_diphoton_LeadR9.png'>
+	<img width="600" border='0' src='./plots/eff65_diphoton_LeadR9.png'>
+      </a>
+    </td>
+    <td align="center">
+      <a href='./plots/87diphoton_LeadR9.png'>
+	<img width="600" border='0' src='./plots/87diphoton_LeadR9.png'>
+      </a>
+    </td>
+    <td align="center">
+      <a href='./plots/eff87_diphoton_LeadR9.png'>
+	<img width="600" border='0' src='./plots/eff87_diphoton_LeadR9.png'>
+      </a>
+    </td>
+  </tr>
+  <tr>
+    <td align="center">
+      <a href='./plots/10diphoton_SubLeadR9.png'>
+	<img width="600" border='0' src='./plots/10diphoton_SubLeadR9.png'>
+      </a>
+    </td>
+    <td align="center">
+      <a href='./plots/eff10_diphoton_SubLeadR9.png'>
+	<img width="600" border='0' src='./plots/eff10_diphoton_SubLeadR9.png'>
+      </a>
+    </td>
+    <td align="center">
+      <a href='./plots/21diphoton_SubLeadR9.png'>
+	<img width="600" border='0' src='./plots/21diphoton_SubLeadR9.png'>
+      </a>
+    </td>
+    <td align="center">
+      <a href='./plots/eff21_diphoton_SubLeadR9.png'>
+	<img width="600" border='0' src='./plots/eff21_diphoton_SubLeadR9.png'>
+      </a>
+    </td>
+    <td align="center">
+      <a href='./plots/43diphoton_SubLeadR9.png'>
+	<img width="600" border='0' src='./plots/43diphoton_SubLeadR9.png'>
+      </a>
+    </td>
+    <td align="center">
+      <a href='./plots/eff43_diphoton_SubLeadR9.png'>
+	<img width="600" border='0' src='./plots/eff43_diphoton_SubLeadR9.png'>
+      </a>
+    </td>
+    <td align="center">
+      <a href='./plots/65diphoton_SubLeadR9.png'>
+	<img width="600" border='0' src='./plots/65diphoton_SubLeadR9.png'>
+      </a>
+    </td>
+    <td align="center">
+      <a href='./plots/eff65_diphoton_SubLeadR9.png'>
+	<img width="600" border='0' src='./plots/eff65_diphoton_SubLeadR9.png'>
+      </a>
+    </td>
+    <td align="center">
+      <a href='./plots/87diphoton_SubLeadR9.png'>
+	<img width="600" border='0' src='./plots/87diphoton_SubLeadR9.png'>
+      </a>
+    </td>
+    <td align="center">
+      <a href='./plots/eff87_diphoton_SubLeadR9.png'>
+	<img width="600" border='0' src='./plots/eff87_diphoton_SubLeadR9.png'>
+      </a>
+    </td>
+  </tr>
+
+<table width="20%" border="1" cellpadding="0" cellspacing="0">
+  <tr>
+    <td align="center">
+      <font size="8">cut[0]=minitree</font>
+    </td>
+    <td align="center">
+      <font size="8">cut[1]=denominator A</font>
+    </td>
+    <td align="center">
+      <font size="8">cut[2]=numerator A</font>
+    </td>
+    <td align="center">
+      <font size="8">cut[3]=denominator B</font>
+    </td>
+    <td align="center">
+      <font size="8">cut[4]=numerator B</font>
+    </td>
+    <td align="center">
+      <font size="8">cut[5]=denominator C</font>
+    </td>
+    <td align="center">
+      <font size="8">cut[6]=numerator C</font>
+    </td>
+    <td align="center">
+      <font size="8">cut[7]=denominator D</font>
+    </td>
+    <td align="center">
+      <font size="8">cut[8]=numerator D</font>
+    </td>
+    <td align="center">
+      <font size="8">eff [1]/[0] </font>
+    </td>
+    <td align="center">
+      <font size="8">eff [2]/[1]</font>
+    </td>
+    <td align="center">
+      <font size="8">eff [4]/[3]</font>
+    </td>
+    <td align="center">
+      <font size="8">eff [6]/[5]</font>
+    </td>
+    <td align="center">
+      <font size="8">eff [8]/[7]</font>
+    </td>
+  </tr> 
+  <tr>
+    <td align="center">
+      <a href='./plots/eta1eta2_0.png'>
+	<img width="600" border='0' src='./plots/eta1eta2_0.png'>
+      </a>
+    </td>
+    <td align="center">
+      <a href='./plots/eta1eta2_1.png'>
+	<img width="600" border='0' src='./plots/eta1eta2_1.png'>
+      </a>
+    </td>
+    <td align="center">
+      <a href='./plots/eta1eta2_2.png'>
+	<img width="600" border='0' src='./plots/eta1eta2_2.png'>
+      </a>
+    </td>
+    <td align="center">
+      <a href='./plots/eta1eta2_3.png'>
+	<img width="600" border='0' src='./plots/eta1eta2_3.png'>
+      </a>
+    </td>
+    <td align="center">
+      <a href='./plots/eta1eta2_4.png'>
+	<img width="600" border='0' src='./plots/eta1eta2_4.png'>
+      </a>
+    </td>
+    <td align="center">
+      <a href='./plots/eta1eta2_5.png'>
+	<img width="600" border='0' src='./plots/eta1eta2_5.png'>
+      </a>
+    </td>
+    <td align="center">
+      <a href='./plots/eta1eta2_6.png'>
+	<img width="600" border='0' src='./plots/eta1eta2_6.png'>
+      </a>
+    </td>
+    <td align="center">
+      <a href='./plots/eta1eta2_7.png'>
+	<img width="600" border='0' src='./plots/eta1eta2_7.png'>
+      </a>
+    </td>
+    <td align="center">
+      <a href='./plots/eta1eta2_8.png'>
+	<img width="600" border='0' src='./plots/eta1eta2_8.png'>
+      </a>
+    </td>
+    <td align="center">
+      <a href='./plots/eff10_eta1eta2.png'>
+	<img width="600" border='0' src='./plots/eff10_eta1eta2.png'>
+      </a>
+    </td>
+    <td align="center">
+      <a href='./plots/eff21_eta1eta2.png'>
+	<img width="600" border='0' src='./plots/eff21_eta1eta2.png'>
+      </a>
+    </td>
+    <td align="center">
+      <a href='./plots/eff43_eta1eta2.png'>
+	<img width="600" border='0' src='./plots/eff43_eta1eta2.png'>
+      </a>
+    </td>
+    <td align="center">
+      <a href='./plots/eff65_eta1eta2.png'>
+	<img width="600" border='0' src='./plots/eff65_eta1eta2.png'>
+      </a>
+    </td>
+    <td align="center">
+      <a href='./plots/eff87_eta1eta2.png'>
+	<img width="600" border='0' src='./plots/eff87_eta1eta2.png'>
+      </a>
+    </td>
+  </tr> 
+  <tr>
+    <td align="center">
+      <a href='./plots/phi1phi2_0.png'>
+	<img width="600" border='0' src='./plots/phi1phi2_0.png'>
+      </a>
+    </td>
+    <td align="center">
+      <a href='./plots/phi1phi2_1.png'>
+	<img width="600" border='0' src='./plots/phi1phi2_1.png'>
+      </a>
+    </td>
+    <td align="center">
+      <a href='./plots/phi1phi2_2.png'>
+	<img width="600" border='0' src='./plots/phi1phi2_2.png'>
+      </a>
+    </td>
+    <td align="center">
+      <a href='./plots/phi1phi2_3.png'>
+	<img width="600" border='0' src='./plots/phi1phi2_3.png'>
+      </a>
+    </td>
+    <td align="center">
+      <a href='./plots/phi1phi2_4.png'>
+	<img width="600" border='0' src='./plots/phi1phi2_4.png'>
+      </a>
+    </td>
+    <td align="center">
+      <a href='./plots/phi1phi2_5.png'>
+	<img width="600" border='0' src='./plots/phi1phi2_5.png'>
+      </a>
+    </td>
+    <td align="center">
+      <a href='./plots/phi1phi2_6.png'>
+	<img width="600" border='0' src='./plots/phi1phi2_6.png'>
+      </a>
+    </td>
+    <td align="center">
+      <a href='./plots/phi1phi2_7.png'>
+	<img width="600" border='0' src='./plots/phi1phi2_7.png'>
+      </a>
+    </td>
+    <td align="center">
+      <a href='./plots/phi1phi2_8.png'>
+	<img width="600" border='0' src='./plots/phi1phi2_8.png'>
+      </a>
+    </td>
+    <td align="center">
+      <a href='./plots/eff10_phi1phi2.png'>
+	<img width="600" border='0' src='./plots/eff10_phi1phi2.png'>
+      </a>
+    </td>
+    <td align="center">
+      <a href='./plots/eff21_phi1phi2.png'>
+	<img width="600" border='0' src='./plots/eff21_phi1phi2.png'>
+      </a>
+    </td>
+    <td align="center">
+      <a href='./plots/eff43_phi1phi2.png'>
+	<img width="600" border='0' src='./plots/eff43_phi1phi2.png'>
+      </a>
+    </td>
+    <td align="center">
+      <a href='./plots/eff65_phi1phi2.png'>
+	<img width="600" border='0' src='./plots/eff65_phi1phi2.png'>
+      </a>
+    </td>
+    <td align="center">
+      <a href='./plots/eff87_phi1phi2.png'>
+	<img width="600" border='0' src='./plots/eff87_phi1phi2.png'>
+      </a>
+    </td>
+  </tr> 
+  <tr>
+    <td align="center">
+      <a href='./plots/wide_pt1pt2_0.png'>
+	<img width="600" border='0' src='./plots/wide_pt1pt2_0.png'>
+      </a>
+    </td>
+    <td align="center">
+      <a href='./plots/wide_pt1pt2_1.png'>
+	<img width="600" border='0' src='./plots/wide_pt1pt2_1.png'>
+      </a>
+    </td>
+    <td align="center">
+      <a href='./plots/wide_pt1pt2_2.png'>
+	<img width="600" border='0' src='./plots/wide_pt1pt2_2.png'>
+      </a>
+    </td>
+    <td align="center">
+      <a href='./plots/wide_pt1pt2_3.png'>
+	<img width="600" border='0' src='./plots/wide_pt1pt2_3.png'>
+      </a>
+    </td>
+    <td align="center">
+      <a href='./plots/wide_pt1pt2_4.png'>
+	<img width="600" border='0' src='./plots/wide_pt1pt2_4.png'>
+      </a>
+    </td>
+    <td align="center">
+      <a href='./plots/wide_pt1pt2_5.png'>
+	<img width="600" border='0' src='./plots/wide_pt1pt2_5.png'>
+      </a>
+    </td>
+    <td align="center">
+      <a href='./plots/wide_pt1pt2_6.png'>
+	<img width="600" border='0' src='./plots/wide_pt1pt2_6.png'>
+      </a>
+    </td>
+    <td align="center">
+      <a href='./plots/wide_pt1pt2_7.png'>
+	<img width="600" border='0' src='./plots/wide_pt1pt2_7.png'>
+      </a>
+    </td>
+    <td align="center">
+      <a href='./plots/wide_pt1pt2_8.png'>
+	<img width="600" border='0' src='./plots/wide_pt1pt2_8.png'>
+      </a>
+    </td>
+    <td align="center">
+      <a href='./plots/eff10_wide_pt1pt2.png'>
+	<img width="600" border='0' src='./plots/eff10_wide_pt1pt2.png'>
+      </a>
+    </td>
+    <td align="center">
+      <a href='./plots/eff21_wide_pt1pt2.png'>
+	<img width="600" border='0' src='./plots/eff21_wide_pt1pt2.png'>
+      </a>
+    </td>
+    <td align="center">
+      <a href='./plots/eff43_wide_pt1pt2.png'>
+	<img width="600" border='0' src='./plots/eff43_wide_pt1pt2.png'>
+      </a>
+    </td>
+    <td align="center">
+      <a href='./plots/eff65_wide_pt1pt2.png'>
+	<img width="600" border='0' src='./plots/eff65_wide_pt1pt2.png'>
+      </a>
+    </td>
+    <td align="center">
+      <a href='./plots/eff87_wide_pt1pt2.png'>
+	<img width="600" border='0' src='./plots/eff87_wide_pt1pt2.png'>
+      </a>
+    </td>
+  </tr> 
+  
+  <tr>
+    <td align="center">
+      <a href='./plots/pt1pt2_0.png'>
+	<img width="600" border='0' src='./plots/pt1pt2_0.png'>
+      </a>
+    </td>
+    <td align="center">
+      <a href='./plots/pt1pt2_1.png'>
+	<img width="600" border='0' src='./plots/pt1pt2_1.png'>
+      </a>
+    </td>
+    <td align="center">
+      <a href='./plots/pt1pt2_2.png'>
+	<img width="600" border='0' src='./plots/pt1pt2_2.png'>
+      </a>
+    </td>
+    <td align="center">
+      <a href='./plots/pt1pt2_3.png'>
+	<img width="600" border='0' src='./plots/pt1pt2_3.png'>
+      </a>
+    </td>
+    <td align="center">
+      <a href='./plots/pt1pt2_4.png'>
+	<img width="600" border='0' src='./plots/pt1pt2_4.png'>
+      </a>
+    </td>
+    <td align="center">
+      <a href='./plots/pt1pt2_5.png'>
+	<img width="600" border='0' src='./plots/pt1pt2_5.png'>
+      </a>
+    </td>
+    <td align="center">
+      <a href='./plots/pt1pt2_6.png'>
+	<img width="600" border='0' src='./plots/pt1pt2_6.png'>
+      </a>
+    </td>
+    <td align="center">
+      <a href='./plots/pt1pt2_7.png'>
+	<img width="600" border='0' src='./plots/pt1pt2_7.png'>
+      </a>
+    </td>
+    <td align="center">
+      <a href='./plots/pt1pt2_8.png'>
+	<img width="600" border='0' src='./plots/pt1pt2_8.png'>
+      </a>
+    </td>
+    <td align="center">
+      <a href='./plots/eff10_pt1pt2.png'>
+	<img width="600" border='0' src='./plots/eff10_pt1pt2.png'>
+      </a>
+    </td>
+    <td align="center">
+      <a href='./plots/eff21_pt1pt2.png'>
+	<img width="600" border='0' src='./plots/eff21_pt1pt2.png'>
+      </a>
+    </td>
+    <td align="center">
+      <a href='./plots/eff43_pt1pt2.png'>
+	<img width="600" border='0' src='./plots/eff43_pt1pt2.png'>
+      </a>
+    </td>
+    <td align="center">
+      <a href='./plots/eff65_pt1pt2.png'>
+	<img width="600" border='0' src='./plots/eff65_pt1pt2.png'>
+      </a>
+    </td>
+    <td align="center">
+      <a href='./plots/eff87_pt1pt2.png'>
+	<img width="600" border='0' src='./plots/eff87_pt1pt2.png'>
+      </a>
+    </td>
+  </tr> 
+  <tr>
+    <td align="center">
+      <a href='./plots/pt1pt2Norm_0.png'>
+	<img width="600" border='0' src='./plots/pt1pt2Norm_0.png'>
+      </a>
+    </td>
+    <td align="center">
+      <a href='./plots/pt1pt2Norm_1.png'>
+	<img width="600" border='0' src='./plots/pt1pt2Norm_1.png'>
+      </a>
+    </td>
+    <td align="center">
+      <a href='./plots/pt1pt2Norm_2.png'>
+	<img width="600" border='0' src='./plots/pt1pt2Norm_2.png'>
+      </a>
+    </td>
+    <td align="center">
+      <a href='./plots/pt1pt2Norm_3.png'>
+	<img width="600" border='0' src='./plots/pt1pt2Norm_3.png'>
+      </a>
+    </td>
+    <td align="center">
+      <a href='./plots/pt1pt2Norm_4.png'>
+	<img width="600" border='0' src='./plots/pt1pt2Norm_4.png'>
+      </a>
+    </td>
+    <td align="center">
+      <a href='./plots/pt1pt2Norm_5.png'>
+	<img width="600" border='0' src='./plots/pt1pt2Norm_5.png'>
+      </a>
+    </td>
+    <td align="center">
+      <a href='./plots/pt1pt2Norm_6.png'>
+	<img width="600" border='0' src='./plots/pt1pt2Norm_6.png'>
+      </a>
+    </td>
+    <td align="center">
+      <a href='./plots/pt1pt2Norm_6.png'>
+	<img width="600" border='0' src='./plots/pt1pt2Norm_7.png'>
+      </a>
+    </td>
+    <td align="center">
+      <a href='./plots/pt1pt2Norm_6.png'>
+	<img width="600" border='0' src='./plots/pt1pt2Norm_8.png'>
+      </a>
+    </td>
+    <td align="center">
+      <a href='./plots/eff10_pt1pt2Norm.png'>
+	<img width="600" border='0' src='./plots/eff10_pt1pt2Norm.png'>
+      </a>
+    </td>
+    <td align="center">
+      <a href='./plots/eff21_pt1pt2Norm.png'>
+	<img width="600" border='0' src='./plots/eff21_pt1pt2Norm.png'>
+      </a>
+    </td>
+    <td align="center">
+      <a href='./plots/eff43_pt1pt2Norm.png'>
+	<img width="600" border='0' src='./plots/eff43_pt1pt2Norm.png'>
+      </a>
+    </td>
+    <td align="center">
+      <a href='./plots/eff65_pt1pt2Norm.png'>
+	<img width="600" border='0' src='./plots/eff65_pt1pt2Norm.png'>
+      </a>
+    </td>
+    <td align="center">
+      <a href='./plots/eff87_pt1pt2Norm.png'>
+	<img width="600" border='0' src='./plots/eff87_pt1pt2Norm.png'>
+      </a>
+    </td>
+  </tr> 
+</table>
+
+</table>
+
+<!-- Piwik --> 
+<script type="text/javascript"> 
+var pkBaseURL = (("https:" == document.location.protocol) ? "https://piwik.web.cern.ch/" : "http://piwik.web.cern.ch/"); 
+document.write(unescape("%3Cscript src='" + pkBaseURL + "piwik.js' type='text/javascript'%3E%3C/script%3E")); 
+</script><script type="text/javascript"> 
+try { 
+var piwikTracker = Piwik.getTracker(pkBaseURL + "piwik.php", 105); 
+piwikTracker.trackPageView(); 
+piwikTracker.enableLinkTracking(); 
+} catch( err ) {} 
+</script><noscript><p><img src="http://piwik.web.cern.ch/piwik.php?idsite=105" style="border:0" alt="" /></p></noscript> 
+<!-- End Piwik Tracking Code -->
+</body>
+</html>

--- a/Validation/test/fwlite_preselection/make_up.C
+++ b/Validation/test/fwlite_preselection/make_up.C
@@ -1,0 +1,873 @@
+#include <iostream>
+#include "Riostream.h"
+#include <fstream>
+#include <iomanip>
+#include <vector>
+#include <string>
+#include <TEfficiency.h>
+#include <TLegend.h>
+#include <TFile.h>
+#include <TH1F.h>
+#include <TH2F.h>
+#include <TGraphAsymmErrors.h>
+#include "TStyle.h"
+#include "TCanvas.h"
+
+//#define Maxselection 1
+//#define Nhltpaths 442
+
+
+TCanvas *Ca0 = new TCanvas( "Ca0", "bit0", 1200, 800 );
+
+void binomialEfficiency1D( TH1F *numerator, TH1F *denominator, string option )
+{
+    //  TH1F * efficiency = numerator->Clone("efficiency");
+    TGraphAsymmErrors *efficiency = new TGraphAsymmErrors( numerator, denominator );
+    efficiency->SetTitle( "Efficiency" );
+    //efficiency->GetXaxis()->SetTitle(numerator->GetXaxis()->GetTitle());
+    efficiency->GetYaxis()->SetTitle( "#epsilon" );
+
+
+    /*
+    for(int j=0;j<=numerator->GetXaxis()->GetNbins() ;j++){
+      if(denominator->GetBinContent(j)!=0){
+        float eff = numerator->GetBinContent(j)/denominator->GetBinContent(j);
+        float err = sqrt(eff*(1-eff)/denominator->GetBinContent(j));
+        //if(err==0.)continue;
+        efficiency->SetBinContent(j,eff);
+        efficiency->SetBinError(j,err);
+        //cout<<"1Deff "<<j<<" "<<eff<<" +/- "<<err<<endl;
+      }
+    }
+    */
+
+    efficiency->Draw( "AP" );
+    efficiency->SetMarkerColor( kRed );
+    efficiency->SetMarkerStyle( 23 );
+    efficiency->SetMarkerSize( 2 );
+    if( option == "p" ) { efficiency->GetXaxis()->SetRangeUser( 0., 120. ); }
+    else if( option == "eta" ) { efficiency->GetXaxis()->SetLimits( -5., 5. ); }
+    else if( option == "phi" ) { efficiency->GetXaxis()->SetLimits( -3.1416, 3.1416 ); }
+    else if( option == "pn" ) { efficiency->GetXaxis()->SetLimits( 0., 1. ); }
+    else if( option == "m" ) { efficiency->GetXaxis()->SetLimits( 60., 180. ); }
+
+    efficiency->GetYaxis()->SetRangeUser( 0., 1. );
+
+    //efficiency->Delete();
+
+    //theFile->cd();
+    //efficiency->Write();
+}
+
+
+void Draw1D( string savedname, string theXtitle, TFile *theFile, int cut1, int cut2 )
+{
+
+    TLegend *leg = new TLegend( 0.65, 0.93, 0.89, 0.7 );
+
+    char char_cut1[20];
+    char char_cut2[20];
+
+    TH1F *histoArray[9  ];
+
+    for( int selection = 0; selection < 9  ; selection++ ) { //Loop over the different histograms
+        //std::string histo = std::to_string(selection);
+        char histo[20];
+        sprintf( histo, "%d", selection );
+        //cout<<savedname+"_"+histo<<endl;
+        sprintf( char_cut1, "%d", cut1 );
+        sprintf( char_cut2, "%d", cut2 );
+        histoArray[selection] = ( TH1F * )( theFile->Get( ( savedname + "_" + histo ).c_str() ) );
+        if( selection == 0 ) {
+            histoArray[selection]->Draw();
+            histoArray[selection]->SetFillColor( kBlue );
+            leg->AddEntry( histoArray[selection], "minitree", "f" );
+        } else if( selection == 1 && ( cut1 == 1 || cut2 == 1 ) ) {
+            histoArray[selection]->Draw( "same" );
+            histoArray[selection]->SetFillColor( kRed );
+            leg->AddEntry( histoArray[selection], "cut[1]", "f" );
+        } else if( selection == 2 && ( cut1 == 2 || cut2 == 2 ) ) {
+            histoArray[selection]->Draw( "same" );
+            histoArray[selection]->SetFillColor( kYellow );
+            leg->AddEntry( histoArray[selection], "cut[2]", "f" );
+        } else if( selection == 3 && ( cut1 == 3 || cut2 == 3 ) ) {
+            histoArray[selection]->Draw( "same" );
+            histoArray[selection]->SetFillColor( kRed );
+            leg->AddEntry( histoArray[selection], "cut[3]", "f" );
+        } else if( selection == 4 && ( cut1 == 4 || cut2 == 4 ) ) {
+            histoArray[selection]->Draw( "same" );
+            histoArray[selection]->SetFillColor( kYellow );
+            leg->AddEntry( histoArray[selection], "cut[4]", "f" );
+
+        } else if( selection == 5 && ( cut1 == 5 || cut2 == 5 ) ) {
+            histoArray[selection]->Draw( "same" );
+            histoArray[selection]->SetFillColor( kRed );
+            leg->AddEntry( histoArray[selection], "cut[5]" );
+        } else if( selection == 6 && ( cut1 == 6 || cut2 == 6 ) ) {
+            histoArray[selection]->Draw( "same" );
+            histoArray[selection]->SetFillColor( kYellow );
+            leg->AddEntry( histoArray[selection], "cut[6]", "f" );
+        } else if( selection == 7 && ( cut1 == 7 || cut2 == 7 ) ) {
+            histoArray[selection]->Draw( "same" );
+            histoArray[selection]->SetFillColor( kRed );
+            leg->AddEntry( histoArray[selection], "cut[7]" );
+        } else if( selection == 8 && ( cut1 == 8 || cut2 == 8 ) ) {
+            histoArray[selection]->Draw( "same" );
+            histoArray[selection]->SetFillColor( kYellow );
+            leg->AddEntry( histoArray[selection], "cut[8]", "f" );
+        }
+        histoArray[selection]->SetXTitle( theXtitle.c_str() );
+        histoArray[selection]->SetMinimum( 0.9 );
+    }
+
+    string folder = "plots/";
+    leg->SetFillColor( 0 );
+    leg->Draw( "same" );
+    Ca0->SaveAs( ( folder + char_cut2 + char_cut1 + savedname + ".png" ).c_str() );
+    Ca0->Clear();
+}
+
+void binomialEfficiency2D( TH2F *numerator, TH2F *denominator, bool text2D, bool ptaxis )
+{
+    if( !numerator ) { cout << "numerator not found" << endl; }
+    if( !denominator ) { cout << "denominator not found" << endl; }
+
+    TH2F *efficiency = ( TH2F * ) numerator->Clone( "efficiency" );
+
+    efficiency->SetTitle( "Efficiency" );
+
+    if( ptaxis ) {
+        efficiency->SetXTitle( "p_{T} Lead (GeV)" );
+        efficiency->SetYTitle( "p_{T} Trail (GeV)" );
+    } else {
+        efficiency->SetXTitle( denominator->GetXaxis()->GetTitle() );
+        efficiency->SetYTitle( denominator->GetYaxis()->GetTitle() );
+    }
+
+    float eff, err;
+    for( int i = 0; i <= numerator->GetXaxis()->GetNbins(); i++ )
+        for( int j = 0; j <= numerator->GetYaxis()->GetNbins(); j++ ) {
+            if( denominator->GetBinContent( i, j ) != 0 ) {
+                eff = numerator->GetBinContent( i, j ) / denominator->GetBinContent( i, j );
+                err = sqrt( eff * ( 1 - eff ) / denominator->GetBinContent( i, j ) );
+                //if(err==0.)continue;
+                efficiency->SetBinContent( i, j, eff );
+                efficiency->SetBinError( i, j, err );
+                //cout<<i<<" "<<j<<" "<<eff<<"+/-"<<err<<endl;
+            }
+        }
+    if( text2D == true ) {
+        efficiency->Draw( "colztextE" );
+    } else {
+        efficiency->Draw( "colz" );
+    }
+}
+
+void Draw2D( string savedname, string theXtitle, string theYtitle, TFile *theFile, bool text2D )
+{
+    TH2F *histoArray2D[9  ];
+    for( int selection = 0; selection < 9  ; selection++ ) { //Loop over the different histograms
+        //std::string histo = std::to_string(selection); THIS WORKS IN C++ BUT NOT IN CINT
+        char histo[20];
+        sprintf( histo, "%d", selection );
+        //cout<<savedname+"_"+histo<<endl;
+        histoArray2D[selection] = ( TH2F * )( theFile->Get( ( savedname + "_" + histo ).c_str() ) );
+        if( selection < 9 ) {
+            histoArray2D[selection]->SetXTitle( theXtitle.c_str() );
+            histoArray2D[selection]->SetYTitle( theYtitle.c_str() );
+            if( text2D ) {
+                histoArray2D[selection]->DrawNormalized( "colztext" );
+            } else {
+                histoArray2D[selection]->Draw( "colz" );
+            }
+            Ca0->SaveAs( ( "plots/" + savedname + "_" + histo + ".png" ).c_str() );
+            Ca0->Clear();
+        }
+    }
+}
+
+void make_up()
+{
+    //  gROOT->Reset();
+    //  gStyle->SetOptStat(1111);
+    gStyle->SetOptStat( 0 );
+    gStyle->SetPalette( 1 );
+    gStyle->SetPaintTextFormat( "2.3f" );
+
+    TFile *theFile = new TFile( "output_hlt.root" );
+
+    if( !theFile ) { return 0; }
+
+    system( "mkdir -p plots" );
+
+    //cout<<"creating canvas"<<endl;
+
+    Ca0->cd();
+
+    //turnon curve
+    //Interesting bits
+
+    //string interesting_bits[]={"418","6","416","8","5","412","233","7","234","10","187","9","22","198","430","404","188","199","21","190","197","208","201","207","195","196","206","193","424","192","204","194","203","205","209","189","200","191"};
+
+    //string in_bits[]={"418","6"}
+    //for(int k=0;k<2;k++){
+
+    TH2F *numerator;
+    TH2F *denominator;
+
+    cout << "going for 2D 2/1" << endl;
+
+    numerator  = ( TH2F * )( theFile->Get( "wide_pt1pt2_2" ) );
+    denominator = ( TH2F * )( theFile->Get( "wide_pt1pt2_1" ) );
+    binomialEfficiency2D( numerator, denominator, true, true );
+    Ca0->SaveAs( ( "plots/eff21_wide_pt1pt2.png" ) );
+    Ca0->Clear();
+
+    numerator  = ( TH2F * )( theFile->Get( "pt1pt2_2" ) );
+    denominator = ( TH2F * )( theFile->Get( "pt1pt2_1" ) );
+    binomialEfficiency2D( numerator, denominator, false, true );
+    Ca0->SaveAs( ( "plots/eff21_pt1pt2.png" ) );
+    Ca0->Clear();
+
+    numerator  = ( TH2F * )( theFile->Get( "pt1pt2Norm_2" ) );
+    denominator = ( TH2F * )( theFile->Get( "pt1pt2Norm_1" ) );
+    denominator->GetXaxis()->SetTitle( "p_{T} Lead / M_{#gamma #gamma}" );
+    denominator->GetYaxis()->SetTitle( "p_{T} Trail / M_{#gamma #gamma}" );
+    binomialEfficiency2D( numerator, denominator, false, false );
+    Ca0->SaveAs( ( "plots/eff21_pt1pt2Norm.png" ) );
+    Ca0->Clear();
+
+    numerator  = ( TH2F * )( theFile->Get( "pt1pt2Zoom_2" ) );
+    denominator = ( TH2F * )( theFile->Get( "pt1pt2Zoom_1" ) );
+    denominator->GetXaxis()->SetTitle( "p_{T} Lead / M_{#gamma #gamma}" );
+    denominator->GetYaxis()->SetTitle( "p_{T} Trail / M_{#gamma #gamma}" );
+    binomialEfficiency2D( numerator, denominator, true, false );
+    Ca0->SaveAs( ( "plots/eff21_pt1pt2Zoom.png" ) );
+    Ca0->Clear();
+
+    numerator  = ( TH2F * )( theFile->Get( "eta1eta2_2" ) );
+    denominator = ( TH2F * )( theFile->Get( "eta1eta2_1" ) );
+    binomialEfficiency2D( numerator, denominator, false, false );
+    Ca0->SaveAs( ( "plots/eff21_eta1eta2.png" ) );
+    Ca0->Clear();
+
+    numerator  = ( TH2F * )( theFile->Get( "phi1phi2_2" ) );
+    denominator = ( TH2F * )( theFile->Get( "phi1phi2_1" ) );
+    binomialEfficiency2D( numerator, denominator, false, false );
+    Ca0->SaveAs( ( "plots/eff21_phi1phi2.png" ) );
+    Ca0->Clear();
+
+    cout << "going for 2D 4/3" << endl;
+
+    numerator  = ( TH2F * )( theFile->Get( "wide_pt1pt2_4" ) );
+    denominator = ( TH2F * )( theFile->Get( "wide_pt1pt2_3" ) );
+    binomialEfficiency2D( numerator, denominator, true, true );
+    Ca0->SaveAs( ( "plots/eff43_wide_pt1pt2.png" ) );
+    Ca0->Clear();
+
+    numerator  = ( TH2F * )( theFile->Get( "pt1pt2_4" ) );
+    denominator = ( TH2F * )( theFile->Get( "pt1pt2_3" ) );
+    binomialEfficiency2D( numerator, denominator, false, true );
+    Ca0->SaveAs( ( "plots/eff43_pt1pt2.png" ) );
+    Ca0->Clear();
+
+    numerator  = ( TH2F * )( theFile->Get( "pt1pt2Norm_4" ) );
+    denominator = ( TH2F * )( theFile->Get( "pt1pt2Norm_3" ) );
+    denominator->GetXaxis()->SetTitle( "p_{T} Lead / M_{#gamma #gamma}" );
+    denominator->GetYaxis()->SetTitle( "p_{T} Trail / M_{#gamma #gamma}" );
+    binomialEfficiency2D( numerator, denominator, false, false );
+    Ca0->SaveAs( ( "plots/eff43_pt1pt2Norm.png" ) );
+    Ca0->Clear();
+
+    numerator  = ( TH2F * )( theFile->Get( "pt1pt2Zoom_4" ) );
+    denominator = ( TH2F * )( theFile->Get( "pt1pt2Zoom_3" ) );
+    denominator->GetXaxis()->SetTitle( "p_{T} Lead / M_{#gamma #gamma}" );
+    denominator->GetYaxis()->SetTitle( "p_{T} Trail / M_{#gamma #gamma}" );
+    binomialEfficiency2D( numerator, denominator, true, false );
+    Ca0->SaveAs( ( "plots/eff43_pt1pt2Zoom.png" ) );
+    Ca0->Clear();
+
+    numerator  = ( TH2F * )( theFile->Get( "eta1eta2_4" ) );
+    denominator = ( TH2F * )( theFile->Get( "eta1eta2_3" ) );
+    binomialEfficiency2D( numerator, denominator, false, false );
+    Ca0->SaveAs( ( "plots/eff43_eta1eta2.png" ) );
+    Ca0->Clear();
+
+    numerator  = ( TH2F * )( theFile->Get( "phi1phi2_4" ) );
+    denominator = ( TH2F * )( theFile->Get( "phi1phi2_3" ) );
+    binomialEfficiency2D( numerator, denominator, false, false );
+    Ca0->SaveAs( ( "plots/eff43_phi1phi2.png" ) );
+    Ca0->Clear();
+
+    cout << "going for 2D 6/5" << endl;
+
+    numerator  = ( TH2F * )( theFile->Get( "wide_pt1pt2_6" ) );
+    denominator = ( TH2F * )( theFile->Get( "wide_pt1pt2_5" ) );
+    binomialEfficiency2D( numerator, denominator, true, true );
+    Ca0->SaveAs( ( "plots/eff65_wide_pt1pt2.png" ) );
+    Ca0->Clear();
+
+    numerator  = ( TH2F * )( theFile->Get( "pt1pt2_6" ) );
+    denominator = ( TH2F * )( theFile->Get( "pt1pt2_5" ) );
+    binomialEfficiency2D( numerator, denominator, false, true );
+    Ca0->SaveAs( ( "plots/eff65_pt1pt2.png" ) );
+    Ca0->Clear();
+
+    numerator  = ( TH2F * )( theFile->Get( "pt1pt2Norm_6" ) );
+    denominator = ( TH2F * )( theFile->Get( "pt1pt2Norm_5" ) );
+    denominator->GetXaxis()->SetTitle( "p_{T} Lead / M_{#gamma #gamma}" );
+    denominator->GetYaxis()->SetTitle( "p_{T} Trail / M_{#gamma #gamma}" );
+    binomialEfficiency2D( numerator, denominator, false, false );
+    Ca0->SaveAs( ( "plots/eff65_pt1pt2Norm.png" ) );
+    Ca0->Clear();
+
+    numerator  = ( TH2F * )( theFile->Get( "pt1pt2Zoom_6" ) );
+    denominator = ( TH2F * )( theFile->Get( "pt1pt2Zoom_5" ) );
+    denominator->GetXaxis()->SetTitle( "p_{T} Lead / M_{#gamma #gamma}" );
+    denominator->GetYaxis()->SetTitle( "p_{T} Trail / M_{#gamma #gamma}" );
+    binomialEfficiency2D( numerator, denominator, true, false );
+    Ca0->SaveAs( ( "plots/eff65_pt1pt2Zoom.png" ) );
+    Ca0->Clear();
+
+    numerator  = ( TH2F * )( theFile->Get( "eta1eta2_6" ) );
+    denominator = ( TH2F * )( theFile->Get( "eta1eta2_5" ) );
+    binomialEfficiency2D( numerator, denominator, false, false );
+    Ca0->SaveAs( ( "plots/eff65_eta1eta2.png" ) );
+    Ca0->Clear();
+
+    numerator  = ( TH2F * )( theFile->Get( "phi1phi2_6" ) );
+    denominator = ( TH2F * )( theFile->Get( "phi1phi2_5" ) );
+    binomialEfficiency2D( numerator, denominator, false, false );
+    Ca0->SaveAs( ( "plots/eff65_phi1phi2.png" ) );
+    Ca0->Clear();
+
+    cout << "going for 2D 8/7" << endl;
+
+    numerator  = ( TH2F * )( theFile->Get( "wide_pt1pt2_8" ) );
+    denominator = ( TH2F * )( theFile->Get( "wide_pt1pt2_7" ) );
+    binomialEfficiency2D( numerator, denominator, true, true );
+    Ca0->SaveAs( ( "plots/eff87_wide_pt1pt2.png" ) );
+    Ca0->Clear();
+
+    numerator  = ( TH2F * )( theFile->Get( "pt1pt2_8" ) );
+    denominator = ( TH2F * )( theFile->Get( "pt1pt2_7" ) );
+    binomialEfficiency2D( numerator, denominator, false, true );
+    Ca0->SaveAs( ( "plots/eff87_pt1pt2.png" ) );
+    Ca0->Clear();
+
+    numerator  = ( TH2F * )( theFile->Get( "pt1pt2Norm_8" ) );
+    denominator = ( TH2F * )( theFile->Get( "pt1pt2Norm_7" ) );
+    denominator->GetXaxis()->SetTitle( "p_{T} Lead / M_{#gamma #gamma}" );
+    denominator->GetYaxis()->SetTitle( "p_{T} Trail / M_{#gamma #gamma}" );
+    binomialEfficiency2D( numerator, denominator, false, false );
+    Ca0->SaveAs( ( "plots/eff87_pt1pt2Norm.png" ) );
+    Ca0->Clear();
+
+    numerator  = ( TH2F * )( theFile->Get( "pt1pt2Zoom_8" ) );
+    denominator = ( TH2F * )( theFile->Get( "pt1pt2Zoom_7" ) );
+    denominator->GetXaxis()->SetTitle( "p_{T} Lead / M_{#gamma #gamma}" );
+    denominator->GetYaxis()->SetTitle( "p_{T} Trail / M_{#gamma #gamma}" );
+    binomialEfficiency2D( numerator, denominator, true, false );
+    Ca0->SaveAs( ( "plots/eff87_pt1pt2Zoom.png" ) );
+    Ca0->Clear();
+
+    numerator  = ( TH2F * )( theFile->Get( "eta1eta2_8" ) );
+    denominator = ( TH2F * )( theFile->Get( "eta1eta2_7" ) );
+    binomialEfficiency2D( numerator, denominator, false, false );
+    Ca0->SaveAs( ( "plots/eff87_eta1eta2.png" ) );
+    Ca0->Clear();
+
+    numerator  = ( TH2F * )( theFile->Get( "phi1phi2_8" ) );
+    denominator = ( TH2F * )( theFile->Get( "phi1phi2_7" ) );
+    binomialEfficiency2D( numerator, denominator, false, false );
+    Ca0->SaveAs( ( "plots/eff87_phi1phi2.png" ) );
+    Ca0->Clear();
+
+    cout << "going for 2D 1/0" << endl;
+
+    numerator  = ( TH2F * )( theFile->Get( "wide_pt1pt2_1" ) );
+    denominator = ( TH2F * )( theFile->Get( "wide_pt1pt2_0" ) );
+    binomialEfficiency2D( numerator, denominator, true, true );
+    Ca0->SaveAs( ( "plots/eff10_wide_pt1pt2.png" ) );
+    Ca0->Clear();
+
+    numerator  = ( TH2F * )( theFile->Get( "pt1pt2_1" ) );
+    denominator = ( TH2F * )( theFile->Get( "pt1pt2_0" ) );
+    binomialEfficiency2D( numerator, denominator, false, true );
+    Ca0->SaveAs( ( "plots/eff10_pt1pt2.png" ) );
+    Ca0->Clear();
+
+    numerator  = ( TH2F * )( theFile->Get( "pt1pt2Norm_1" ) );
+    denominator = ( TH2F * )( theFile->Get( "pt1pt2Norm_0" ) );
+    denominator->GetXaxis()->SetTitle( "p_{T} Lead / M_{#gamma #gamma}" );
+    denominator->GetYaxis()->SetTitle( "p_{T} Trail / M_{#gamma #gamma}" );
+    binomialEfficiency2D( numerator, denominator, false, false );
+    Ca0->SaveAs( ( "plots/eff10_pt1pt2Norm.png" ) );
+    Ca0->Clear();
+
+    numerator  = ( TH2F * )( theFile->Get( "pt1pt2Zoom_1" ) );
+    denominator = ( TH2F * )( theFile->Get( "pt1pt2Zoom_0" ) );
+    denominator->GetXaxis()->SetTitle( "p_{T} Lead / M_{#gamma #gamma}" );
+    denominator->GetYaxis()->SetTitle( "p_{T} Trail / M_{#gamma #gamma}" );
+    binomialEfficiency2D( numerator, denominator, true, false );
+    Ca0->SaveAs( ( "plots/eff10_pt1pt2Zoom.png" ) );
+    Ca0->Clear();
+
+    numerator  = ( TH2F * )( theFile->Get( "eta1eta2_1" ) );
+    denominator = ( TH2F * )( theFile->Get( "eta1eta2_0" ) );
+    binomialEfficiency2D( numerator, denominator, false, false );
+    Ca0->SaveAs( ( "plots/eff10_eta1eta2.png" ) );
+    Ca0->Clear();
+
+    numerator  = ( TH2F * )( theFile->Get( "phi1phi2_1" ) );
+    denominator = ( TH2F * )( theFile->Get( "phi1phi2_0" ) );
+    binomialEfficiency2D( numerator, denominator, false, false );
+    Ca0->SaveAs( ( "plots/eff10_phi1phi2.png" ) );
+    Ca0->Clear();
+
+    //Binomial Efficiency 1D
+
+    TH1F *numerator1D;
+    TH1F *denominator1D;
+
+    cout << "going for 1D 2/1" << endl;
+
+    numerator1D = ( TH1F * )( theFile->Get( "higgsEta_2" ) );
+    denominator1D = ( TH1F * )( theFile->Get( "higgsEta_1" ) );
+    binomialEfficiency1D( numerator1D, denominator1D, "eta" );
+    Ca0->SaveAs( ( "plots/eff21_higgsEta.png" ) );
+    Ca0->Clear();
+
+    numerator1D = ( TH1F * )( theFile->Get( "higgsPhi_2" ) );
+    denominator1D = ( TH1F * )( theFile->Get( "higgsPhi_1" ) );
+    binomialEfficiency1D( numerator1D, denominator1D, "phi" );
+    Ca0->SaveAs( ( "plots/eff21_higgsPhi.png" ) );
+    Ca0->Clear();
+
+    numerator1D = ( TH1F * )( theFile->Get( "higgsP_2" ) );
+    denominator1D = ( TH1F * )( theFile->Get( "higgsP_1" ) );
+    binomialEfficiency1D( numerator1D, denominator1D, "p" );
+    Ca0->SaveAs( ( "plots/eff21_higgsP.png" ) );
+    Ca0->Clear();
+
+    numerator1D = ( TH1F * )( theFile->Get( "diphoton_LeadR9_2" ) );
+    denominator1D = ( TH1F * )( theFile->Get( "diphoton_LeadR9_1" ) );
+    binomialEfficiency1D( numerator1D, denominator1D, "p" );
+    Ca0->SaveAs( ( "plots/eff21_diphoton_LeadR9.png" ) );
+    Ca0->Clear();
+
+    numerator1D = ( TH1F * )( theFile->Get( "diphoton_SubLeadR9_2" ) );
+    denominator1D = ( TH1F * )( theFile->Get( "diphoton_SubLeadR9_1" ) );
+    binomialEfficiency1D( numerator1D, denominator1D, "p" );
+    Ca0->SaveAs( ( "plots/eff21_diphoton_SubLeadR9.png" ) );
+    Ca0->Clear();
+
+    numerator1D = ( TH1F * )( theFile->Get( "higgsPt_2" ) );
+    denominator1D = ( TH1F * )( theFile->Get( "higgsPt_1" ) );
+    binomialEfficiency1D( numerator1D, denominator1D, "p" );
+    Ca0->SaveAs( ( "plots/eff21_higgsPt.png" ) );
+    Ca0->Clear();
+
+    numerator1D = ( TH1F * )( theFile->Get( "massDiphoton_2" ) );
+    denominator1D = ( TH1F * )( theFile->Get( "massDiphoton_1" ) );
+    binomialEfficiency1D( numerator1D, denominator1D, "m" );
+    Ca0->SaveAs( ( "plots/eff21_massDiphoton.png" ) );
+    Ca0->Clear();
+
+    numerator1D = ( TH1F * )( theFile->Get( "massHiggs_2" ) );
+    denominator1D = ( TH1F * )( theFile->Get( "massHiggs_1" ) );
+    binomialEfficiency1D( numerator1D, denominator1D, "m" );
+    Ca0->SaveAs( ( "plots/eff21_massHiggs.png" ) );
+    Ca0->Clear();
+
+    numerator1D = ( TH1F * )( theFile->Get( "ptLead_2" ) );
+    denominator1D = ( TH1F * )( theFile->Get( "ptLead_1" ) );
+    binomialEfficiency1D( numerator1D, denominator1D, "p" );
+    Ca0->SaveAs( ( "plots/eff21_ptLead.png" ) );
+    Ca0->Clear();
+
+    numerator1D = ( TH1F * )( theFile->Get( "ptTrail_2" ) );
+    denominator1D = ( TH1F * )( theFile->Get( "ptTrail_1" ) );
+    binomialEfficiency1D( numerator1D, denominator1D, "p" );
+    Ca0->SaveAs( ( "plots/eff21_ptTrail.png" ) );
+    Ca0->Clear();
+
+    numerator1D = ( TH1F * )( theFile->Get( "ptLeadNorm_2" ) );
+    denominator1D = ( TH1F * )( theFile->Get( "ptLeadNorm_1" ) );
+    binomialEfficiency1D( numerator1D, denominator1D, "pn" );
+    Ca0->SaveAs( ( "plots/eff21_ptLeadNorm.png" ) );
+    Ca0->Clear();
+
+    numerator1D = ( TH1F * )( theFile->Get( "ptTrailNorm_2" ) );
+    denominator1D = ( TH1F * )( theFile->Get( "ptTrailNorm_1" ) );
+    binomialEfficiency1D( numerator1D, denominator1D, "pn" );
+    Ca0->SaveAs( ( "plots/eff21_ptTrailNorm.png" ) );
+    Ca0->Clear();
+
+    cout << "going for 1D 4/3" << endl;
+
+    numerator1D = ( TH1F * )( theFile->Get( "higgsEta_4" ) );
+    denominator1D = ( TH1F * )( theFile->Get( "higgsEta_3" ) );
+    binomialEfficiency1D( numerator1D, denominator1D, "eta" );
+    Ca0->SaveAs( ( "plots/eff43_higgsEta.png" ) );
+    Ca0->Clear();
+
+    numerator1D = ( TH1F * )( theFile->Get( "higgsPhi_4" ) );
+    denominator1D = ( TH1F * )( theFile->Get( "higgsPhi_3" ) );
+    binomialEfficiency1D( numerator1D, denominator1D, "phi" );
+    Ca0->SaveAs( ( "plots/eff43_higgsPhi.png" ) );
+    Ca0->Clear();
+
+    numerator1D = ( TH1F * )( theFile->Get( "higgsP_4" ) );
+    denominator1D = ( TH1F * )( theFile->Get( "higgsP_3" ) );
+    binomialEfficiency1D( numerator1D, denominator1D, "p" );
+    Ca0->SaveAs( ( "plots/eff43_higgsP.png" ) );
+    Ca0->Clear();
+
+    numerator1D = ( TH1F * )( theFile->Get( "diphoton_LeadR9_4" ) );
+    denominator1D = ( TH1F * )( theFile->Get( "diphoton_LeadR9_3" ) );
+    binomialEfficiency1D( numerator1D, denominator1D, "p" );
+    Ca0->SaveAs( ( "plots/eff43_diphoton_LeadR9.png" ) );
+    Ca0->Clear();
+
+    numerator1D = ( TH1F * )( theFile->Get( "diphoton_SubLeadR9_4" ) );
+    denominator1D = ( TH1F * )( theFile->Get( "diphoton_SubLeadR9_3" ) );
+    binomialEfficiency1D( numerator1D, denominator1D, "p" );
+    Ca0->SaveAs( ( "plots/eff43_diphoton_SubLeadR9.png" ) );
+    Ca0->Clear();
+
+    numerator1D = ( TH1F * )( theFile->Get( "higgsPt_4" ) );
+    denominator1D = ( TH1F * )( theFile->Get( "higgsPt_3" ) );
+    binomialEfficiency1D( numerator1D, denominator1D, "p" );
+    Ca0->SaveAs( ( "plots/eff43_higgsPt.png" ) );
+    Ca0->Clear();
+
+    numerator1D = ( TH1F * )( theFile->Get( "massDiphoton_4" ) );
+    denominator1D = ( TH1F * )( theFile->Get( "massDiphoton_3" ) );
+    binomialEfficiency1D( numerator1D, denominator1D, "m" );
+    Ca0->SaveAs( ( "plots/eff43_massDiphoton.png" ) );
+    Ca0->Clear();
+
+    numerator1D = ( TH1F * )( theFile->Get( "massHiggs_4" ) );
+    denominator1D = ( TH1F * )( theFile->Get( "massHiggs_3" ) );
+    binomialEfficiency1D( numerator1D, denominator1D, "m" );
+    Ca0->SaveAs( ( "plots/eff43_massHiggs.png" ) );
+    Ca0->Clear();
+
+    numerator1D = ( TH1F * )( theFile->Get( "ptLead_4" ) );
+    denominator1D = ( TH1F * )( theFile->Get( "ptLead_3" ) );
+    binomialEfficiency1D( numerator1D, denominator1D, "p" );
+    Ca0->SaveAs( ( "plots/eff43_ptLead.png" ) );
+    Ca0->Clear();
+
+    numerator1D = ( TH1F * )( theFile->Get( "ptTrail_4" ) );
+    denominator1D = ( TH1F * )( theFile->Get( "ptTrail_3" ) );
+    binomialEfficiency1D( numerator1D, denominator1D, "p" );
+    Ca0->SaveAs( ( "plots/eff43_ptTrail.png" ) );
+    Ca0->Clear();
+
+    numerator1D = ( TH1F * )( theFile->Get( "ptLeadNorm_4" ) );
+    denominator1D = ( TH1F * )( theFile->Get( "ptLeadNorm_3" ) );
+    binomialEfficiency1D( numerator1D, denominator1D, "pn" );
+    Ca0->SaveAs( ( "plots/eff43_ptLeadNorm.png" ) );
+    Ca0->Clear();
+
+    numerator1D = ( TH1F * )( theFile->Get( "ptTrailNorm_4" ) );
+    denominator1D = ( TH1F * )( theFile->Get( "ptTrailNorm_3" ) );
+    binomialEfficiency1D( numerator1D, denominator1D, "pn" );
+    Ca0->SaveAs( ( "plots/eff43_ptTrailNorm.png" ) );
+
+
+    cout << "going for 1D 6/5" << endl;
+
+    numerator1D = ( TH1F * )( theFile->Get( "higgsEta_6" ) );
+    denominator1D = ( TH1F * )( theFile->Get( "higgsEta_5" ) );
+    binomialEfficiency1D( numerator1D, denominator1D, "eta" );
+    Ca0->SaveAs( ( "plots/eff65_higgsEta.png" ) );
+    Ca0->Clear();
+
+    numerator1D = ( TH1F * )( theFile->Get( "higgsPhi_6" ) );
+    denominator1D = ( TH1F * )( theFile->Get( "higgsPhi_5" ) );
+    binomialEfficiency1D( numerator1D, denominator1D, "phi" );
+    Ca0->SaveAs( ( "plots/eff65_higgsPhi.png" ) );
+    Ca0->Clear();
+
+    numerator1D = ( TH1F * )( theFile->Get( "higgsP_6" ) );
+    denominator1D = ( TH1F * )( theFile->Get( "higgsP_5" ) );
+    binomialEfficiency1D( numerator1D, denominator1D, "p" );
+    Ca0->SaveAs( ( "plots/eff65_higgsP.png" ) );
+    Ca0->Clear();
+
+    numerator1D = ( TH1F * )( theFile->Get( "diphoton_LeadR9_6" ) );
+    denominator1D = ( TH1F * )( theFile->Get( "diphoton_LeadR9_5" ) );
+    binomialEfficiency1D( numerator1D, denominator1D, "p" );
+    Ca0->SaveAs( ( "plots/eff65_diphoton_LeadR9.png" ) );
+    Ca0->Clear();
+
+    numerator1D = ( TH1F * )( theFile->Get( "diphoton_SubLeadR9_6" ) );
+    denominator1D = ( TH1F * )( theFile->Get( "diphoton_SubLeadR9_5" ) );
+    binomialEfficiency1D( numerator1D, denominator1D, "p" );
+    Ca0->SaveAs( ( "plots/eff65_diphoton_SubLeadR9.png" ) );
+    Ca0->Clear();
+
+    numerator1D = ( TH1F * )( theFile->Get( "higgsPt_6" ) );
+    denominator1D = ( TH1F * )( theFile->Get( "higgsPt_5" ) );
+    binomialEfficiency1D( numerator1D, denominator1D, "p" );
+    Ca0->SaveAs( ( "plots/eff65_higgsPt.png" ) );
+    Ca0->Clear();
+
+    numerator1D = ( TH1F * )( theFile->Get( "massDiphoton_6" ) );
+    denominator1D = ( TH1F * )( theFile->Get( "massDiphoton_5" ) );
+    binomialEfficiency1D( numerator1D, denominator1D, "m" );
+    Ca0->SaveAs( ( "plots/eff65_massDiphoton.png" ) );
+    Ca0->Clear();
+
+    numerator1D = ( TH1F * )( theFile->Get( "massHiggs_6" ) );
+    denominator1D = ( TH1F * )( theFile->Get( "massHiggs_5" ) );
+    binomialEfficiency1D( numerator1D, denominator1D, "m" );
+    Ca0->SaveAs( ( "plots/eff65_massHiggs.png" ) );
+    Ca0->Clear();
+
+    numerator1D = ( TH1F * )( theFile->Get( "ptLead_6" ) );
+    denominator1D = ( TH1F * )( theFile->Get( "ptLead_5" ) );
+    binomialEfficiency1D( numerator1D, denominator1D, "p" );
+    Ca0->SaveAs( ( "plots/eff65_ptLead.png" ) );
+    Ca0->Clear();
+
+    numerator1D = ( TH1F * )( theFile->Get( "ptTrail_6" ) );
+    denominator1D = ( TH1F * )( theFile->Get( "ptTrail_5" ) );
+    binomialEfficiency1D( numerator1D, denominator1D, "p" );
+    Ca0->SaveAs( ( "plots/eff65_ptTrail.png" ) );
+    Ca0->Clear();
+
+    numerator1D = ( TH1F * )( theFile->Get( "ptLeadNorm_6" ) );
+    denominator1D = ( TH1F * )( theFile->Get( "ptLeadNorm_5" ) );
+    binomialEfficiency1D( numerator1D, denominator1D, "pn" );
+    Ca0->SaveAs( ( "plots/eff65_ptLeadNorm.png" ) );
+    Ca0->Clear();
+
+    numerator1D = ( TH1F * )( theFile->Get( "ptTrailNorm_6" ) );
+    denominator1D = ( TH1F * )( theFile->Get( "ptTrailNorm_5" ) );
+    binomialEfficiency1D( numerator1D, denominator1D, "pn" );
+    Ca0->SaveAs( ( "plots/eff65_ptTrailNorm.png" ) );
+
+    cout << "going for 1D 8/7" << endl;
+
+    numerator1D = ( TH1F * )( theFile->Get( "higgsEta_8" ) );
+    denominator1D = ( TH1F * )( theFile->Get( "higgsEta_7" ) );
+    binomialEfficiency1D( numerator1D, denominator1D, "eta" );
+    Ca0->SaveAs( ( "plots/eff87_higgsEta.png" ) );
+    Ca0->Clear();
+
+    numerator1D = ( TH1F * )( theFile->Get( "higgsPhi_8" ) );
+    denominator1D = ( TH1F * )( theFile->Get( "higgsPhi_7" ) );
+    binomialEfficiency1D( numerator1D, denominator1D, "phi" );
+    Ca0->SaveAs( ( "plots/eff87_higgsPhi.png" ) );
+    Ca0->Clear();
+
+    numerator1D = ( TH1F * )( theFile->Get( "higgsP_8" ) );
+    denominator1D = ( TH1F * )( theFile->Get( "higgsP_7" ) );
+    binomialEfficiency1D( numerator1D, denominator1D, "p" );
+    Ca0->SaveAs( ( "plots/eff87_higgsP.png" ) );
+    Ca0->Clear();
+
+    numerator1D = ( TH1F * )( theFile->Get( "diphoton_LeadR9_8" ) );
+    denominator1D = ( TH1F * )( theFile->Get( "diphoton_LeadR9_7" ) );
+    binomialEfficiency1D( numerator1D, denominator1D, "p" );
+    Ca0->SaveAs( ( "plots/eff87_diphoton_LeadR9.png" ) );
+    Ca0->Clear();
+
+    numerator1D = ( TH1F * )( theFile->Get( "diphoton_SubLeadR9_8" ) );
+    denominator1D = ( TH1F * )( theFile->Get( "diphoton_SubLeadR9_7" ) );
+    binomialEfficiency1D( numerator1D, denominator1D, "p" );
+    Ca0->SaveAs( ( "plots/eff87_diphoton_SubLeadR9.png" ) );
+    Ca0->Clear();
+
+    numerator1D = ( TH1F * )( theFile->Get( "higgsPt_8" ) );
+    denominator1D = ( TH1F * )( theFile->Get( "higgsPt_7" ) );
+    binomialEfficiency1D( numerator1D, denominator1D, "p" );
+    Ca0->SaveAs( ( "plots/eff87_higgsPt.png" ) );
+    Ca0->Clear();
+
+    numerator1D = ( TH1F * )( theFile->Get( "massDiphoton_8" ) );
+    denominator1D = ( TH1F * )( theFile->Get( "massDiphoton_7" ) );
+    binomialEfficiency1D( numerator1D, denominator1D, "m" );
+    Ca0->SaveAs( ( "plots/eff87_massDiphoton.png" ) );
+    Ca0->Clear();
+
+    numerator1D = ( TH1F * )( theFile->Get( "massHiggs_8" ) );
+    denominator1D = ( TH1F * )( theFile->Get( "massHiggs_7" ) );
+    binomialEfficiency1D( numerator1D, denominator1D, "m" );
+    Ca0->SaveAs( ( "plots/eff87_massHiggs.png" ) );
+    Ca0->Clear();
+
+    numerator1D = ( TH1F * )( theFile->Get( "ptLead_8" ) );
+    denominator1D = ( TH1F * )( theFile->Get( "ptLead_7" ) );
+    binomialEfficiency1D( numerator1D, denominator1D, "p" );
+    Ca0->SaveAs( ( "plots/eff87_ptLead.png" ) );
+    Ca0->Clear();
+
+    numerator1D = ( TH1F * )( theFile->Get( "ptTrail_8" ) );
+    denominator1D = ( TH1F * )( theFile->Get( "ptTrail_7" ) );
+    binomialEfficiency1D( numerator1D, denominator1D, "p" );
+    Ca0->SaveAs( ( "plots/eff87_ptTrail.png" ) );
+    Ca0->Clear();
+
+    numerator1D = ( TH1F * )( theFile->Get( "ptLeadNorm_8" ) );
+    denominator1D = ( TH1F * )( theFile->Get( "ptLeadNorm_7" ) );
+    binomialEfficiency1D( numerator1D, denominator1D, "pn" );
+    Ca0->SaveAs( ( "plots/eff87_ptLeadNorm.png" ) );
+    Ca0->Clear();
+
+    numerator1D = ( TH1F * )( theFile->Get( "ptTrailNorm_8" ) );
+    denominator1D = ( TH1F * )( theFile->Get( "ptTrailNorm_7" ) );
+    binomialEfficiency1D( numerator1D, denominator1D, "pn" );
+    Ca0->SaveAs( ( "plots/eff87_ptTrailNorm.png" ) );
+
+
+    cout << "going for 1D 1/0" << endl;
+
+    numerator1D = ( TH1F * )( theFile->Get( "higgsEta_1" ) );
+    denominator1D = ( TH1F * )( theFile->Get( "higgsEta_0" ) );
+    binomialEfficiency1D( numerator1D, denominator1D, "eta" );
+    Ca0->SaveAs( ( "plots/eff10_higgsEta.png" ) );
+    Ca0->Clear();
+
+    numerator1D = ( TH1F * )( theFile->Get( "higgsPhi_1" ) );
+    denominator1D = ( TH1F * )( theFile->Get( "higgsPhi_0" ) );
+    binomialEfficiency1D( numerator1D, denominator1D, "phi" );
+    Ca0->SaveAs( ( "plots/eff10_higgsPhi.png" ) );
+    Ca0->Clear();
+
+    numerator1D = ( TH1F * )( theFile->Get( "higgsP_1" ) );
+    denominator1D = ( TH1F * )( theFile->Get( "higgsP_0" ) );
+    binomialEfficiency1D( numerator1D, denominator1D, "p" );
+    Ca0->SaveAs( ( "plots/eff10_higgsP.png" ) );
+    Ca0->Clear();
+
+    numerator1D = ( TH1F * )( theFile->Get( "diphoton_LeadR9_1" ) );
+    denominator1D = ( TH1F * )( theFile->Get( "diphoton_LeadR9_0" ) );
+    binomialEfficiency1D( numerator1D, denominator1D, "p" );
+    Ca0->SaveAs( ( "plots/eff10_diphoton_LeadR9.png" ) );
+    Ca0->Clear();
+
+    numerator1D = ( TH1F * )( theFile->Get( "diphoton_SubLeadR9_1" ) );
+    denominator1D = ( TH1F * )( theFile->Get( "diphoton_SubLeadR9_0" ) );
+    binomialEfficiency1D( numerator1D, denominator1D, "p" );
+    Ca0->SaveAs( ( "plots/eff10_diphoton_SubLeadR9.png" ) );
+    Ca0->Clear();
+
+    numerator1D = ( TH1F * )( theFile->Get( "higgsPt_1" ) );
+    denominator1D = ( TH1F * )( theFile->Get( "higgsPt_0" ) );
+    binomialEfficiency1D( numerator1D, denominator1D, "p" );
+    Ca0->SaveAs( ( "plots/eff10_higgsPt.png" ) );
+    Ca0->Clear();
+
+    numerator1D = ( TH1F * )( theFile->Get( "massDiphoton_1" ) );
+    denominator1D = ( TH1F * )( theFile->Get( "massDiphoton_0" ) );
+    binomialEfficiency1D( numerator1D, denominator1D, "m" );
+    Ca0->SaveAs( ( "plots/eff10_massDiphoton.png" ) );
+    Ca0->Clear();
+
+    numerator1D = ( TH1F * )( theFile->Get( "massHiggs_1" ) );
+    denominator1D = ( TH1F * )( theFile->Get( "massHiggs_0" ) );
+    binomialEfficiency1D( numerator1D, denominator1D, "m" );
+    Ca0->SaveAs( ( "plots/eff10_massHiggs.png" ) );
+    Ca0->Clear();
+
+    numerator1D = ( TH1F * )( theFile->Get( "ptLead_1" ) );
+    denominator1D = ( TH1F * )( theFile->Get( "ptLead_0" ) );
+    binomialEfficiency1D( numerator1D, denominator1D, "p" );
+    Ca0->SaveAs( ( "plots/eff10_ptLead.png" ) );
+    Ca0->Clear();
+
+    numerator1D = ( TH1F * )( theFile->Get( "ptTrail_1" ) );
+    denominator1D = ( TH1F * )( theFile->Get( "ptTrail_0" ) );
+    binomialEfficiency1D( numerator1D, denominator1D, "p" );
+    Ca0->SaveAs( ( "plots/eff10_ptTrail.png" ) );
+    Ca0->Clear();
+
+    numerator1D = ( TH1F * )( theFile->Get( "ptLeadNorm_1" ) );
+    denominator1D = ( TH1F * )( theFile->Get( "ptLeadNorm_0" ) );
+    binomialEfficiency1D( numerator1D, denominator1D, "pn" );
+    Ca0->SaveAs( ( "plots/eff10_ptLeadNorm.png" ) );
+    Ca0->Clear();
+
+    numerator1D = ( TH1F * )( theFile->Get( "ptTrailNorm_1" ) );
+    denominator1D = ( TH1F * )( theFile->Get( "ptTrailNorm_0" ) );
+    binomialEfficiency1D( numerator1D, denominator1D, "pn" );
+    Ca0->SaveAs( ( "plots/eff10_ptTrailNorm.png" ) );
+
+    cout << "going for Draw2D" << endl;
+    gStyle->SetPaintTextFormat( "1.0f" );
+    TH1F *cutflow = ( TH1F * )( theFile->Get( "cutflow" ) );
+    cutflow->Draw( "" );
+    cutflow->Draw( "htextsame" );
+    cutflow->SetFillColor( kYellow );
+    cutflow->SetXTitle( "cut[]" );
+    Ca0->SaveAs( "plots/cutflow.png" );
+    Ca0->Clear();
+
+    gStyle->SetPaintTextFormat( "1.3f" );
+    Draw2D( "wide_pt1pt2", "p_{T} Lead (GeV)", "p_{T} Trail (GeV)", theFile, true );
+    Draw2D( "phi1phi2", "#phi_{Lead}", "#phi_{Trail}", theFile, false );
+    Draw2D( "eta1eta2", "#eta_{Lead}", "#eta_{Trail}", theFile, false );
+    Draw2D( "pt1pt2", "p_{T} Lead (GeV)", "p_{T} Trail (GeV)", theFile, false );
+    Draw2D( "pt1pt2Norm", "p_{T} Lead / M_{#gamma #gamma}", "p_{T} Trail / M_{#gamma #gamma}", theFile, false );
+    Draw2D( "pt1pt2Zoom", "p_{T} Lead / M_{#gamma #gamma}", "p_{T} Trail / M_{#gamma #gamma}", theFile, false );
+
+
+    cout << "going for Draw1D" << endl;
+
+    int cut1 = 0;
+    int cut2 = 1;
+    Draw1D( "higgsEta", "#eta_{H}", theFile, cut1, cut2 );
+    Draw1D( "higgsPhi", "#phi_{H}", theFile, cut1, cut2 );
+    Draw1D( "higgsPt", "p (GeV)", theFile, cut1, cut2 );
+    Draw1D( "higgsP", "p (GeV)", theFile, cut1, cut2 );
+    Draw1D( "diphoton_LeadR9", "diphoton_LeadR9", theFile, cut1, cut2 );
+    Draw1D( "diphoton_SubLeadR9", "diphoton_SubLeadR9", theFile, cut1, cut2 );
+
+    for( cut1 = 1; cut1 <= 7; cut1 = cut1 + 2 ) {
+        cut2 = cut1 + 1;
+        Draw1D( "higgsEta", "#eta_{H}", theFile, cut1, cut2 );
+        Draw1D( "higgsPhi", "#phi_{H}", theFile, cut1, cut2 );
+        Draw1D( "higgsPt", "p (GeV)", theFile, cut1, cut2 );
+        Draw1D( "higgsP", "p (GeV)", theFile, cut1, cut2 );
+        Draw1D( "diphoton_LeadR9", "diphoton_LeadR9", theFile, cut1, cut2 );
+        Draw1D( "diphoton_SubLeadR9", "diphoton_SubLeadR9", theFile, cut1, cut2 );
+    }
+
+    //Ca0->SetLogy();
+
+    cut1 = 0;
+    cut2 = 1;
+    Draw1D( "ptLead", "p_{T} Lead (GeV)", theFile, cut1, cut2 );
+    Draw1D( "ptTrail", "p_{T} Trail (GeV)", theFile, cut1, cut2 );
+    Draw1D( "ptLeadNorm", "p_{T} Lead / M_{#gamma #gamma} ", theFile, cut1, cut2 );
+    Draw1D( "ptTrailNorm", "p_{T} Trail / M_{#gamma #gamma}", theFile, cut1, cut2 );
+    Draw1D( "massDiphoton", "mass_{#gamma #gamma} (GeV)", theFile, cut1, cut2 );
+    Draw1D( "massHiggs", "mass_{H} (GeV)", theFile, cut1, cut2 );
+
+
+    for( cut1 = 1; cut1 <= 7; cut1 = cut1 + 2 ) {
+        cut2 = cut1 + 1;
+        Draw1D( "ptLead", "p_{T} Lead (GeV)", theFile, cut1, cut2 );
+        Draw1D( "ptTrail", "p_{T} Trail (GeV)", theFile, cut1, cut2 );
+        Draw1D( "ptLeadNorm", "p_{T} Lead / M_{#gamma #gamma} ", theFile, cut1, cut2 );
+        Draw1D( "ptTrailNorm", "p_{T} Trail / M_{#gamma #gamma}", theFile, cut1, cut2 );
+        Draw1D( "massDiphoton", "mass_{#gamma #gamma} (GeV)", theFile, cut1, cut2 );
+        Draw1D( "massHiggs", "mass_{H} (GeV)", theFile, cut1, cut2 );
+    }
+
+    exit( 0 );
+}
+
+// Local Variables:
+// mode:c++
+// indent-tabs-mode:nil
+// tab-width:4
+// c-basic-offset:4
+// End:
+// vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4
+

--- a/Validation/test/fwlite_preselection/publish.sh
+++ b/Validation/test/fwlite_preselection/publish.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+root -b make_up.C
+export date_string=`date | sed -e "s| |_|g" -e "s|:|_|g" -e "s|,||g" -e "s|(UTC+0100)||g"`
+echo $date_string
+mkdir ~/www/higgs/flashgg/preselection/$date_string
+ls ~/www/higgs/flashgg/preselection/$date_string
+cp -rf *.C *.root plots index.html ~/www/higgs/flashgg/preselection/$date_string
+echo "http://test-carrillo.web.cern.ch/test-carrillo/higgs/flashgg/preselection/$date_string"


### PR DESCRIPTION
In this pull request:
0. A stand-alone configuration has been added to run just the preselection on top of the microAOD MicroAOD/test/testPreselection.py (for test porpuses or future changes in the preselection, no need to run again the rest of the algorithm)
1. The template with not tuned variables/thresholds but with the rho correction algorithm has been ported to MicroAOD/python/flashggPreselectedDiPhotons_cfi.py. 
2. A tool to compare diphoton collections (up to 4) has been added Validation/plugins/DiphotonPreselectionValidation.cc
3. This tool can be used for the validation of the preselection by comparing the diphoton collection produced after the preselection (with and/or without rho correction), here an example Validation/python/DiphotonPreselection_Validator.py
4. The variables and the thresholds need to be tunned before plugging the preselected collection to the rest of the analysis. 