### PR TITLE
this should fix the weight computation when maxEvents is set

### DIFF
--- a/MetaData/python/samples_utils.py
+++ b/MetaData/python/samples_utils.py
@@ -671,7 +671,7 @@ class SamplesManager(object):
         if not found:
             raise Exception("No dataset matched the request: /%s/%s" % ( primary, str(secondary) ))
         
-        if maxEvents > -1 and totEvents > maxEvents:
+        if jobId != -1 and maxEvents > -1 and totEvents > maxEvents:
             totWeights = maxEvents / totEvents * totWeights
             totEvents = maxEvents
         maxEvents = int(totEvents)


### PR DESCRIPTION
When submitting fggRunJobs.py jobs with maxEvents set and job splitting turned on, we found two issues related to weight computation:

1. The number of events run is typically greater than maxEvents; the number of files is chosen to reach _at least_ maxEvents, and then the final file is completed.  This behavior may be counterintuitive but is harmless, and there are no plans to fix it.
2. The set maxEvents is used in calculating the event weights, rather than the true number of events in the files to be run.  This can give weights that are off by up to (100/N)%, which is significant if only a few jobs are run because maxEvents is small.

This PR fixes item 2 only.  I need to test it before I accept it.