### PR TITLE
added IntLumi variable into workspaces. 

### DIFF
--- a/MetaData/python/JobConfig.py
+++ b/MetaData/python/JobConfig.py
@@ -166,6 +166,11 @@ class JobConfig(object):
                             wei *= xsec.get("br",1.)
                             wei *= xsec.get("kf",1.)
                             obj.lumiWeight = wei
+                    if hasattr(obj,"intLumi"):
+                        if isdata:
+                            obj.intLumi=self.targetLumi #FIXME is this where this info should come from for data?
+                        else:
+                            obj.intLumi=self.targetLumi
             
             for name,obj in process.__dict__.iteritems():
                 if hasattr(obj,"processId"):

--- a/MetaData/python/JobConfig.py
+++ b/MetaData/python/JobConfig.py
@@ -168,7 +168,9 @@ class JobConfig(object):
                             obj.lumiWeight = wei
                     if hasattr(obj,"intLumi"):
                         if isdata:
-                            obj.intLumi=self.targetLumi #FIXME is this where this info should come from for data?
+                            obj.intLumi= 0 # should not be used in final fits.
+                            # setting to 0 will cause error if someone tries to use
+                            #it for normalization downsteram
                         else:
                             obj.intLumi=self.targetLumi
             

--- a/Taggers/interface/CollectionDumper.h
+++ b/Taggers/interface/CollectionDumper.h
@@ -186,8 +186,10 @@ namespace flashgg {
         if( dumpWorkspace_ ) {
             ws_ = fs.make<RooWorkspace>( workspaceName_.c_str(), workspaceName_.c_str() );
             dynamic_cast<RooRealVar *>( ws_->factory( "weight[1.]" ) )->setConstant( false );
-            RooRealVar* intLumi = new RooRealVar("IntLumi","IntLumi",intLumi_*0.001,0,30000000);
-            //workspace expects intlumi in /fb not /pb
+            RooRealVar* intLumi = new RooRealVar("IntLumi","IntLumi",intLumi_);
+            //workspace expects intlumi in /pb
+            intLumi->setConstant(); 
+            // don't want this param to float in the fits at any point
             ws_->import(*intLumi);
         } else {
             ws_ = 0;

--- a/Taggers/interface/CollectionDumper.h
+++ b/Taggers/interface/CollectionDumper.h
@@ -86,6 +86,7 @@ namespace flashgg {
         double lumiWeight_;
         int maxCandPerEvent_;
         double sqrtS_;
+        double intLumi_;
         std::string nameTemplate_;
 
         bool dumpTrees_;
@@ -118,6 +119,7 @@ namespace flashgg {
         lumiWeight_( cfg.getParameter<double>( "lumiWeight" ) ),
         maxCandPerEvent_( cfg.getParameter<int>( "maxCandPerEvent" ) ),
         sqrtS_( cfg.getUntrackedParameter<double>( "sqrtS", 13. ) ),
+        intLumi_( cfg.getUntrackedParameter<double>( "intLumi",1000. ) ),
         nameTemplate_( cfg.getUntrackedParameter<std::string>( "nameTemplate", "$COLLECTION" ) ),
         dumpTrees_( cfg.getUntrackedParameter<bool>( "dumpTrees", false ) ),
         dumpWorkspace_( cfg.getUntrackedParameter<bool>( "dumpWorkspace", false ) ),
@@ -184,6 +186,9 @@ namespace flashgg {
         if( dumpWorkspace_ ) {
             ws_ = fs.make<RooWorkspace>( workspaceName_.c_str(), workspaceName_.c_str() );
             dynamic_cast<RooRealVar *>( ws_->factory( "weight[1.]" ) )->setConstant( false );
+            RooRealVar* intLumi = new RooRealVar("IntLumi","IntLumi",intLumi_*0.001,0,30000000);
+            //workspace expects intlumi in /fb not /pb
+            ws_->import(*intLumi);
         } else {
             ws_ = 0;
         }

--- a/Taggers/python/tagsDumpConfig_cff.py
+++ b/Taggers/python/tagsDumpConfig_cff.py
@@ -6,7 +6,8 @@ tagsDumpConfig = cms.PSet(
     generatorInfo = cms.InputTag("generator"),
     processId = cms.string(""),
     maxCandPerEvent = cms.int32(-1),
-    lumiWeight = cms.double(1.0),
+    lumiWeight = cms.double(1.0),# Over-written by metaData if using fggRunJobs
+    intLumi = cms.untracked.double(1000.), # in /pb. to be over-written by metaData if using fggRunJobs
     classifierCfg = cms.PSet(categories=cms.VPSet()),
     categories = cms.VPSet(),
 


### PR DESCRIPTION
This is a small PR which adds the `intLumi` into the final workspaces as an extra `RooRealVar`. The value of `intlumi` is either specified directly as an optional dumper config parameter or over-written by the metaData when using `fggRunJobs.py` using the value given by `targetLumi`.

@musella can you check this implementation is what you expected after our discussion on Monday?
Any comments or suggestions welcome!

replaces https://github.com/cms-analysis/flashgg/pull/364

ested with fggRunJobs.py --load test_jobs.json -d testMe -x cmsRun Systematics/test/MicroAODtoWorkspace.py maxEvents=100
and intLumi is being pulled through correctly.
Also tested cmsRun Taggers/test/diphotonsDumper_cfg.py inputFiles=file:/afs/cern.ch/user/m/musella/public/forLuie/diphotonsMicroAOD.root and works fine

