### PR TITLE
fixing certain use cases in WorkspaceCombiner

### DIFF
--- a/Taggers/bin/hadd_workspaces.cc
+++ b/Taggers/bin/hadd_workspaces.cc
@@ -25,6 +25,8 @@ int main( int argc, char *argv[] )
 
     merger.GetWorkspaces( merger.GetFirstFile() );
 
+    cout << endl << " Got workspaces " << endl << endl;
+
     merger.MergeWorkspaces();
 
     cout << endl << " Merging trees and histos " << endl << endl;


### PR DESCRIPTION
Fix two issues with using WorkspaceCombiner on a large scale:

   * Ignore old "cycles" (i.e. versions) of workspace objects.
   * append rather than re-import datasets with the same name (e.g. from job splitting)