### PR TITLE
handeling extra cmsRun arguments in prepareCrabJobs.py

### DIFF
--- a/MetaData/work/crabConfig_TEMPLATE.py
+++ b/MetaData/work/crabConfig_TEMPLATE.py
@@ -5,6 +5,7 @@
 
 from WMCore.Configuration import Configuration
 config = Configuration()
+import os
 
 config.section_("General")
 config.General.requestName = "JOBNAME"
@@ -13,6 +14,13 @@ config.General.transferLogs = False
 config.section_("JobType")
 config.JobType.pluginName = "Analysis"
 config.JobType.psetName = "PSET"
+
+## to include local file in the sendbox, this will put the file in the directory where cmsRun runs
+#config.JobType.inputFiles   = [ os.environ['CMSSW_BASE'] + '/src/'+ 'flashgg/MetaData/data/PY8_RunIISpring15DR74_bx50_MC.db' ]
+
+## incrase jobs time wall, maximum 2800 minutes (46 hours)
+#config.JobType.maxJobRuntimeMin = 2800
+
 ## config.JobType.maxMemoryMB = 3000 # For memory leaks. NB. will block jobs on many sites
 ## config.JobType.scriptExe = "cmsWrapper.sh"
 config.JobType.pyCfgParams = PYCFG_PARAMS

--- a/MetaData/work/prepareCrabJobs.py
+++ b/MetaData/work/prepareCrabJobs.py
@@ -116,8 +116,8 @@ parser = OptionParser(option_list=[
         make_option("-e","--extraPyCfgParam",
                     dest="extraPyCfgParam",
                     action="store",type="string",
-                    default="puppi=0",
-                    help="Extra python config parameters. Default: %default")
+                    default=None,
+                    help="Extra python config parameters. The arguments must be : -e 'arg1 arg2 ...' ")
         
         ]
                       )
@@ -259,8 +259,7 @@ if options.createCrabConfig:
         
         # apprend extra parameters
         if options.extraPyCfgParam:
-            #print "options.extraPyCfgParam:",options.extraPyCfgParam
-            replacements["PYCFG_PARAMS"].append(str("%s" % options.extraPyCfgParam))
+            replacements["PYCFG_PARAMS"].extend(map( lambda x: '"%s"' % x, options.extraPyCfgParam.split(" ") ))
             
         # associate the processedLabel to the globaltag from the json filex
         if gtJson.get(processedLabel,None):

--- a/MetaData/work/prepareCrabJobs.py
+++ b/MetaData/work/prepareCrabJobs.py
@@ -109,7 +109,16 @@ parser = OptionParser(option_list=[
                     dest="globalTags",
                     action="store",type="string",
                     default="campaigns/globalTagsLookup.json",
-                    help="List of global tags to be used for data and MC. Default: %default")
+                    help="List of global tags to be used for data and MC. Default: %default"),
+        
+        # include additional parameters for cmsRun, such as the parameters from microAODCustomize
+        # the default here is puppi=0 (as an example) see microAODCustomize_cfg.py for more detail
+        make_option("-e","--extraPyCfgParam",
+                    dest="extraPyCfgParam",
+                    action="store",type="string",
+                    default="puppi=0",
+                    help="Extra python config parameters. Default: %default")
+        
         ]
                       )
 # parse the command line
@@ -247,7 +256,12 @@ if options.createCrabConfig:
         position = ProcessedDataset.find("-v")
         processedLabel = ProcessedDataset[:position]
         # print processedLabel
-
+        
+        # apprend extra parameters
+        if options.extraPyCfgParam:
+            #print "options.extraPyCfgParam:",options.extraPyCfgParam
+            replacements["PYCFG_PARAMS"].append(str("%s" % options.extraPyCfgParam))
+            
         # associate the processedLabel to the globaltag from the json filex
         if gtJson.get(processedLabel,None):
             globalTag = gtJson[processedLabel]


### PR DESCRIPTION
I added an option in `prepareCrabJobs.py` to include extra arguments. 
Example : If you want to send a crab job to run `cmsRun microAODstd.py puppi=2` you have to include the option `-e puppi=2` when you run `./prepareCrabJobs.py ... ` 