### PR TITLE
Lighter Systematic Dumping with rooDataHists

### DIFF
--- a/Systematics/python/SystematicDumperDefaultVariables.py
+++ b/Systematics/python/SystematicDumperDefaultVariables.py
@@ -1,5 +1,8 @@
 minimalVariables = ["CMS_hgg_mass[160,100,180]:=diPhoton().mass",
-                    "dZ             :=abs(tagTruth().genPV().z-diPhoton().vtx().z)"]
+                    "dZ[2,0,2]:=abs(tagTruth().genPV().z-diPhoton().vtx().z)"] #only need to know if dZ<1 or dz>1
+										#when doing systematics, variables need to have a binning
+										#specified, otherwise the rooDataHist end up empty.
+										#an assert in the code prevents you from doing this.
 minimalHistograms = []
 
 defaultVariables=["CMS_hgg_mass[160,100,180]:=diPhoton().mass", 

--- a/Systematics/test/MicroAODtoWorkspace.py
+++ b/Systematics/test/MicroAODtoWorkspace.py
@@ -89,7 +89,7 @@ import flashgg.Taggers.dumperConfigTools as cfgTools
 process.tagsDumper.className = "DiPhotonTagDumper"
 process.tagsDumper.src = "flashggSystTagMerger"
 process.tagsDumper.processId = "test"
-process.tagsDumper.dumpTrees = True
+process.tagsDumper.dumpTrees = False
 process.tagsDumper.dumpWorkspace = True
 process.tagsDumper.dumpHistos = False
 process.tagsDumper.quietRooFit = True
@@ -120,13 +120,15 @@ for tag in tagList:
           definedSysts.add(systlabel)
       else:
           cutstring = None
+      isBinnedOnly = (systlabel !=  "")
       cfgTools.addCategory(process.tagsDumper,
                            systlabel,
                            classname=tagName,
                            cutbased=cutstring,
                            subcats=tagCats, 
                            variables=minimalVariables,
-                           histograms=minimalHistograms
+                           histograms=minimalHistograms,
+                           binnedOnly=isBinnedOnly
                            )
 
 process.p = cms.Path((process.flashggDiPhotonSystematics+process.flashggMuonSystematics+process.flashggElectronSystematics)*

--- a/Systematics/test/MicroAODtoWorkspace.py
+++ b/Systematics/test/MicroAODtoWorkspace.py
@@ -141,8 +141,8 @@ process.p = cms.Path((process.flashggDiPhotonSystematics+process.flashggMuonSyst
 ############################
 ## Dump the output Python ##
 ############################
-processDumpFile = open('processDump.py', 'w')
-print >> processDumpFile, process.dumpPython()
+#processDumpFile = open('processDump.py', 'w')
+#print >> processDumpFile, process.dumpPython()
 
 
 

--- a/Systematics/test/systematicsDumper_cfg.py
+++ b/Systematics/test/systematicsDumper_cfg.py
@@ -3,7 +3,7 @@ import FWCore.ParameterSet.Config as cms
 import FWCore.Utilities.FileUtils as FileUtils
 from FWCore.ParameterSet.VarParsing import VarParsing
 from flashgg.MetaData.samples_utils import SamplesManager
-from flashgg.Systematics.SystematicDumperDefaultVariables import defaultVariables,defaultHistograms
+from flashgg.Systematics.SystematicDumperDefaultVariables import minimalVariables,minimalHistograms
 
 ## CMD LINE OPTIONS ##
 options = VarParsing('analysis')

--- a/Taggers/interface/WorkspaceCombiner.h
+++ b/Taggers/interface/WorkspaceCombiner.h
@@ -98,6 +98,10 @@ private :
     vector<string> workspaceNames;
 
     vector<vector<RooDataSet *> > data; //[workspace][dataset(cat)]
+    
+    vector<vector<RooDataHist *> > dataH; //[workspace][dataset(cat)]
+    
+    vector<vector<RooRealVar *> > vars; //[workspace][dataset(cat)]
 
     vector<TTree *> trees;
 

--- a/Taggers/python/dumperConfigTools.py
+++ b/Taggers/python/dumperConfigTools.py
@@ -7,7 +7,7 @@ def addCategories(pset,cats,variables,histograms,mvas=None):
         addCategory(pset,*cat,variables=variables,histograms=histograms,mvas=mvas)
 
 # -----------------------------------------------------------------------
-def addCategory(pset,label,cutbased=None,subcats=0,variables=[],histograms=[],mvas=None,classname=None):
+def addCategory(pset,label,cutbased=None,subcats=0,variables=[],histograms=[],mvas=None,classname=None,binnedOnly=None):
     
    
     if subcats >= 0:
@@ -17,6 +17,7 @@ def addCategory(pset,label,cutbased=None,subcats=0,variables=[],histograms=[],mv
                           histograms=cms.VPSet(),
                           )
         if classname: catDef.className=cms.string(classname)
+        if binnedOnly: catDef.binnedOnly=cms.bool(binnedOnly)
          
         addVariables( catDef.variables, variables )
         addHistograms( catDef.histograms, histograms  )


### PR DESCRIPTION
It became clear after the last campaign that dumping systematic using full RooDataSets was too heavy, as we were running out of memory when adding files.
* Therefore, this PR adds the option to use RooDataHists instead, using the binning provided in the dumper config. The default is RooDataSets.
* The MicroAODtoWorkspace.py config now by default dumps systematics into RooDataHists, while the nominal collection is still a RooDataSet
* Space saved is substantial: testing on 30k events from a ggH sample, the size of an all-DataSet file is ~2.3MB while the size of the new syst-DataHist format is only 342KB. This is because to first order the size of a DataSet scales linearly with nEvents, while DataHists are ~constant.
* Also modified hadd_workspaces to correctly add RooDataHists together if they're present.  And also RooRealVars (like intLumi) are covered.

@musella please let me know if you have any comments about implementation, as this touches the Dumper framework.  