### PR TITLE
Updated preselection

### DIFF
--- a/MicroAOD/python/flashggPreselectedDiPhotons_cfi.py
+++ b/MicroAOD/python/flashggPreselectedDiPhotons_cfi.py
@@ -1,8 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
 phoEffArea=cms.PSet( var=cms.string("abs(superCluster.eta)"), bins=cms.vdouble(0.,0.9,1.5,2,2.2,3), vals=cms.vdouble(0.16544,0.16544,0.13212,0.13212,0.13212) )
-#phoEffArea=cms.PSet( var=cms.string("abs(superCluster.eta)"), bins=cms.vdouble(0.,0.9,1.5,2,2.2,3), vals=cms.vdouble(1.,1.,1.,1.,1.) )
-#neuEffArea=cms.PSet( var=cms.string("abs(superCluster.eta)"), bins=cms.vdouble(0.,0.9,1.5,2,2.2,3), vals=cms.vdouble(0.04,0.059,0.05,0.05,0.15) )
 
 rediscoveryHLTvariables = cms.vstring(
     "pfPhoIso03", 
@@ -11,6 +9,7 @@ rediscoveryHLTvariables = cms.vstring(
     "full5x5_r9"
     )
 
+#cuts to mimic category trigger cuts
 rediscoveryHLTcutsV1 = cms.VPSet(
     cms.PSet(cut=cms.string("isEB && full5x5_r9>0.85"), ##EB high R9
              selection = cms.VPSet(
@@ -55,6 +54,7 @@ rediscoveryHLTcutsV1 = cms.VPSet(
              )
     )
 
+#cuts here mimic the miniAOD photon cuts and the non-category based trigger cuts
 flashggPreselectedDiPhotons = cms.EDFilter(
     "GenericDiPhotonCandidateSelector",
     src = cms.InputTag("flashggDiPhotons"),

--- a/MicroAOD/python/flashggPreselectedDiPhotons_cfi.py
+++ b/MicroAOD/python/flashggPreselectedDiPhotons_cfi.py
@@ -1,47 +1,71 @@
 import FWCore.ParameterSet.Config as cms
 
-#changed to match trigger logic
-#uses objects which don't quite match HLT objects
-#needs to be updated with final preselection
-flashggPreselectedDiPhotons = cms.EDFilter("DiPhotonCandidateSelector",
-                                   src = cms.InputTag("flashggDiPhotons"),
-                                   cut = cms.string("""(leadingPhoton.pt > 30. && subLeadingPhoton.pt>18) &&
-                                                    (abs(leadingPhoton.superCluster.eta) < 2.5 && abs(subLeadingPhoton.superCluster.eta) < 2.5) &&
-                                    (  leadingPhoton.hadronicOverEm < 0.1 && subLeadingPhoton.hadronicOverEm < 0.1) &&
-                                    (( leadingPhoton.r9 > 0.5 && leadingPhoton.isEB) || (leadingPhoton.r9 > 0.8 && leadingPhoton.isEE)) &&
-                                    (( subLeadingPhoton.r9 > 0.5 && subLeadingPhoton.isEB) || (subLeadingPhoton.r9 > 0.8 && subLeadingPhoton.isEE)) &&
-                                    (
-                                        ( leadingPhoton.isEB &&
-                                        (leadingPhoton.r9>0.85 || 
-                                        (leadingPhoton.sigmaIetaIeta < 0.015 && 
-                                         leadingPhoton.pfChgIsoWrtChosenVtx02 < 6.0 && 
-                                         leadingPhoton.trkSumPtHollowConeDR03 < 6.0 )))  ||
-                                        ( leadingPhoton.isEE &&
-                                        (leadingPhoton.r9>0.9 || 
-                                        (leadingPhoton.sigmaIetaIeta < 0.035 && 
-                                         leadingPhoton.pfChgIsoWrtChosenVtx02 < 6.0 && 
-                                         leadingPhoton.trkSumPtHollowConeDR03 < 6.0 ))) 
-                                     )
-                                     &&
-                                    (
-                                        ( subLeadingPhoton.isEB &&
-                                        (subLeadingPhoton.r9>0.85 || 
-                                        (subLeadingPhoton.sigmaIetaIeta < 0.015 && 
-                                         subLeadingPhoton.pfChgIsoWrtChosenVtx02 < 6.0 && 
-                                         subLeadingPhoton.trkSumPtHollowConeDR03 < 6.0 )))  ||
-                                        ( subLeadingPhoton.isEE &&
-                                        (subLeadingPhoton.r9>0.9 || 
-                                        (subLeadingPhoton.sigmaIetaIeta < 0.035 && 
-                                         subLeadingPhoton.pfChgIsoWrtChosenVtx02 < 6.0 && 
-                                         subLeadingPhoton.trkSumPtHollowConeDR03 < 6.0 ))) 
-                                     )
-                                        &&
-                                     (leadingPhoton.pt > 14 && leadingPhoton.hadTowOverEm()<0.15 && 
-                                     (leadingPhoton.r9()>0.8 || leadingPhoton.chargedHadronIso()<20 
-                                      || leadingPhoton.chargedHadronIso()<0.3*leadingPhoton.pt())) &&
-                                     (subLeadingPhoton.pt > 14 && subLeadingPhoton.hadTowOverEm()<0.15 &&
-                                     (subLeadingPhoton.r9()>0.8 || subLeadingPhoton.chargedHadronIso()<20 
-                                      || subLeadingPhoton.chargedHadronIso()<0.3*subLeadingPhoton.pt()))               
+phoEffArea=cms.PSet( var=cms.string("abs(superCluster.eta)"), bins=cms.vdouble(0.,0.9,1.5,2,2.2,3), vals=cms.vdouble(0.16544,0.16544,0.13212,0.13212,0.13212) )
+#phoEffArea=cms.PSet( var=cms.string("abs(superCluster.eta)"), bins=cms.vdouble(0.,0.9,1.5,2,2.2,3), vals=cms.vdouble(1.,1.,1.,1.,1.) )
+#neuEffArea=cms.PSet( var=cms.string("abs(superCluster.eta)"), bins=cms.vdouble(0.,0.9,1.5,2,2.2,3), vals=cms.vdouble(0.04,0.059,0.05,0.05,0.15) )
 
-                                     """)
-                                   )
+rediscoveryHLTvariables = cms.vstring(
+    "pfPhoIso03", 
+    "trkSumPtHollowConeDR03",
+    "full5x5_sigmaIetaIeta",
+    "full5x5_r9"
+    )
+
+rediscoveryHLTcutsV1 = cms.VPSet(
+    cms.PSet(cut=cms.string("isEB && full5x5_r9>0.85"), ##EB high R9
+             selection = cms.VPSet(
+            cms.PSet(max=cms.string("100000.0"), 
+                     rhocorr=phoEffArea,
+                     ),
+            cms.PSet(max=cms.string("100000.0")),
+            cms.PSet(max=cms.string("100000.0")),
+            cms.PSet(min=cms.string("0.5"))
+            ),
+             ),
+    
+    cms.PSet(cut=cms.string("isEE && full5x5_r9>0.90"),  ##EE high R9
+             selection = cms.VPSet(
+            cms.PSet(max=cms.string("100000.0"), 
+                     rhocorr=phoEffArea,
+                     ),
+            cms.PSet(max=cms.string("100000.0")),
+            cms.PSet(max=cms.string("100000.0")),
+            cms.PSet(min=cms.string("0.8"))
+            ),
+             ),
+    cms.PSet(cut=cms.string("isEB && full5x5_r9<=0.85"),  #EB low R9
+             selection = cms.VPSet(
+            cms.PSet(max=cms.string("4.0"), 
+                     rhocorr=phoEffArea,
+                     ),
+            cms.PSet(max=cms.string("6.0")),
+            cms.PSet(max=cms.string("0.015")),
+            cms.PSet(min=cms.string("0.5"))
+            ),       
+             ),       
+    cms.PSet(cut=cms.string("isEE && full5x5_r9<=0.90"),  ##EE low R9
+             selection = cms.VPSet(
+            cms.PSet(max=cms.string("4.0"), 
+                     rhocorr=phoEffArea,
+                     ),
+            cms.PSet(max=cms.string("6.0")),
+            cms.PSet(max=cms.string("0.015")),
+            cms.PSet(min=cms.string("0.8"))
+            ),
+             )
+    )
+
+flashggPreselectedDiPhotons = cms.EDFilter(
+    "GenericDiPhotonCandidateSelector",
+    src = cms.InputTag("flashggDiPhotons"),
+    rho = cms.InputTag("fixedGridRhoAll"),
+    cut = cms.string(
+        "    (leadingPhoton.full5x5_r9>0.8||leadingPhoton.egChargedHadronIso<20||leadingPhoton.egChargedHadronIso/leadingPhoton.pt<0.3)"
+        " && (subLeadingPhoton.full5x5_r9>0.8||subLeadingPhoton.egChargedHadronIso<20||subLeadingPhoton.egChargedHadronIso/subLeadingPhoton.pt<0.3)"
+        " && (leadingPhoton.hadronicOverEm < 0.08 && subLeadingPhoton.hadronicOverEm < 0.08)"
+        " && (leadingPhoton.pt >30.0 && subLeadingPhoton.pt > 20.0)"
+        " && (abs(leadingPhoton.superCluster.eta) < 2.5 && abs(subLeadingPhoton.superCluster.eta) < 2.5)"
+        ),
+    variables = rediscoveryHLTvariables,
+    categories = rediscoveryHLTcutsV1
+    )


### PR DESCRIPTION
Updated the Diphoton preselection.
Will be used by default.  
Some changes in the structure of the file to use the rho correction; I think it's slightly more readable this way.  
Lines:
63,64 apply miniAOD cuts (mimic miniAOD photon selection)
65-67 apply the non-category dependent cuts (mimic trigger)
13-56 apply the category dependent cuts (mimic trigger)

