### PR TITLE
Dump pdfWeights into workspaces

### DIFF
--- a/DataFormats/interface/PDFWeightObject.h
+++ b/DataFormats/interface/PDFWeightObject.h
@@ -13,6 +13,7 @@ namespace flashgg {
     public:
 
         PDFWeightObject();
+        //PDFWeightObject( const PDFWeightObject& );
         ~PDFWeightObject();
         
         vector<uint16_t> pdf_weight_container;

--- a/DataFormats/src/PDFWeightObject.cc
+++ b/DataFormats/src/PDFWeightObject.cc
@@ -6,6 +6,9 @@ using namespace std;
 PDFWeightObject::PDFWeightObject()
 {}
 
+//PDFWeightObject::PDFWeightObject( const PDFWeightObject& )
+//{}
+
 PDFWeightObject::~PDFWeightObject()
 {}
 

--- a/MicroAOD/test/microAODstd.py
+++ b/MicroAOD/test/microAODstd.py
@@ -72,6 +72,7 @@ process.MessageLogger.cerr.threshold = 'ERROR' # can't get suppressWarning to wo
 #                                        monitorPssAndPrivate = cms.untracked.bool(True)
 #                                       )
 
+process.load("flashgg/MicroAOD/flashggPDFWeightObject_cfi")
 process.load("flashgg/MicroAOD/flashggMicroAODSequence_cff")
 
 # NEEDED FOR ANYTHING PRIOR TO reMiniAOD
@@ -85,7 +86,8 @@ process.out = cms.OutputModule("PoolOutputModule", fileName = cms.untracked.stri
 # All jets are now handled in MicroAODCustomize.py
 # Switch from PFCHS to PUPPI with puppi=1 argument (both if puppi=2)
 
-process.p = cms.Path(process.flashggMicroAODSequence)
+#process.p = cms.Path(process.flashggMicroAODSequence)
+process.p = cms.Path(process.flashggPDFWeightObject*process.flashggMicroAODSequence)
 process.e = cms.EndPath(process.out)
 
 # Uncomment these lines to run the example commissioning module and send its output to root

--- a/Systematics/test/MicroAODtoWorkspace.py
+++ b/Systematics/test/MicroAODtoWorkspace.py
@@ -139,11 +139,11 @@ for tag in tagList:
       else:
           currentVariables = systematicVariables
       
-			isBinnedOnly = (systlabel !=  "")
+      isBinnedOnly = (systlabel !=  "")
       dumpPdfWeights = (systlabel ==  "")
       nPdfWeights = 213
       
-			cfgTools.addCategory(process.tagsDumper,
+      cfgTools.addCategory(process.tagsDumper,
                            systlabel,
                            classname=tagName,
                            cutbased=cutstring,
@@ -152,7 +152,7 @@ for tag in tagList:
                            histograms=minimalHistograms,
                            binnedOnly=isBinnedOnly,
                            dumpPdfWeights=dumpPdfWeights,
-													 nPdfWeights=nPdfWeights
+                           nPdfWeights=nPdfWeights
                            )
 
 process.p = cms.Path((process.flashggDiPhotonSystematics+process.flashggMuonSystematics+process.flashggElectronSystematics)*

--- a/Systematics/test/MicroAODtoWorkspace.py
+++ b/Systematics/test/MicroAODtoWorkspace.py
@@ -134,19 +134,25 @@ for tag in tagList:
           definedSysts.add(systlabel)
       else:
           cutstring = None
-      isBinnedOnly = (systlabel !=  "")
       if systlabel == "":
           currentVariables = variablesToUse
       else:
           currentVariables = systematicVariables
-      cfgTools.addCategory(process.tagsDumper,
+      
+			isBinnedOnly = (systlabel !=  "")
+      dumpPdfWeights = (systlabel ==  "")
+      nPdfWeights = 213
+      
+			cfgTools.addCategory(process.tagsDumper,
                            systlabel,
                            classname=tagName,
                            cutbased=cutstring,
                            subcats=tagCats, 
                            variables=currentVariables,
                            histograms=minimalHistograms,
-                           binnedOnly=isBinnedOnly
+                           binnedOnly=isBinnedOnly,
+                           dumpPdfWeights=dumpPdfWeights,
+													 nPdfWeights=nPdfWeights
                            )
 
 process.p = cms.Path((process.flashggDiPhotonSystematics+process.flashggMuonSystematics+process.flashggElectronSystematics)*

--- a/Taggers/interface/CollectionDumper.h
+++ b/Taggers/interface/CollectionDumper.h
@@ -158,7 +158,6 @@ namespace flashgg {
        
         pdfWeightHistosBooked_=false;
 
-            std:: cout << "LC DEBUG dump PDF weights (pre-cats) ? " << dumpPdfWeights_ << std::endl;
         auto categories = cfg.getParameter<std::vector<edm::ParameterSet> >( "categories" );
         for( auto &cat : categories ) {
             auto label   = cat.getParameter<std::string>( "label" );
@@ -175,7 +174,6 @@ namespace flashgg {
             }
             if (dumpPdfWeights_ == false ) {
             dumpPdfWeights_ = cat.exists("dumpPdfWeights")? cat.getParameter<bool>( "dumpPdfWeights" ) : false;
-            std:: cout << "LC DEBUG dump PDF weights? " << dumpPdfWeights_ << std::endl;
             }
             std::string classname = ( cat.exists("className") ? cat.getParameter<std::string>( "className" ) : "" );
             //<------
@@ -212,9 +210,7 @@ namespace flashgg {
         }
 
         if(dumpPdfWeights_){
-            std::cout << "LC DEBUG DUMP PDF WEIGHTS " << std::endl;
             //if (cfg.exists("flashggPDFWeightObject")){
-            std::cout << "LC DEBUG DUMP PDF WEIGHTS 2" << std::endl;
                 pdfWeightToken_= cfg.getUntrackedParameter<edm::InputTag>("flashggPDFWeightObject",edm::InputTag("flashggPDFWeightObject"));
            // }
         }

--- a/Taggers/interface/CollectionDumper.h
+++ b/Taggers/interface/CollectionDumper.h
@@ -26,6 +26,7 @@
 #include "flashgg/MicroAOD/interface/ClassNameClassifier.h"
 #include "flashgg/MicroAOD/interface/CutAndClassBasedClassifier.h"
 #include "flashgg/Taggers/interface/GlobalVariablesDumper.h"
+#include "flashgg/DataFormats/interface/PDFWeightObject.h"
 
 #include "FWCore/Utilities/interface/Exception.h"
 
@@ -79,9 +80,10 @@ namespace flashgg {
 
     protected:
         double eventWeight( const edm::EventBase &event );
+        vector<double> pdfWeights( const edm::EventBase &event );
 
         /// float eventWeight(const edm::EventBase& event);
-        edm::InputTag src_, genInfo_;
+        edm::InputTag src_, genInfo_, pdfWeightToken_;
         std::string processId_;
         double lumiWeight_;
         int maxCandPerEvent_;
@@ -100,6 +102,11 @@ namespace flashgg {
         
         // event weight
         float weight_;
+        vector<double> pdfWeights_;
+        int pdfWeightSize_;
+        bool pdfWeightHistosBooked_;
+        bool dumpPdfWeights_;
+        int nPdfWeights_;
 
         //std::map<std::string, std::vector<dumper_type> > dumpers_; FIXME template key
         std::map< KeyT, std::vector<dumper_type> > dumpers_;
@@ -134,6 +141,10 @@ namespace flashgg {
         if( cfg.getUntrackedParameter<bool>( "quietRooFit", false ) ) {
             RooMsgService::instance().setGlobalKillBelow( RooFit::WARNING );
         }
+	    
+        
+        nPdfWeights_=0;
+        dumpPdfWeights_=false;
 
         std::map<std::string, std::string> replacements;
         replacements.insert( std::make_pair( "$COLLECTION", src_.label() ) );
@@ -144,12 +155,30 @@ namespace flashgg {
         if( dumpGlobalVariables_ ) {
             globalVarsDumper_ = new GlobalVariablesDumper( cfg.getParameter<edm::ParameterSet>( "globalVariables" ) );
         }
+       
+        pdfWeightHistosBooked_=false;
 
+            std:: cout << "LC DEBUG dump PDF weights (pre-cats) ? " << dumpPdfWeights_ << std::endl;
         auto categories = cfg.getParameter<std::vector<edm::ParameterSet> >( "categories" );
         for( auto &cat : categories ) {
             auto label   = cat.getParameter<std::string>( "label" );
             auto subcats = cat.getParameter<int>( "subcats" );
+            
+            //------->
+            //if any of the categories need pdfWeight dumping, we want to have the info in the WS
+            //the logic of this code is that dumpPdfWeights_ is false or nPdfWeights_ is 0
+            //we check to see what the category says. If any of the categories have more than 0 pdfWeight
+            //and want dumpPdfWeights_ true, then the if fails and we don't check: the value stays true or >0
+            //this relies on the fact that we want nPdfWeights the same for all cats.
+            if (nPdfWeights_ == 0) {
+            nPdfWeights_ = cat.exists("nPdfWeights") ?  cat.getParameter<int>( "nPdfWeights" ) : 0;
+            }
+            if (dumpPdfWeights_ == false ) {
+            dumpPdfWeights_ = cat.exists("dumpPdfWeights")? cat.getParameter<bool>( "dumpPdfWeights" ) : false;
+            std:: cout << "LC DEBUG dump PDF weights? " << dumpPdfWeights_ << std::endl;
+            }
             std::string classname = ( cat.exists("className") ? cat.getParameter<std::string>( "className" ) : "" );
+            //<------
             
             auto name = nameTemplate_;
             if( ! label.empty() ) {
@@ -182,10 +211,23 @@ namespace flashgg {
             }
         }
 
+        if(dumpPdfWeights_){
+            std::cout << "LC DEBUG DUMP PDF WEIGHTS " << std::endl;
+            //if (cfg.exists("flashggPDFWeightObject")){
+            std::cout << "LC DEBUG DUMP PDF WEIGHTS 2" << std::endl;
+                pdfWeightToken_= cfg.getUntrackedParameter<edm::InputTag>("flashggPDFWeightObject",edm::InputTag("flashggPDFWeightObject"));
+           // }
+        }
+
         workspaceName_ = formatString( workspaceName_, replacements );
         if( dumpWorkspace_ ) {
             ws_ = fs.make<RooWorkspace>( workspaceName_.c_str(), workspaceName_.c_str() );
             dynamic_cast<RooRealVar *>( ws_->factory( "weight[1.]" ) )->setConstant( false );
+            if (dumpPdfWeights_){
+                for( int j=0; j<nPdfWeights_;j++ ) {
+                    dynamic_cast<RooRealVar *>( ws_->factory( Form("pdfWeight_%d[1.]",j)) )->setConstant( false );
+                }
+            }
             RooRealVar* intLumi = new RooRealVar("IntLumi","IntLumi",intLumi_);
             //workspace expects intlumi in /pb
             intLumi->setConstant(); 
@@ -197,7 +239,7 @@ namespace flashgg {
         for( auto &dumpers : dumpers_ ) {
             for( auto &dumper : dumpers.second ) {
                 if( dumpWorkspace_ ) {
-                    dumper.bookRooDataset( *ws_, "weight", replacements );
+                    dumper.bookRooDataset( *ws_, "weight", replacements);
                 }
                 if( dumpTrees_ ) {
                     TFileDirectory dir = fs.mkdir( "trees" );
@@ -248,6 +290,28 @@ namespace flashgg {
         }
 
     template<class C, class T, class U>
+
+        vector<double> CollectionDumper<C, T, U>::pdfWeights( const edm::EventBase &event )
+        {   
+            vector<double> pdfWeights;
+            edm::Handle<vector<flashgg::PDFWeightObject> > WeightHandle;
+            event.getByLabel( pdfWeightToken_, WeightHandle );
+
+
+            for( unsigned int weight_index = 0; weight_index < (*WeightHandle).size(); weight_index++ ){
+                std::vector<float> uncompressed = (*WeightHandle)[weight_index].uncompress();
+                for( unsigned int j=0; j<(*WeightHandle)[weight_index].pdf_weight_container.size();j++ ) {
+                    pdfWeights.push_back(uncompressed[j]);
+                }
+            }
+
+
+            return pdfWeights;
+        }
+
+
+
+    template<class C, class T, class U>
         void CollectionDumper<C, T, U>::analyze( const edm::EventBase &event )
         {
             edm::Handle<collection_type> collectionH;
@@ -256,21 +320,25 @@ namespace flashgg {
             weight_ = eventWeight( event );
 
             if( globalVarsDumper_ ) { globalVarsDumper_->fill( event ); }
+            if( dumpPdfWeights_){
+                pdfWeights_ =pdfWeights( event );
+            }
+
             int nfilled = maxCandPerEvent_;
 
             for( auto &cand : collection ) {
                 auto cat = classifier_( cand );
                 auto which = dumpers_.find( cat.first );
-                
+
                 if( which != dumpers_.end() ) {
                     int isub = ( hasSubcat_[cat.first] ? cat.second : 0 );
                     // FIXME per-candidate weights
-                    which->second[isub].fill( cand, weight_, maxCandPerEvent_ - nfilled );
+                    which->second[isub].fill( cand, weight_, pdfWeights_, maxCandPerEvent_ - nfilled );
                     --nfilled;
                 } else if( throwOnUnclassified_ ) {
                     throw cms::Exception( "Runtime error" ) << "could not find dumper for category [" << cat.first << "," << cat.second << "]"
-                                                            << "If you want to allow this (eg because you don't want to dump some of the candidates in the collection)\n"
-                                                            << "please set throwOnUnclassified in the dumper configuration\n";
+                        << "If you want to allow this (eg because you don't want to dump some of the candidates in the collection)\n"
+                        << "please set throwOnUnclassified in the dumper configuration\n";
                 }
                 if( ( maxCandPerEvent_ > 0 )  && nfilled == 0 ) { break; }
             }

--- a/Taggers/python/dumperConfigTools.py
+++ b/Taggers/python/dumperConfigTools.py
@@ -7,7 +7,7 @@ def addCategories(pset,cats,variables,histograms,mvas=None):
         addCategory(pset,*cat,variables=variables,histograms=histograms,mvas=mvas)
 
 # -----------------------------------------------------------------------
-def addCategory(pset,label,cutbased=None,subcats=0,variables=[],histograms=[],mvas=None,classname=None,binnedOnly=None):
+def addCategory(pset,label,cutbased=None,subcats=0,variables=[],histograms=[],mvas=None,classname=None,binnedOnly=None,dumpPdfWeights=None,nPdfWeights=None):
     
    
     if subcats >= 0:
@@ -18,7 +18,10 @@ def addCategory(pset,label,cutbased=None,subcats=0,variables=[],histograms=[],mv
                           )
         if classname: catDef.className=cms.string(classname)
         if binnedOnly: catDef.binnedOnly=cms.bool(binnedOnly)
-         
+        if dumpPdfWeights: catDef.dumpPdfWeights=cms.bool(dumpPdfWeights)
+        if nPdfWeights: catDef.nPdfWeights=cms.int32(nPdfWeights)
+        
+
         addVariables( catDef.variables, variables )
         addHistograms( catDef.histograms, histograms  )
         if mvas: 


### PR DESCRIPTION
Dumps pdfWeights into workspaces:
* based off previous work by @molmedon 
* adds pdfWeigtht calculation into microAOD processing be default
* adds pdfWeight dumping into workspaces by default (nominal collections only)
* current default nWeights is 213. however, this is too many at present and will need to be adapted following an additional piece of work by @molmedon (should be 100-102).
* an exception is thrown if specified nWeights in config does not match the true number of weights.
* tested that this does not break other people's dumper using standard test with photon dumper.