### PR TITLE
change kept pileup collection name

### DIFF
--- a/MicroAOD/python/flashggMicroAODOutputCommands_cff.py
+++ b/MicroAOD/python/flashggMicroAODOutputCommands_cff.py
@@ -23,8 +23,7 @@ microAODDefaultOutputCommand = cms.untracked.vstring("drop *",
                                                      "keep *_generator_*_*",
                                                      "keep *_slimmedGenJets_*_*",
                                                      "keep *_flashggDiPhotons_*_*", # STILL NEEDED
-                                                     "keep *_addPileupInfo_*_*", # Huge - a few Validation codes use this
-                                                                                 # PileupSummaryInfos_addPileupInfo__HLT. 4602.5 1640.32
+                                                     "keep *_slimmedAddPileupInfo_*_*", # Was huge in old MiniAod - hopefully better now
                                                      "keep *GsfElectronCore*_*_*_*", # needed by at least one Tag
 
                                                      "keep *_flashggSelected*_*_*",


### PR DESCRIPTION
Get collection name correct for reMiniAOD.  Previously I switched the module that reads the collection, but didn't update the output list.