### PR TITLE
PDFWeightObjectProducer

### DIFF
--- a/DataFormats/interface/PDFWeightObject.h
+++ b/DataFormats/interface/PDFWeightObject.h
@@ -1,0 +1,27 @@
+#ifndef FLASHgg_PDFWeightObject_h
+#define FLASHgg_PDFWeightObject_h
+
+#include "SimDataFormats/GeneratorProducts/interface/GenEventInfoProduct.h"
+#include "DataFormats/PatCandidates/interface/libminifloat.h"
+#include <vector>
+
+using namespace std;
+
+namespace flashgg {
+
+    class PDFWeightObject : public GenEventInfoProduct
+    {
+    public:
+
+        PDFWeightObject();
+        PDFWeightObject( const PDFWeightObject& );
+        ~PDFWeightObject();
+        
+        vector<uint16_t> pdf_weight_container;
+        
+        vector<float> uncompress() const;
+        
+      };
+ }
+
+#endif

--- a/DataFormats/src/PDFWeightObject.cc
+++ b/DataFormats/src/PDFWeightObject.cc
@@ -1,0 +1,32 @@
+#include "flashgg/DataFormats/interface/PDFWeightObject.h"
+
+using namespace flashgg;
+using namespace std;
+
+PDFWeightObject::PDFWeightObject()
+{}
+
+PDFWeightObject::PDFWeightObject( const PDFWeightObject& )
+{}
+
+PDFWeightObject::~PDFWeightObject()
+{}
+
+vector<float> PDFWeightObject::uncompress() const {
+
+	vector<float> uncompressed_vector;
+
+	int size = PDFWeightObject::pdf_weight_container.size();	
+
+	for(int i = 0; i<size; i++ ){
+
+		uint16_t compressed_weight = PDFWeightObject::pdf_weight_container[i];
+
+		float uncompressed_weight = MiniFloatConverter::float16to32( compressed_weight );	
+
+		uncompressed_vector.push_back( uncompressed_weight );
+	}
+
+	return uncompressed_vector;
+}
+

--- a/DataFormats/src/classes.h
+++ b/DataFormats/src/classes.h
@@ -28,6 +28,7 @@
 #include "flashgg/DataFormats/interface/TagTruthBase.h"
 #include "flashgg/DataFormats/interface/VBFTagTruth.h"
 #include "flashgg/DataFormats/interface/WeightedObject.h"
+#include "flashgg/DataFormats/interface/PDFWeightObject.h"
 
 #include <vector>
 #include <map>
@@ -35,6 +36,13 @@
 namespace  {
     struct dictionary {
         flashgg::WeightedObject                                             fgg_obj;
+        
+        flashgg::PDFWeightObject                                             fgg_pobj;
+        edm::Ptr<flashgg::PDFWeightObject>                                ptr_fgg_pobj;
+        edm::Wrapper<flashgg::PDFWeightObject>                            wrp_fgg_pobj;
+        std::vector<flashgg::PDFWeightObject>                             vec_fgg_pobj;
+        edm::Wrapper<std::vector<flashgg::PDFWeightObject> >               wrp_vec_fgg_pobj;
+
 
         flashgg::Photon                                                   fgg_pho;
         edm::Ptr<flashgg::Photon>                                     ptr_fgg_pho;

--- a/DataFormats/src/classes_def.xml
+++ b/DataFormats/src/classes_def.xml
@@ -1,5 +1,10 @@
 <lcgdict>
 <class name="flashgg::WeightedObject"/>
+<class name="flashgg::PDFWeightObject"/>
+<class name="edm::Ptr<flashgg::PDFWeightObject>"/>
+<class name="std::vector<flashgg::PDFWeightObject>"/>
+<class name="edm::Wrapper<std::vector<flashgg::PDFWeightObject> >"/>
+
 <class name="flashgg::DiPhotonMVAResult"/>
 <!--
 <class name="edm::Wrapper<flashgg::DiPhotonMVAResult>"/>

--- a/MicroAOD/plugins/PDFWeightObjectProducer.cc
+++ b/MicroAOD/plugins/PDFWeightObjectProducer.cc
@@ -1,0 +1,185 @@
+#include <memory>
+#include <iostream>
+#include <string>
+#include <algorithm>
+#include <iterator>
+#include <cctype>
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "DataFormats/Common/interface/Handle.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "flashgg/DataFormats/interface/PDFWeightObject.h"
+#include "SimDataFormats/GeneratorProducts/interface/LHEEventProduct.h"
+#include "SimDataFormats/GeneratorProducts/interface/LHERunInfoProduct.h"
+#include "DataFormats/PatCandidates/interface/libminifloat.h"
+
+using namespace std;
+using namespace edm;
+
+namespace flashgg {
+
+	class PDFWeightProducer : public edm::EDProducer
+	{
+		public:
+			PDFWeightProducer( const edm::ParameterSet & );
+		private:
+			void produce( edm::Event &, const edm::EventSetup & );
+			EDGetTokenT<LHEEventProduct> LHEEventToken_;
+			string tag_;
+			string pdfset_;
+			string delimiter_1_;
+			string delimiter_2_;
+			string delimiter_3_;
+			void beginRun( edm::Run const &, edm::EventSetup const &iSetup );
+			vector<int> weight_indices;
+			string removeSpace( string line );
+	};
+
+	PDFWeightProducer::PDFWeightProducer( const edm::ParameterSet &iConfig ):
+		LHEEventToken_( consumes<LHEEventProduct>( iConfig.getUntrackedParameter<InputTag>( "LHEEventTag", InputTag( "LHEEventProduct" ) ) ) )
+	{
+
+		tag_ = iConfig.getUntrackedParameter<string>( "tag", "initrwgt" );
+		pdfset_ = iConfig.getUntrackedParameter<string>( "pdfset", "PDF_variation" );
+		delimiter_1_ = iConfig.getUntrackedParameter<string>( "delimiter_1", "id=\"" );
+		delimiter_2_ = iConfig.getUntrackedParameter<string>( "delimiter_2", "\">" );
+		delimiter_3_ = iConfig.getUntrackedParameter<string>( "delimiter_3", "</weightgroup>" );
+
+		produces<vector<flashgg::PDFWeightObject> >();
+
+	}
+
+	string removeSpaces( string str )
+	{
+		str.erase( remove_if( str.begin(), str.end(), ::isspace ), str.end() );
+		return str;
+	}
+
+	void PDFWeightProducer::beginRun( edm::Run const &iRun, edm::EventSetup const &iSetup )
+	{
+		Handle<LHERunInfoProduct> run;
+		typedef vector<LHERunInfoProduct::Header>::const_iterator headers_const_iterator;
+
+		iRun.getByLabel( "externalLHEProducer", run );
+		LHERunInfoProduct myLHERunInfoProduct = *( run.product() );
+
+		int upper_index = 0;
+
+		for( headers_const_iterator iter = myLHERunInfoProduct.headers_begin(); iter != myLHERunInfoProduct.headers_end(); iter++ ) {
+			if( ( iter->tag() ).compare( tag_ ) == 0 ) {
+				//cout << iter->tag() << endl;
+				vector<string> lines = iter->lines();
+			for( unsigned int iLine = 0; iLine < lines.size(); iLine++ ) {
+					string line = lines.at( iLine );
+					//cout << line << endl;
+					size_t pos = line.find( pdfset_ );
+					string token;
+					while( ( pos = line.find( pdfset_ ) ) != std::string::npos ) {
+						token = line.substr( pos, pdfset_.length() );
+						//std::cout << token << std::endl;
+						if( token.compare( pdfset_ ) == 0 ) {
+							upper_index = 1 + iLine;
+							break;
+						} else {
+
+							upper_index = 0;
+
+						}
+
+					}
+
+					if( upper_index != 0 ) { break; }
+				}
+
+				for( unsigned int nLine = upper_index; nLine < lines.size(); nLine++ ) {
+
+					string nline = lines.at( nLine );
+
+					//cout << nline << endl;	
+					
+					string jline = removeSpaces( nline );
+
+					//cout << nline.length() << endl;
+
+					if( jline.compare( delimiter_3_ ) == 0 ) { break; }
+
+					string ntoken;
+					string mtoken;
+
+					size_t mpos_1 = jline.find( delimiter_1_ );
+					size_t mpos_3 = jline.find( delimiter_2_ );
+
+					ntoken = jline.erase( mpos_3 );
+					mtoken = jline.substr( mpos_1 + delimiter_1_.length() );
+					//cout << mtoken << endl;
+	
+
+					int wgt = stoi( mtoken );
+
+					PDFWeightProducer::weight_indices.push_back( wgt );
+
+				}
+
+				break;
+
+			}
+		}
+
+	}
+
+
+
+	void PDFWeightProducer::produce( Event &evt, const EventSetup & )
+	{
+		Handle<LHEEventProduct> LHEEventHandle;
+		evt.getByToken( LHEEventToken_, LHEEventHandle );
+
+		std::auto_ptr<vector<flashgg::PDFWeightObject> > PDFWeight( new vector<flashgg::PDFWeightObject> );
+
+		flashgg::PDFWeightObject pdfWeight;
+
+		float weight = 1;
+		uint16_t weight_16 =1;
+
+		//cout << "weight_container size " << LHEEventHandle->weights().size() << " num_weight " << PDFWeightProducer::weight_indices.size() << endl;
+		//int lower_bound = LHEEventHandle->weights().size() - PDFWeightProducer::weight_indices.size();
+		int upper_bound = LHEEventHandle->weights().size();
+		int size = PDFWeightProducer::weight_indices.size();
+		//cout << "lower_bound " << lower_bound << " upper_bound " << upper_bound << endl;
+		for( int i = 0; i < upper_bound; i++ ) {
+
+			int id_i = stoi( LHEEventHandle->weights()[i].id );
+
+			for( int j = 0; j<size; j++ ){
+
+				int id_j = PDFWeightProducer::weight_indices[j];	
+//				cout << "id_i " << id_i << " id_j " << id_j << endl;
+			if( id_i == id_j ){
+
+				        //cout << "inner index " << j << " index " << PDFWeightProducer::weight_indices[j] << " id " << LHEEventHandle->weights()[i].id << endl;
+					weight = LHEEventHandle->weights()[i].wgt / LHEEventHandle->originalXWGTUP();
+					//cout << "weight " << weight << endl;
+					weight_16 = MiniFloatConverter::float32to16(weight);
+
+					pdfWeight.pdf_weight_container.push_back( weight_16 );
+				}
+
+			}
+		}
+
+		PDFWeight->push_back( pdfWeight );
+
+		evt.put( PDFWeight );
+
+		pdfWeight.pdf_weight_container.size();
+
+	}
+
+}
+
+typedef flashgg::PDFWeightProducer FlashggPDFWeightProducer;
+DEFINE_FWK_MODULE( FlashggPDFWeightProducer );
+

--- a/MicroAOD/python/flashggPDFWeightObject_cfi.py
+++ b/MicroAOD/python/flashggPDFWeightObject_cfi.py
@@ -1,0 +1,10 @@
+import FWCore.ParameterSet.Config as cms
+
+flashggPDFWeightObject = cms.EDProducer('FlashggPDFWeightProducer',
+		tag = cms.untracked.string("initrwgt"),
+		pdfset = cms.untracked.string("PDF_variation"),
+		delimiter_1 = cms.untracked.string("id=\""),
+		delimiter_2 = cms.untracked.string("\">"),
+		delimiter_3 = cms.untracked.string("</weightgroup>"),
+		LHEEventTag = cms.untracked.InputTag('externalLHEProducer'),
+		)

--- a/Validation/plugins/PDFValidation.cc
+++ b/Validation/plugins/PDFValidation.cc
@@ -1,0 +1,143 @@
+#include <memory>
+
+#include "FWCore/Framework/interface/EDAnalyzer.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "DataFormats/Common/interface/Handle.h"
+#include "DataFormats/Common/interface/Ptr.h"
+#include "DataFormats/Common/interface/PtrVector.h"
+#include "SimDataFormats/GeneratorProducts/interface/GenEventInfoProduct.h"
+#include "SimDataFormats/GeneratorProducts/interface/LHEEventProduct.h"
+#include "SimDataFormats/GeneratorProducts/interface/LHERunInfoProduct.h"
+#include "flashgg/DataFormats/interface/PDFWeightObject.h"
+#include <iostream>
+#include <string>
+
+using namespace std;
+using namespace edm;
+
+class PDFWeight : public edm::EDAnalyzer
+{
+	public:
+		explicit PDFWeight( const edm::ParameterSet & );
+		~PDFWeight();
+
+	private:
+
+		virtual void beginJob() override;
+		virtual void analyze( const edm::Event &, const edm::EventSetup & ) override;
+		virtual void endJob() override;
+		virtual void beginRun( edm::Run const &, edm::EventSetup const &iSetup );
+
+		edm::EDGetTokenT<GenEventInfoProduct> genParticleToken_;
+		edm::EDGetTokenT<LHEEventProduct> LHEEventToken_;
+		edm::EDGetTokenT<LHERunInfoProduct> LHERunToken_;
+		edm::EDGetTokenT<vector<flashgg::PDFWeightObject> > WeightToken_;
+};
+
+PDFWeight::PDFWeight( const edm::ParameterSet &iConfig ):
+	genParticleToken_( consumes<GenEventInfoProduct>( iConfig.getUntrackedParameter<InputTag> ( "GenEventInfoProductTag", InputTag( "generator" ) ) ) ),
+	LHEEventToken_( consumes<LHEEventProduct>( iConfig.getUntrackedParameter<InputTag> ( "LHETag", InputTag( "LHEEventProduct" ) ) ) ),
+	LHERunToken_( consumes<LHERunInfoProduct>( iConfig.getUntrackedParameter<InputTag> ( "LHERunTag", InputTag( "LHERunInfoProduct" ) ) ) ),
+	WeightToken_( consumes<vector<flashgg::PDFWeightObject> >( iConfig.getUntrackedParameter<InputTag>( "WeightTag", InputTag( "flashggPDFWeightObject" ) ) ) )
+{
+
+}
+
+PDFWeight::~PDFWeight()
+{
+}
+
+	void
+PDFWeight::analyze( const edm::Event &evt, const edm::EventSetup &iSetup )
+{
+
+	//    Handle<GenEventInfoProduct> genParticles;
+	//    evt.getByToken( genParticleToken_, genParticles );
+	//    const PtrVector<GenEventInfoProduct>& gens = genParticles->ptrVector();
+
+	//   cout << "the event weight  " << genParticles->weight() << endl;
+
+	//    Handle<LHEEventProduct> LHEHandle;
+	//    evt.getByToken( LHEEventToken_, LHEHandle );
+
+	//    Handle<vector<flashgg::PDFWeightObject> > WeightHandle;
+	//    evt.getByToken( WeightToken_, WeightHandle );
+	//    const PtrVector<flashgg::PDFWeightObject> mcWeightPointers = WeightHandle->ptrVector();
+
+	//cout << "XS  " << LHEHandle->originalXWGTUP() << endl;
+
+	//        for( unsigned int weight_index = 0; weight_index < (*WeightHandle).size(); weight_index++ ){
+	//            std::vector<float> uncompressed = (*WeightHandle)[weight_index].uncompress();
+	//            for( unsigned int j=0; j<(*WeightHandle)[weight_index].pdf_weight_container.size();j++ ) {
+	//                    cout << "compresed weight " << (*WeightHandle)[weight_index].pdf_weight_container[j] << endl;
+	//                    cout << "uncompressed weight " << uncompressed[j] << endl;
+	//       }
+	//    }
+}
+
+
+	void
+PDFWeight::beginJob()
+{
+}
+
+	void
+PDFWeight::endJob()
+{
+}
+
+
+	void
+PDFWeight::beginRun( edm::Run const &iRun, edm::EventSetup const &iSetup )
+{
+	Handle<LHERunInfoProduct> run;
+	typedef vector<LHERunInfoProduct::Header>::const_iterator headers_const_iterator;
+
+	iRun.getByLabel( "externalLHEProducer", run );
+	LHERunInfoProduct myLHERunInfoProduct = *( run.product() );
+
+	for( headers_const_iterator iter = myLHERunInfoProduct.headers_begin(); iter != myLHERunInfoProduct.headers_end(); iter++ ) {
+		if( iter->tag() == "init" )
+		{ cout << iter->tag() << endl; }
+		vector<string> lines = iter->lines();
+		for( unsigned int iLine = 0; iLine < lines.size(); iLine++ ) {
+			cout << lines.at( iLine );
+		}
+	}
+}
+
+
+/*
+   void
+   PDFWeight::endRun(edm::Run const&, edm::EventSetup const&)
+   {
+   }
+   */
+
+/*
+   void
+   PDFWeight::beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&)
+   {
+   }
+   */
+
+/*
+   void
+   PDFWeight::endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&)
+   {
+   }
+   */
+
+DEFINE_FWK_MODULE( PDFWeight );
+// Local Variables:
+// mode:c++
+// indent-tabs-mode:nil
+// tab-width:4
+// c-basic-offset:4
+// End:
+// vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4

--- a/Validation/python/pdfValidation_cfg.py
+++ b/Validation/python/pdfValidation_cfg.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 import FWCore.Utilities.FileUtils as FileUtils
 
-process = cms.Process("FLASHggMicroAOD")
+process = cms.Process("PDFWeight")
 
 process.load("FWCore.MessageService.MessageLogger_cfi")
 
@@ -13,7 +13,7 @@ process.load("Configuration.StandardSequences.MagneticField_cff")
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_condDBv2_cff")
 from Configuration.AlCa.GlobalTag import GlobalTag
 
-process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32( 1000) )
+process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32( 1000 ) )
 process.MessageLogger.cerr.FwkReport.reportEvery = cms.untracked.int32( 1000 )
 
 process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:run2_mc')
@@ -53,8 +53,15 @@ if current_gt.count("::All"):
 #                                                                         "/store/relval/CMSSW_7_4_0_pre9/RelValH130GGgluonfusion_13/MINIAODSIM/PU25ns_MCRUN2_74_V7-v1/00000/C65FAFAA-4CD4-E411-9026-0025905A607E.root"))
 
 # Spring15
+#process.source = cms.Source("PoolSource", fileNames=cms.untracked.vstring("/store/mc/RunIISpring15DR74/TTJets_SingleLeptFromT_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/Asympt25ns_MCRUN2_74_V9-v1/20000/02AE0634-0B23-E511-8E6F-02163E0133CA.root"))
+
 #process.source = cms.Source("PoolSource",fileNames=cms.untracked.vstring("/store/mc/RunIISpring15DR74/ttHJetToGG_M125_13TeV_amcatnloFXFX_madspin_pythia8/MINIAODSIM/Asympt50ns_MCRUN2_74_V9A-v1/70000/0232BC3C-01FF-E411-8779-0025907B4FC2.root"))
-#process.source = cms.Source("PoolSource",fileNames=cms.untracked.vstring("/store/mc/RunIISpring15DR74/GluGluHToGG_M-125_13TeV_powheg_pythia8/MINIAODSIM/Asympt50ns_MCRUN2_74_V9A-v1/30000/54ECB9A4-912E-E511-BB7D-002590A831CA.root"))
+
+process.source = cms.Source("PoolSource",fileNames=cms.untracked.vstring("/store/mc/RunIISpring15DR74/GluGluHToGG_M125_13TeV_amcatnloFXFX_pythia8/MINIAODSIM/Asympt25ns_MCRUN2_74_V9-v1/50000/4E503483-EA32-E511-AB07-02163E013542.root"))
+
+#process.source = cms.Source ("PoolSource",fileNames = cms.untracked.vstring("file:myMicroAODOutputFile.root"))
+
+
 process.MessageLogger.cerr.threshold = 'ERROR' # can't get suppressWarning to work: disable all warnings for now
 # process.MessageLogger.suppressWarning.extend(['SimpleMemoryCheck','MemoryCheck']) # this would have been better...
 
@@ -65,32 +72,11 @@ process.MessageLogger.cerr.threshold = 'ERROR' # can't get suppressWarning to wo
 #                                        monitorPssAndPrivate = cms.untracked.bool(True)
 #                                       )
 
-#process.load("flashgg/MicroAOD/flashggPDFWeightObject_cfi")
-process.load("flashgg/MicroAOD/flashggMicroAODSequence_cff")
+process.PDFValidation = cms.EDAnalyzer('PDFWeight',
+					GenEventInfoProductTag=cms.untracked.InputTag('generator'),
+					LHETag=cms.untracked.InputTag('externalLHEProducer'),
+					LHERunTag=cms.untracked.InputTag('LHERunInfoProduct')
+					)
 
-from flashgg.MicroAOD.flashggMicroAODOutputCommands_cff import microAODDefaultOutputCommand
-process.out = cms.OutputModule("PoolOutputModule", fileName = cms.untracked.string('myMicroAODOutputFile.root'),
-                               outputCommands = microAODDefaultOutputCommand
-                               )
-
-# All jets are now handled in MicroAODCustomize.py
-# Switch from PFCHS to PUPPI with puppi=1 argument (both if puppi=2)
-
-process.p = cms.Path(process.flashggMicroAODSequence)
-#process.p = cms.Path(process.flashggPDFWeightObject*process.flashggMicroAODSequence)
-process.e = cms.EndPath(process.out)
-
-# Uncomment these lines to run the example commissioning module and send its output to root
-#process.commissioning = cms.EDAnalyzer('flashggCommissioning',
-#                                       PhotonTag=cms.untracked.InputTag('flashggPhotons'),
-#                                       DiPhotonTag = cms.untracked.InputTag('flashggDiPhotons'),
-#                                       VertexTag=cms.untracked.InputTag('offlineSlimmedPrimaryVertices')
-#)
-#process.TFileService = cms.Service("TFileService",
-#                                   fileName = cms.string("commissioningTree.root")
-#)
-#process.p *= process.commissioning
-
-
-from flashgg.MicroAOD.MicroAODCustomize import customize
-customize(process)
+process.p = cms.Path(process.PDFValidation)
+#process.e = cms.EndPath(process.out)


### PR DESCRIPTION
This pull request has everything it needs :) 

Each dataset may have different pdfsets. For this reason I include a separate cc file (PDFValidation.cc/pdfValidation_cfi.py) which will run over the lines of LHEEventProduct. This way we can easily check by hand which pdfsets are stored in the file.  Once we have the name we can make a configuration (flashggPDFWeightObject_cfi.py) with some parameters that are needed. I did not include it into the main workflow (just added commented lines) because if the name of the pdfset is not found the script will crash (maybe this should change).  