### PR TITLE
flashggElectron updated to use RecoEgamma/ElectronIndentification tools

### DIFF
--- a/MicroAOD/python/flashggElectrons_cfi.py
+++ b/MicroAOD/python/flashggElectrons_cfi.py
@@ -1,5 +1,23 @@
 import FWCore.ParameterSet.Config as cms
 
+from PhysicsTools.SelectorUtils.tools.vid_id_tools import *
+
+process = cms.Process("FLASHggMicroAOD")
+
+# turn on VID producer, indicate data format  to be
+# DataFormat.AOD or DataFormat.MiniAOD, as appropriate 
+
+dataFormat = DataFormat.MiniAOD
+
+switchOnVIDElectronIdProducer(process, dataFormat)
+
+# define which IDs we want to produce
+my_id_modules = ['RecoEgamma.ElectronIdentification.Identification.mvaElectronID_Spring15_25ns_nonTrig_V1_cff']
+
+#add them to the VID producer
+for idmod in my_id_modules:
+    setupAllVIDIdsInModule(process,idmod,setupVIDElectronSelection)
+
 flashggElectrons = cms.EDProducer('FlashggElectronProducer',
 		verbose = cms.untracked.bool(False),
 		electronTag = cms.InputTag('slimmedElectrons'),
@@ -8,16 +26,6 @@ flashggElectrons = cms.EDProducer('FlashggElectronProducer',
 		beamSpotTag = cms.InputTag( "offlineBeamSpot" ),
 		reducedEBRecHitCollection = cms.InputTag('reducedEcalRecHitsEB'),
 		reducedEERecHitCollection = cms.InputTag('reducedEcalRecHitsEE'),
-		method = cms.string("BDT"),
 		rhoFixedGridCollection = cms.InputTag('fixedGridRhoAll'),
-		mvaWeightFile = cms.vstring(
-			"flashgg/MicroAOD/data/Electrons_BDTG_NonTrigV0_Cat1.weights.xml",
-			"flashgg/MicroAOD/data/Electrons_BDTG_NonTrigV0_Cat2.weights.xml",
-			"flashgg/MicroAOD/data/Electrons_BDTG_NonTrigV0_Cat3.weights.xml",
-			"flashgg/MicroAOD/data/Electrons_BDTG_NonTrigV0_Cat4.weights.xml",
-			"flashgg/MicroAOD/data/Electrons_BDTG_NonTrigV0_Cat5.weights.xml",
-			"flashgg/MicroAOD/data/Electrons_BDTG_NonTrigV0_Cat6.weights.xml",
-			),
-		Trig = cms.bool(False),
-		NoIP = cms.bool(False),
+                mvaValuesMap = cms.InputTag("electronMVAValueMapProducer:ElectronMVAEstimatorRun2Spring15NonTrig25nsV1Values"),
 		)

--- a/MicroAOD/python/flashggMicroAODOutputCommands_cff.py
+++ b/MicroAOD/python/flashggMicroAODOutputCommands_cff.py
@@ -34,8 +34,9 @@ microAODDefaultOutputCommand = cms.untracked.vstring("drop *",
                                                      "drop *_flashggElectrons_*_*",
 
                                                      "keep *_flashggFinalJets_*_*",
-                                                     "keep *_flashggFinalPuppiJets_*_*"
-
+                                                     "keep *_flashggFinalPuppiJets_*_*",
+						     "drop floatedmValueMap_electronMVAValueMapProducer_*_*",
+						     "drop intedmValueMap_electronMVAValueMapProducer_*_*"
                                                      )
 
 # Should be included for now for ongoing studies, but to be removed some day

--- a/MicroAOD/python/flashggMicroAODSequence_cff.py
+++ b/MicroAOD/python/flashggMicroAODSequence_cff.py
@@ -11,6 +11,11 @@ from flashgg.MicroAOD.flashggFinalEGamma_cfi import flashggFinalEGamma
 from flashgg.MicroAOD.flashggLeptonSelectors_cff import flashggSelectedMuons,flashggSelectedElectrons
 from flashgg.MicroAOD.flashggMicroAODGenSequence_cff import *
 
+from PhysicsTools.SelectorUtils.centralIDRegistry import central_id_registry
+from RecoEgamma.ElectronIdentification.ElectronMVAValueMapProducer_cfi import *
+
+
+
 eventCount = cms.EDProducer("EventCountProducer")
 weightsCount = cms.EDProducer("WeightsCountProducer",
                               generator=cms.InputTag("generator"),
@@ -23,7 +28,7 @@ weightsCount = cms.EDProducer("WeightsCountProducer",
 
 flashggMicroAODSequence = cms.Sequence(eventCount+weightsCount
                                        +flashggVertexMapUnique+flashggVertexMapNonUnique
-                                       +flashggElectrons*flashggSelectedElectrons
+                                       +electronMVAValueMapProducer*flashggElectrons*flashggSelectedElectrons
                                        +flashggMuons*flashggSelectedMuons
                                        +flashggMicroAODGenSequence
                                        +flashggPhotons*flashggDiPhotons*flashggPreselectedDiPhotons


### PR DESCRIPTION
Updated flashggElectron to follow more closely RecoEgamma. We only need to update the electron config from now on to change the weight file we want (not download them) .  Egamma experts in the group, could you check the changes to see if this is the best way to implement the VID in flashgg?  