### PR TITLE
fix typo in sigmaIetaIeta cut for low R9 EE

### DIFF
--- a/MicroAOD/python/flashggPreselectedDiPhotons_cfi.py
+++ b/MicroAOD/python/flashggPreselectedDiPhotons_cfi.py
@@ -48,7 +48,7 @@ rediscoveryHLTcutsV1 = cms.VPSet(
                      rhocorr=phoEffArea,
                      ),
             cms.PSet(max=cms.string("6.0")),
-            cms.PSet(max=cms.string("0.015")),
+            cms.PSet(max=cms.string("0.035")),
             cms.PSet(min=cms.string("0.8"))
             ),
              )


### PR DESCRIPTION
Per email thread, we've had a typo in the sigmaIetaIeta cut for the preselection since it was updated in September. @mplaner can you confirm this is the correct fix?