### PR TITLE
workspaces: tidy hadd script, store systematics by default for sig only

### DIFF
--- a/Systematics/scripts/hadd_all.py
+++ b/Systematics/scripts/hadd_all.py
@@ -1,7 +1,16 @@
 from os import listdir,popen,access,F_OK
 
+dobig = False
+dobigsig = True
+
 filelist = {}
 bigfiles = []
+bigsigfiles = []
+
+def printAndExec(cmd):
+    print cmd
+    result = popen(cmd).read()
+    print result
 
 for fn in listdir("."):
     if fn.count(".root"):
@@ -22,6 +31,9 @@ for fnr in filelist.keys():
     print fnr,result
     assert(result[-1]+1 == len(result))
     bigfile = fnr.replace("_%i","")
+    bigfiles.append(bigfile)
+    if bigfile.count("HToGG") or bigfile.count("ttHJetToGG"):
+        bigsigfiles.append(bigfile)
     if access(bigfile,F_OK):
         print "skipping",bigfile
         continue
@@ -38,24 +50,23 @@ for fnr in filelist.keys():
                 print "skipping",mediumfile
                 continue
             cmd = "hadd_workspaces %s %s" % (mediumfile," ".join(fnr%fnn for fnn in subres[i]))
-            print cmd
-            result = popen(cmd).read()
-            print result
+            printAndExec(cmd)
             mediumlist.append(mediumfile)
         cmd = "hadd_workspaces %s %s" % (bigfile," ".join(mediumlist))    
-        print cmd
-        result = popen(cmd).read()
-        print result
+        printAndExec(cmd)
     else:    
         cmd = "hadd_workspaces %s %s" % (bigfile," ".join([fnr%fnn for fnn in result]))
-        print cmd
-        result = popen(cmd).read()
-        print result
-    bigfiles += [bigfile]
+        print AndExec(cmd)
 
 print
-cmd = "hadd_workspaces everything.root %s" % (" ".join(bigfiles))
-print cmd
-result = popen(cmd).read()
-print result
+if not access("everything.root",F_OK) and dobig:
+    cmd = "hadd_workspaces everything.root %s" % (" ".join(bigfiles))
+    printAndExec(cmd)
+else:
+    print "skipping everything.root"
 
+if not access("allsig.root",F_OK) and dobigsig:
+    cmd = "hadd_workspaces allsig.root %s" % (" ".join(bigfiles))
+    printAndExec(cmd)
+else:
+    print "skipping allsig.root"

--- a/Systematics/test/MicroAODtoWorkspace.py
+++ b/Systematics/test/MicroAODtoWorkspace.py
@@ -38,13 +38,19 @@ process.flashggSystTagMerger = cms.EDProducer("TagMerger",src=cms.VInputTag("fla
 
 process.systematicsTagSequences = cms.Sequence()
 systlabels = [""]
-for r9 in ["HighR9","LowR9"]:
-    for direction in ["Up","Down"]:
-        systlabels.append("MCSmear%sEE%s01sigma" % (r9,direction))
-        for var in ["Rho","Phi"]:
-            systlabels.append("MCSmear%sEB%s%s01sigma" % (r9,var,direction))
-        for region in ["EB","EE"]:
-            systlabels.append("MCScale%s%s%s01sigma" % (r9,region,direction))
+
+# import flashgg customization to check if we have signal or background
+from flashgg.MetaData.JobConfig import customize
+#print "customize.processType:",customize.processType
+# Only run systematics for signal events
+if customize.processType == "signal":
+    for r9 in ["HighR9","LowR9"]:
+        for direction in ["Up","Down"]:
+            systlabels.append("MCSmear%sEE%s01sigma" % (r9,direction))
+            for var in ["Rho","Phi"]:
+                systlabels.append("MCSmear%sEB%s%s01sigma" % (r9,var,direction))
+            for region in ["EB","EE"]:
+                systlabels.append("MCScale%s%s%s01sigma" % (r9,region,direction))
 
 for systlabel in systlabels:
     if systlabel == "":
@@ -146,8 +152,6 @@ process.p = cms.Path((process.flashggDiPhotonSystematics+process.flashggMuonSyst
 
 
 
-# import flashgg customization
-from flashgg.MetaData.JobConfig import customize
 # set default options if needed
 customize.setDefault("maxEvents",-1)
 customize.setDefault("targetLumi",20e+3)

--- a/Systematics/test/MicroAODtoWorkspace.py
+++ b/Systematics/test/MicroAODtoWorkspace.py
@@ -41,9 +41,11 @@ systlabels = [""]
 
 # import flashgg customization to check if we have signal or background
 from flashgg.MetaData.JobConfig import customize
-#print "customize.processType:",customize.processType
+customize.parse()
+print "customize.processId:",customize.processId
 # Only run systematics for signal events
-if customize.processType == "signal":
+if customize.processId.count("h_"):
+    print "Adding systematics"
     for r9 in ["HighR9","LowR9"]:
         for direction in ["Up","Down"]:
             systlabels.append("MCSmear%sEE%s01sigma" % (r9,direction))


### PR DESCRIPTION
N.B. This PR is relevant only to direct workspace building from MicroAOD and an ad hoc script for adding the results.  We might need some systematics for some background studies (e.g. DY) but these would have different configuration files anyway!