### PR TITLE
Standard VBFTag dumper

### DIFF
--- a/DataFormats/interface/VBFMVAResult.h
+++ b/DataFormats/interface/VBFMVAResult.h
@@ -7,20 +7,35 @@
 
 
 namespace flashgg {
-
+    
     class VBFMVAResult
     {
-
+        
     public:
         VBFMVAResult();
-        //  VBFMVAResult(const VBFMVAResult&) = default;  // C++11 only? Should happen automagically anyway
         VBFMVAResult( edm::Ptr<VBFMVAResult> );
+        
         // diJet Info
+        flashgg::Jet leadJet;
+        flashgg::Jet subleadJet;
+        // 3rd jet
+        flashgg::Jet subsubleadJet;
 
-        Jet leadJet;
-        Jet subleadJet;
+        edm::Ptr<flashgg::Jet> leadJet_ptr;
+        edm::Ptr<flashgg::Jet> subleadJet_ptr;
+        // 3rd jet
+        edm::Ptr<flashgg::Jet> subsubleadJet_ptr; 
 
-
+        bool hasValidVBFTriJet;
+        
+        // di-photon info 
+        flashgg::DiPhotonCandidate diphoton;
+        
+        // event based variables
+        int  n_rec_jets;
+        int  n_gen_jets;
+        int  n_diphotons;
+        
         // Input variables
         float dijet_leadEta ;
         float dijet_subleadEta;
@@ -28,20 +43,31 @@ namespace flashgg {
         float dijet_LeadJPt ;
         float dijet_SubJPt;
         float dijet_Zep;
-        float dijet_dPhi_trunc;
+        float dijet_dphi_trunc;
+        float dijet_dipho_dphi;
         float dijet_Mjj;
+        float dijet_dy;
+        float dijet_leady ;
+        float dijet_subleady;
+        float dijet_dipho_pt;
+        float dijet_minDRJetPho;
+        
         float dipho_PToM;
         float leadPho_PToM;
         float sublPho_PToM;
-
+        
+        // some 3-jet based variables 
+        
         float VBFMVAValue() const {return vbfMvaResult_value;}
-
+        
         // Output
         float vbfMvaResult_value;
+        float vbfMvaResult_value_bdt;
+        float vbfMvaResult_value_bdtg;
     };
-
+    
     typedef std::map<edm::Ptr<DiPhotonCandidate>, VBFMVAResult> VBFMVAResultMap;
-
+    
 }
 
 #endif

--- a/DataFormats/interface/VBFMVAResult.h
+++ b/DataFormats/interface/VBFMVAResult.h
@@ -5,7 +5,6 @@
 #include "flashgg/DataFormats/interface/DiPhotonCandidate.h"
 #include "flashgg/DataFormats/interface/Jet.h"
 
-
 namespace flashgg {
     
     class VBFMVAResult
@@ -16,20 +15,25 @@ namespace flashgg {
         VBFMVAResult( edm::Ptr<VBFMVAResult> );
         
         // diJet Info
-        flashgg::Jet leadJet;
-        flashgg::Jet subleadJet;
+        //flashgg::Jet leadJet;
+        //flashgg::Jet subleadJet;
         // 3rd jet
-        flashgg::Jet subsubleadJet;
-
+        //flashgg::Jet subsubleadJet;
+        reco::Candidate::LorentzVector leadJet;
+        reco::Candidate::LorentzVector subleadJet;
+        reco::Candidate::LorentzVector subsubleadJet;
+        
         edm::Ptr<flashgg::Jet> leadJet_ptr;
         edm::Ptr<flashgg::Jet> subleadJet_ptr;
         // 3rd jet
         edm::Ptr<flashgg::Jet> subsubleadJet_ptr; 
-
+        // 4-vec of the 3 jets
+        
+        
         bool hasValidVBFTriJet;
         
         // di-photon info 
-        flashgg::DiPhotonCandidate diphoton;
+        // flashgg::DiPhotonCandidate diphoton;
         
         // event based variables
         int  n_rec_jets;

--- a/DataFormats/interface/VBFTag.h
+++ b/DataFormats/interface/VBFTag.h
@@ -23,7 +23,12 @@ namespace flashgg {
         const VBFMVAResult VBFMVA() const ;
         const Jet leadingJet() const; //needs to be validated
         const Jet subLeadingJet() const; //needs to be validated
-
+        const Jet subSubLeadingJet() const; //needs to be validated // 3rd Jet needed for VBF studies
+        
+        const edm::Ptr<flashgg::Jet> leadingJet_ptr() const; //needs to be validated
+        const edm::Ptr<flashgg::Jet> subLeadingJet_ptr() const; //needs to be validated
+        const edm::Ptr<flashgg::Jet> subSubLeadingJet_ptr() const; //needs to be validated // 3rd Jet needed for VBF studies
+        const bool hasValidVBFTriJet() const; 
     private:
         VBFDiPhoDiJetMVAResult vbfDiPhoDiJet_mva_result_;
     };

--- a/DataFormats/interface/VBFTag.h
+++ b/DataFormats/interface/VBFTag.h
@@ -21,9 +21,9 @@ namespace flashgg {
 
         const VBFDiPhoDiJetMVAResult VBFDiPhoDiJetMVA() const;
         const VBFMVAResult VBFMVA() const ;
-        const Jet leadingJet() const; //needs to be validated
-        const Jet subLeadingJet() const; //needs to be validated
-        const Jet subSubLeadingJet() const; //needs to be validated // 3rd Jet needed for VBF studies
+        const reco::Candidate::LorentzVector leadingJet() const; //needs to be validated
+        const reco::Candidate::LorentzVector subLeadingJet() const; //needs to be validated
+        const reco::Candidate::LorentzVector subSubLeadingJet() const; //needs to be validated // 3rd Jet needed for VBF studies
         
         const edm::Ptr<flashgg::Jet> leadingJet_ptr() const; //needs to be validated
         const edm::Ptr<flashgg::Jet> subLeadingJet_ptr() const; //needs to be validated

--- a/DataFormats/interface/VBFTagTruth.h
+++ b/DataFormats/interface/VBFTagTruth.h
@@ -5,6 +5,8 @@
 #include "DataFormats/HepMCCandidate/interface/GenParticle.h"
 #include "DataFormats/Common/interface/Ptr.h"
 #include "flashgg/DataFormats/interface/TagTruthBase.h"
+#include "flashgg/DataFormats/interface/Jet.h"
+#include "DataFormats/Math/interface/deltaR.h"
 
 namespace flashgg {
 
@@ -18,70 +20,883 @@ namespace flashgg {
         //        VBFTagTruth(const VBFTagTruth &b);
 
         // Functions for dumping
-        float pt_genJetMatchingToJ1() const { return ( hasClosestGenJetToLeadingJet() ? closestGenJetToLeadingJet()->pt() : -1. ); }
-        float eta_genJetMatchingToJ1() const { return ( hasClosestGenJetToLeadingJet() ? closestGenJetToLeadingJet()->eta() : -999. );}
-        float phi_genJetMatchingToJ1() const { return ( hasClosestGenJetToLeadingJet() ? closestGenJetToLeadingJet()->phi() : -999. );}
-        float pt_genJetMatchingToJ2() const { return ( hasClosestGenJetToSubLeadingJet() ? closestGenJetToSubLeadingJet()->pt() : -1. );}
-        float eta_genJetMatchingToJ2() const { return ( hasClosestGenJetToSubLeadingJet() ? closestGenJetToSubLeadingJet()->eta() : -999. );}
-        float phi_genJetMatchingToJ2() const { return ( hasClosestGenJetToSubLeadingJet() ? closestGenJetToSubLeadingJet()->phi() : -999. );}
-        float pt_genPartMatchingToJ1() const { return ( hasClosestParticleToLeadingJet() ? closestParticleToLeadingJet()->pt() : -1. );}
-        float eta_genPartMatchingToJ1() const { return ( hasClosestParticleToLeadingJet() ? closestParticleToLeadingJet()->eta() : -999. );}
-        float phi_genPartMatchingToJ1() const { return ( hasClosestParticleToLeadingJet() ? closestParticleToLeadingJet()->phi() : -999. );}
-        float pt_genPartMatchingToJ2() const { return ( hasClosestParticleToSubLeadingJet() ? closestParticleToSubLeadingJet()->pt() : -1. );}
-        float eta_genPartMatchingToJ2() const { return ( hasClosestParticleToSubLeadingJet() ? closestParticleToSubLeadingJet()->eta() : -999. );}
-        float phi_genPartMatchingToJ2() const { return ( hasClosestParticleToSubLeadingJet() ? closestParticleToSubLeadingJet()->phi() : -999. );}
-        float pt_genPartMatchingToPho1() const { return ( hasClosestParticleToLeadingPhoton() ? closestParticleToLeadingPhoton()->pt() : -1. );}
-        float eta_genPartMatchingToPho1() const { return ( hasClosestParticleToLeadingPhoton() ? closestParticleToLeadingPhoton()->eta() : -999. );}
-        float phi_genPartMatchingToPho1() const { return ( hasClosestParticleToLeadingPhoton() ? closestParticleToLeadingPhoton()->phi() : -999. );}
-        float pt_genPartMatchingToPho2() const { return ( hasClosestParticleToSubLeadingPhoton() ? closestParticleToSubLeadingPhoton()->pt() : -1. );}
-        float eta_genPartMatchingToPho2() const { return ( hasClosestParticleToSubLeadingPhoton() ? closestParticleToSubLeadingPhoton()->eta() : -999. );}
-        float phi_genPartMatchingToPho2() const { return ( hasClosestParticleToSubLeadingPhoton() ? closestParticleToSubLeadingPhoton()->phi() : -999. );}
-        float pt_Q1() const { return ( hasLeadingQuark() ? leadingQuark()->pt() : -1. ); }
-        float eta_Q1() const { return ( hasLeadingQuark() ? leadingQuark()->eta() : -999. ); }
-        float phi_Q1() const { return ( hasLeadingQuark() ? leadingQuark()->phi() : -999. ); }
-        float pt_Q2() const { return ( hasSubLeadingQuark() ? subLeadingQuark()->pt() : -1. ); }
-        float eta_Q2() const { return ( hasSubLeadingQuark() ? subLeadingQuark()->eta() : -999. ); }
-        float phi_Q2() const { return ( hasSubLeadingQuark() ? subLeadingQuark()->phi() : -999. ); }
+        float pt_genJetMatchingToJ1() const { return ( hasClosestGenJetToLeadingJet() ? closestGenJetToLeadingJet()->pt() : -9999. ); }
+        float eta_genJetMatchingToJ1() const { return ( hasClosestGenJetToLeadingJet() ? closestGenJetToLeadingJet()->eta() : -9999. );}
+        float phi_genJetMatchingToJ1() const { return ( hasClosestGenJetToLeadingJet() ? closestGenJetToLeadingJet()->phi() : -9999. );}
+        float pt_genJetMatchingToJ2() const { return ( hasClosestGenJetToSubLeadingJet() ? closestGenJetToSubLeadingJet()->pt() : -9999. );}
+        float eta_genJetMatchingToJ2() const { return ( hasClosestGenJetToSubLeadingJet() ? closestGenJetToSubLeadingJet()->eta() : -9999. );}
+        float phi_genJetMatchingToJ2() const { return ( hasClosestGenJetToSubLeadingJet() ? closestGenJetToSubLeadingJet()->phi() : -9999. );}
+        float pt_genJetMatchingToJ3() const { return ( hasClosestGenJetToSubSubLeadingJet() ? closestGenJetToSubSubLeadingJet()->pt() : -9999. );}
+        float eta_genJetMatchingToJ3() const { return ( hasClosestGenJetToSubSubLeadingJet() ? closestGenJetToSubSubLeadingJet()->eta() : -9999. );}
+        float phi_genJetMatchingToJ3() const { return ( hasClosestGenJetToSubSubLeadingJet() ? closestGenJetToSubSubLeadingJet()->phi() : -9999. );}
+        float pt_genPartMatchingToJ1() const { return ( hasClosestParticleToLeadingJet() ? closestParticleToLeadingJet()->pt() : -9999. );}
+        float eta_genPartMatchingToJ1() const { return ( hasClosestParticleToLeadingJet() ? closestParticleToLeadingJet()->eta() : -9999. );}
+        float phi_genPartMatchingToJ1() const { return ( hasClosestParticleToLeadingJet() ? closestParticleToLeadingJet()->phi() : -9999. );}
+        float pt_genPartMatchingToJ2() const { return ( hasClosestParticleToSubLeadingJet() ? closestParticleToSubLeadingJet()->pt() : -9999. );}
+        float eta_genPartMatchingToJ2() const { return ( hasClosestParticleToSubLeadingJet() ? closestParticleToSubLeadingJet()->eta() : -9999. );}
+        float phi_genPartMatchingToJ2() const { return ( hasClosestParticleToSubLeadingJet() ? closestParticleToSubLeadingJet()->phi() : -9999. );}
+        float pt_genPartMatchingToJ3() const { return ( hasClosestParticleToSubSubLeadingJet() ? closestParticleToSubSubLeadingJet()->pt() : -9999. );}
+        float eta_genPartMatchingToJ3() const { return ( hasClosestParticleToSubSubLeadingJet() ? closestParticleToSubSubLeadingJet()->eta() : -9999. );}
+        float phi_genPartMatchingToJ3() const { return ( hasClosestParticleToSubSubLeadingJet() ? closestParticleToSubSubLeadingJet()->phi() : -9999. );}
+        float pt_genPartMatchingToPho1() const { return ( hasClosestParticleToLeadingPhoton() ? closestParticleToLeadingPhoton()->pt() : -9999. );}
+        float eta_genPartMatchingToPho1() const { return ( hasClosestParticleToLeadingPhoton() ? closestParticleToLeadingPhoton()->eta() : -9999. );}
+        float phi_genPartMatchingToPho1() const { return ( hasClosestParticleToLeadingPhoton() ? closestParticleToLeadingPhoton()->phi() : -9999. );}
+        float pt_genPartMatchingToPho2() const { return ( hasClosestParticleToSubLeadingPhoton() ? closestParticleToSubLeadingPhoton()->pt() : -9999. );}
+        float eta_genPartMatchingToPho2() const { return ( hasClosestParticleToSubLeadingPhoton() ? closestParticleToSubLeadingPhoton()->eta() : -9999. );}
+        float phi_genPartMatchingToPho2() const { return ( hasClosestParticleToSubLeadingPhoton() ? closestParticleToSubLeadingPhoton()->phi() : -9999. );}
+        float pt_P1() const { return ( hasLeadingParton() ? leadingParton()->pt() : -9999. ); }
+        float eta_P1() const { return ( hasLeadingParton() ? leadingParton()->eta() : -9999. ); }
+        float phi_P1() const { return ( hasLeadingParton() ? leadingParton()->phi() : -9999. ); }
+        float pt_P2() const { return ( hasSubLeadingParton() ? subLeadingParton()->pt() : -9999. ); }
+        float eta_P2() const { return ( hasSubLeadingParton() ? subLeadingParton()->eta() : -9999. ); }
+        float phi_P2() const { return ( hasSubLeadingParton() ? subLeadingParton()->phi() : -9999. ); }
+        float pt_P3() const { return ( hasSubSubLeadingParton() ? subSubLeadingParton()->pt() : -9999. ); }
+        float eta_P3() const { return ( hasSubSubLeadingParton() ? subSubLeadingParton()->eta() : -9999. ); }
+        float phi_P3() const { return ( hasSubSubLeadingParton() ? subSubLeadingParton()->phi() : -9999. ); }
+        float pt_J1() const { return ( hasLeadingJet() ? leadingJet()->pt() : -9999. ); }
+        float eta_J1() const { return ( hasLeadingJet() ? leadingJet()->eta() : -9999. ); }
+        float phi_J1() const { return ( hasLeadingJet() ? leadingJet()->phi() : -9999. ); }
+        float pt_J2() const { return ( hasSubLeadingJet() ? subLeadingJet()->pt() : -9999. ); }
+        float eta_J2() const { return ( hasSubLeadingJet() ? subLeadingJet()->eta() : -9999. ); }
+        float phi_J2() const { return ( hasSubLeadingJet() ? subLeadingJet()->phi() : -9999. ); }
+        float pt_J3() const { return ( hasSubSubLeadingJet() ? subSubLeadingJet()->pt() : -9999. ); }
+        float eta_J3() const { return ( hasSubSubLeadingJet() ? subSubLeadingJet()->eta() : -9999. ); }
+        float phi_J3() const { return ( hasSubSubLeadingJet() ? subSubLeadingJet()->phi() : -9999. ); }
+
+        //DeltaRs between Jet and truth
+        float dR_genJetMatchingToJ1() const { return ( hasClosestGenJetToLeadingJet() ? deltaR(closestGenJetToLeadingJet()->eta(),closestGenJetToLeadingJet()->phi(),
+                                                                                               eta_J1(),phi_J1()) : -9999. );}
+        float dR_genJetMatchingToJ2() const { return ( hasClosestGenJetToSubLeadingJet() ? deltaR(closestGenJetToSubLeadingJet()->eta(),closestGenJetToSubLeadingJet()->phi(),
+                                                                                               eta_J2(),phi_J2()) : -9999. );}
+        float dR_genJetMatchingToJ3() const { return ( hasClosestGenJetToSubSubLeadingJet() ? deltaR(closestGenJetToSubSubLeadingJet()->eta(),closestGenJetToSubSubLeadingJet()->phi(),
+                                                                                               eta_J3(),phi_J3()) : -9999. );}
+        float dR_particleMatchingToJ1() const { return ( hasClosestParticleToLeadingJet() ? deltaR(closestParticleToLeadingJet()->eta(),closestParticleToLeadingJet()->phi(),
+                                                                                               eta_J1(),phi_J1()) : -9999. );}
+        float dR_particleMatchingToJ2() const { return ( hasClosestParticleToSubLeadingJet() ? deltaR(closestParticleToSubLeadingJet()->eta(),closestParticleToSubLeadingJet()->phi(),
+                                                                                               eta_J2(),phi_J2()) : -9999. );}
+        float dR_particleMatchingToJ3() const { return ( hasClosestParticleToSubSubLeadingJet() ? deltaR(closestParticleToSubSubLeadingJet()->eta(),closestParticleToSubSubLeadingJet()->phi(),
+                                                                                               eta_J3(),phi_J3()) : -9999. );}
+        float dR_partonMatchingToJ1() const { return ( hasLeadingJet() && hasClosestPartonToLeadingJet() ? deltaR(closestPartonToLeadingJet()->eta(),closestPartonToLeadingJet()->phi(),
+                                                                                               eta_J1(),phi_J1()) : -9999. );}
+        float dR_partonMatchingToJ2() const { return ( hasSubLeadingJet() && hasClosestPartonToSubLeadingJet() ? deltaR(closestPartonToSubLeadingJet()->eta(),closestPartonToSubLeadingJet()->phi(),
+                                                                                               eta_J2(),phi_J2()) : -9999. );}
+        float dR_partonMatchingToJ3() const { return ( hasSubSubLeadingJet() && hasClosestPartonToSubSubLeadingJet() ? deltaR(closestPartonToSubSubLeadingJet()->eta(),closestPartonToSubSubLeadingJet()->phi(),
+                                                                                               eta_J3(),phi_J3()) : -9999. );}
+                  
+
+    //MVA vars
+        //Hemispheres
+        //Flashgg jets
+        int hemisphere_J1() const { if (hasLeadingJet()) { return ( leadingJet()->eta() > 0 ? 1 : -1 ); }else{ return 0;}}
+        int hemisphere_J2() const { if (hasSubLeadingJet()) { return ( subLeadingJet()->eta() > 0 ? 1 : -1 ); }else{ return 0;}}
+        int hemisphere_J3() const { if (hasSubSubLeadingJet()) { return ( subSubLeadingJet()->eta() > 0 ? 1 : -1 ); }else{ return 0;}}
+        //GenJets
+        int hemisphere_J1_GenJet() const { if (hasClosestGenJetToLeadingJet()) { return ( closestGenJetToLeadingJet()->eta() > 0 ? 1 : -1 ); }else{ return 0;}}
+        int hemisphere_J2_GenJet() const { if (hasClosestGenJetToSubLeadingJet()) { return ( closestGenJetToSubLeadingJet()->eta() > 0 ? 1 : -1 ); }else{ return 0;}}
+        int hemisphere_J3_GenJet() const { if (hasClosestGenJetToSubSubLeadingJet()) { return ( closestGenJetToSubSubLeadingJet()->eta() > 0 ? 1 : -1 ); }else{ return 0;}}
+        //Particles
+        int hemisphere_J1_GenParticle() const { if (hasClosestParticleToLeadingJet()) { return ( closestParticleToLeadingJet()->eta() > 0 ? 1 : -1 ); }else{ return 0;}}
+        int hemisphere_J2_GenParticle() const { if (hasClosestParticleToSubLeadingJet()) { return ( closestParticleToSubLeadingJet()->eta() > 0 ? 1 : -1 ); }else{ return 0;}}
+        int hemisphere_J3_GenParticle() const { if (hasClosestParticleToSubSubLeadingJet()) { return ( closestParticleToSubSubLeadingJet()->eta() > 0 ? 1 : -1 ); }else{ return 0;}}
+        //Truth partons
+        int hemisphere_P1() const { if (hasLeadingParton()) {return (leadingParton()->eta() > 0 ? 1 : -1 ); }else{ return 0;}} 
+        int hemisphere_P2() const { if (hasSubLeadingParton()) {return (subLeadingParton()->eta() > 0 ? 1 : -1 ); }else{ return 0;}} 
+        int hemisphere_P3() const { if (hasSubSubLeadingParton()) {return (subSubLeadingParton()->eta() > 0 ? 1 : -1 ); }else{ return 0;}} 
+        //Opposite hemispheres
+        int oppHemispheres_J12() const { if (hasLeadingJet() && hasSubLeadingJet()) {return hemisphere_J1()*hemisphere_J2();}else{return 0;}}
+        int oppHemispheres_J13() const { if (hasLeadingJet() && hasSubSubLeadingJet()) {return hemisphere_J1()*hemisphere_J3();}else{return 0;}}
+        int oppHemispheres_J23() const { if (hasSubLeadingJet() && hasSubSubLeadingJet()) {return hemisphere_J2()*hemisphere_J3();}else{return 0;}}
+        int oppHemispheres_J12_GenJet() const { if (hasClosestGenJetToLeadingJet() && hasClosestGenJetToSubLeadingJet()) 
+                                              {return hemisphere_J1_GenJet()*hemisphere_J2_GenJet();}else{return 0;}}
+        int oppHemispheres_J13_GenJet() const { if (hasClosestGenJetToLeadingJet() && hasClosestGenJetToSubSubLeadingJet()) 
+                                              {return hemisphere_J1_GenJet()*hemisphere_J3_GenJet();}else{return 0;}}
+        int oppHemispheres_J23_GenJet() const { if (hasClosestGenJetToSubLeadingJet() && hasClosestGenJetToSubSubLeadingJet()) 
+                                              {return hemisphere_J2_GenJet()*hemisphere_J3_GenJet();}else{return 0;}}
+        int oppHemispheres_J12_GenParticle() const { if (hasClosestParticleToLeadingJet() && hasClosestParticleToSubLeadingJet()) 
+                                              {return hemisphere_J1_GenParticle()*hemisphere_J2_GenParticle();}else{return 0;}}
+        int oppHemispheres_J13_GenParticle() const { if (hasClosestParticleToLeadingJet() && hasClosestParticleToSubSubLeadingJet()) 
+                                              {return hemisphere_J1_GenParticle()*hemisphere_J3_GenParticle();}else{return 0;}}
+        int oppHemispheres_J23_GenParticle() const { if (hasClosestParticleToSubLeadingJet() && hasClosestParticleToSubSubLeadingJet()) 
+                                              {return hemisphere_J2_GenParticle()*hemisphere_J3_GenParticle();}else{return 0;}}
+        int oppHemispheres_P12() const { if (hasLeadingParton() && hasSubLeadingParton()) {return hemisphere_P1()*hemisphere_P2();}else{return 0;}}
+        int oppHemispheres_P13() const { if (hasLeadingParton() && hasSubSubLeadingParton()) {return hemisphere_P1()*hemisphere_P3();}else{return 0;}}
+        int oppHemispheres_P23() const { if (hasSubLeadingParton() && hasSubSubLeadingParton()) {return hemisphere_P2()*hemisphere_P3();}else{return 0;}}
+
+        //Delta Rs between jets
+        float dR_J1J2_FggJet() const {if(hasLeadingJet() && hasSubLeadingJet()) {return deltaR(leadingJet()->eta(),leadingJet()->phi(),
+                                                                               subLeadingJet()->eta(),subLeadingJet()->phi()); }else{return -9999.;}}
+        float dR_J1J3_FggJet() const {if(hasLeadingJet() && hasSubSubLeadingJet()) {return deltaR(leadingJet()->eta(),leadingJet()->phi(),
+                                                                               subSubLeadingJet()->eta(),subSubLeadingJet()->phi()); }else{return -9999.;}}
+        float dR_J2J3_FggJet() const {if(hasSubLeadingJet() && hasSubSubLeadingJet()) {return deltaR(subLeadingJet()->eta(),subLeadingJet()->phi(),
+                                                                               subSubLeadingJet()->eta(),subSubLeadingJet()->phi()); }else{return -9999.;}}
+        float dR_min_J13J23_FggJet() const {if (hasLeadingJet() && hasSubLeadingJet() && hasSubSubLeadingJet()) {
+                                            return dR_J1J3_FggJet() < dR_J2J3_FggJet() ? dR_J1J3_FggJet() : dR_J2J3_FggJet();
+                                           }else{return -9999.;}}
+        float dR_J1J2_GenJet() const {if(hasClosestGenJetToLeadingJet() && hasClosestGenJetToSubLeadingJet()) {
+                                                                 return deltaR(closestGenJetToLeadingJet()->eta(),closestGenJetToLeadingJet()->phi(),
+                                                                               closestGenJetToSubLeadingJet()->eta(),closestGenJetToSubLeadingJet()->phi());
+                                     }else{return -9999.;}}
+        float dR_J1J3_GenJet() const {if(hasClosestGenJetToLeadingJet() && hasClosestGenJetToSubSubLeadingJet()) {
+                                                                 return deltaR(closestGenJetToLeadingJet()->eta(),closestGenJetToLeadingJet()->phi(),
+                                                                               closestGenJetToSubSubLeadingJet()->eta(),closestGenJetToSubSubLeadingJet()->phi());
+                                     }else{return -9999.;}}
+        float dR_J2J3_GenJet() const {if(hasClosestGenJetToSubLeadingJet() && hasClosestGenJetToSubSubLeadingJet()) {
+                                                                 return deltaR(closestGenJetToSubLeadingJet()->eta(),closestGenJetToSubLeadingJet()->phi(),
+                                                                               closestGenJetToSubSubLeadingJet()->eta(),closestGenJetToSubSubLeadingJet()->phi());
+                                     }else{return -9999.;}}
+        float dR_J1J2_GenParticle() const {if(hasClosestParticleToLeadingJet() && hasClosestParticleToSubLeadingJet()) {
+                                                                 return deltaR(closestParticleToLeadingJet()->eta(),closestParticleToLeadingJet()->phi(),
+                                                                               closestParticleToSubLeadingJet()->eta(),closestParticleToSubLeadingJet()->phi());
+                                     }else{return -9999.;}}
+        float dR_J1J3_GenParticle() const {if(hasClosestParticleToLeadingJet() && hasClosestParticleToSubSubLeadingJet()) {
+                                                                 return deltaR(closestParticleToLeadingJet()->eta(),closestParticleToLeadingJet()->phi(),
+                                                                               closestParticleToSubSubLeadingJet()->eta(),closestParticleToSubSubLeadingJet()->phi());
+                                     }else{return -9999.;}}
+        float dR_J2J3_GenParticle() const {if(hasClosestParticleToSubLeadingJet() && hasClosestParticleToSubSubLeadingJet()) {
+                                                                 return deltaR(closestParticleToSubLeadingJet()->eta(),closestParticleToSubLeadingJet()->phi(),
+                                                                               closestParticleToSubSubLeadingJet()->eta(),closestParticleToSubSubLeadingJet()->phi());
+                                     }else{return -9999.;}}
+        float dR_P1P2_Partons() const {if(hasLeadingParton() && hasSubLeadingParton()) { return deltaR(leadingParton()->eta(),leadingParton()->phi(),
+                                                                                                       subLeadingParton()->eta(),subLeadingParton()->phi());
+                                      }else{return -9999.;}}
+        float dR_P1P3_Partons() const {if(hasLeadingParton() && hasSubSubLeadingParton()) { return deltaR(leadingParton()->eta(),leadingParton()->phi(),
+                                                                                                          subSubLeadingParton()->eta(),subSubLeadingParton()->phi());
+                                      }else{return -9999.;}}
+        float dR_P2P3_Partons() const {if(hasSubLeadingParton() && hasSubSubLeadingParton()) { return deltaR(subLeadingParton()->eta(),subLeadingParton()->phi(),
+                                                                                                             subSubLeadingParton()->eta(),subSubLeadingParton()->phi());
+                                      }else{return -9999.;}}
+       
+        //Invariant Masses 
+        //(mjj)
+        float mjj_J1J2_FggJet() const {if (hasLeadingJet() && hasSubLeadingJet()) { return (leadingJet()->p4() + subLeadingJet()->p4()).mass(); }else{return -9999.;}}
+        float mjj_J1J3_FggJet() const {if (hasLeadingJet() && hasSubSubLeadingJet()) { return (leadingJet()->p4() + subSubLeadingJet()->p4()).mass(); }else{return -9999.;}}
+        float mjj_J2J3_FggJet() const {if (hasSubLeadingJet() && hasSubSubLeadingJet()) { return (subSubLeadingJet()->p4() + subSubLeadingJet()->p4()).mass(); }else{return -9999.;}}
+        float mjj_J1J2_GenJet() const {if (hasClosestGenJetToLeadingJet() && hasClosestGenJetToSubLeadingJet()) {
+                                            return (closestGenJetToLeadingJet()->p4() + closestGenJetToSubLeadingJet()->p4()).mass(); }else{return -9999.;}}
+        float mjj_J1J3_GenJet() const {if (hasClosestGenJetToLeadingJet() && hasClosestGenJetToSubSubLeadingJet()) {
+                                            return (closestGenJetToLeadingJet()->p4() + closestGenJetToSubSubLeadingJet()->p4()).mass(); }else{return -9999.;}}
+        float mjj_J2J3_GenJet() const {if (hasClosestGenJetToSubLeadingJet() && hasClosestGenJetToSubSubLeadingJet()) {
+                                            return (closestGenJetToSubLeadingJet()->p4() + closestGenJetToSubSubLeadingJet()->p4()).mass(); }else{return -9999.;}}
+        float mjj_J1J2_GenParticle() const {if (hasClosestParticleToLeadingJet() && hasClosestParticleToSubLeadingJet()) {
+                                            return (closestParticleToLeadingJet()->p4() + closestParticleToSubLeadingJet()->p4()).mass(); }else{return -9999.;}}
+        float mjj_J1J3_GenParticle() const {if (hasClosestParticleToLeadingJet() && hasClosestParticleToSubSubLeadingJet()) {
+                                            return (closestParticleToLeadingJet()->p4() + closestParticleToSubSubLeadingJet()->p4()).mass(); }else{return -9999.;}}
+        float mjj_J2J3_GenParticle() const {if (hasClosestParticleToSubLeadingJet() && hasClosestParticleToSubSubLeadingJet()) {
+                                            return (closestParticleToSubLeadingJet()->p4() + closestParticleToSubSubLeadingJet()->p4()).mass(); }else{return -9999.;}}
+        float mjj_P1P2_Partons() const {if (hasLeadingParton() && hasSubLeadingParton()) {
+                                            return (leadingParton()->p4() + subLeadingParton()->p4()).mass();}else{return -9999.;}}
+        float mjj_P1P3_Partons() const {if (hasLeadingParton() && hasSubSubLeadingParton()) {
+                                            return (leadingParton()->p4() + subSubLeadingParton()->p4()).mass();}else{return -9999.;}}
+        float mjj_P2P3_Partons() const {if (hasSubLeadingParton() && hasSubSubLeadingParton()) {
+                                            return (subLeadingParton()->p4() + subSubLeadingParton()->p4()).mass();}else{return -9999.;}}
+        //(mjjj)
+        float mjjj_FggJet() const {if (hasLeadingJet() && hasSubLeadingJet() && hasSubSubLeadingJet()) {
+                                    return (leadingJet()->p4() + subLeadingJet()->p4() + subSubLeadingJet()->p4()).mass(); 
+                                    }else{return -9999.;}}
+        float mjjj_GenJet() const {if (hasClosestGenJetToLeadingJet() && hasClosestGenJetToSubLeadingJet() && hasClosestGenJetToSubSubLeadingJet()) {
+                                            return (closestGenJetToLeadingJet()->p4() + closestGenJetToSubLeadingJet()->p4() + closestGenJetToSubSubLeadingJet()->p4()).mass(); 
+                                    }else{return -9999.;}}
+        float mjjj_GenParticle() const {if (hasClosestParticleToLeadingJet() && hasClosestParticleToSubLeadingJet() && hasClosestParticleToSubSubLeadingJet()) {
+                                            return (closestParticleToLeadingJet()->p4() + closestParticleToSubLeadingJet()->p4() + closestParticleToSubSubLeadingJet()->p4()).mass();
+                                    }else{return -9999.;}}
+        float mjjj_Partons() const {if ( hasLeadingParton() && hasSubLeadingParton() && hasSubSubLeadingParton() ) {
+                                            return (leadingParton()->p4() + subLeadingParton()->p4() + subSubLeadingParton()->p4()).mass();
+                                    }else{return -9999.;}}
+
+        //dEtas
+        float dEta_J1J2_FggJet() const {if (hasLeadingJet() && hasSubLeadingJet()) { return fabs(leadingJet()->eta()-subLeadingJet()->eta()); }else{return -9999.;}}
+        float dEta_J1J3_FggJet() const {if (hasLeadingJet() && hasSubSubLeadingJet()) { return fabs(leadingJet()->eta()-subSubLeadingJet()->eta()); }else{return -9999.;}}
+        float dEta_J2J3_FggJet() const {if (hasSubLeadingJet() && hasSubSubLeadingJet()) { return fabs(subLeadingJet()->eta()-subSubLeadingJet()->eta()); }else{return -9999.;}}
+        float dEta_J1J2_GenJet() const {if (hasClosestGenJetToLeadingJet() && hasClosestGenJetToSubLeadingJet()) {
+                                            return fabs(closestGenJetToLeadingJet()->eta() - closestGenJetToSubLeadingJet()->eta()); }else{return -9999.;}}
+        float dEta_J1J3_GenJet() const {if (hasClosestGenJetToLeadingJet() && hasClosestGenJetToSubSubLeadingJet()) {
+                                            return fabs(closestGenJetToLeadingJet()->eta() - closestGenJetToSubSubLeadingJet()->eta()); }else{return -9999.;}}
+        float dEta_J2J3_GenJet() const {if (hasClosestGenJetToSubLeadingJet() && hasClosestGenJetToSubSubLeadingJet()) {
+                                            return fabs(closestGenJetToSubLeadingJet()->eta() - closestGenJetToSubSubLeadingJet()->eta()); }else{return -9999.;}}
+        float dEta_J1J2_GenParticle() const {if (hasClosestParticleToLeadingJet() && hasClosestParticleToSubLeadingJet()) {
+                                            return fabs(closestParticleToLeadingJet()->eta() - closestParticleToSubLeadingJet()->eta()); }else{return -9999.;}}
+        float dEta_J1J3_GenParticle() const {if (hasClosestParticleToLeadingJet() && hasClosestParticleToSubSubLeadingJet()) {
+                                            return fabs(closestParticleToLeadingJet()->eta() - closestParticleToSubSubLeadingJet()->eta()); }else{return -9999.;}}
+        float dEta_J2J3_GenParticle() const {if (hasClosestParticleToSubLeadingJet() && hasClosestParticleToSubSubLeadingJet()) {
+                                            return fabs(closestParticleToSubLeadingJet()->eta() - closestParticleToSubSubLeadingJet()->eta()); }else{return -9999.;}}
+        float dEta_P1P2_Partons() const {if (hasLeadingParton() && hasSubLeadingParton()) {
+                                            return fabs(leadingParton()->eta()-subLeadingParton()->eta()); }else{return -9999.;}}
+        float dEta_P1P3_Partons() const {if (hasLeadingParton() && hasSubSubLeadingParton()) {
+                                            return fabs(leadingParton()->eta() - subSubLeadingParton()->eta()); }else{return -9999.;}}
+        float dEta_P2P3_Partons() const {if (hasSubLeadingParton() && hasSubSubLeadingParton()) {
+                                            return fabs(subLeadingParton()->eta() - subSubLeadingParton()->eta()); }else{return -9999.;}}
+        //Zeppenfelds
+        //(Zepjj)
+        float zepjj_J1J2_FggJet() const {if (hasLeadingJet() && hasSubLeadingJet()) {
+                                            return fabs(diPhoton()->eta() - 0.5*(leadingJet()->eta() + subLeadingJet()->eta())); }else{return -9999.;}}
+        float zepjj_J1J3_FggJet() const {if (hasLeadingJet() && hasSubSubLeadingJet()) {
+                                            return fabs(diPhoton()->eta() - 0.5*(leadingJet()->eta() + subSubLeadingJet()->eta())); }else{return -9999.;}}
+        float zepjj_J2J3_FggJet() const {if (hasSubLeadingJet() && hasSubSubLeadingJet()) {
+                                            return fabs(diPhoton()->eta() - 0.5*(subLeadingJet()->eta() + subSubLeadingJet()->eta())); }else{return -9999.;}}
+        float zepjj_J1J2_GenJet() const {if (hasClosestGenJetToLeadingJet() && hasClosestGenJetToSubLeadingJet()) {
+                                            return fabs(diPhoton()->eta() - 0.5*(closestGenJetToLeadingJet()->eta() + closestGenJetToSubLeadingJet()->eta())); 
+                                         }else{return -9999.;}}
+        float zepjj_J1J3_GenJet() const {if (hasClosestGenJetToLeadingJet() && hasClosestGenJetToSubSubLeadingJet()) {
+                                            return fabs(diPhoton()->eta() - 0.5*(closestGenJetToLeadingJet()->eta() + closestGenJetToSubSubLeadingJet()->eta())); 
+                                         }else{return -9999.;}}
+        float zepjj_J2J3_GenJet() const {if (hasClosestGenJetToSubLeadingJet() && hasClosestGenJetToSubSubLeadingJet()) {
+                                            return fabs(diPhoton()->eta() - 0.5*(closestGenJetToSubLeadingJet()->eta() + closestGenJetToSubSubLeadingJet()->eta()));
+                                         }else{return -9999.;}}
+        float zepjj_J1J2_GenParticle() const {if (hasClosestParticleToLeadingJet() && hasClosestParticleToSubLeadingJet()) {
+                                            return fabs(diPhoton()->eta() - 0.5*(closestParticleToLeadingJet()->eta() + closestParticleToSubLeadingJet()->eta()));
+                                           }else{return -9999.;}}
+        float zepjj_J1J3_GenParticle() const {if (hasClosestParticleToLeadingJet() && hasClosestParticleToSubSubLeadingJet()) {
+                                            return fabs(diPhoton()->eta() - 0.5*(closestParticleToLeadingJet()->eta() + closestParticleToSubSubLeadingJet()->eta())); 
+                                           }else{return -9999.;}}
+        float zepjj_J2J3_GenParticle() const {if (hasClosestParticleToSubLeadingJet() && hasClosestParticleToSubSubLeadingJet()) {
+                                            return fabs(diPhoton()->eta() - 0.5*(closestParticleToSubLeadingJet()->eta() + closestParticleToSubSubLeadingJet()->eta())); 
+                                           }else{return -9999.;}}
+        float zepjj_P1P2_Partons() const {if (hasLeadingParton() && hasSubLeadingParton()) {
+                                            return fabs(diPhoton()->eta() - 0.5*(leadingParton()->eta() + subLeadingParton()->eta())); }else{return -9999.;}}
+        float zepjj_P1P3_Partons() const {if (hasLeadingParton() && hasSubSubLeadingParton()) {
+                                            return fabs(diPhoton()->eta() - 0.5*(leadingParton()->eta() + subSubLeadingParton()->eta())); }else{return -9999.;}}
+        float zepjj_P2P3_Partons() const {if (hasSubLeadingParton() && hasSubSubLeadingParton()) {
+                                            return fabs(diPhoton()->eta() - 0.5*(subLeadingParton()->eta() + subSubLeadingParton()->eta())); }else{return -9999.;}}
+        //(Zepjjj)
+        float zepjjj_FggJet() const {if (hasLeadingJet() && hasSubLeadingJet() && hasSubSubLeadingJet()) {
+                                            return fabs(diPhoton()->eta() - (leadingJet()->eta() + subLeadingJet()->eta() + subSubLeadingJet()->eta())/3 ); 
+                                    }else{return -9999.;}}
+        float zepjjj_GenJet() const {if (hasClosestGenJetToLeadingJet() && hasClosestGenJetToSubLeadingJet() && hasClosestGenJetToSubSubLeadingJet()) {
+                                            return fabs(diPhoton()->eta() - (closestGenJetToLeadingJet()->eta() + closestGenJetToSubLeadingJet()->eta() 
+                                                                                + closestGenJetToSubSubLeadingJet()->eta())/3); }else{return -9999.;}}
+        float zepjjj_GenParticle() const {if (hasClosestParticleToLeadingJet() && hasClosestParticleToSubLeadingJet() && hasClosestParticleToSubSubLeadingJet()) {
+                                            return fabs(diPhoton()->eta() - (closestParticleToLeadingJet()->eta() + closestParticleToSubLeadingJet()->eta() 
+                                                                                + closestParticleToSubSubLeadingJet()->eta())/3); }else{return -9999.;}}
+        float zepjjj_Partons() const {if (hasLeadingParton() && hasSubLeadingParton() && hasSubSubLeadingParton()) {
+                                            return fabs(diPhoton()->eta() - (leadingParton()->eta() + subLeadingParton()->eta() + subSubLeadingParton()->eta())); 
+                                      }else{return -9999.;}}
+        //dPhi
+        //(jj)
+        float dPhijj_J1J2_FggJet() const {if (hasLeadingJet() && hasSubLeadingJet()) {
+                                            return fabs(deltaPhi(diPhoton()->phi(),(leadingJet()->p4()+subLeadingJet()->p4()).phi())); }else{return -9999.;}}       
+        float dPhijj_J1J3_FggJet() const {if (hasLeadingJet() && hasSubSubLeadingJet()) {
+                                            return fabs(deltaPhi(diPhoton()->phi(),(leadingJet()->p4()+subSubLeadingJet()->p4()).phi())); }else{return -9999.;}}       
+        float dPhijj_J2J3_FggJet() const {if (hasSubLeadingJet() && hasSubSubLeadingJet()) {
+                                            return fabs(deltaPhi(diPhoton()->phi(),(subLeadingJet()->p4()+subSubLeadingJet()->p4()).phi())); }else{return -9999.;}}       
+        float dPhijj_J1J2_GenJet() const {if (hasClosestGenJetToLeadingJet() && hasClosestGenJetToSubLeadingJet()) {
+                                            return fabs(deltaPhi(diPhoton()->phi(),(closestGenJetToLeadingJet()->p4() + closestGenJetToSubLeadingJet()->p4()).phi())); 
+                                          }else{return -9999.;}}
+        float dPhijj_J1J3_GenJet() const {if (hasClosestGenJetToLeadingJet() && hasClosestGenJetToSubSubLeadingJet()) {
+                                            return fabs(deltaPhi(diPhoton()->phi(),(closestGenJetToLeadingJet()->p4() + closestGenJetToSubSubLeadingJet()->p4()).phi()));
+                                          }else{return -9999.;}}
+        float dPhijj_J2J3_GenJet() const {if (hasClosestGenJetToSubLeadingJet() && hasClosestGenJetToSubSubLeadingJet()) {
+                                            return fabs(deltaPhi(diPhoton()->phi(),(closestGenJetToSubLeadingJet()->p4() + closestGenJetToSubSubLeadingJet()->p4()).phi()));
+                                         }else{return -9999.;}}
+        float dPhijj_J1J2_GenParticle() const {if (hasClosestParticleToLeadingJet() && hasClosestParticleToSubLeadingJet()) {
+                                            return fabs(deltaPhi(diPhoton()->phi(),(closestParticleToLeadingJet()->p4() + closestParticleToSubLeadingJet()->p4()).phi()));
+                                         }else{return -9999.;}}
+        float dPhijj_J1J3_GenParticle() const {if (hasClosestParticleToLeadingJet() && hasClosestParticleToSubSubLeadingJet()) {
+                                            return fabs(deltaPhi(diPhoton()->phi(),(closestParticleToLeadingJet()->p4() + closestParticleToSubSubLeadingJet()->p4()).phi()));
+                                         }else{return -9999.;}}
+        float dPhijj_J2J3_GenParticle() const {if (hasClosestParticleToSubLeadingJet() && hasClosestParticleToSubSubLeadingJet()) {
+                                            return fabs(deltaPhi(diPhoton()->phi(),(closestParticleToSubLeadingJet()->p4() + closestParticleToSubSubLeadingJet()->p4()).phi()));
+                                         }else{return -9999.;}}
+        float dPhijj_P1P2_Partons()  const {if (hasLeadingParton() && hasSubLeadingParton()) {
+                                            return fabs(deltaPhi(diPhoton()->phi(),(leadingParton()->p4() + subLeadingParton()->p4()).phi())); }else{return -9999.;}}
+        float dPhijj_P1P3_Partons()  const {if (hasLeadingParton() && hasSubSubLeadingParton()) {
+                                            return fabs(deltaPhi(diPhoton()->phi(),(leadingParton()->p4() + subSubLeadingParton()->p4()).phi())); }else{return -9999.;}}
+        float dPhijj_P2P3_Partons()  const {if (hasSubLeadingParton() && hasSubSubLeadingParton()) {
+                                            return fabs(deltaPhi(diPhoton()->phi(),(subLeadingParton()->p4() + subSubLeadingParton()->p4()).phi())); }else{return -9999.;}}
+        //(jjj)
+        float dPhijjj_FggJet() const {if (hasLeadingJet() && hasSubLeadingJet() && hasSubSubLeadingJet()) {
+                                            return fabs(deltaPhi(diPhoton()->phi(),(leadingJet()->p4()+subLeadingJet()->p4()+subSubLeadingJet()->p4()).phi()));
+                                      }else{return -9999.;}}       
+        float dPhijjj_GenJet() const {if (hasClosestGenJetToLeadingJet() && hasClosestGenJetToSubLeadingJet() && hasClosestGenJetToSubSubLeadingJet()) {
+                                            return fabs(deltaPhi(diPhoton()->phi(),(closestGenJetToLeadingJet()->p4() + closestGenJetToSubLeadingJet()->p4()
+                                                                                +closestGenJetToSubSubLeadingJet()->p4()).phi())); }else{return -9999.;}}
+        float dPhijjj_GenParticle() const {if (hasClosestParticleToLeadingJet() && hasClosestParticleToSubLeadingJet() && hasClosestParticleToSubSubLeadingJet()) {
+                                            return fabs(deltaPhi(diPhoton()->phi(),(closestParticleToLeadingJet()->p4() + closestParticleToSubLeadingJet()->p4()
+                                                                                +closestParticleToSubSubLeadingJet()->p4()).phi())); }else{return -9999.;}}
+        float dPhijjj_Partons() const {if (hasLeadingParton() && hasSubLeadingParton() && hasSubSubLeadingParton()) {
+                                            return fabs(deltaPhi(diPhoton()->phi(),(leadingParton()->p4()+subLeadingParton()->p4()+subSubLeadingParton()->p4()).phi()));
+                                       }else{return -9999.;}}
+
+        //3Jet eta minus diff in eta
+        float dEta_J1J2J3_FggJet() const {if (hasLeadingJet() && hasSubLeadingJet() && hasSubSubLeadingJet()) {return fabs(eta_J1()-fabs(eta_J2()-eta_J3()));}else{return -9999.;}}
+        float dEta_J2J3J1_FggJet() const {if (hasLeadingJet() && hasSubLeadingJet() && hasSubSubLeadingJet()) {return fabs(eta_J2()-fabs(eta_J3()-eta_J1()));}else{return -9999.;}}
+        float dEta_J3J1J2_FggJet() const {if (hasLeadingJet() && hasSubLeadingJet() && hasSubSubLeadingJet()) {return fabs(eta_J3()-fabs(eta_J1()-eta_J2()));}else{return -9999.;}}
+        float dEta_J1J2J3_GenJet() const {if (hasClosestGenJetToLeadingJet() && hasClosestGenJetToSubLeadingJet() && hasClosestGenJetToSubSubLeadingJet()) 
+                                          {return fabs(eta_genJetMatchingToJ1() - fabs (eta_genJetMatchingToJ2()-eta_genJetMatchingToJ3()));}else{return 999.;}}
+        float dEta_J2J3J1_GenJet() const {if (hasClosestGenJetToLeadingJet() && hasClosestGenJetToSubLeadingJet() && hasClosestGenJetToSubSubLeadingJet()) 
+                                          {return fabs(eta_genJetMatchingToJ2() - fabs (eta_genJetMatchingToJ3()-eta_genJetMatchingToJ1()));}else{return 999.;}}
+        float dEta_J3J1J2_GenJet() const {if (hasClosestGenJetToLeadingJet() && hasClosestGenJetToSubLeadingJet() && hasClosestGenJetToSubSubLeadingJet()) 
+                                          {return fabs(eta_genJetMatchingToJ3() - fabs (eta_genJetMatchingToJ1()-eta_genJetMatchingToJ2()));}else{return 999.;}}
+        float dEta_J1J2J3_GenParticle() const {if (hasClosestParticleToLeadingJet() && hasClosestParticleToSubLeadingJet() && hasClosestParticleToSubSubLeadingJet()) 
+                                          {return fabs(eta_genJetMatchingToJ1() - fabs (eta_genJetMatchingToJ2()-eta_genJetMatchingToJ3()));}else{return 999.;}}
+        float dEta_J2J3J1_GenParticle() const {if (hasClosestParticleToLeadingJet() && hasClosestParticleToSubLeadingJet() && hasClosestParticleToSubSubLeadingJet()) 
+                                          {return fabs(eta_genJetMatchingToJ2() - fabs (eta_genJetMatchingToJ3()-eta_genJetMatchingToJ1()));}else{return 999.;}}
+        float dEta_J3J1J2_GenParticle() const {if (hasClosestParticleToLeadingJet() && hasClosestParticleToSubLeadingJet() && hasClosestParticleToSubSubLeadingJet()) 
+                                          {return fabs(eta_genJetMatchingToJ3() - fabs (eta_genJetMatchingToJ1()-eta_genJetMatchingToJ2()));}else{return 999.;}}
+        float dEta_P1P2P3_Partons() const {if (hasLeadingParton() && hasSubLeadingParton() && hasSubSubLeadingParton()) 
+                                          {return fabs(eta_P1()-fabs(eta_P2()-eta_P3()));}else{return -9999.;}}
+        float dEta_P2P3P1_Partons() const {if (hasLeadingParton() && hasSubLeadingParton() && hasSubSubLeadingParton()) 
+                                          {return fabs(eta_P2()-fabs(eta_P3()-eta_P1()));}else{return -9999.;}}
+        float dEta_P3P1P2_Partons() const {if (hasLeadingParton() && hasSubLeadingParton() && hasSubSubLeadingParton()) 
+                                          {return fabs(eta_P3()-fabs(eta_P1()-eta_P2()));}else{return -9999.;}}
+
+        //3Jet eta of jet  minus mean of other two jets
+        float dEta_dJ1_J2J3_FggJet() const {if (hasLeadingJet() && hasSubLeadingJet() && hasSubSubLeadingJet()) {return fabs(eta_J1() - 0.5*(eta_J2()+eta_J3()));}else{return -9999.;}}
+        float dEta_dJ2_J3J1_FggJet() const {if (hasLeadingJet() && hasSubLeadingJet() && hasSubSubLeadingJet()) {return fabs(eta_J2() - 0.5*(eta_J3()+eta_J1()));}else{return -9999.;}}
+        float dEta_dJ3_J1J2_FggJet() const {if (hasLeadingJet() && hasSubLeadingJet() && hasSubSubLeadingJet()) {return fabs(eta_J3() - 0.5*(eta_J1()+eta_J2()));}else{return -9999.;}}
+        float dEta_dJ1_J2J3_GenJet() const {if (hasClosestGenJetToLeadingJet() && hasClosestGenJetToSubLeadingJet() && hasClosestGenJetToSubSubLeadingJet()) 
+                                           {return fabs(eta_genJetMatchingToJ1() - 0.5*(eta_genJetMatchingToJ2()+eta_genJetMatchingToJ3()));}else{return -9999.;}}
+        float dEta_dJ2_J3J1_GenJet() const {if (hasClosestGenJetToLeadingJet() && hasClosestGenJetToSubLeadingJet() && hasClosestGenJetToSubSubLeadingJet()) 
+                                           {return fabs(eta_genJetMatchingToJ2() - 0.5*(eta_genJetMatchingToJ3()+eta_genJetMatchingToJ1()));}else{return -9999.;}}
+        float dEta_dJ3_J1J2_GenJet() const {if (hasClosestGenJetToLeadingJet() && hasClosestGenJetToSubLeadingJet() && hasClosestGenJetToSubSubLeadingJet()) 
+                                           {return fabs(eta_genJetMatchingToJ3() - 0.5*(eta_genJetMatchingToJ1()+eta_genJetMatchingToJ2()));}else{return -9999.;}}
+        float dEta_dJ1_J2J3_GenParticle() const {if (hasClosestParticleToLeadingJet() && hasClosestParticleToSubLeadingJet() && hasClosestParticleToSubSubLeadingJet()) 
+                                           {return fabs(eta_genJetMatchingToJ1() - 0.5*(eta_genJetMatchingToJ2()+eta_genJetMatchingToJ3()));}else{return -9999.;}}
+        float dEta_dJ2_J3J1_GenParticle() const {if (hasClosestParticleToLeadingJet() && hasClosestParticleToSubLeadingJet() && hasClosestParticleToSubSubLeadingJet()) 
+                                           {return fabs(eta_genJetMatchingToJ2() - 0.5*(eta_genJetMatchingToJ3()+eta_genJetMatchingToJ1()));}else{return -9999.;}}
+        float dEta_dJ3_J1J2_GenParticle() const {if (hasClosestParticleToLeadingJet() && hasClosestParticleToSubLeadingJet() && hasClosestParticleToSubSubLeadingJet()) 
+                                           {return fabs(eta_genJetMatchingToJ3() - 0.5*(eta_genJetMatchingToJ1()+eta_genJetMatchingToJ2()));}else{return -9999.;}}
+        float dEta_dJ1_J2J3_Parton() const {if (hasLeadingParton() && hasSubLeadingParton() && hasSubSubLeadingParton()) 
+                                           {return fabs(eta_J1() - 0.5*(eta_J2()+eta_J3()));}else{return -9999.;}}
+        float dEta_dJ2_J3J1_Parton() const {if (hasLeadingParton() && hasSubLeadingParton() && hasSubSubLeadingParton())    
+                                           {return fabs(eta_J2() - 0.5*(eta_J3()+eta_J1()));}else{return -9999.;}}
+        float dEta_dJ3_J1J2_Parton() const {if (hasLeadingParton() && hasSubLeadingParton() && hasSubSubLeadingParton()) 
+                                           {return fabs(eta_J3() - 0.5*(eta_J1()+eta_J2()));}else{return -9999.;}}
+
+        //3Jet mjj differences
+        float mjj_d12_13plus23_FggJet() const {if (hasLeadingJet() && hasSubLeadingJet() && hasSubSubLeadingJet()) {
+                                              return (mjj_J1J2_FggJet() - mjj_J1J3_FggJet() - mjj_J2J3_FggJet());}else{return -9999.;}}
+        float mjj_d12_13_FggJet() const {if (hasLeadingJet() && hasSubLeadingJet() && hasSubSubLeadingJet()) {
+                                              return (mjj_J1J2_FggJet() - mjj_J1J3_FggJet());}else{return -9999.;}}
+        float mjj_d12_23_FggJet() const {if (hasLeadingJet() && hasSubLeadingJet() && hasSubSubLeadingJet()) {
+                                              return (mjj_J1J2_FggJet() - mjj_J2J3_FggJet());}else{return -9999.;}}
+        float mjj_d13_23_FggJet() const {if (hasLeadingJet() && hasSubLeadingJet() && hasSubSubLeadingJet()) {
+                                              return (mjj_J1J3_FggJet() - mjj_J2J3_FggJet());}else{return -9999.;}}
+        float mjj_d12_13plus23_GenJet() const {if (hasClosestGenJetToLeadingJet() && hasClosestGenJetToSubLeadingJet() && hasClosestGenJetToSubSubLeadingJet()) {
+                                              return (mjj_J1J2_GenJet() - mjj_J1J3_GenJet() - mjj_J2J3_GenJet());}else{return -9999.;}}
+        float mjj_d12_13_GenJet() const {if (hasClosestGenJetToLeadingJet() && hasClosestGenJetToSubLeadingJet() && hasClosestGenJetToSubSubLeadingJet()) {
+                                              return (mjj_J1J2_GenJet() - mjj_J1J3_GenJet());}else{return -9999.;}}
+        float mjj_d12_23_GenJet() const {if (hasClosestGenJetToLeadingJet() && hasClosestGenJetToSubLeadingJet() && hasClosestGenJetToSubSubLeadingJet()) {
+                                              return (mjj_J1J2_GenJet() - mjj_J2J3_GenJet());}else{return -9999.;}}
+        float mjj_d13_23_GenJet() const {if (hasClosestGenJetToLeadingJet() && hasClosestGenJetToSubLeadingJet() && hasClosestGenJetToSubSubLeadingJet()) {
+                                              return (mjj_J1J3_GenJet() - mjj_J2J3_GenJet());}else{return -9999.;}}
+        float mjj_d12_13plus23_GenParticle() const {if (hasClosestParticleToLeadingJet() && hasClosestParticleToSubLeadingJet() && hasClosestParticleToSubSubLeadingJet()) {
+                                              return (mjj_J1J2_GenParticle() - mjj_J1J3_GenParticle() - mjj_J2J3_GenParticle());}else{return -9999.;}}
+        float mjj_d12_13_GenParticle() const {if (hasClosestParticleToLeadingJet() && hasClosestParticleToSubLeadingJet() && hasClosestParticleToSubSubLeadingJet()) {
+                                              return (mjj_J1J2_GenParticle() - mjj_J1J3_GenParticle());}else{return -9999.;}}
+        float mjj_d12_23_GenParticle() const {if (hasClosestParticleToLeadingJet() && hasClosestParticleToSubLeadingJet() && hasClosestParticleToSubSubLeadingJet()) {
+                                              return (mjj_J1J2_GenParticle() - mjj_J2J3_GenParticle());}else{return -9999.;}}
+        float mjj_d13_23_GenParticle() const {if (hasClosestParticleToLeadingJet() && hasClosestParticleToSubLeadingJet() && hasClosestParticleToSubSubLeadingJet()) {
+                                              return (mjj_J1J3_GenParticle() - mjj_J2J3_GenParticle());}else{return -9999.;}}
+        float mjj_d12_13plus23_Partons() const {if (hasLeadingParton() && hasSubLeadingParton() && hasSubSubLeadingParton()) {
+                                              return (mjj_P1P2_Partons() - mjj_P1P3_Partons() - mjj_P2P3_Partons());}else{return -9999.;}}
+        float mjj_d12_13_Partons() const {if (hasLeadingParton() && hasSubLeadingParton() && hasSubSubLeadingParton()) {
+                                              return (mjj_P1P2_Partons() - mjj_P1P3_Partons());}else{return -9999.;}}
+        float mjj_d12_23_Partons() const {if (hasLeadingParton() && hasSubLeadingParton() && hasSubSubLeadingParton()) {
+                                              return (mjj_P1P2_Partons() - mjj_P2P3_Partons());}else{return -9999.;}}
+        float mjj_d13_23_Partons() const {if (hasLeadingParton() && hasSubLeadingParton() && hasSubSubLeadingParton()) {
+                                              return (mjj_P1P3_Partons() - mjj_P2P3_Partons());}else{return -9999.;}}
+
+        //DeltaRs between dijets and diphotons
+        float dR_DP_12_FggJet() const {if (hasLeadingJet() && hasSubLeadingJet() && hasSubSubLeadingJet()) {
+                                       return deltaR(diPhoton()->eta(),diPhoton()->phi(),(leadingJet()->p4()+subLeadingJet()->p4()).eta(),
+                                                    (leadingJet()->p4()+subLeadingJet()->p4()).phi());}else{return -9999.;}}
+        float dR_DP_13_FggJet() const {if (hasLeadingJet() && hasSubLeadingJet() && hasSubSubLeadingJet()) {
+                                       return deltaR(diPhoton()->eta(),diPhoton()->phi(),(leadingJet()->p4()+subSubLeadingJet()->p4()).eta(),
+                                                    (leadingJet()->p4()+subSubLeadingJet()->p4()).phi());}else{return -9999.;}}
+        float dR_DP_23_FggJet() const {if (hasLeadingJet() && hasSubLeadingJet() && hasSubSubLeadingJet()) {
+                                       return deltaR(diPhoton()->eta(),diPhoton()->phi(),(subLeadingJet()->p4()+subSubLeadingJet()->p4()).eta(),
+                                                    (subLeadingJet()->p4()+subSubLeadingJet()->p4()).phi());}else{return -9999.;}}
+        float dR_DP_12_GenJet() const {if (hasClosestGenJetToLeadingJet() && hasClosestGenJetToSubLeadingJet() && hasClosestGenJetToSubSubLeadingJet()) {
+                                       return deltaR(diPhoton()->eta(),diPhoton()->phi(),(closestGenJetToLeadingJet()->p4()+closestGenJetToSubLeadingJet()->p4()).eta(),
+                                                    (closestGenJetToLeadingJet()->p4()+closestGenJetToSubLeadingJet()->p4()).phi());}else{return -9999.;}}
+        float dR_DP_13_GenJet() const {if (hasClosestGenJetToLeadingJet() && hasClosestGenJetToSubLeadingJet() && hasClosestGenJetToSubSubLeadingJet()) {
+                                       return deltaR(diPhoton()->eta(),diPhoton()->phi(),(closestGenJetToLeadingJet()->p4()+closestGenJetToSubSubLeadingJet()->p4()).eta(),
+                                                    (closestGenJetToLeadingJet()->p4()+closestGenJetToSubSubLeadingJet()->p4()).phi());}else{return -9999.;}}
+        float dR_DP_23_GenJet() const {if (hasClosestGenJetToLeadingJet() && hasClosestGenJetToSubLeadingJet() && hasClosestGenJetToSubSubLeadingJet()) {
+                                       return deltaR(diPhoton()->eta(),diPhoton()->phi(),(closestGenJetToSubLeadingJet()->p4()+closestGenJetToSubSubLeadingJet()->p4()).eta(),
+                                                    (closestGenJetToSubLeadingJet()->p4()+closestGenJetToSubSubLeadingJet()->p4()).phi());}else{return -9999.;}}
+        float dR_DP_12_GenParticle() const {if (hasClosestParticleToLeadingJet() && hasClosestParticleToSubLeadingJet() && hasClosestParticleToSubSubLeadingJet()) {
+                                       return deltaR(diPhoton()->eta(),diPhoton()->phi(),(closestParticleToLeadingJet()->p4()+closestParticleToSubLeadingJet()->p4()).eta(),
+                                                    (closestParticleToLeadingJet()->p4()+closestParticleToSubLeadingJet()->p4()).phi());}else{return -9999.;}}
+        float dR_DP_13_GenParticle() const {if (hasClosestParticleToLeadingJet() && hasClosestParticleToSubLeadingJet() && hasClosestParticleToSubSubLeadingJet()) {
+                                       return deltaR(diPhoton()->eta(),diPhoton()->phi(),(closestParticleToLeadingJet()->p4()+closestParticleToSubSubLeadingJet()->p4()).eta(),
+                                                    (closestParticleToLeadingJet()->p4()+closestParticleToSubSubLeadingJet()->p4()).phi());}else{return -9999.;}}
+        float dR_DP_23_GenParticle() const {if (hasClosestParticleToLeadingJet() && hasClosestParticleToSubLeadingJet() && hasClosestParticleToSubSubLeadingJet()) {
+                                       return deltaR(diPhoton()->eta(),diPhoton()->phi(),(closestParticleToSubLeadingJet()->p4()+closestParticleToSubSubLeadingJet()->p4()).eta(),
+                                                    (closestParticleToSubLeadingJet()->p4()+closestParticleToSubSubLeadingJet()->p4()).phi());}else{return -9999.;}}
+        float dR_DP_12_Partons() const {if (hasLeadingParton() && hasSubLeadingParton() && hasSubSubLeadingParton()) {
+                                       return deltaR(diPhoton()->eta(),diPhoton()->phi(),(leadingParton()->p4()+subLeadingParton()->p4()).eta(),
+                                                    (leadingParton()->p4()+subLeadingParton()->p4()).phi());}else{return -9999.;}}
+        float dR_DP_13_Partons() const {if (hasLeadingParton() && hasSubLeadingParton() && hasSubSubLeadingParton()) {
+                                       return deltaR(diPhoton()->eta(),diPhoton()->phi(),(leadingParton()->p4()+subSubLeadingParton()->p4()).eta(),
+                                                    (leadingParton()->p4()+subSubLeadingParton()->p4()).phi());}else{return -9999.;}}
+        float dR_DP_23_Partons() const {if (hasLeadingParton() && hasSubLeadingParton() && hasSubSubLeadingParton()) {
+                                       return deltaR(diPhoton()->eta(),diPhoton()->phi(),(subLeadingParton()->p4()+subSubLeadingParton()->p4()).eta(),
+                                                    (subLeadingParton()->p4()+subSubLeadingParton()->p4()).phi());}else{return -9999.;}}
+
+        //DeltaRs between individual jets and photons
+        float dR_Ph1_1_FggJet() const {if (hasLeadingJet()) { return deltaR(diPhoton()->leadingPhoton()->eta(),diPhoton()->leadingPhoton()->phi(),
+                                                                     leadingJet()->eta(),leadingJet()->phi()); }else{return -9999.;}}
+        float dR_Ph1_2_FggJet() const {if (hasSubLeadingJet()) { return deltaR(diPhoton()->leadingPhoton()->eta(),diPhoton()->leadingPhoton()->phi(),
+                                                                     subLeadingJet()->eta(),subLeadingJet()->phi()); }else{return -9999.;}}
+        float dR_Ph1_3_FggJet() const {if (hasSubSubLeadingJet()) { return deltaR(diPhoton()->leadingPhoton()->eta(),diPhoton()->leadingPhoton()->phi(),
+                                                                     subSubLeadingJet()->eta(),subSubLeadingJet()->phi()); }else{return -9999.;}}
+        float dR_Ph2_1_FggJet() const {if (hasLeadingJet()) { return deltaR(diPhoton()->subLeadingPhoton()->eta(),diPhoton()->subLeadingPhoton()->phi(),
+                                                                     leadingJet()->eta(),leadingJet()->phi()); }else{return -9999.;}}
+        float dR_Ph2_2_FggJet() const {if (hasSubLeadingJet()) { return deltaR(diPhoton()->subLeadingPhoton()->eta(),diPhoton()->subLeadingPhoton()->phi(),
+                                                                     subLeadingJet()->eta(),subLeadingJet()->phi()); }else{return -9999.;}}
+        float dR_Ph2_3_FggJet() const {if (hasSubSubLeadingJet()) { return deltaR(diPhoton()->subLeadingPhoton()->eta(),diPhoton()->subLeadingPhoton()->phi(),
+                                                                     subSubLeadingJet()->eta(),subSubLeadingJet()->phi()); }else{return -9999.;}}
+        float dR_Ph1_1_GenJet() const {if (hasClosestGenJetToLeadingJet()) { return deltaR(diPhoton()->leadingPhoton()->eta(),diPhoton()->leadingPhoton()->phi(),
+                                                                     closestGenJetToLeadingJet()->eta(),closestGenJetToLeadingJet()->phi()); }else{return -9999.;}}
+        float dR_Ph1_2_GenJet() const {if (hasClosestGenJetToSubLeadingJet()) { return deltaR(diPhoton()->leadingPhoton()->eta(),diPhoton()->leadingPhoton()->phi(),
+                                                                     subLeadingJet()->eta(),subLeadingJet()->phi()); }else{return -9999.;}}
+        float dR_Ph1_3_GenJet() const {if (hasClosestGenJetToSubSubLeadingJet()) { return deltaR(diPhoton()->leadingPhoton()->eta(),diPhoton()->leadingPhoton()->phi(),
+                                                                     subSubLeadingJet()->eta(),subSubLeadingJet()->phi()); }else{return -9999.;}}
+        float dR_Ph2_1_GenJet() const {if (hasClosestGenJetToLeadingJet()) { return deltaR(diPhoton()->subLeadingPhoton()->eta(),diPhoton()->subLeadingPhoton()->phi(),
+                                                                     closestGenJetToLeadingJet()->eta(),closestGenJetToLeadingJet()->phi()); }else{return -9999.;}}
+        float dR_Ph2_2_GenJet() const {if (hasClosestGenJetToSubLeadingJet()) { return deltaR(diPhoton()->subLeadingPhoton()->eta(),diPhoton()->subLeadingPhoton()->phi(),
+                                                                     subLeadingJet()->eta(),subLeadingJet()->phi()); }else{return -9999.;}}
+        float dR_Ph2_3_GenJet() const {if (hasClosestGenJetToSubSubLeadingJet()) { return deltaR(diPhoton()->subLeadingPhoton()->eta(),diPhoton()->subLeadingPhoton()->phi(),
+                                                                     subSubLeadingJet()->eta(),subSubLeadingJet()->phi()); }else{return -9999.;}}
+        float dR_Ph1_1_GenParticle() const {if (hasClosestParticleToLeadingJet()) { return deltaR(diPhoton()->leadingPhoton()->eta(),diPhoton()->leadingPhoton()->phi(),
+                                                                     closestParticleToLeadingJet()->eta(),closestParticleToLeadingJet()->phi()); }else{return -9999.;}}
+        float dR_Ph1_2_GenParticle() const {if (hasClosestParticleToSubLeadingJet()) { return deltaR(diPhoton()->leadingPhoton()->eta(),diPhoton()->leadingPhoton()->phi(),
+                                                                     subLeadingJet()->eta(),subLeadingJet()->phi()); }else{return -9999.;}}
+        float dR_Ph1_3_GenParticle() const {if (hasClosestParticleToSubSubLeadingJet()) { return deltaR(diPhoton()->leadingPhoton()->eta(),diPhoton()->leadingPhoton()->phi(),
+                                                                     subSubLeadingJet()->eta(),subSubLeadingJet()->phi()); }else{return -9999.;}}
+        float dR_Ph2_1_GenParticle() const {if (hasClosestParticleToLeadingJet()) { return deltaR(diPhoton()->subLeadingPhoton()->eta(),diPhoton()->subLeadingPhoton()->phi(),
+                                                                     closestParticleToLeadingJet()->eta(),closestParticleToLeadingJet()->phi()); }else{return -9999.;}}
+        float dR_Ph2_2_GenParticle() const {if (hasClosestParticleToSubLeadingJet()) { return deltaR(diPhoton()->subLeadingPhoton()->eta(),diPhoton()->subLeadingPhoton()->phi(),
+                                                                     subLeadingJet()->eta(),subLeadingJet()->phi()); }else{return -9999.;}}
+        float dR_Ph2_3_GenParticle() const {if (hasClosestParticleToSubSubLeadingJet()) { return deltaR(diPhoton()->subLeadingPhoton()->eta(),diPhoton()->subLeadingPhoton()->phi(),
+                                                                     subSubLeadingJet()->eta(),subSubLeadingJet()->phi()); }else{return -9999.;}}
+        float dR_Ph1_1_Partons() const {if (hasLeadingParton()) { return deltaR(diPhoton()->leadingPhoton()->eta(),diPhoton()->leadingPhoton()->phi(),
+                                                                     leadingParton()->eta(),leadingParton()->phi()); }else{return -9999.;}}
+        float dR_Ph1_2_Partons() const {if (hasSubLeadingParton()) { return deltaR(diPhoton()->leadingPhoton()->eta(),diPhoton()->leadingPhoton()->phi(),
+                                                                     subLeadingParton()->eta(),subLeadingParton()->phi()); }else{return -9999.;}}
+        float dR_Ph1_3_Partons() const {if (hasSubSubLeadingParton()) { return deltaR(diPhoton()->leadingPhoton()->eta(),diPhoton()->leadingPhoton()->phi(),
+                                                                     subSubLeadingParton()->eta(),subSubLeadingParton()->phi()); }else{return -9999.;}}
+        float dR_Ph2_1_Partons() const {if (hasLeadingParton()) { return deltaR(diPhoton()->subLeadingPhoton()->eta(),diPhoton()->subLeadingPhoton()->phi(),
+                                                                     leadingParton()->eta(),leadingParton()->phi()); }else{return -9999.;}}
+        float dR_Ph2_2_Partons() const {if (hasSubLeadingParton()) { return deltaR(diPhoton()->subLeadingPhoton()->eta(),diPhoton()->subLeadingPhoton()->phi(),
+                                                                     subLeadingParton()->eta(),subLeadingParton()->phi()); }else{return -9999.;}}
+        float dR_Ph2_3_Partons() const {if (hasSubSubLeadingParton()) { return deltaR(diPhoton()->subLeadingPhoton()->eta(),diPhoton()->subLeadingPhoton()->phi(),
+                                                                     subSubLeadingParton()->eta(),subSubLeadingParton()->phi()); }else{return -9999.;}}
+        //dR between the trijet and diphoton
+        float dR_DP_123_FggJet() const {if (hasLeadingJet() && hasSubLeadingJet() && hasSubSubLeadingJet()) {
+                                       return deltaR(diPhoton()->eta(),diPhoton()->phi(),(leadingJet()->p4()+subLeadingJet()->p4()+subSubLeadingJet()->p4()).eta(),
+                                                    (leadingJet()->p4()+subLeadingJet()->p4()+subSubLeadingJet()->p4()).phi());}else{return -9999.;}}
+        float dR_DP_123_GenJet() const {if (hasClosestGenJetToLeadingJet() && hasClosestGenJetToSubLeadingJet() && hasClosestGenJetToSubSubLeadingJet()) {
+                                       return deltaR(diPhoton()->eta(),diPhoton()->phi(),   
+                                                    (closestGenJetToLeadingJet()->p4()+closestGenJetToSubLeadingJet()->p4()+closestGenJetToSubSubLeadingJet()->p4()).eta(),
+                                                    (closestGenJetToLeadingJet()->p4()+closestGenJetToSubLeadingJet()->p4()+closestGenJetToSubSubLeadingJet()->p4()).phi());}
+                                        else{return -9999.;}}
+        float dR_DP_123_GenParticle() const {if (hasClosestParticleToLeadingJet() && hasClosestParticleToSubLeadingJet() && hasClosestParticleToSubSubLeadingJet()) {
+                                       return deltaR(diPhoton()->eta(),diPhoton()->phi(),   
+                                                    (closestParticleToLeadingJet()->p4()+closestParticleToSubLeadingJet()->p4()+closestParticleToSubSubLeadingJet()->p4()).eta(),
+                                                    (closestParticleToLeadingJet()->p4()+closestParticleToSubLeadingJet()->p4()+closestParticleToSubSubLeadingJet()->p4()).phi());}
+                                        else{return -9999.;}}
+        float dR_DP_123_Partons() const {if (hasLeadingParton() && hasSubLeadingParton() && hasSubSubLeadingParton()) {
+                                       return deltaR(diPhoton()->eta(),diPhoton()->phi(),(leadingParton()->p4()+subLeadingParton()->p4()+subSubLeadingParton()->p4()).eta(),
+                                                    (leadingParton()->p4()+subLeadingParton()->p4()+subSubLeadingParton()->p4()).phi());}else{return -9999.;}}
+//ADD TO STRUCTS AND SCRIPT 
+        //Pt variable methods
+        float missingP4_dPhi_jjj_FggJet() const {if (hasLeadingJet() && hasSubLeadingJet() && hasSubSubLeadingJet()) {
+                                                 return fabs(deltaPhi((leadingJet()->p4() + subLeadingJet()->p4() + subSubLeadingJet()->p4() + diPhoton()->p4()).phi(), 
+                                                                 diPhoton()->phi()));
+                                                }else{return -9999.;}}               
+        float missingP4_dPhi_jj_FggJet() const {if (hasLeadingJet() && hasSubLeadingJet()) {
+                                                return fabs(deltaPhi((leadingJet()->p4() + subLeadingJet()->p4() + diPhoton()->p4()).phi(), 
+                                                                 diPhoton()->phi()));
+                                                }else{return -9999.;}}               
+        float missingP4_Pt_jjj_FggJet() const {if (hasLeadingJet() && hasSubLeadingJet() && hasSubSubLeadingJet()) {
+                                               return (leadingJet()->p4() + subLeadingJet()->p4() + subSubLeadingJet()->p4() + diPhoton()->p4()).Pt();
+                                               }else{return -9999.;}}
+        float missingP4_Pt_jj_FggJet() const {if (hasLeadingJet() && hasSubLeadingJet()) {
+                                              return (leadingJet()->p4() + subLeadingJet()->p4() + diPhoton()->p4()).Pt();
+                                              }else{return -9999.;}}
+        float missingP4_dPhi_jjj_GenJet() const {if (hasClosestGenJetToLeadingJet() && hasClosestGenJetToSubLeadingJet() && hasClosestGenJetToSubSubLeadingJet()) {
+                                                 return fabs(deltaPhi((closestGenJetToLeadingJet()->p4() + closestGenJetToSubLeadingJet()->p4()
+                                                                 + closestGenJetToSubSubLeadingJet()->p4() + diPhoton()->p4()).phi(), 
+                                                                 diPhoton()->phi()));
+                                                }else{return -9999.;}}               
+        float missingP4_dPhi_jj_GenJet() const {if (hasClosestGenJetToLeadingJet() && hasClosestGenJetToSubLeadingJet()) {
+                                                return fabs(deltaPhi((closestGenJetToLeadingJet()->p4() + closestGenJetToSubLeadingJet()->p4() + diPhoton()->p4()).phi(), 
+                                                                 diPhoton()->phi()));
+                                                }else{return -9999.;}}               
+        float missingP4_Pt_jjj_GenJet() const {if (hasClosestGenJetToLeadingJet() && hasClosestGenJetToSubLeadingJet() && hasClosestGenJetToSubSubLeadingJet()) {
+                                               return (closestGenJetToLeadingJet()->p4() + closestGenJetToSubLeadingJet()->p4() 
+                                                       + closestGenJetToSubSubLeadingJet()->p4() + diPhoton()->p4()).Pt();
+                                               }else{return -9999.;}}
+        float missingP4_Pt_jj_GenJet() const {if (hasClosestGenJetToLeadingJet() && hasClosestGenJetToSubLeadingJet()) {
+                                              return (closestGenJetToLeadingJet()->p4() + closestGenJetToSubLeadingJet()->p4() + diPhoton()->p4()).Pt();
+                                              }else{return -9999.;}}
+        float missingP4_dPhi_jjj_GenParticle() const {if (hasClosestParticleToLeadingJet() && hasClosestParticleToSubLeadingJet() && hasClosestParticleToSubSubLeadingJet()) {
+                                                 return fabs(deltaPhi((closestParticleToLeadingJet()->p4() + closestParticleToSubLeadingJet()->p4()
+                                                                 + closestParticleToSubSubLeadingJet()->p4() + diPhoton()->p4()).phi(), 
+                                                                 diPhoton()->phi()));
+                                                }else{return -9999.;}}               
+        float missingP4_dPhi_jj_GenParticle() const {if (hasClosestParticleToLeadingJet() && hasClosestParticleToSubLeadingJet()) {
+                                                return fabs(deltaPhi((closestParticleToLeadingJet()->p4() + closestParticleToSubLeadingJet()->p4() + diPhoton()->p4()).phi(), 
+                                                                 diPhoton()->phi()));
+                                                }else{return -9999.;}}               
+        float missingP4_Pt_jjj_GenParticle() const {if (hasClosestParticleToLeadingJet() && hasClosestParticleToSubLeadingJet() && hasClosestParticleToSubSubLeadingJet()) {
+                                               return (closestParticleToLeadingJet()->p4() + closestParticleToSubLeadingJet()->p4() 
+                                                       + closestParticleToSubSubLeadingJet()->p4() + diPhoton()->p4()).Pt();
+                                               }else{return -9999.;}}
+        float missingP4_Pt_jj_GenParticle() const {if (hasClosestParticleToLeadingJet() && hasClosestParticleToSubLeadingJet()) {
+                                              return (closestParticleToLeadingJet()->p4() + closestParticleToSubLeadingJet()->p4() + diPhoton()->p4()).Pt();
+                                              }else{return -9999.;}}
+        float missingP4_dPhi_jjj_Partons() const {if (hasLeadingParton() && hasSubLeadingParton() && hasSubSubLeadingParton()) {
+                                                 return fabs(deltaPhi((leadingParton()->p4() + subLeadingParton()->p4() + subSubLeadingParton()->p4() + diPhoton()->p4()).phi(), 
+                                                                 diPhoton()->phi()));
+                                                }else{return -9999.;}}               
+        float missingP4_dPhi_jj_Partons() const {if (hasLeadingParton() && hasSubLeadingParton()) {
+                                                return fabs(deltaPhi((leadingParton()->p4() + subLeadingParton()->p4() + diPhoton()->p4()).phi(), 
+                                                                 diPhoton()->phi()));
+                                                }else{return -9999.;}}               
+        float missingP4_Pt_jjj_Partons() const {if (hasLeadingParton() && hasSubLeadingParton() && hasSubSubLeadingParton()) {
+                                               return (leadingParton()->p4() + subLeadingParton()->p4() + subSubLeadingParton()->p4() + diPhoton()->p4()).Pt();
+                                               }else{return -9999.;}}
+        float missingP4_Pt_jj_Partons() const {if (hasLeadingParton() && hasSubLeadingParton()) {
+                                              return (leadingParton()->p4() + subLeadingParton()->p4() + diPhoton()->p4()).Pt();
+                                              }else{return -9999.;}}
+
+        //pt variables, difference between jj and jjj
+        float missingP4_dPhi_d3J2J_FggJet() const {if (hasLeadingJet() && hasSubLeadingJet() && hasSubSubLeadingJet()) {
+                                                      return missingP4_dPhi_jjj_FggJet() - missingP4_dPhi_jj_FggJet();
+                                                 }else{return -9999.;}}      
+        float missingP4_Pt_d3J2J_FggJet() const {if (hasLeadingJet() && hasSubLeadingJet() && hasSubSubLeadingJet()) {
+                                                      return missingP4_Pt_jjj_FggJet() - missingP4_Pt_jj_FggJet();
+                                                 }else{return -9999.;}}      
+        float missingP4_dPhi_d3J2J_GenJet() const {if (hasClosestGenJetToLeadingJet() && hasClosestGenJetToSubLeadingJet() && hasClosestGenJetToSubSubLeadingJet()) {
+                                                      return missingP4_dPhi_jjj_GenJet() - missingP4_dPhi_jj_GenJet();
+                                                 }else{return -9999.;}}      
+        float missingP4_Pt_d3J2J_GenJet() const {if (hasClosestGenJetToLeadingJet() && hasClosestGenJetToSubLeadingJet() && hasClosestGenJetToSubSubLeadingJet()) {
+                                                      return missingP4_Pt_jjj_GenJet() - missingP4_Pt_jj_GenJet();
+                                                 }else{return -9999.;}}      
+        float missingP4_dPhi_d3J2J_GenParticle() const {if (hasClosestParticleToLeadingJet() && hasClosestParticleToSubLeadingJet() && hasClosestParticleToSubSubLeadingJet()) {
+                                                      return missingP4_dPhi_jjj_GenParticle() - missingP4_dPhi_jj_GenParticle();
+                                                 }else{return -9999.;}}      
+        float missingP4_Pt_d3J2J_GenParticle() const {if (hasClosestParticleToLeadingJet() && hasClosestParticleToSubLeadingJet() && hasClosestParticleToSubSubLeadingJet()) {
+                                                      return missingP4_Pt_jjj_GenParticle() - missingP4_Pt_jj_GenParticle();
+                                                 }else{return -9999.;}}      
+        float missingP4_dPhi_d3J2J_Partons() const {if (hasLeadingParton() && hasSubLeadingParton() && hasSubSubLeadingParton()) {
+                                                      return missingP4_dPhi_jjj_Partons() - missingP4_dPhi_jj_Partons();
+                                                 }else{return -9999.;}}      
+        float missingP4_Pt_d3J2J_Partons() const {if (hasLeadingParton() && hasSubLeadingParton() && hasSubSubLeadingParton()) {
+                                                      return missingP4_Pt_jjj_Partons() - missingP4_Pt_jj_Partons();
+                                                 }else{return -9999.;}}      
+
+        //More delta phis 
+        float dPhi_12_FggJet() const {if (hasLeadingJet() && hasSubLeadingJet()) {
+                                            return fabs(deltaPhi(leadingJet()->phi(),subLeadingJet()->phi()));
+                                      }else{return -9999.;}}
+        float dPhi_13_FggJet() const {if (hasLeadingJet() && hasSubSubLeadingJet()) {
+                                            return fabs(deltaPhi(leadingJet()->phi(),subSubLeadingJet()->phi()));
+                                      }else{return -9999.;}}
+        float dPhi_23_FggJet() const {if (hasSubLeadingJet() && hasSubSubLeadingJet()) {
+                                            return fabs(deltaPhi(subLeadingJet()->phi(),subSubLeadingJet()->phi()));
+                                      }else{return -9999.;}}
+        float dPhi_max_FggJet() const {if (hasLeadingJet() && hasSubLeadingJet() && hasSubSubLeadingJet()) {
+                                            if (dPhi_12_FggJet() > dPhi_13_FggJet() && dPhi_12_FggJet() > dPhi_23_FggJet()) {return dPhi_12_FggJet();}
+                                            else if (dPhi_13_FggJet() > dPhi_12_FggJet() && dPhi_13_FggJet() > dPhi_23_FggJet()) {return dPhi_13_FggJet();}
+                                            else {return dPhi_23_FggJet();}}
+                                        else {return -9999.;}}
+        float dPhi_min_FggJet() const {if (hasLeadingJet() && hasSubLeadingJet() && hasSubSubLeadingJet()) {
+                                            if (dPhi_12_FggJet() < dPhi_13_FggJet() && dPhi_12_FggJet() < dPhi_23_FggJet()) {return dPhi_12_FggJet();}
+                                            else if (dPhi_13_FggJet() < dPhi_12_FggJet() && dPhi_13_FggJet() < dPhi_23_FggJet()) {return dPhi_13_FggJet();}
+                                            else {return dPhi_23_FggJet();}}
+                                        else {return -9999.;}}
+        float dPhi_min_max_FggJet() const {if (hasLeadingJet() && hasSubLeadingJet() && hasSubSubLeadingJet()) {
+                                                return dPhi_max_FggJet() - dPhi_min_FggJet();
+                                           }else{return -9999.;}}
+
+        float dPhi_12_GenJet() const {if (hasClosestGenJetToLeadingJet() && hasClosestGenJetToSubLeadingJet()) {
+                                            return fabs(deltaPhi(closestGenJetToLeadingJet()->phi(),closestGenJetToSubLeadingJet()->phi()));
+                                      }else{return -9999.;}}
+        float dPhi_13_GenJet() const {if (hasClosestGenJetToLeadingJet() && hasClosestGenJetToSubSubLeadingJet()) {
+                                            return fabs(deltaPhi(closestGenJetToLeadingJet()->phi(),closestGenJetToSubSubLeadingJet()->phi()));
+                                      }else{return -9999.;}}
+        float dPhi_23_GenJet() const {if (hasClosestGenJetToSubLeadingJet() && hasClosestGenJetToSubSubLeadingJet()) {
+                                            return fabs(deltaPhi(closestGenJetToSubLeadingJet()->phi(),closestGenJetToSubSubLeadingJet()->phi()));
+                                      }else{return -9999.;}}
+        float dPhi_max_GenJet() const {if (hasClosestGenJetToLeadingJet() && hasClosestGenJetToSubLeadingJet() && hasClosestGenJetToSubSubLeadingJet()) {
+                                            if (dPhi_12_GenJet() > dPhi_13_GenJet() && dPhi_12_GenJet() > dPhi_23_GenJet()) {return dPhi_12_GenJet();}
+                                            else if (dPhi_13_GenJet() > dPhi_12_GenJet() && dPhi_13_GenJet() > dPhi_23_GenJet()) {return dPhi_13_GenJet();}
+                                            else {return dPhi_23_GenJet();}}
+                                        else {return -9999.;}}
+        float dPhi_min_GenJet() const {if (hasClosestGenJetToLeadingJet() && hasClosestGenJetToSubLeadingJet() && hasClosestGenJetToSubSubLeadingJet()) {
+                                            if (dPhi_12_GenJet() < dPhi_13_GenJet() && dPhi_12_GenJet() < dPhi_23_GenJet()) {return dPhi_12_GenJet();}
+                                            else if (dPhi_13_GenJet() < dPhi_12_GenJet() && dPhi_13_GenJet() < dPhi_23_GenJet()) {return dPhi_13_GenJet();}
+                                            else {return dPhi_23_GenJet();}}
+                                        else {return -9999.;}}
+        float dPhi_min_max_GenJet() const {if (hasClosestGenJetToLeadingJet() && hasClosestGenJetToSubLeadingJet() && hasClosestGenJetToSubSubLeadingJet()) {
+                                                return dPhi_max_GenJet() - dPhi_min_GenJet();
+                                           }else{return -9999.;}}
+
+        float dPhi_12_GenParticle() const {if (hasClosestParticleToLeadingJet() && hasClosestParticleToSubLeadingJet()) {
+                                            return fabs(deltaPhi(closestParticleToLeadingJet()->phi(),closestParticleToSubLeadingJet()->phi()));
+                                      }else{return -9999.;}}
+        float dPhi_13_GenParticle() const {if (hasClosestParticleToLeadingJet() && hasClosestParticleToSubSubLeadingJet()) {
+                                            return fabs(deltaPhi(closestParticleToLeadingJet()->phi(),closestParticleToSubSubLeadingJet()->phi()));
+                                      }else{return -9999.;}}
+        float dPhi_23_GenParticle() const {if (hasClosestParticleToSubLeadingJet() && hasClosestParticleToSubSubLeadingJet()) {
+                                            return fabs(deltaPhi(closestParticleToSubLeadingJet()->phi(),closestParticleToSubSubLeadingJet()->phi()));
+                                      }else{return -9999.;}}
+        float dPhi_max_GenParticle() const {if (hasClosestParticleToLeadingJet() && hasClosestParticleToSubLeadingJet() && hasClosestParticleToSubSubLeadingJet()) {
+                                            if (dPhi_12_GenParticle() > dPhi_13_GenParticle() && dPhi_12_GenParticle() > dPhi_23_GenParticle()) {return dPhi_12_GenParticle();}
+                                            else if (dPhi_13_GenParticle() > dPhi_12_GenParticle() && dPhi_13_GenParticle() > dPhi_23_GenParticle()) {return dPhi_13_GenParticle();}
+                                            else {return dPhi_23_GenParticle();}}
+                                        else {return -9999.;}}
+        float dPhi_min_GenParticle() const {if (hasClosestParticleToLeadingJet() && hasClosestParticleToSubLeadingJet() && hasClosestParticleToSubSubLeadingJet()) {
+                                            if (dPhi_12_GenParticle() < dPhi_13_GenParticle() && dPhi_12_GenParticle() < dPhi_23_GenParticle()) {return dPhi_12_GenParticle();}
+                                            else if (dPhi_13_GenParticle() < dPhi_12_GenParticle() && dPhi_13_GenParticle() < dPhi_23_GenParticle()) {return dPhi_13_GenParticle();}
+                                            else {return dPhi_23_GenParticle();}}
+                                        else {return -9999.;}}
+        float dPhi_min_max_GenParticle() const {if (hasClosestParticleToLeadingJet() && hasClosestParticleToSubLeadingJet() && hasClosestParticleToSubSubLeadingJet()) {
+                                                return dPhi_max_GenParticle() - dPhi_min_GenParticle();
+                                           }else{return -9999.;}}
+
+        float dPhi_12_Partons() const {if (hasLeadingParton() && hasSubLeadingParton()) {
+                                            return fabs(deltaPhi(leadingParton()->phi(),subLeadingParton()->phi()));
+                                      }else{return -9999.;}}
+        float dPhi_13_Partons() const {if (hasLeadingParton() && hasSubSubLeadingParton()) {
+                                            return fabs(deltaPhi(leadingParton()->phi(),subSubLeadingParton()->phi()));
+                                      }else{return -9999.;}}
+        float dPhi_23_Partons() const {if (hasSubLeadingParton() && hasSubSubLeadingParton()) {
+                                            return fabs(deltaPhi(subLeadingParton()->phi(),subSubLeadingParton()->phi()));
+                                      }else{return -9999.;}}
+        float dPhi_max_Partons() const {if (hasLeadingParton() && hasSubLeadingParton() && hasSubSubLeadingParton()) {
+                                            if (dPhi_12_Partons() > dPhi_13_Partons() && dPhi_12_Partons() > dPhi_23_Partons()) {return dPhi_12_Partons();}
+                                            else if (dPhi_13_Partons() > dPhi_12_Partons() && dPhi_13_Partons() > dPhi_23_Partons()) {return dPhi_13_Partons();}
+                                            else {return dPhi_23_Partons();}}
+                                        else {return -9999.;}}
+        float dPhi_min_Partons() const {if (hasLeadingParton() && hasSubLeadingParton() && hasSubSubLeadingParton()) {
+                                            if (dPhi_12_Partons() < dPhi_13_Partons() && dPhi_12_Partons() < dPhi_23_Partons()) {return dPhi_12_Partons();}
+                                            else if (dPhi_13_Partons() < dPhi_12_Partons() && dPhi_13_Partons() < dPhi_23_Partons()) {return dPhi_13_Partons();}
+                                            else {return dPhi_23_Partons();}}
+                                        else {return -9999.;}}
+        float dPhi_min_max_Partons() const {if (hasLeadingParton() && hasSubLeadingParton() && hasSubSubLeadingParton()) {
+                                                return dPhi_max_Partons() - dPhi_min_Partons();
+                                           }else{return -9999.;}}
+
+        //4-Momentum simplex volume
+        float simplex_volume_DP_12_FggJet() const {
+            if (hasDiPhoton() && hasLeadingJet() && hasSubLeadingJet()) {
+                float volume = momentumSimplexVolume( leadingJet()->p4(),subLeadingJet()->p4());
+                return volume;
+            }else{return -9999.;} 
+        }
+        float simplex_volume_DP_12_GenJet() const {
+            if (hasDiPhoton() && hasClosestGenJetToLeadingJet() && hasClosestGenJetToSubLeadingJet()) {
+                float volume = momentumSimplexVolume( closestGenJetToLeadingJet()->p4(),closestGenJetToSubLeadingJet()->p4());
+                return volume;
+            }else{return -9999.;} 
+        }
+        float simplex_volume_DP_12_GenParticle() const {
+            if (hasDiPhoton() && hasClosestParticleToLeadingJet() && hasClosestParticleToSubLeadingJet()) {
+                float volume = momentumSimplexVolume( closestParticleToLeadingJet()->p4(),closestParticleToSubLeadingJet()->p4());
+                return volume;
+            }else{return -9999.;} 
+        }
+        float simplex_volume_DP_12_Partons() const {
+            if (hasDiPhoton() && hasLeadingParton() && hasSubLeadingParton()) {
+                float volume = momentumSimplexVolume( leadingParton()->p4(),subLeadingParton()->p4());
+                return volume;
+            }else{return -9999.;} 
+        }
+
+        float momentumSimplexVolume (ROOT::Math::LorentzVector<ROOT::Math::PxPyPzE4D<double> > jet1,
+                                     ROOT::Math::LorentzVector<ROOT::Math::PxPyPzE4D<double> > jet2) const {
+
+            float volume(0.0);
+            std::vector<float> p1(4);
+            std::vector<float> p2(4);
+            std::vector<float> p3(4);
+            std::vector<float> p4(4);
+
+            p1[0] = jet1.T();p1[1] = jet1.X();p1[2] = jet1.Y();p1[3] = jet1.Z();
+            p2[0] = jet2.T();p2[1] = jet2.X();p2[2] = jet2.Y();p2[3] = jet2.Z();
+            p3[0] = diPhoton()->leadingPhoton()->p4().T();p3[1] = diPhoton()->leadingPhoton()->p4().X();
+            p3[2] = diPhoton()->leadingPhoton()->p4().Y();p3[3] = diPhoton()->leadingPhoton()->p4().Z();
+            p4[0] = diPhoton()->subLeadingPhoton()->p4().T();p4[1] = diPhoton()->subLeadingPhoton()->p4().X();
+            p4[2] = diPhoton()->subLeadingPhoton()->p4().Y();p4[3] = diPhoton()->subLeadingPhoton()->p4().Z();
+
+            for (unsigned i(0);i<4;i++) {
+                for (unsigned j(0);j<4;j++) {                                      
+                    for (unsigned k(0);k<4;k++) {                                      
+                        for (unsigned l(0);l<4;l++) {                                      
+                            //Levi-Civita
+                            std::vector<unsigned> indices(4);
+                            indices[0] = i; indices[1] = j; indices[2] = k; indices[3] = l;
+                            int element(1);
+                            for (unsigned m(0);m<4;m++) {
+                                for (unsigned n(0);n<4;n++) {
+                                    if (m <= n) continue;     
+                                    int value = indices[m]-indices[n];
+                                    if (value < 0) {element *= -1;}
+                                    else if (value == 0) {element *= 0;} 
+                                } 
+                            }
+                            //Momentum elements
+                            float temp(1.0);
+                            temp *= p1[i]*p2[j]*p3[k]*p4[l];
+                            temp *= (float)element;
+                            volume += temp;
+                        }
+                    }
+                }
+            }
+            return fabs((1.0/24.0)*volume);
+        }
 
 
+
+
+
+        //Has (thing) methods
         bool hasClosestGenJetToLeadingJet() const { return closestGenJetToLeadingJet_.isNonnull(); }
         bool hasClosestGenJetToSubLeadingJet() const { return closestGenJetToSubLeadingJet_.isNonnull(); }
+        bool hasClosestGenJetToSubSubLeadingJet() const { return closestGenJetToSubSubLeadingJet_.isNonnull(); }
         bool hasClosestParticleToLeadingJet() const { return closestParticleToLeadingJet_.isNonnull(); }
         bool hasClosestParticleToSubLeadingJet() const { return closestParticleToSubLeadingJet_.isNonnull(); }
+        bool hasClosestParticleToSubSubLeadingJet() const { return closestParticleToSubSubLeadingJet_.isNonnull(); }
+        bool hasClosestPartonToLeadingJet() const { return closestPartonToLeadingJet_.isNonnull(); }
+        bool hasClosestPartonToSubLeadingJet() const { return closestPartonToSubLeadingJet_.isNonnull(); }
+        bool hasClosestPartonToSubSubLeadingJet() const { return closestPartonToSubSubLeadingJet_.isNonnull(); }
         bool hasClosestParticleToLeadingPhoton() const { return closestParticleToLeadingPhoton_.isNonnull(); }
         bool hasClosestParticleToSubLeadingPhoton() const { return closestParticleToSubLeadingPhoton_.isNonnull(); }
-        bool hasLeadingQuark() const { return leadingQuark_.isNonnull(); }
-        bool hasSubLeadingQuark() const { return subLeadingQuark_.isNonnull(); }
+        bool hasDiPhoton() const { return diPhoton_.isNonnull(); }
+        bool hasLeadingJet() const { return leadingJet_.isNonnull(); }
+        bool hasSubLeadingJet() const { return subLeadingJet_.isNonnull(); }
+        bool hasSubSubLeadingJet() const { return subSubLeadingJet_.isNonnull(); }
+        bool hasLeadingParton() const { return leadingParton_.isNonnull(); }
+        bool hasSubLeadingParton() const { return subLeadingParton_.isNonnull(); }
+        bool hasSubSubLeadingParton() const { return subSubLeadingParton_.isNonnull(); }
+        bool hasLeadingGenJet() const { return leadingGenJet_.isNonnull(); }
+        bool hasSubLeadingGenJet() const { return subLeadingGenJet_.isNonnull(); }
+        bool hasSubSubLeadingGenJet() const { return subSubLeadingGenJet_.isNonnull(); }
+        bool hasDijet() const {return numberOfFggJets() > 1;} bool hasTrijet() const {return numberOfFggJets() > 2;}
 
+        //Getter methods
         const edm::Ptr<reco::GenJet> closestGenJetToLeadingJet() const { return closestGenJetToLeadingJet_; }
         const edm::Ptr<reco::GenJet> closestGenJetToSubLeadingJet() const { return closestGenJetToSubLeadingJet_; }
+        const edm::Ptr<reco::GenJet> closestGenJetToSubSubLeadingJet() const { return closestGenJetToSubSubLeadingJet_; }
         const edm::Ptr<reco::GenParticle> closestParticleToLeadingJet() const { return closestParticleToLeadingJet_; }
         const edm::Ptr<reco::GenParticle> closestParticleToSubLeadingJet() const { return closestParticleToSubLeadingJet_; }
+        const edm::Ptr<reco::GenParticle> closestParticleToSubSubLeadingJet() const { return closestParticleToSubSubLeadingJet_; }
+        const edm::Ptr<reco::GenParticle> closestPartonToLeadingJet() const { return closestPartonToLeadingJet_; }
+        const edm::Ptr<reco::GenParticle> closestPartonToSubLeadingJet() const { return closestPartonToSubLeadingJet_; }
+        const edm::Ptr<reco::GenParticle> closestPartonToSubSubLeadingJet() const { return closestPartonToSubSubLeadingJet_; }
         const edm::Ptr<reco::GenParticle> closestParticleToLeadingPhoton() const { return closestParticleToLeadingPhoton_; }
         const edm::Ptr<reco::GenParticle> closestParticleToSubLeadingPhoton() const { return closestParticleToSubLeadingPhoton_; }
-        const edm::Ptr<reco::GenParticle> leadingQuark() const { return leadingQuark_; }
-        const edm::Ptr<reco::GenParticle> subLeadingQuark() const { return subLeadingQuark_; }
+
+        //Setter methods
+        const edm::Ptr<reco::GenParticle> leadingParton() const { return leadingParton_; }
+        const edm::Ptr<reco::GenParticle> subLeadingParton() const { return subLeadingParton_; }
+        const edm::Ptr<reco::GenParticle> subSubLeadingParton() const { return subSubLeadingParton_; }
+        const edm::Ptr<reco::GenJet> leadingGenJet() const { return leadingGenJet_; }
+        const edm::Ptr<reco::GenJet> subLeadingGenJet() const { return subLeadingGenJet_; }
+        const edm::Ptr<reco::GenJet> subSubLeadingGenJet() const { return subSubLeadingGenJet_; }
+        const edm::Ptr<flashgg::Jet> leadingJet() const {return leadingJet_; }
+        const edm::Ptr<flashgg::Jet> subLeadingJet() const {return subLeadingJet_; }
+        const edm::Ptr<flashgg::Jet> subSubLeadingJet() const {return subSubLeadingJet_; }
+        const edm::Ptr<flashgg::DiPhotonCandidate> diPhoton() const { return diPhoton_; }
+        const std::vector<edm::Ptr<reco::GenParticle>> ptOrderedPartons() const {return ptOrderedPartons_;}
+        const std::vector<edm::Ptr<reco::GenJet>> ptOrderedGenJets() const {return ptOrderedGenJets_;}
+        const std::vector<edm::Ptr<flashgg::Jet>> ptOrderedFggJets() const {return ptOrderedFggJets_;}
 
         void setClosestGenJetToLeadingJet( const edm::Ptr<reco::GenJet> &val ) { closestGenJetToLeadingJet_ = val; }
         void setClosestGenJetToSubLeadingJet( const edm::Ptr<reco::GenJet> &val ) { closestGenJetToSubLeadingJet_ = val; }
+        void setClosestGenJetToSubSubLeadingJet( const edm::Ptr<reco::GenJet> &val ) { closestGenJetToSubSubLeadingJet_ = val; }
         void setClosestParticleToLeadingJet( const edm::Ptr<reco::GenParticle> &val ) { closestParticleToLeadingJet_ = val; }
         void setClosestParticleToSubLeadingJet( const edm::Ptr<reco::GenParticle> &val ) { closestParticleToSubLeadingJet_ = val; }
+        void setClosestParticleToSubSubLeadingJet( const edm::Ptr<reco::GenParticle> &val ) { closestParticleToSubSubLeadingJet_ = val; }
+        void setClosestPartonToLeadingJet( const edm::Ptr<reco::GenParticle> &val ) { closestPartonToLeadingJet_ = val; }
+        void setClosestPartonToSubLeadingJet( const edm::Ptr<reco::GenParticle> &val ) { closestPartonToSubLeadingJet_ = val; }
+        void setClosestPartonToSubSubLeadingJet( const edm::Ptr<reco::GenParticle> &val ) { closestPartonToSubSubLeadingJet_ = val; }
         void setClosestParticleToLeadingPhoton( const edm::Ptr<reco::GenParticle> &val ) { closestParticleToLeadingPhoton_ = val; }
         void setClosestParticleToSubLeadingPhoton( const edm::Ptr<reco::GenParticle> &val ) { closestParticleToSubLeadingPhoton_ = val; }
-        void setLeadingQuark( const edm::Ptr<reco::GenParticle> &val ) { leadingQuark_ = val; }
-        void setSubLeadingQuark( const edm::Ptr<reco::GenParticle> &val ) { subLeadingQuark_ = val; }
+        void setLeadingParton( const edm::Ptr<reco::GenParticle> &val ) { leadingParton_ = val; }
+        void setSubLeadingParton( const edm::Ptr<reco::GenParticle> &val ) { subLeadingParton_ = val; }
+        void setSubSubLeadingParton( const edm::Ptr<reco::GenParticle> &val ) { subSubLeadingParton_ = val; }
+        void setLeadingJet      ( const edm::Ptr<flashgg::Jet> &val ) { leadingJet_       = val; }
+        void setSubLeadingJet   ( const edm::Ptr<flashgg::Jet> &val ) { subLeadingJet_    = val; }
+        void setSubSubLeadingJet( const edm::Ptr<flashgg::Jet> &val ) { subSubLeadingJet_ = val; }
+        void setLeadingGenJet( const edm::Ptr<reco::GenJet> &val ) { leadingGenJet_ = val; }
+        void setSubLeadingGenJet( const edm::Ptr<reco::GenJet> &val ) { subLeadingGenJet_ = val; }
+        void setSubSubLeadingGenJet( const edm::Ptr<reco::GenJet> &val ) { subSubLeadingGenJet_ = val; }
+        void setPtOrderedPartons( const std::vector<edm::Ptr<reco::GenParticle>> &val ) { ptOrderedPartons_ = val; }
+        void setPtOrderedGenJets( const std::vector<edm::Ptr<reco::GenJet>> &val ) { ptOrderedGenJets_ = val; }
+        void setPtOrderedFggJets( const std::vector<edm::Ptr<flashgg::Jet>> &val ) { ptOrderedFggJets_ = val; }
+        void setDiPhoton( const edm::Ptr<flashgg::DiPhotonCandidate> &val ) {diPhoton_ = val;}
 
+        //Counts
+        unsigned int numberOfPartons() const {return ptOrderedPartons_.size();} 
+        unsigned int numberOfGenJets() const {return ptOrderedGenJets_.size();} 
+        unsigned int numberOfFggJets() const {return ptOrderedFggJets_.size();} 
+        unsigned int numberOfDistinctMatchedPartons() const { 
+            if (hasClosestPartonToLeadingJet() && hasClosestPartonToSubLeadingJet() && !hasClosestPartonToSubSubLeadingJet()) {
+                return ( closestPartonToLeadingJet() != closestPartonToSubLeadingJet() ? 2 : 0 );
+            }else if (hasClosestPartonToLeadingJet() && hasClosestPartonToSubLeadingJet() && hasClosestPartonToSubSubLeadingJet()) {
+                unsigned numDistinct(0);
+                numDistinct += ( closestPartonToLeadingJet() != closestPartonToSubLeadingJet() ? 2 : 0 );
+                numDistinct += ( closestPartonToLeadingJet() != closestPartonToSubSubLeadingJet() ? 2 : 0 );
+                numDistinct += ( closestPartonToSubLeadingJet() != closestPartonToSubSubLeadingJet() ? 2 : 0 );
+                return numDistinct/2;
+            }else if (hasClosestPartonToLeadingJet()){return 1;}else{return 0;}
+        }
+        unsigned int numberOfMatchesAfterDRCut(float dRCut) const {
+            unsigned int count(0);
+            if (hasClosestPartonToLeadingJet() && hasClosestPartonToSubLeadingJet() && !hasClosestPartonToSubSubLeadingJet()) {
+                count += (fabs(dR_partonMatchingToJ1()) < dRCut ? 1 : 0 );
+                count += (fabs(dR_partonMatchingToJ2()) < dRCut ? 1 : 0 );
+            }else if (hasClosestPartonToLeadingJet() && hasClosestPartonToSubLeadingJet() && hasClosestPartonToSubSubLeadingJet()) {
+                count += (fabs(dR_partonMatchingToJ1()) < dRCut ? 1 : 0 );
+                count += (fabs(dR_partonMatchingToJ2()) < dRCut ? 1 : 0 );
+                count += (fabs(dR_partonMatchingToJ3()) < dRCut ? 1 : 0 );
+            }else if (hasClosestPartonToLeadingJet()) {
+                count += (fabs(dR_partonMatchingToJ1()) < dRCut ? 1 : 0 );
+            }
+            return count;
+        } 
+
+        //Clone
         VBFTagTruth *clone() const;
 
     private:
         edm::Ptr<reco::GenJet> closestGenJetToLeadingJet_;
         edm::Ptr<reco::GenJet> closestGenJetToSubLeadingJet_;
+        edm::Ptr<reco::GenJet> closestGenJetToSubSubLeadingJet_;
         edm::Ptr<reco::GenParticle> closestParticleToLeadingJet_;
         edm::Ptr<reco::GenParticle> closestParticleToSubLeadingJet_;
+        edm::Ptr<reco::GenParticle> closestParticleToSubSubLeadingJet_;
+        edm::Ptr<reco::GenParticle> closestPartonToLeadingJet_;
+        edm::Ptr<reco::GenParticle> closestPartonToSubLeadingJet_;
+        edm::Ptr<reco::GenParticle> closestPartonToSubSubLeadingJet_;
         edm::Ptr<reco::GenParticle> closestParticleToLeadingPhoton_;
         edm::Ptr<reco::GenParticle> closestParticleToSubLeadingPhoton_;
-        edm::Ptr<reco::GenParticle> leadingQuark_;
-        edm::Ptr<reco::GenParticle> subLeadingQuark_;
+
+        edm::Ptr<flashgg::Jet> leadingJet_;
+        edm::Ptr<flashgg::Jet> subLeadingJet_;
+        edm::Ptr<flashgg::Jet> subSubLeadingJet_;
+
+        edm::Ptr<reco::GenParticle> leadingParton_;
+        edm::Ptr<reco::GenParticle> subLeadingParton_;
+        edm::Ptr<reco::GenParticle> subSubLeadingParton_;
+
+        edm::Ptr<reco::GenJet> leadingGenJet_;
+        edm::Ptr<reco::GenJet> subLeadingGenJet_;
+        edm::Ptr<reco::GenJet> subSubLeadingGenJet_;
+
+        edm::Ptr<flashgg::DiPhotonCandidate> diPhoton_;
+
+        std::vector<edm::Ptr<reco::GenParticle>> ptOrderedPartons_;
+        std::vector<edm::Ptr<reco::GenJet>> ptOrderedGenJets_;
+        std::vector<edm::Ptr<flashgg::Jet>> ptOrderedFggJets_;
+        
     };
 }
 

--- a/DataFormats/interface/VBFTagTruth.h
+++ b/DataFormats/interface/VBFTagTruth.h
@@ -807,7 +807,7 @@ namespace flashgg {
         const std::vector<edm::Ptr<reco::GenParticle>> ptOrderedPartons() const {return ptOrderedPartons_;}
         const std::vector<edm::Ptr<reco::GenJet>> ptOrderedGenJets() const {return ptOrderedGenJets_;}
         const std::vector<edm::Ptr<flashgg::Jet>> ptOrderedFggJets() const {return ptOrderedFggJets_;}
-
+        
         void setClosestGenJetToLeadingJet( const edm::Ptr<reco::GenJet> &val ) { closestGenJetToLeadingJet_ = val; }
         void setClosestGenJetToSubLeadingJet( const edm::Ptr<reco::GenJet> &val ) { closestGenJetToSubLeadingJet_ = val; }
         void setClosestGenJetToSubSubLeadingJet( const edm::Ptr<reco::GenJet> &val ) { closestGenJetToSubSubLeadingJet_ = val; }

--- a/DataFormats/src/Jet.cc
+++ b/DataFormats/src/Jet.cc
@@ -76,7 +76,7 @@ bool Jet::passesJetID( JetIDLevel level) const
     int   CHM      = this->chargedMultiplicity();
     int   NumNeutralParticles = this->neutralMultiplicity();
     
-    std::cout  << "DEBUG:: eta= " << eta << " NHF=" << NHF << std::endl;
+    //std::cout  << "DEBUG:: eta= " << eta << " NHF=" << NHF << std::endl;
     
     bool jetID_barel_loose  =  (NHF<0.99 && NEMF<0.99 && NumConst>1) && ((abs(eta)<=2.4 && CHF>0 && CHM>0 && CEMF<0.99) || abs(eta)>2.4) && abs(eta)<=3.0;
     bool jetID_barel_tight  =  (NHF<0.90 && NEMF<0.90 && NumConst>1) && ((abs(eta)<=2.4 && CHF>0 && CHM>0 && CEMF<0.99) || abs(eta)>2.4) && abs(eta)<=3.0;

--- a/DataFormats/src/VBFMVAResult.cc
+++ b/DataFormats/src/VBFMVAResult.cc
@@ -2,39 +2,86 @@
 
 
 namespace flashgg {
-
-    VBFMVAResult::VBFMVAResult() :
-        leadJet(),
-        subleadJet(),
-        dijet_leadEta( -9999. ),
-        dijet_subleadEta( -9999. ),
-        dijet_abs_dEta( -9999. ),
-        dijet_LeadJPt( -9999. ),
-        dijet_SubJPt( -9999. ),
-        dijet_Zep( -9999. ),
-        dijet_dPhi_trunc( -9999. ),
-        dijet_Mjj( -9999. ),
-        dipho_PToM( -9999. ),
-        leadPho_PToM( -9999. ),
-        sublPho_PToM( -9999. ),
-        vbfMvaResult_value( -9999. ) {}
-
+    VBFMVAResult::VBFMVAResult () :
+        leadJet                (),
+        subleadJet             (),
+        subsubleadJet          (),
+        leadJet_ptr            (),
+        subleadJet_ptr         (),
+        subsubleadJet_ptr      (),
+        hasValidVBFTriJet      (  0),
+        n_rec_jets             ( -1),
+        n_gen_jets             ( -1),
+        n_diphotons            ( -1),
+        dijet_leadEta          ( -9999. ),
+        dijet_subleadEta       ( -9999. ),
+        dijet_abs_dEta         ( -9999. ),
+        dijet_LeadJPt          ( -9999. ),
+        dijet_SubJPt           ( -9999. ),
+        dijet_Zep              ( -9999. ),
+        dijet_dphi_trunc       ( -9999. ),
+        dijet_dipho_dphi       ( -9999. ),
+        dijet_Mjj              ( -9999. ),
+        dijet_dy               ( -9999. ),
+        dijet_leady            ( -9999. ),
+        dijet_subleady         ( -9999. ),
+        dijet_dipho_pt         ( -9999. ),
+        dijet_minDRJetPho      ( -9999. ),
+        
+        dipho_PToM             ( -9999. ),
+        leadPho_PToM           ( -9999. ),
+        sublPho_PToM           ( -9999. ),
+        
+        vbfMvaResult_value     ( -9999. ),
+        vbfMvaResult_value_bdt ( -9999. ),
+        vbfMvaResult_value_bdtg( -9999. )
+    {}
+    
     VBFMVAResult::VBFMVAResult( edm::Ptr<VBFMVAResult> x )
     {
-        leadJet = x->leadJet;
-        subleadJet = x->subleadJet;
-        dijet_leadEta = x-> dijet_leadEta ;
-        dijet_leadEta   = x-> dijet_leadEta    ;
+        leadJet          = x->leadJet;
+        subleadJet       = x->subleadJet;
+    
+        leadJet_ptr      = x->leadJet_ptr;
+        subleadJet_ptr   = x->subleadJet_ptr;
+        
+        // 3-jets additional variables
+        subsubleadJet     = x->subsubleadJet;
+        subsubleadJet_ptr = x->subsubleadJet_ptr;
+        hasValidVBFTriJet = x->hasValidVBFTriJet;
+        
+        n_rec_jets       = x->n_rec_jets;
+        n_gen_jets       = x->n_gen_jets;
+        n_diphotons      = x->n_diphotons;
+        
+        dijet_leadEta    = x->dijet_leadEta    ;
+        dijet_leadEta    = x->dijet_leadEta    ;
+        
         dijet_subleadEta = x->dijet_subleadEta ;
-        dijet_LeadJPt    = x->dijet_LeadJPt ;
-        dijet_SubJPt     = x->dijet_SubJPt ;
-        dijet_Zep        = x->dijet_Zep ;
-        dijet_dPhi_trunc = x->dijet_dPhi_trunc ;
-        dijet_Mjj        = x->dijet_Mjj ;
-        dipho_PToM       = x->dipho_PToM ;
-        leadPho_PToM = x->leadPho_PToM ;
-        sublPho_PToM = x->sublPho_PToM ;
-        vbfMvaResult_value     = x->vbfMvaResult_value;
+        dijet_LeadJPt    = x->dijet_LeadJPt    ;
+        dijet_SubJPt     = x->dijet_SubJPt     ; 
+        dijet_Zep        = x->dijet_Zep        ;
+        
+        dijet_dphi_trunc = x->dijet_dphi_trunc ;
+        dijet_dipho_dphi = x->dijet_dipho_dphi ;
+        dijet_dipho_pt   = x->dijet_dipho_pt   ;
+        dijet_Mjj        = x->dijet_Mjj        ;
+        
+        dipho_PToM       = x->dipho_PToM     ;
+        leadPho_PToM     = x->leadPho_PToM   ;
+        sublPho_PToM     = x->sublPho_PToM   ;
+        dijet_minDRJetPho= x->dijet_minDRJetPho    ;
+        
+        dijet_leady      = x->dijet_leady    ;
+        dijet_subleady   = x->dijet_subleady ;
+        dijet_dy         = x->dijet_dy;
+        
+        
+        // VBF MVA results different methods
+        // need to be remove at some point ?
+        vbfMvaResult_value      = x->vbfMvaResult_value;
+        vbfMvaResult_value_bdt  = x->vbfMvaResult_value_bdt;
+        vbfMvaResult_value_bdtg = x->vbfMvaResult_value_bdtg;
     }
 }
 // Local Variables:

--- a/DataFormats/src/VBFMVAResult.cc
+++ b/DataFormats/src/VBFMVAResult.cc
@@ -41,7 +41,7 @@ namespace flashgg {
     {
         leadJet          = x->leadJet;
         subleadJet       = x->subleadJet;
-    
+        
         leadJet_ptr      = x->leadJet_ptr;
         subleadJet_ptr   = x->subleadJet_ptr;
         
@@ -75,7 +75,6 @@ namespace flashgg {
         dijet_leady      = x->dijet_leady    ;
         dijet_subleady   = x->dijet_subleady ;
         dijet_dy         = x->dijet_dy;
-        
         
         // VBF MVA results different methods
         // need to be remove at some point ?

--- a/DataFormats/src/VBFTag.cc
+++ b/DataFormats/src/VBFTag.cc
@@ -37,6 +37,33 @@ const Jet VBFTag::subLeadingJet() const
     return vbfDiPhoDiJet_mva_result_.vbfMvaResult.subleadJet;
 }
 
+const Jet VBFTag::subSubLeadingJet() const
+{
+    //! adding a third jets for the VBF studies
+    return vbfDiPhoDiJet_mva_result_.vbfMvaResult.subsubleadJet;
+}
+
+const edm::Ptr<Jet> VBFTag::leadingJet_ptr() const
+{
+    return vbfDiPhoDiJet_mva_result_.vbfMvaResult.leadJet_ptr;
+}
+
+const edm::Ptr<Jet> VBFTag::subLeadingJet_ptr() const
+{
+    return vbfDiPhoDiJet_mva_result_.vbfMvaResult.subleadJet_ptr;
+}
+
+const edm::Ptr<Jet> VBFTag::subSubLeadingJet_ptr() const
+{
+    //! adding a third jets for the VBF studies
+    return vbfDiPhoDiJet_mva_result_.vbfMvaResult.subsubleadJet_ptr;
+}
+
+const bool VBFTag::hasValidVBFTriJet() const
+{
+    return vbfDiPhoDiJet_mva_result_.vbfMvaResult.hasValidVBFTriJet;
+}
+
 // Local Variables:
 // mode:c++
 // indent-tabs-mode:nil

--- a/DataFormats/src/VBFTag.cc
+++ b/DataFormats/src/VBFTag.cc
@@ -27,17 +27,17 @@ const VBFMVAResult VBFTag::VBFMVA() const
     return vbfDiPhoDiJet_mva_result_.vbfMvaResult;
 }
 
-const Jet VBFTag::leadingJet() const
+const reco::Candidate::LorentzVector VBFTag::leadingJet() const
 {
     return vbfDiPhoDiJet_mva_result_.vbfMvaResult.leadJet;
 }
 
-const Jet VBFTag::subLeadingJet() const
+const reco::Candidate::LorentzVector  VBFTag::subLeadingJet() const
 {
     return vbfDiPhoDiJet_mva_result_.vbfMvaResult.subleadJet;
 }
 
-const Jet VBFTag::subSubLeadingJet() const
+const reco::Candidate::LorentzVector  VBFTag::subSubLeadingJet() const
 {
     //! adding a third jets for the VBF studies
     return vbfDiPhoDiJet_mva_result_.vbfMvaResult.subsubleadJet;

--- a/DataFormats/src/VBFTagTruth.cc
+++ b/DataFormats/src/VBFTagTruth.cc
@@ -17,8 +17,8 @@ VBFTagTruth::VBFTagTruth(const VBFTagTruth &b) : TagTruthBase::TagTruthBase(b)
     setClosestParticleToSubLeadingJet(b.closestParticleToSubLeadingJet());
     setClosestParticleToLeadingPhoton(b.closestParticleToLeadingPhoton());
     setClosestParticleToSubLeadingPhoton(b.closestParticleToSubLeadingPhoton());
-    setLeadingQuark(b.leadingQuark());
-    setSubLeadingQuark(b.subLeadingQuark());
+    setLeadingQuark(b.leadingParton());
+    setSubLeadingQuark(b.subLeadingParton());
 }
 */
 
@@ -28,14 +28,22 @@ VBFTagTruth *VBFTagTruth::clone() const
     VBFTagTruth *result = new VBFTagTruth;
     result->setClosestGenJetToLeadingJet( closestGenJetToLeadingJet() );
     result->setClosestGenJetToSubLeadingJet( closestGenJetToSubLeadingJet() );
+    result->setClosestGenJetToSubSubLeadingJet( closestGenJetToSubSubLeadingJet() );
     result->setClosestParticleToLeadingJet( closestParticleToLeadingJet() );
     result->setClosestParticleToSubLeadingJet( closestParticleToSubLeadingJet() );
+    result->setClosestParticleToSubSubLeadingJet( closestParticleToSubSubLeadingJet() );
     result->setClosestParticleToLeadingPhoton( closestParticleToLeadingPhoton() );
     result->setClosestParticleToSubLeadingPhoton( closestParticleToSubLeadingPhoton() );
-    result->setLeadingQuark( leadingQuark() );
-    result->setSubLeadingQuark( subLeadingQuark() );
+    result->setLeadingParton( leadingParton() );
+    result->setSubLeadingParton( subLeadingParton() );
+    result->setSubLeadingParton( subSubLeadingParton() );
+    result->setPtOrderedPartons( ptOrderedPartons() );
+    result->setPtOrderedGenJets( ptOrderedGenJets() );
+    result->setPtOrderedFggJets( ptOrderedFggJets() );
+    result->setDiPhoton( diPhoton() );
     result->setGenPV( genPV() );
     return result;
+
 }
 
 // Local Variables:

--- a/DataFormats/src/classes_def.xml
+++ b/DataFormats/src/classes_def.xml
@@ -15,8 +15,8 @@
 </class>
 <class name="std::vector<flashgg::DiPhotonMVAResult>"/>
 <class name="edm::Wrapper<std::vector<flashgg::DiPhotonMVAResult> >"/>
-<class name="flashgg::VBFMVAResult" ClassVersion="11">
-  <version ClassVersion="11" checksum="3901442033"/>
+<class name="flashgg::VBFMVAResult" ClassVersion="12">
+  <version ClassVersion="12" checksum="585243665"/>
 </class>
 <class name="std::vector<flashgg::VBFMVAResult>"/>
 <class name="edm::Wrapper<std::vector<flashgg::VBFMVAResult> >"/>

--- a/DataFormats/src/classes_def.xml
+++ b/DataFormats/src/classes_def.xml
@@ -15,8 +15,8 @@
 </class>
 <class name="std::vector<flashgg::DiPhotonMVAResult>"/>
 <class name="edm::Wrapper<std::vector<flashgg::DiPhotonMVAResult> >"/>
-<class name="flashgg::VBFMVAResult" ClassVersion="10">
-  <version ClassVersion="10" checksum="3407874632"/>
+<class name="flashgg::VBFMVAResult" ClassVersion="11">
+  <version ClassVersion="11" checksum="3901442033"/>
 </class>
 <class name="std::vector<flashgg::VBFMVAResult>"/>
 <class name="edm::Wrapper<std::vector<flashgg::VBFMVAResult> >"/>
@@ -60,8 +60,8 @@
 <class name="std::vector<edm::Ptr<flashgg::Jet> >"/>
 <class name="edm::OwnVector<flashgg::DiPhotonTagBase, edm::ClonePolicy<flashgg::DiPhotonTagBase> >" />
 <class name="edm::Wrapper<edm::OwnVector<flashgg::DiPhotonTagBase, edm::ClonePolicy<flashgg::DiPhotonTagBase> > >" />
-<class name="flashgg::VBFTagTruth" ClassVersion="10">
-  <version ClassVersion="10" checksum="573481217"/>
+<class name="flashgg::VBFTagTruth" ClassVersion="11">
+  <version ClassVersion="11" checksum="2745005875"/>
 </class>
 <class name="std::vector<flashgg::VBFTagTruth>"/>
 <class name="edm::Wrapper<std::vector<flashgg::VBFTagTruth> >"/>

--- a/Taggers/plugins/TagTestAnalyzer.cc
+++ b/Taggers/plugins/TagTestAnalyzer.cc
@@ -147,16 +147,16 @@ namespace flashgg {
                                   << " " << truth->closestParticleToSubLeadingPhoton()->pdgId() << std::endl;
                     }
                     std::cout << "\t\t------------------------------------------" << std::endl;
-                    if( truth->leadingQuark().isNonnull() ) {
-                        std::cout << "\t\tleadingQuark pt eta id " << truth->leadingQuark()->pt() << " " << truth->leadingQuark()->eta()
-                                  << " " << truth->leadingQuark()->pdgId() << std::endl;
+                    if( truth->leadingParton().isNonnull() ) {
+                        std::cout << "\t\tleadingParton pt eta id " << truth->leadingParton()->pt() << " " << truth->leadingParton()->eta()
+                                  << " " << truth->leadingParton()->pdgId() << std::endl;
                     }
-                    if( truth->subLeadingQuark().isNonnull() ) {
-                        std::cout << "\t\tsubLeadingQuark pt eta id "  << truth->subLeadingQuark()->pt() << " " << truth->subLeadingQuark()->eta()
-                                  << " " << truth->subLeadingQuark()->pdgId() << std::endl;
+                    if( truth->subLeadingParton().isNonnull() ) {
+                        std::cout << "\t\tsubLeadingQuark pt eta id "  << truth->subLeadingParton()->pt() << " " << truth->subLeadingParton()->eta()
+                                  << " " << truth->subLeadingParton()->pdgId() << std::endl;
                     }
-                    if( truth->leadingQuark().isNonnull() && truth->subLeadingQuark().isNonnull() ) {
-                        std::cout << "\t\tDiquark mass: " << ( truth->leadingQuark()->p4() + truth->subLeadingQuark()->p4() ).mass() << std::endl;
+                    if( truth->leadingParton().isNonnull() && truth->subLeadingParton().isNonnull() ) {
+                        std::cout << "\t\tDiquark mass: " << ( truth->leadingParton()->p4() + truth->subLeadingParton()->p4() ).mass() << std::endl;
                     }
                 }
 

--- a/Taggers/plugins/VBFDiPhoDiJetMVAProducer.cc
+++ b/Taggers/plugins/VBFDiPhoDiJetMVAProducer.cc
@@ -85,24 +85,24 @@ namespace flashgg {
         Handle<View<flashgg::VBFMVAResult> > vbfMvaResults;
         evt.getByToken( vbfMvaResultToken_, vbfMvaResults );
 //		const PtrVector<flashgg::VBFMVAResult>& vbfMvaResultPointers = vbfMvaResults->ptrVector();
-
+        
         Handle<View<flashgg::DiPhotonMVAResult> > mvaResults;
         evt.getByToken( mvaResultToken_, mvaResults );
 //		const PtrVector<flashgg::DiPhotonMVAResult>& mvaResultPointers = mvaResults->ptrVector();
-
-        std::auto_ptr<vector<VBFDiPhoDiJetMVAResult> > vbfDiPhoDiJet_results( new
-                vector<VBFDiPhoDiJetMVAResult> ); // one per diphoton, always in same order, vector is more efficient than map
+        
+        std::auto_ptr<vector<VBFDiPhoDiJetMVAResult> > vbfDiPhoDiJet_results( new vector<VBFDiPhoDiJetMVAResult> );
+        // one per diphoton, always in same order, vector is more efficient than map
 
         for( unsigned int candIndex = 0; candIndex < diPhotons->size() ; candIndex++ ) {
-
+            
             edm::Ptr<flashgg::DiPhotonMVAResult> dipho_mvares = mvaResults->ptrAt( candIndex );
             dipho_mva_ = dipho_mvares->result;
 
             edm::Ptr<flashgg::VBFMVAResult> vbf_mvares = vbfMvaResults->ptrAt( candIndex );
             dijet_mva_ = vbf_mvares->vbfMvaResult_value;
-
+            
             flashgg::VBFDiPhoDiJetMVAResult mvares;
-
+            
 
             auto leadPho_p4 = diPhotons->ptrAt( candIndex )->leadingPhoton()->p4();
             auto sublPho_p4 =  diPhotons->ptrAt( candIndex )->subLeadingPhoton()->p4();
@@ -120,9 +120,9 @@ namespace flashgg {
             mvares.dijet_mva =   dijet_mva_ ;
             mvares.dipho_mva =   dipho_mva_ ;
             mvares.dipho_PToM =   dipho_PToM_ ;
-
+                        
             mvares.vbfMvaResult = ( VBFMVAResult )vbf_mvares;
-
+            
             vbfDiPhoDiJet_results->push_back( mvares );
         }
         evt.put( vbfDiPhoDiJet_results );

--- a/Taggers/plugins/VBFMVAProducer.cc
+++ b/Taggers/plugins/VBFMVAProducer.cc
@@ -13,6 +13,8 @@
 
 #include "TMVA/Reader.h"
 #include "TMath.h"
+#include "DataFormats/Math/interface/deltaR.h"
+#include <string>
 
 using namespace std;
 using namespace edm;
@@ -21,251 +23,342 @@ namespace flashgg {
 
     class VBFMVAProducer : public EDProducer
     {
-
+        
     public:
         VBFMVAProducer( const ParameterSet & );
     private:
         void produce( Event &, const EventSetup & ) override;
-
+        
         EDGetTokenT<View<DiPhotonCandidate> > diPhotonToken_;
         //EDGetTokenT<View<flashgg::Jet> > jetTokenDz_;
         std::vector<edm::InputTag> inputTagJets_;
 
         unique_ptr<TMVA::Reader>VbfMva_;
         FileInPath vbfMVAweightfile_;
-        bool _isLegacyMVA;
-        bool _usePuJetID;
-        double _minDijetMinv;
-
+        string     _MVAMethod;
+        bool       _usePuJetID;
+        bool       _useJetID;
+        bool       _merge3rdJet;
+        double     _thirdJetDRCut;
+        string     _JetIDLevel;
+        double     _minDijetMinv;
+        
         typedef std::vector<edm::Handle<edm::View<flashgg::Jet> > > JetCollectionVector;
-
-        float dijet_leadEta_;
+        
+        float dijet_leadEta_   ;
         float dijet_subleadEta_;
         float dijet_abs_dEta_;
-        float dijet_LeadJPt_;
-        float dijet_SubJPt_;
-        float dijet_Zep_;
-        float dijet_dPhi_trunc_;
-        float dijet_Mjj_;
-        float dipho_PToM_;
+        float dijet_LeadJPt_ ;
+        float dijet_SubJPt_  ;
+        float dijet_Zep_     ;
+        float dijet_dphi_trunc_;
+        float dijet_dipho_dphi_;
+        float dijet_Mjj_   ;
+        float dijet_minDRJetPho_ ;
+        float dijet_dy_    ;
+        float dijet_leady_    ;
+        float dijet_subleady_ ;
+        float dijet_dipho_pt_ ;
+        
+        float dipho_PToM_  ;
         float leadPho_PToM_;
         float sublPho_PToM_;
 
-
     };
-
+    
     VBFMVAProducer::VBFMVAProducer( const ParameterSet &iConfig ) :
         diPhotonToken_( consumes<View<flashgg::DiPhotonCandidate> >( iConfig.getParameter<InputTag> ( "DiPhotonTag" ) ) ),
         //jetTokenDz_( consumes<View<flashgg::Jet> >( iConfig.getParameter<InputTag>( "JetTag" ) ) ),
-        inputTagJets_( iConfig.getParameter<std::vector<edm::InputTag> >( "inputTagJets" ) ),
-        _isLegacyMVA( iConfig.getUntrackedParameter<bool>( "UseLegacyMVA" , false ) ),
-        _usePuJetID( iConfig.getUntrackedParameter<bool>( "UsePuJetID" , false ) ),
-        _minDijetMinv( iConfig.getParameter<double>( "MinDijetMinv" ) )
+        inputTagJets_ ( iConfig.getParameter<std::vector<edm::InputTag> >( "inputTagJets" ) ),
+        _MVAMethod    ( iConfig.getUntrackedParameter<string> ( "MVAMethod"    , "BDT"  ) ),
+        _usePuJetID   ( iConfig.getUntrackedParameter<bool>   ( "UsePuJetID"   , false  ) ),
+        _useJetID     ( iConfig.getUntrackedParameter<bool>   ( "UseJetID"     , false  ) ),
+        _merge3rdJet  ( iConfig.getUntrackedParameter<bool>   ( "merge3rdJet"  , false  ) ),
+        _thirdJetDRCut( iConfig.getUntrackedParameter<double> ( "thirdJetDRCut", 1.8    ) ),
+        _JetIDLevel   ( iConfig.getUntrackedParameter<string> ( "JetIDLevel"   , "Loose") ), // Loose == 0, Tight == 1
+        _minDijetMinv ( iConfig.getParameter<double>          ( "MinDijetMinv" ) )
     {
-
         vbfMVAweightfile_ = iConfig.getParameter<edm::FileInPath>( "vbfMVAweightfile" );
-
-        dijet_leadEta_ = -999.;
+        
+        dijet_leadEta_    = -999.;
         dijet_subleadEta_ = -999.;
-        dijet_abs_dEta_ = -999.;
-        dijet_LeadJPt_ = -999.;
-        dijet_SubJPt_ = -999.;
-        dijet_Zep_ = -999.;
-        dijet_dPhi_trunc_ = -999.;
-        dijet_Mjj_ = -999.;
-        dipho_PToM_ = -999.;
-        leadPho_PToM_ = -999.;
-        sublPho_PToM_ = -999.;
-
-
-        VbfMva_.reset( new TMVA::Reader( "!Color:Silent" ) );
-
-        if( _isLegacyMVA ) {
-            // legacy input var
-            VbfMva_->AddVariable( "dijet_leadEta", &dijet_leadEta_ );
-            VbfMva_->AddVariable( "dijet_subleadEta", &dijet_subleadEta_ );
-            VbfMva_->AddVariable( "dijet_LeadJPt", &dijet_LeadJPt_ );
-            VbfMva_->AddVariable( "dijet_SubJPt", &dijet_SubJPt_ );
-            VbfMva_->AddVariable( "dijet_Zep", &dijet_Zep_ );
-            VbfMva_->AddVariable( "min(dijet_dPhi,2.916)", &dijet_dPhi_trunc_ );
-            VbfMva_->AddVariable( "dijet_Mjj", &dijet_Mjj_ );
-            VbfMva_->AddVariable( "dipho_pt/mass", &dipho_PToM_ );
-            VbfMva_->BookMVA( "BDTG", vbfMVAweightfile_.fullPath() );
-        } else {
-            // new flashgg var
-            VbfMva_->AddVariable( "dijet_LeadJPt" , &dijet_LeadJPt_ );
-            VbfMva_->AddVariable( "dijet_SubJPt" , &dijet_SubJPt_ );
-            VbfMva_->AddVariable( "dijet_abs_dEta" , &dijet_abs_dEta_ );
-            VbfMva_->AddVariable( "dijet_Mjj" , &dijet_Mjj_ );
-            VbfMva_->AddVariable( "dijet_Zep" , &dijet_Zep_ );
-            VbfMva_->AddVariable( "dijet_dPhi_trunc", &dijet_dPhi_trunc_ );
-            //VbfMva_->AddVariable("dipho_pt/mass", &dipho_PToM_);
-            VbfMva_->AddVariable( "leadPho_PToM", &leadPho_PToM_ );
-            VbfMva_->AddVariable( "sublPho_PToM", &sublPho_PToM_ );
-            VbfMva_->BookMVA( "BDT", vbfMVAweightfile_.fullPath() );
+        dijet_abs_dEta_   = -999.;
+        dijet_LeadJPt_    = -999.;
+        dijet_SubJPt_     = -999.;
+        dijet_Zep_        = -999.;
+        dijet_dphi_trunc_ = -999.;
+        dijet_dipho_dphi_ = -999.;
+        dijet_Mjj_        = -999.;
+        dijet_dy_         = -999.;
+        dipho_PToM_       = -999.;
+        leadPho_PToM_     = -999.;
+        sublPho_PToM_     = -999.;
+        dijet_minDRJetPho_= -999.;
+        dijet_dipho_pt_   = -999.;
+        dijet_leady_      = -999.;
+        dijet_subleady_   = -999.;
+        
+        if (_MVAMethod != ""){
+            VbfMva_.reset( new TMVA::Reader( "!Color:Silent" ) );
+            // set of VBF variables
+            VbfMva_->AddVariable( "dijet_LeadJPt"     , &dijet_LeadJPt_    );
+            VbfMva_->AddVariable( "dijet_SubJPt"      , &dijet_SubJPt_     );
+            VbfMva_->AddVariable( "dijet_abs_dEta"    , &dijet_abs_dEta_   );
+            //VbfMva_->AddVariable( "dijet_dy"          , &dijet_dy_         );
+            VbfMva_->AddVariable( "dijet_Mjj"         , &dijet_Mjj_        );
+            VbfMva_->AddVariable( "dijet_Zep"         , &dijet_Zep_        );
+            //VbfMva_->AddVariable( "dijet_minDRJetPho" , &dijet_minDRJetPho_);
+            //VbfMva_->AddVariable( "dijet_dipho_dphi"  , &dijet_dipho_dphi_ );
+            VbfMva_->AddVariable( "dijet_dPhi_trunc"  , &dijet_dphi_trunc_ );
+            //VbfMva_->AddVariable( "dipho_PToM"        , &dipho_PToM_       );
+            VbfMva_->AddVariable( "leadPho_PToM"      , &leadPho_PToM_);
+            VbfMva_->AddVariable( "sublPho_PToM"      , &sublPho_PToM_);
+            //new variables
+            VbfMva_->BookMVA( _MVAMethod.c_str() , vbfMVAweightfile_.fullPath() );
         }
-
-
         produces<vector<VBFMVAResult> >();
-
+        
     }
-
+    
     void VBFMVAProducer::produce( Event &evt, const EventSetup & )
     {
         Handle<View<flashgg::DiPhotonCandidate> > diPhotons;
         evt.getByToken( diPhotonToken_, diPhotons );
-        // const PtrVector<flashgg::DiPhotonCandidate>& diPhotonPointers = diPhotons->ptrVector();
-        //Handle<View<flashgg::Jet> > jetsDz;
-        //evt.getByToken( jetTokenDz_, jetsDz );
-        //	const PtrVector<flashgg::Jet>& jetPointersDz = jetsDz->ptrVector();
-        // get the iso deposits
-        //IsoDepositMaps electronIso(inputTagElectronIsoDeposits_.size());
-        //IsoDepositMaps photonIsoDep(inputTagPhotonIsoDeposits_.size());
-
+        
         JetCollectionVector Jets( inputTagJets_.size() );
         for( size_t j = 0; j < inputTagJets_.size(); ++j ) {
             evt.getByLabel( inputTagJets_[j], Jets[j] );
         }
-
+        
         std::auto_ptr<vector<VBFMVAResult> > vbf_results( new vector<VBFMVAResult> );
-
-
         for( unsigned int candIndex = 0; candIndex < diPhotons->size() ; candIndex++ ) {
-
+            
             flashgg::VBFMVAResult mvares;
-
-            dijet_leadEta_ = -999.;
+            
+            dijet_leadEta_    = -999.;
             dijet_subleadEta_ = -999.;
-            dijet_abs_dEta_ = -999.;
-            dijet_LeadJPt_ = -999.;
-            dijet_SubJPt_ = -999.;
-            dijet_Zep_ = -999.;
-            dijet_dPhi_trunc_ = -999.;
-            dijet_Mjj_ = -999.;
-            dipho_PToM_ = -999.;
-            leadPho_PToM_ = -999.;
-            sublPho_PToM_ = -999.;
-
-
+            dijet_abs_dEta_   = -999.;
+            dijet_LeadJPt_    = -999.;
+            dijet_SubJPt_     = -999.;
+            dijet_Zep_        = -999.;
+            dijet_dphi_trunc_ = -999.;
+            dijet_dipho_dphi_ = -999.;
+            dijet_Mjj_        = -999.;
+            dijet_dy_         = -999.;
+            dijet_minDRJetPho_= -999.;
+            dijet_dipho_pt_   = -999.;
+            dijet_leady_      = -999.;
+            dijet_subleady_   = -999.;
+            
+            dipho_PToM_       = -999.;
+            leadPho_PToM_     = -999.;
+            sublPho_PToM_     = -999.;
+           
+ 
             // First find dijet by looking for highest-pt jets...
-            std::pair <int, int> dijet_indices( -1, -1 );
+            std::pair <int, int>     dijet_indices( -1, -1 );
             std::pair <float, float> dijet_pts( -1., -1. );
-            //			float PuIDCutoff = 0.8;
+            int jet_3_index = -1;
+            int jet_3_pt    = -1;
             float dr2pho = 0.5;
-
+            
             float phi1 = diPhotons->ptrAt( candIndex )->leadingPhoton()->phi();
             float eta1 = diPhotons->ptrAt( candIndex )->leadingPhoton()->eta();
             float phi2 = diPhotons->ptrAt( candIndex )->subLeadingPhoton()->phi();
             float eta2 = diPhotons->ptrAt( candIndex )->subLeadingPhoton()->eta();
 
-            bool hasValidVBFDijet = 0;
-
+            bool hasValidVBFDiJet  = 0;
+            bool hasValidVBFTriJet = 0;
+            
+            int  n_jets_count = 0;
             // take the jets corresponding to the diphoton candidate
             unsigned int jetCollectionIndex = diPhotons->ptrAt( candIndex )->jetCollectionIndex();
-
+                        
             for( UInt_t jetLoop = 0; jetLoop < Jets[jetCollectionIndex]->size() ; jetLoop++ ) {
-
                 Ptr<flashgg::Jet> jet  = Jets[jetCollectionIndex]->ptrAt( jetLoop );
-
-                //pass PU veto??
                 //if (jet->puJetId(diPhotons[candIndex]) <  PuIDCutoff) {continue;}
-                if( _usePuJetID && !jet->passesPuJetId( diPhotons->ptrAt( candIndex ) ) ) { continue; }
+                if( _usePuJetID && !jet->passesPuJetId(diPhotons->ptrAt( candIndex ))){ continue;}
+                if( _useJetID ){
+                    if( _JetIDLevel == "Loose" && !jet->passesJetID  ( flashgg::Loose ) ) continue;
+                    if( _JetIDLevel == "Tight" && !jet->passesJetID  ( flashgg::Tight ) ) continue;
+                }
+                
                 // within eta 4.7?
                 if( fabs( jet->eta() ) > 4.7 ) { continue; }
+
                 // close to lead photon?
                 float dPhi = deltaPhi( jet->phi(), phi1 );
                 float dEta = jet->eta() - eta1;
                 if( sqrt( dPhi * dPhi + dEta * dEta ) < dr2pho ) { continue; }
+                
                 // close to sublead photon?
                 dPhi = deltaPhi( jet->phi(), phi2 );
                 dEta = jet->eta() - eta2;
                 if( sqrt( dPhi * dPhi + dEta * dEta ) < dr2pho ) { continue; }
-
+                
                 if( jet->pt() > dijet_pts.first ) {
                     // if pt of this jet is higher than the one currently in lead position
                     // then shift back lead jet into sublead position...
                     dijet_indices.second = dijet_indices.first;
-                    dijet_pts.second = dijet_pts.first;
+                    dijet_pts.second     = dijet_pts.first;
                     // .. and put the new jet as the lead jet.
                     dijet_indices.first = jetLoop;
-                    dijet_pts.first = jet->pt();
-                } else if( jet->pt() > dijet_pts.second ) {
-                    // if the jet's pt isn't as high as the lead jet's but i higher than the sublead jet's
-                    // The replace the sublead jet by this new jet.
+                    dijet_pts.first     = jet->pt();
+                    
+                    // trijet indicies
+                    //jet_3_index = dijet_indices.second;
+                    //jet_3_pt    = dijet_pts.second;
+                } else if( jet->pt() > dijet_pts.second ) { 
+                    // for the 3rd jets
+                    jet_3_index = dijet_indices.second;
+                    jet_3_pt    = dijet_pts.second;
+                    
+                    // this condition is added here to force to have the leading 
+                    // and subleading jets in two different hemispheres 
+                    // if the jet's pt isn't as high as the lead jet's but i higher 
+                    // than the sublead jet's The replace the sublead jet by this new jet.
                     dijet_indices.second = jetLoop;
-                    dijet_pts.second = jet->pt();
+                    dijet_pts.second     = jet->pt();
+                    
+                }else if( jet->pt() > jet_3_pt ){//&& dijet_indices.first != int(jetLoop) && dijet_indices.second != int(jetLoop)){
+                    jet_3_index = jetLoop;
+                    jet_3_pt    = jet->pt();
                 }
+                n_jets_count++;
                 // if the jet's pt is neither higher than the lead jet or sublead jet, then forget it!
-                if( dijet_indices.first != -1 && dijet_indices.second != -1 ) {hasValidVBFDijet = 1;}
-
+                if( dijet_indices.first != -1 && dijet_indices.second != -1 ) {hasValidVBFDiJet  = 1;}
+                if( hasValidVBFDiJet          && jet_3_index != -1          ) {hasValidVBFTriJet = 1;}
             }
-            //std::cout << "[VBF] has valid VBF Dijet ? "<< hasValidVBFDijet<< std::endl;
-            if( hasValidVBFDijet ) {
 
-                std::pair < Ptr<flashgg::Jet>, Ptr<flashgg::Jet> > dijet;
-                // fill dijet pair with lead jet as first, sublead as second.
-                dijet.first =  Jets[jetCollectionIndex]->ptrAt( dijet_indices.first );
-                dijet.second =  Jets[jetCollectionIndex]->ptrAt( dijet_indices.second );
 
-                dijet_leadEta_ = dijet.first->eta();
-                dijet_subleadEta_ = dijet.second->eta();
-                dijet_abs_dEta_ = std::fabs( dijet.first->eta() - dijet.second->eta() );
-                dijet_LeadJPt_ = dijet.first->pt();
-                dijet_SubJPt_ = dijet.second->pt();
+            //Third jet deltaR cut and merge index finding
+            int indexToMergeWithJ3(-1);
+            //float thirdJetDRCut(1.8);
 
-                auto leadPho_p4 = diPhotons->ptrAt( candIndex )->leadingPhoton()->p4();
-                auto sublPho_p4 =  diPhotons->ptrAt( candIndex )->subLeadingPhoton()->p4();
-                auto leadJet_p4 =  dijet.first->p4();
-                auto sublJet_p4 =  dijet.second->p4();
+            //Getting the P4s
+            std::vector<reco::Candidate::LorentzVector> diPhotonP4s(2);
+            std::vector<reco::Candidate::LorentzVector> jetP4s;
 
-                auto diphoton_p4 = leadPho_p4 + sublPho_p4;
-                auto dijet_p4 = leadJet_p4 + sublJet_p4;
-                float dijet_dPhi_ = fabs( dijet_p4.Phi() - diphoton_p4.Phi() );
+            diPhotonP4s[0] = diPhotons->ptrAt( candIndex )->leadingPhoton()->p4(); 
+            diPhotonP4s[1] = diPhotons->ptrAt( candIndex )->subLeadingPhoton()->p4(); 
+            if ( hasValidVBFDiJet ) {
+                jetP4s.push_back(Jets[jetCollectionIndex]->ptrAt(dijet_indices.first)->p4());
+                jetP4s.push_back(Jets[jetCollectionIndex]->ptrAt(dijet_indices.second)->p4());
+            }
+            if ( hasValidVBFTriJet ) {
 
-                dijet_dPhi_trunc_ = std::min( dijet_dPhi_, ( float ) 2.916 );
+                jetP4s.push_back(Jets[jetCollectionIndex]->ptrAt(jet_3_index)->p4());
 
-                dijet_Zep_ = fabs( diphoton_p4.Eta() - 0.5 * ( leadJet_p4.Eta() + sublJet_p4.Eta() ) );
-                dijet_dPhi_ = deltaPhi( dijet_p4.Phi(), diphoton_p4.Phi() );
-                dijet_Mjj_ = dijet_p4.M();
-                dipho_PToM_ = diphoton_p4.Pt() / diphoton_p4.M();
-                leadPho_PToM_ = diPhotons->ptrAt( candIndex )->leadingPhoton()->pt() / diphoton_p4.M();
-                sublPho_PToM_ = diPhotons->ptrAt( candIndex )->subLeadingPhoton()->pt() / diphoton_p4.M();
+                float dR_13 = deltaR(jetP4s[0].eta(),jetP4s[0].phi(),jetP4s[2].eta(),jetP4s[2].phi());
+                float dR_23 = deltaR(jetP4s[1].eta(),jetP4s[1].phi(),jetP4s[2].eta(),jetP4s[2].phi());
+                
+                if (dR_13 < dR_23) {
+                    indexToMergeWithJ3 = dR_13 < _thirdJetDRCut ? 0 : -1;
+                }else{
+                    indexToMergeWithJ3 = dR_23 < _thirdJetDRCut ? 1 : -1;
+                }
 
-                //debug stuff
-                //	std::cout<<"numbr of jets " <<  Jets[jetCollectionIndex]->size() << std::endl;
-                //	std::cout<<"jet indices: " <<  dijet_indices.first << "	" << dijet_indices.second << std::endl;
+                if (dR_13 > _thirdJetDRCut && dR_23 > _thirdJetDRCut) {
+                    hasValidVBFTriJet = 0;
+                }
+                
+                //std::cout << "Third jet merge info:" << std::endl;
+                //std::cout << setw(12) << dR_13 << setw(12) << dR_23 << setw(12) << indexToMergeWithJ3 << std::endl;
+            }
+           
+            if( hasValidVBFDiJet ) {
+                std::pair<reco::Candidate::LorentzVector,reco::Candidate::LorentzVector> dijetP4s;
+                
+                //std ::cout << "-->before  jet_1 pt:" << jetP4s[0].pt() << std::endl;
+                //std ::cout << "-->before  jet_2 pt:" << jetP4s[1].pt() << std::endl;
+                if (indexToMergeWithJ3 != -1 && _merge3rdJet ) {
+                    //std::cout << "Hey I am merging jets : " << indexToMergeWithJ3+1 << " with jet 3" << std::endl;    
+                    dijetP4s.first  = jetP4s[ indexToMergeWithJ3 == 0 ? 1 : 0 ];
+                    dijetP4s.second = jetP4s[ indexToMergeWithJ3 ] + jetP4s[2];                 
+                    if (dijetP4s.second.pt() > dijetP4s.first.pt()) { std::swap(dijetP4s.first, dijetP4s.second);}
+                }else{
+                    dijetP4s.first  = jetP4s[0];
+                    dijetP4s.second = jetP4s[1];
+                }
+                
+                //std ::cout << "-->after  jet_1 pt:" << dijetP4s.first.pt()  << std::endl;
+                //std ::cout << "-->after  jet_2 pt:" << dijetP4s.second.pt() << std::endl;
+                
+                dijet_leadEta_    = dijetP4s.first.eta();
+                dijet_subleadEta_ = dijetP4s.second.eta();
+                
+                dijet_abs_dEta_   = fabs( dijetP4s.first.eta() - dijetP4s.second.eta());
+                
+                dijet_LeadJPt_    = dijetP4s.first.pt();
+                dijet_SubJPt_     = dijetP4s.second.pt();
+                
+                dijet_dphi_trunc_ = std::min((float) abs( (dijetP4s.first + dijetP4s.second).phi() - (diPhotonP4s[0] + diPhotonP4s[1]).phi()), (float) 2.916);
+                dijet_dipho_dphi_ = fabs( (dijetP4s.first + dijetP4s.second).phi() - (diPhotonP4s[0] + diPhotonP4s[1]).phi() );
+
+                dijet_dipho_pt_   = (dijetP4s.first + dijetP4s.second + diPhotonP4s[0] + diPhotonP4s[1]).pt(); 
+                
+                dijet_Zep_        = fabs( (diPhotonP4s[0]+diPhotonP4s[1]).eta() - 0.5*(dijetP4s.first.eta()+dijetP4s.second.eta()) );
+                
+                dijet_Mjj_        = (dijetP4s.first + dijetP4s.second).M();
+
+                dipho_PToM_       = (diPhotonP4s[0] + diPhotonP4s[1]).Pt()/(diPhotonP4s[0] + diPhotonP4s[1]).M();
+                leadPho_PToM_     = diPhotonP4s[0].pt()/(diPhotonP4s[0] + diPhotonP4s[1]).M();
+                sublPho_PToM_     = diPhotonP4s[1].pt()/(diPhotonP4s[0] + diPhotonP4s[1]).M();
+                
+                dijet_minDRJetPho_ = std::min( std::min(deltaR( dijetP4s.first ,diPhotonP4s[0] ),
+                                                        deltaR( dijetP4s.second,diPhotonP4s[0] )),
+                                               std::min(deltaR( dijetP4s.first ,diPhotonP4s[1] ),
+                                                        deltaR( dijetP4s.second,diPhotonP4s[1] ))        
+                                              );
+                
+                dijet_dy_         = fabs( (dijetP4s.first + dijetP4s.second).Rapidity() - (diPhotonP4s[0] + diPhotonP4s[1]).Rapidity() );
+                
+                dijet_leady_      = dijetP4s.first.Rapidity();
+
+                dijet_subleady_   = dijetP4s.second.Rapidity();
+                
                 mvares.leadJet    = *Jets[jetCollectionIndex]->ptrAt( dijet_indices.first );
                 mvares.subleadJet = *Jets[jetCollectionIndex]->ptrAt( dijet_indices.second );
-
-
-                //debug stuff
-                //std::cout << mvares.leadJet.eta() << std::endl;
-                //std::cout << mvares.subleadJet.eta() << std::endl;
-
+                
+                mvares.leadJet_ptr    = Jets[jetCollectionIndex]->ptrAt( dijet_indices.first );
+                mvares.subleadJet_ptr = Jets[jetCollectionIndex]->ptrAt( dijet_indices.second );
+                mvares.diphoton       = *diPhotons->ptrAt( candIndex );
+            }else{
+                mvares.leadJet_ptr    = edm::Ptr<flashgg::Jet>();
+                mvares.subleadJet_ptr = edm::Ptr<flashgg::Jet>();
             }
-
-            if( _isLegacyMVA ) {
-                mvares.vbfMvaResult_value = VbfMva_->EvaluateMVA( "BDTG" );
-            } else {
-                mvares.vbfMvaResult_value = VbfMva_->EvaluateMVA( "BDT" );
+            
+            if ( hasValidVBFDiJet && hasValidVBFTriJet){
+                mvares.subsubleadJet     = *Jets[jetCollectionIndex]->ptrAt( jet_3_index );
+                mvares.subsubleadJet_ptr =  Jets[jetCollectionIndex]->ptrAt( jet_3_index );
+                mvares.hasValidVBFTriJet = 1;
+            }else{
+                mvares.subsubleadJet_ptr =  edm::Ptr<flashgg::Jet>();
             }
+            
 
-            //	mvares.vbfMvaResult_value = VbfMva_->EvaluateMVA("BDT");
-            //std::cout <<" debug mva " <<  mvares.vbfMvaResult_value << std::endl;
-            mvares.dijet_leadEta = dijet_leadEta_ ;
+            if (_MVAMethod != "") 
+                mvares.vbfMvaResult_value = VbfMva_->EvaluateMVA( _MVAMethod.c_str() );
+            
+            mvares.dijet_leadEta    = dijet_leadEta_ ;
             mvares.dijet_subleadEta = dijet_subleadEta_ ;
-            mvares.dijet_abs_dEta = dijet_abs_dEta_ ;
-            mvares.dijet_LeadJPt = dijet_LeadJPt_ ;
-            mvares.dijet_SubJPt = dijet_SubJPt_ ;
-            mvares.dijet_Zep =    dijet_Zep_ ;
-            mvares.dijet_dPhi_trunc = dijet_dPhi_trunc_ ;
-            mvares.dijet_Mjj =    dijet_Mjj_ ;
-            mvares.dipho_PToM =   dipho_PToM_ ;
-            mvares.sublPho_PToM = sublPho_PToM_ ;
-            mvares.leadPho_PToM = leadPho_PToM_ ;
-
+            mvares.dijet_abs_dEta   = dijet_abs_dEta_ ;
+            mvares.dijet_LeadJPt    = dijet_LeadJPt_ ;
+            mvares.dijet_SubJPt     = dijet_SubJPt_ ;
+            mvares.dijet_Zep        = dijet_Zep_ ;
+            mvares.dijet_dphi_trunc = dijet_dphi_trunc_ ;
+            mvares.dijet_dipho_dphi = dijet_dipho_dphi_ ;
+            mvares.dijet_Mjj        = dijet_Mjj_ ;
+            mvares.dipho_PToM       = dipho_PToM_ ;
+            mvares.sublPho_PToM     = sublPho_PToM_ ;
+            mvares.leadPho_PToM     = leadPho_PToM_ ;
+            mvares.dijet_minDRJetPho= dijet_minDRJetPho_;
+            mvares.dijet_dy         = dijet_dy_;
+            mvares.dijet_dipho_pt   = dijet_dipho_pt_ ;
+            mvares.dijet_leady      = dijet_leady_   ;
+            mvares.dijet_subleady   = dijet_subleady_;
+            
             vbf_results->push_back( mvares );
-
         }
         evt.put( vbf_results );
     }

--- a/Taggers/plugins/VBFMVAProducer.cc
+++ b/Taggers/plugins/VBFMVAProducer.cc
@@ -246,7 +246,7 @@ namespace flashgg {
                 jetP4s.push_back(Jets[jetCollectionIndex]->ptrAt(dijet_indices.second)->p4());
             }
             if ( hasValidVBFTriJet ) {
-
+                
                 jetP4s.push_back(Jets[jetCollectionIndex]->ptrAt(jet_3_index)->p4());
 
                 float dR_13 = deltaR(jetP4s[0].eta(),jetP4s[0].phi(),jetP4s[2].eta(),jetP4s[2].phi());
@@ -314,23 +314,27 @@ namespace flashgg {
                 dijet_dy_         = fabs( (dijetP4s.first + dijetP4s.second).Rapidity() - (diPhotonP4s[0] + diPhotonP4s[1]).Rapidity() );
                 
                 dijet_leady_      = dijetP4s.first.Rapidity();
-
+                
                 dijet_subleady_   = dijetP4s.second.Rapidity();
                 
-                mvares.leadJet    = *Jets[jetCollectionIndex]->ptrAt( dijet_indices.first );
-                mvares.subleadJet = *Jets[jetCollectionIndex]->ptrAt( dijet_indices.second );
+                mvares.n_rec_jets = n_jets_count;
+                //mvares.leadJet    = *Jets[jetCollectionIndex]->ptrAt( dijet_indices.first );
+                //mvares.subleadJet = *Jets[jetCollectionIndex]->ptrAt( dijet_indices.second );
+                mvares.leadJet        = dijetP4s.first;
+                mvares.subleadJet     = dijetP4s.second;
                 
                 mvares.leadJet_ptr    = Jets[jetCollectionIndex]->ptrAt( dijet_indices.first );
                 mvares.subleadJet_ptr = Jets[jetCollectionIndex]->ptrAt( dijet_indices.second );
-                mvares.diphoton       = *diPhotons->ptrAt( candIndex );
+                //mvares.diphoton       = *diPhotons->ptrAt( candIndex );
             }else{
                 mvares.leadJet_ptr    = edm::Ptr<flashgg::Jet>();
                 mvares.subleadJet_ptr = edm::Ptr<flashgg::Jet>();
             }
             
             if ( hasValidVBFDiJet && hasValidVBFTriJet){
-                mvares.subsubleadJet     = *Jets[jetCollectionIndex]->ptrAt( jet_3_index );
-                mvares.subsubleadJet_ptr =  Jets[jetCollectionIndex]->ptrAt( jet_3_index );
+                //mvares.subsubleadJet     = *Jets[jetCollectionIndex]->ptrAt( jet_3_index );
+                mvares.subsubleadJet     = Jets[jetCollectionIndex]->ptrAt( jet_3_index )->p4();
+                mvares.subsubleadJet_ptr = Jets[jetCollectionIndex]->ptrAt( jet_3_index );
                 mvares.hasValidVBFTriJet = 1;
             }else{
                 mvares.subsubleadJet_ptr =  edm::Ptr<flashgg::Jet>();

--- a/Taggers/plugins/VBFTagProducer.cc
+++ b/Taggers/plugins/VBFTagProducer.cc
@@ -35,12 +35,12 @@ namespace flashgg {
         void produce( Event &, const EventSetup & ) override;
         int chooseCategory( float );
 
-        EDGetTokenT<View<DiPhotonCandidate> > diPhotonToken_;
+        EDGetTokenT<View<DiPhotonCandidate> >      diPhotonToken_;
         EDGetTokenT<View<VBFDiPhoDiJetMVAResult> > vbfDiPhoDiJetMvaResultToken_;
-        EDGetTokenT<View<VBFMVAResult> > vbfMvaResultToken_;
-        EDGetTokenT<View<DiPhotonMVAResult> > mvaResultToken_;
-        EDGetTokenT<View<reco::GenParticle> > genPartToken_;
-        EDGetTokenT<View<reco::GenJet> > genJetToken_;
+        EDGetTokenT<View<VBFMVAResult> >           vbfMvaResultToken_;
+        EDGetTokenT<View<DiPhotonMVAResult> >      mvaResultToken_;
+        EDGetTokenT<View<reco::GenParticle> >      genPartToken_;
+        EDGetTokenT<View<reco::GenJet> >           genJetToken_;
         string systLabel_;
 
         vector<double> boundaries;
@@ -52,21 +52,19 @@ namespace flashgg {
         vbfDiPhoDiJetMvaResultToken_( consumes<View<flashgg::VBFDiPhoDiJetMVAResult> >( iConfig.getParameter<InputTag> ( "VBFDiPhoDiJetMVAResultTag" ) ) ),
         mvaResultToken_( consumes<View<flashgg::DiPhotonMVAResult> >( iConfig.getParameter<InputTag> ( "MVAResultTag" ) ) ),
         genPartToken_( consumes<View<reco::GenParticle> >( iConfig.getParameter<InputTag> ( "GenParticleTag" ) ) ),
-        genJetToken_( consumes<View<reco::GenJet> >( iConfig.getParameter<InputTag> ( "GenJetTag" ) ) ),
-        systLabel_( iConfig.getParameter<string> ( "SystLabel" ) )
+        genJetToken_ ( consumes<View<reco::GenJet> >( iConfig.getParameter<InputTag> ( "GenJetTag" ) ) ),
+        systLabel_   ( iConfig.getParameter<string> ( "SystLabel" ) )
     {
         vector<double> default_boundaries;
         default_boundaries.push_back( 0.52 );
         default_boundaries.push_back( 0.85 );
         default_boundaries.push_back( 0.915 );
         default_boundaries.push_back( 1 ); // from here
-        //https://github.com/h2gglobe/h2gglobe/blob/master/AnalysisScripts/massfac_mva_binned/massfactorizedmvaanalysis.dat#L32
-
+                
         // getUntrackedParameter<vector<float> > has no library, so we use double transiently
         boundaries = iConfig.getUntrackedParameter<vector<double > >( "Boundaries", default_boundaries );
-
         assert( is_sorted( boundaries.begin(), boundaries.end() ) ); // we are counting on ascending order - update this to give an error message or exception
-
+        
         produces<vector<VBFTag> >();
         produces<vector<VBFTagTruth> >();
     }
@@ -80,16 +78,16 @@ namespace flashgg {
         }
         return -1; // Does not pass, object will not be produced
     }
-
+    
     void VBFTagProducer::produce( Event &evt, const EventSetup & )
     {
 
         Handle<View<flashgg::DiPhotonCandidate> > diPhotons;
         evt.getByToken( diPhotonToken_, diPhotons );
-
+        
         Handle<View<flashgg::DiPhotonMVAResult> > mvaResults;
         evt.getByToken( mvaResultToken_, mvaResults );
-
+        
         Handle<View<flashgg::VBFDiPhoDiJetMVAResult> > vbfDiPhoDiJetMvaResults;
         evt.getByToken( vbfDiPhoDiJetMvaResultToken_, vbfDiPhoDiJetMvaResults );
 
@@ -98,17 +96,19 @@ namespace flashgg {
 
         Handle<View<reco::GenJet> > genJets;
         evt.getByToken( genJetToken_, genJets );
-
-        std::auto_ptr<vector<VBFTag> > tags( new vector<VBFTag> );
+        
+        std::auto_ptr<vector<VBFTag> >      tags  ( new vector<VBFTag> );
         std::auto_ptr<vector<VBFTagTruth> > truths( new vector<VBFTagTruth> );
 
         unsigned int idx = 0;
         edm::RefProd<vector<VBFTagTruth> > rTagTruth = evt.getRefBeforePut<vector<VBFTagTruth> >();
-
-        unsigned int index_leadq = std::numeric_limits<unsigned int>::max(), index_subleadq = std::numeric_limits<unsigned int>::max();
-        float pt_leadq = 0., pt_subleadq = 0.;
+        
+        unsigned int index_leadq       = std::numeric_limits<unsigned int>::max();
+        unsigned int index_subleadq    = std::numeric_limits<unsigned int>::max();
+        unsigned int index_subsubleadq = std::numeric_limits<unsigned int>::max();
+        float pt_leadq = 0., pt_subleadq = 0., pt_subsubleadq = 0.;
         Point higgsVtx;
-
+        
         if( ! evt.isRealData() ) {
             for( unsigned int genLoop = 0 ; genLoop < genParticles->size(); genLoop++ ) {
                 int pdgid = genParticles->ptrAt( genLoop )->pdgId();
@@ -127,27 +127,31 @@ namespace flashgg {
                             index_leadq = genLoop;
                             pt_leadq = part->pt();
                         } else if( part->pt() > pt_subleadq ) {
+                            index_subsubleadq  = index_subleadq;
+                            pt_subsubleadq     = pt_subleadq;
                             index_subleadq = genLoop;
-                            pt_subleadq = part->pt();
+                            pt_subleadq    = part->pt();
+                        }else if( part->pt() > pt_subsubleadq ){
+                            index_subsubleadq = genLoop;
+                            pt_subleadq       = part->pt();
                         }
                     }
                 }
             }
         }
-        assert( diPhotons->size() == vbfDiPhoDiJetMvaResults->size() ); // We are relying on corresponding sets - update this to give an error/exception
-        assert( diPhotons->size() ==
-                mvaResults->size() ); // We are relying on corresponding sets - update this to give an error/exception
-
+        // We are relying on corresponding sets - update this to give an error/exception
+        assert( diPhotons->size() == vbfDiPhoDiJetMvaResults->size() ); 
+        assert( diPhotons->size() == mvaResults->size() ); // We are relying on corresponding sets - update this to give an error/exception
+        //std::cout << "-----------------------------------------------------" << std::endl;
         for( unsigned int candIndex = 0; candIndex < diPhotons->size() ; candIndex++ ) {
             edm::Ptr<flashgg::VBFDiPhoDiJetMVAResult> vbfdipho_mvares = vbfDiPhoDiJetMvaResults->ptrAt( candIndex );
-            edm::Ptr<flashgg::DiPhotonMVAResult> mvares = mvaResults->ptrAt( candIndex );
-            edm::Ptr<flashgg::DiPhotonCandidate> dipho = diPhotons->ptrAt( candIndex );
-
+            edm::Ptr<flashgg::DiPhotonMVAResult>      mvares          = mvaResults->ptrAt( candIndex );
+            edm::Ptr<flashgg::DiPhotonCandidate>      dipho           = diPhotons->ptrAt( candIndex );
+            
             VBFTag tag_obj( dipho, mvares, vbfdipho_mvares );
             tag_obj.setDiPhotonIndex( candIndex );
-
-            tag_obj.setSystLabel( systLabel_ );
-
+            tag_obj.setSystLabel    ( systLabel_ );
+            
             int catnum = chooseCategory( vbfdipho_mvares->vbfDiPhoDiJetMvaResult );
             tag_obj.setCategoryNumber( catnum );
             unsigned int index_gp_leadjet = std::numeric_limits<unsigned int>::max();
@@ -156,6 +160,7 @@ namespace flashgg {
             unsigned int index_gp_subleadphoton = std::numeric_limits<unsigned int>::max();
             unsigned int index_gj_leadjet = std::numeric_limits<unsigned int>::max();
             unsigned int index_gj_subleadjet = std::numeric_limits<unsigned int>::max();
+            
             float dr_gp_leadjet = 999.;
             float dr_gp_subleadjet = 999.;
             float dr_gp_leadphoton = 999.;
@@ -194,6 +199,7 @@ namespace flashgg {
                 if( index_gp_subleadjet < std::numeric_limits<unsigned int>::max() ) { truth_obj.setClosestParticleToSubLeadingJet( genParticles->ptrAt( index_gp_subleadjet ) ); }
                 if( index_gp_leadphoton < std::numeric_limits<unsigned int>::max() ) { truth_obj.setClosestParticleToLeadingPhoton( genParticles->ptrAt( index_gp_leadphoton ) ); }
                 if( index_gp_subleadphoton < std::numeric_limits<unsigned int>::max() ) { truth_obj.setClosestParticleToSubLeadingPhoton( genParticles->ptrAt( index_gp_subleadphoton ) ); }
+                
                 for( unsigned int gjLoop = 0 ; gjLoop < genJets->size() ; gjLoop++ ) {
                     edm::Ptr<reco::GenJet> gj = genJets->ptrAt( gjLoop );
                     float dr = deltaR( tag_obj.leadingJet().eta(), tag_obj.leadingJet().phi(), gj->eta(), gj->phi() );
@@ -209,11 +215,182 @@ namespace flashgg {
                 }
                 if( index_gj_leadjet < std::numeric_limits<unsigned int>::max() ) { truth_obj.setClosestGenJetToLeadingJet( genJets->ptrAt( index_gj_leadjet ) ); }
                 if( index_gj_subleadjet < std::numeric_limits<unsigned int>::max() ) { truth_obj.setClosestGenJetToSubLeadingJet( genJets->ptrAt( index_gj_subleadjet ) ); }
-
-                if( index_leadq < std::numeric_limits<unsigned int>::max() ) { truth_obj.setLeadingQuark( genParticles->ptrAt( index_leadq ) ); }
-                if( index_subleadq < std::numeric_limits<unsigned int>::max() ) { truth_obj.setSubLeadingQuark( genParticles->ptrAt( index_subleadq ) ); }
+                
+                if( index_leadq < std::numeric_limits<unsigned int>::max() ) { truth_obj.setLeadingParton( genParticles->ptrAt( index_leadq ) ); }
+                if( index_subleadq < std::numeric_limits<unsigned int>::max() ) { truth_obj.setSubLeadingParton( genParticles->ptrAt( index_subleadq ) ); }
+                if( index_subsubleadq < std::numeric_limits<unsigned int>::max()) { truth_obj.setSubSubLeadingParton( genParticles->ptrAt( index_subsubleadq ));}
             }
             truth_obj.setGenPV( higgsVtx );
+            // Yacine: filling tagTruth Tag with 3 jets matchings
+            // the idea is to fill the truth_obj using Jack's 
+            // implementation
+            
+            // photon overla removal
+            std::vector<edm::Ptr<reco::GenJet>> ptOrderedgenJets;
+            for( unsigned int jetLoop( 0 ); jetLoop < genJets->size(); jetLoop++ ) {
+                edm::Ptr<reco::GenJet> gj = genJets->ptrAt(jetLoop );
+                unsigned insertionIndex( 0 );
+                for( unsigned int i( 0 ); i < ptOrderedgenJets.size(); i++ ) {
+                    if( gj->pt() <= ptOrderedgenJets[i]->pt() && gj != ptOrderedgenJets[i] ) { insertionIndex = i + 1; }
+                }
+                //Remove photons        
+                float dr_leadPhoton    = deltaR( gj->eta(), gj->phi(),dipho->leadingPhoton()->eta(),dipho->leadingPhoton()->phi() ); 
+                float dr_subLeadPhoton = deltaR( gj->eta(), gj->phi(),dipho->subLeadingPhoton()->eta(),dipho->subLeadingPhoton()->phi() ); 
+                if( dr_leadPhoton > 0.1 && dr_subLeadPhoton > 0.1 ) {
+                    ptOrderedgenJets.insert( ptOrderedgenJets.begin() + insertionIndex, gj );
+                }
+            }
+            
+            //truth_obj.setPtOrderedgenJets(ptOrderedgenJets);
+            if (ptOrderedgenJets.size() == 1) {
+                truth_obj.setLeadingGenJet(ptOrderedgenJets[0]);
+            }
+            if (ptOrderedgenJets.size() == 2) {
+                truth_obj.setLeadingGenJet(ptOrderedgenJets[0]);
+                truth_obj.setSubLeadingGenJet(ptOrderedgenJets[1]);
+            }
+            if (ptOrderedgenJets.size() == 3) {
+                truth_obj.setLeadingGenJet(ptOrderedgenJets[0]);
+                truth_obj.setSubLeadingGenJet(ptOrderedgenJets[1]);
+                truth_obj.setSubSubLeadingGenJet(ptOrderedgenJets[2]);
+            }
+            
+            //std::cout << "DEBUG tag_obj.subSubLeadingJet_ptr()->pt() == " << tag_obj.subSubLeadingJet_ptr()->pt() << std::endl;
+            truth_obj.setLeadingJet      ( tag_obj.leadingJet_ptr() );
+            truth_obj.setSubLeadingJet   ( tag_obj.subLeadingJet_ptr() );
+            truth_obj.setSubSubLeadingJet( tag_obj.subSubLeadingJet_ptr() );
+            truth_obj.setDiPhoton        ( dipho );           
+ 
+            //-------------------
+            // GenParticles matching
+            if ( genParticles->size() > 0 ) {
+                float dr(999.0);
+                unsigned gpIndex(0);
+                for (unsigned partLoop(0);partLoop<genParticles->size();partLoop++) {
+                    edm::Ptr<reco::GenParticle> particle = genParticles->ptrAt(partLoop);
+                    float deltaR_temp = deltaR(tag_obj.leadingJet().eta(),tag_obj.leadingJet().phi(),particle->eta(),particle->phi());
+                    if (deltaR_temp < dr) {dr = deltaR_temp; gpIndex = partLoop;}
+                }
+                truth_obj.setClosestParticleToLeadingJet(genParticles->ptrAt(gpIndex));
+            }
+            ////Sublead
+            if (genParticles->size() > 0) {
+                float dr(999.0);
+                unsigned gpIndex(0);
+                for (unsigned partLoop(0);partLoop<genParticles->size();partLoop++) {
+                    edm::Ptr<reco::GenParticle> particle = genParticles->ptrAt(partLoop);
+                    float deltaR_temp = deltaR(tag_obj.subLeadingJet().eta(),tag_obj.subLeadingJet().phi(),particle->eta(),particle->phi());
+                    if (deltaR_temp < dr) {dr = deltaR_temp; gpIndex = partLoop;}
+                }
+                truth_obj.setClosestParticleToSubLeadingJet(genParticles->ptrAt(gpIndex));
+            }
+            //////Subsublead
+            if (genParticles->size() > 0 &&  tag_obj.VBFMVA().hasValidVBFTriJet ) {
+                float dr(999.0);
+                unsigned gpIndex(0);
+                for (unsigned partLoop(0);partLoop<genParticles->size();partLoop++) {
+                    edm::Ptr<reco::GenParticle> particle = genParticles->ptrAt(partLoop);
+                    float deltaR_temp = deltaR(tag_obj.subSubLeadingJet().eta(),tag_obj.subSubLeadingJet().phi(),particle->eta(),particle->phi());
+                    if (deltaR_temp < dr) {dr = deltaR_temp; gpIndex = partLoop;}
+                }
+                truth_obj.setClosestParticleToSubSubLeadingJet(genParticles->ptrAt(gpIndex));
+            } 
+            ////----------------
+            //// GetJet matching
+            if ( ptOrderedgenJets.size() > 0) {
+                float dr(999.0);
+                unsigned gpIndex(0);
+                for (unsigned partLoop(0);partLoop<ptOrderedgenJets.size();partLoop++) {
+                    edm::Ptr<reco::GenJet> particle = ptOrderedgenJets[partLoop];
+                    float deltaR_temp = deltaR(tag_obj.leadingJet().eta(),tag_obj.leadingJet().phi(),particle->eta(),particle->phi());
+                    if (deltaR_temp < dr) {dr = deltaR_temp; gpIndex = partLoop;}
+                }
+                truth_obj.setClosestGenJetToLeadingJet(ptOrderedgenJets[gpIndex]);
+            }
+            //Subl
+            if (ptOrderedgenJets.size() > 0) {
+                float dr(999.0);
+                unsigned gpIndex(0);
+                for (unsigned partLoop(0);partLoop<ptOrderedgenJets.size();partLoop++) {
+                    edm::Ptr<reco::GenJet> particle = ptOrderedgenJets[partLoop];
+                    float deltaR_temp = deltaR(tag_obj.subLeadingJet().eta(),tag_obj.subLeadingJet().phi(),particle->eta(),particle->phi());
+                    if (deltaR_temp < dr) {dr = deltaR_temp; gpIndex = partLoop;}
+                }
+                truth_obj.setClosestGenJetToSubLeadingJet(ptOrderedgenJets[gpIndex]);
+            }
+            //Subsublead
+            if (ptOrderedgenJets.size() > 0 &&  tag_obj.VBFMVA().hasValidVBFTriJet ) {
+                float dr(999.0);
+                unsigned gpIndex(0);
+                for (unsigned partLoop(0);partLoop<ptOrderedgenJets.size();partLoop++) {
+                    edm::Ptr<reco::GenJet> particle = ptOrderedgenJets[partLoop];
+                    float deltaR_temp = deltaR(tag_obj.subSubLeadingJet().eta(),tag_obj.subSubLeadingJet().phi(),particle->eta(),particle->phi());
+                    if (deltaR_temp < dr) {dr = deltaR_temp; gpIndex = partLoop;}
+                }
+                truth_obj.setClosestGenJetToSubSubLeadingJet(ptOrderedgenJets[gpIndex]);
+            }
+            // --------
+            //Partons
+            //Lead
+            std::vector<edm::Ptr<reco::GenParticle>> ptOrderedPartons;
+            for (unsigned int genLoop(0);genLoop < genParticles->size();genLoop++) {
+                edm::Ptr<reco::GenParticle> gp = genParticles->ptrAt(genLoop);
+                bool isGluon = abs( gp->pdgId() ) < 7 && gp->numberOfMothers() == 0;
+                bool isQuark = gp->pdgId() == 21 && gp->numberOfMothers() == 0;
+                if (isGluon || isQuark) {
+                    unsigned int insertionIndex(0);
+                    for (unsigned int parLoop(0);parLoop<ptOrderedPartons.size();parLoop++) {
+                        if (gp->pt() < ptOrderedPartons[parLoop]->pt()) { insertionIndex = parLoop + 1; }
+                    }
+                    ptOrderedPartons.insert( ptOrderedPartons.begin() + insertionIndex, gp);
+                }
+            }
+            if ( ptOrderedPartons.size() > 0 ) {
+                float dr(999.0);
+                unsigned pIndex(0);
+                for (unsigned partLoop(0);partLoop<ptOrderedPartons.size();partLoop++) {
+                    float deltaR_temp = deltaR(tag_obj.leadingJet().eta(),tag_obj.leadingJet().phi(),
+                                               ptOrderedPartons[partLoop]->eta(),ptOrderedPartons[partLoop]->phi());
+                    if (deltaR_temp < dr) {dr = deltaR_temp; pIndex = partLoop;}
+                }
+                truth_obj.setClosestPartonToLeadingJet( ptOrderedPartons[pIndex] );
+            }
+            //Sublead
+            if (ptOrderedPartons.size() > 0) {
+                float dr(999.0);
+                unsigned pIndex(0);
+                for (unsigned partLoop(0);partLoop<ptOrderedPartons.size();partLoop++) {
+                    float deltaR_temp = deltaR(tag_obj.subLeadingJet().eta(),tag_obj.subLeadingJet().phi(),
+                                               ptOrderedPartons[partLoop]->eta(),ptOrderedPartons[partLoop]->phi());
+                    if (deltaR_temp < dr) {dr = deltaR_temp; pIndex = partLoop;}
+                }
+                truth_obj.setClosestPartonToSubLeadingJet( ptOrderedPartons[pIndex] );
+            }
+            //SubSublead
+            if (ptOrderedPartons.size() > 0 && tag_obj.VBFMVA().hasValidVBFTriJet ) {
+                float dr(999.0);
+                unsigned pIndex(0);
+                for (unsigned partLoop(0);partLoop<ptOrderedPartons.size();partLoop++) {
+                    float deltaR_temp = deltaR(tag_obj.subSubLeadingJet().eta(),tag_obj.subSubLeadingJet().phi(),
+                                               ptOrderedPartons[partLoop]->eta(),ptOrderedPartons[partLoop]->phi());
+                    if (deltaR_temp < dr) {dr = deltaR_temp; pIndex = partLoop;}
+                }
+                truth_obj.setClosestPartonToSubSubLeadingJet( ptOrderedPartons[pIndex] );
+            }
+            //------------------
+            float dr_leadPhoton(999.),dr_subLeadPhoton(999.);
+            unsigned gpIndex1(0),gpIndex2(0);
+            for (unsigned partLoop(0);partLoop < genParticles->size();partLoop++) {
+                edm::Ptr<reco::GenParticle> particle = genParticles->ptrAt(partLoop);
+                float deltaR_temp = deltaR(dipho->leadingPhoton()->eta(),dipho->leadingPhoton()->phi(),particle->eta(),particle->phi());
+                if (deltaR_temp < dr_leadPhoton) {dr_leadPhoton = deltaR_temp; gpIndex1 = partLoop;}
+                deltaR_temp = deltaR(dipho->subLeadingPhoton()->eta(),dipho->subLeadingPhoton()->phi(),particle->eta(),particle->phi());
+                if (deltaR_temp < dr_subLeadPhoton) {dr_subLeadPhoton = deltaR_temp; gpIndex2 = partLoop;}
+            }
+            truth_obj.setClosestParticleToLeadingPhoton(genParticles->ptrAt(gpIndex1));
+            truth_obj.setClosestParticleToSubLeadingPhoton(genParticles->ptrAt(gpIndex2));
+            
+            // saving the collection
             if( tag_obj.categoryNumber() >= 0 ) {
                 tags->push_back( tag_obj );
                 if( ! evt.isRealData() ) {
@@ -222,7 +399,13 @@ namespace flashgg {
                 }
             }
         }
+        
+        
+        
+        
 
+
+        
         evt.put( tags );
         evt.put( truths );
     }

--- a/Taggers/plugins/VBFTagProducer.cc
+++ b/Taggers/plugins/VBFTagProducer.cc
@@ -33,7 +33,7 @@ namespace flashgg {
 
     private:
         void produce( Event &, const EventSetup & ) override;
-        int chooseCategory( float );
+        int  chooseCategory( float );
 
         EDGetTokenT<View<DiPhotonCandidate> >      diPhotonToken_;
         EDGetTokenT<View<VBFDiPhoDiJetMVAResult> > vbfDiPhoDiJetMvaResultToken_;
@@ -399,13 +399,7 @@ namespace flashgg {
                 }
             }
         }
-        
-        
-        
-        
-
-
-        
+                
         evt.put( tags );
         evt.put( truths );
     }

--- a/Taggers/python/VBFTagVariables.py
+++ b/Taggers/python/VBFTagVariables.py
@@ -1,0 +1,152 @@
+dipho_variables=[
+    "dipho_sumpt            := diPhoton.sumPt",
+    "dipho_cosphi           := abs(cos(diPhoton.leadingPhoton.phi - diPhoton.subLeadingPhoton.phi))",
+    "dipho_mass             := diPhoton.mass",
+    "dipho_leadPt           := diPhoton.leadingPhoton.pt",
+    "dipho_leadEt           := diPhoton.leadingPhoton.et",
+    "dipho_leadEta          := diPhoton.leadingPhoton.eta",
+    "dipho_leadPhi          := diPhoton.leadingPhoton.phi",
+    "dipho_lead_sieie       := diPhoton.leadingPhoton.sigmaIetaIeta",
+    "dipho_lead_hoe         := diPhoton.leadingPhoton.hadronicOverEm",
+    "dipho_lead_sigmaEoE    := diPhoton.leadingPhoton.sigEOverE",
+    "dipho_lead_ptoM        := diPhoton.leadingPhoton.pt/diPhoton.mass",
+    "dipho_leadR9           := diPhoton.leadingPhoton.r9",
+    "dipho_subleadPt        := diPhoton.subLeadingPhoton.pt",
+    "dipho_subleadEt        := diPhoton.subLeadingPhoton.et",
+    "dipho_subleadEta       := diPhoton.subLeadingPhoton.eta",
+    "dipho_subleadPhi       := diPhoton.subLeadingPhoton.phi",
+    "dipho_sublead_sieie    := diPhoton.subLeadingPhoton.sigmaIetaIeta",
+    "dipho_sublead_hoe      := diPhoton.subLeadingPhoton.hadronicOverEm",
+    "dipho_sublead_sigmaEoE := diPhoton.subLeadingPhoton.sigEOverE",
+    "dipho_sublead_ptoM     := diPhoton.subLeadingPhoton.pt/diPhoton.mass",
+    "dipho_subleadR9        := diPhoton.subLeadingPhoton.r9",
+    "dipho_leadIDMVA        := diPhoton.leadingView.phoIdMvaWrtChosenVtx",
+    "dipho_subleadIDMVA     := diPhoton.subLeadingView.phoIdMvaWrtChosenVtx",
+    "dipho_lead_elveto      := diPhoton.leadingPhoton.passElectronVeto",
+    "dipho_sublead_elveto   := diPhoton.subLeadingPhoton.passElectronVeto"
+    ]
+
+dijet_variables=[
+    "dijet_abs_dEta         :=  abs(VBFMVA.dijet_leadEta - VBFMVA.dijet_subleadEta)",
+    "dijet_leadEta          :=  VBFMVA.dijet_leadEta    ",
+    "dijet_subleadEta       :=  VBFMVA.dijet_subleadEta ",
+    "dijet_leady            :=  VBFMVA.dijet_leady      ",
+    "dijet_subleady         :=  VBFMVA.dijet_subleady   ",
+    "dijet_LeadJPt          :=  VBFMVA.dijet_LeadJPt    ",
+    "dijet_SubJPt           :=  VBFMVA.dijet_SubJPt     ",
+    "dijet_Zep              :=  VBFMVA.dijet_Zep        ",
+    "dijet_Mjj              :=  VBFMVA.dijet_Mjj        ",
+    "dipho_PToM             :=  VBFMVA.dipho_PToM       ",
+    "leadPho_PToM           :=  VBFMVA.leadPho_PToM     ",
+    "sublPho_PToM           :=  VBFMVA.sublPho_PToM     ",
+    "dijet_dipho_dphi_trunc :=  VBFMVA.dijet_dphi_trunc ",
+    "dijet_dipho_pt         :=  VBFMVA.dijet_dipho_pt   ",
+    "dijet_dphi             :=  abs(deltaPhi(VBFMVA.leadJet.phi, VBFMVA.subleadJet.phi))",
+    "dijet_dipho_dphi       :=  VBFMVA.dijet_dipho_dphi ",
+    "dijet_dPhi_trunc       :=  VBFMVA.dijet_dphi_trunc ",
+    "cos_dijet_dipho_dphi   :=  cos(VBFMVA.dijet_dipho_dphi)",
+    "dijet_minDRJetPho      :=  VBFMVA.dijet_minDRJetPho",
+    "has3Jet                :=  hasValidVBFTriJet",
+    "dijet_mva              :=  VBFMVA.VBFMVAValue",
+    "dipho_dijet_MVA        :=  VBFDiPhoDiJetMVA.VBFDiPhoDiJetMVAValue()",
+    "dipho_mva              :=  diPhotonMVA.mvaValue()",
+    "dijet_dipho_dphi_trunc :=  VBFMVA.dijet_dipho_dphi ",
+    # new variables
+    "jet1_pt             := leadingJet.pt",
+    "jet2_pt             := subLeadingJet.pt",
+    "jet3_pt             := subSubLeadingJet.pt",
+    "jet1_eta            := leadingJet.eta",
+    "jet2_eta            := subLeadingJet.eta",
+    "jet3_eta            := subSubLeadingJet.eta",
+    "Mjj := sqrt((leadingJet.energy+subLeadingJet.energy)^2-(leadingJet.px+subLeadingJet.px)^2-(leadingJet.py+subLeadingJet.py)^2-(leadingJet.pz+subLeadingJet.pz)^2)"
+]
+truth_variables=[
+    "J1J2_mjj            := tagTruth().mjj_J1J2_FggJet()",
+    "J1J3_mjj            := tagTruth().mjj_J1J3_FggJet()",
+    "J2J3_mjj            := tagTruth().mjj_J2J3_FggJet()",
+    "Mjjj                := tagTruth().mjjj_FggJet()",
+    "J1J2_dEta           := tagTruth().dEta_J1J2_FggJet()",
+    "J1J3_dEta           := tagTruth().dEta_J1J3_FggJet()",
+    "J2J3_dEta           := tagTruth().dEta_J2J3_FggJet()",
+    "J1J2_Zep            := tagTruth().zepjj_J1J2_FggJet()",
+    "J1J3_Zep            := tagTruth().zepjj_J1J3_FggJet()",
+    "J2J3_Zep            := tagTruth().zepjj_J2J3_FggJet()",
+    "J1J2J3_Zep          := tagTruth().zepjjj_FggJet()",
+
+    "J1J2_dipho_dPhi     := tagTruth().dPhijj_J1J2_FggJet()",
+    "J1J3_dipho_dPhi     := tagTruth().dPhijj_J1J3_FggJet()",
+    "J2J3_dipho_dPhi     := tagTruth().dPhijj_J2J3_FggJet()",
+    
+    "J1J2J3_dipho_dPhi   := tagTruth().dPhijjj_FggJet()",
+    
+    "J1J2_dR             := tagTruth().dR_J1J2_FggJet()",
+    "J1J3_dR             := tagTruth().dR_J1J3_FggJet()",
+    "J2J3_dR             := tagTruth().dR_J2J3_FggJet()",
+    
+    "dEta_J1_J2J3        := tagTruth().dEta_J1J2J3_FggJet()",
+    "dEta_J2_J3J1        := tagTruth().dEta_J2J3J1_FggJet()",
+    "dEta_J3_J1J2        := tagTruth().dEta_J3J1J2_FggJet()",
+
+    "dEta_dJ1_J2J3       := tagTruth().dEta_dJ1_J2J3_FggJet()",
+    "dEta_dJ2_J3J1       := tagTruth().dEta_dJ2_J3J1_FggJet()",
+    "dEta_dJ3_J1J2       := tagTruth().dEta_dJ3_J1J2_FggJet()",
+
+    "dMjj_d12_13plus23   := tagTruth().mjj_d12_13plus23_FggJet()",
+    "dMjj_d12_13         := tagTruth().mjj_d12_13_FggJet()",
+    "dMjj_d12_23         := tagTruth().mjj_d12_23_FggJet()",
+    "dMjj_d13_23         := tagTruth().mjj_d13_23_FggJet()",
+
+    "dR_dipho_dijet12    := tagTruth().dR_DP_12_FggJet()",
+    "dR_dipho_dijet13    := tagTruth().dR_DP_13_FggJet()",
+    "dR_dipho_dijet23    := tagTruth().dR_DP_23_FggJet()",
+
+    "dR_Photon1_J1       := tagTruth().dR_Ph1_1_FggJet()",
+    "dR_Photon1_J2       := tagTruth().dR_Ph1_2_FggJet()",
+    "dR_Photon1_J3       := tagTruth().dR_Ph1_3_FggJet()",
+    "dR_Photon2_J1       := tagTruth().dR_Ph2_1_FggJet()",
+    "dR_Photon2_J2       := tagTruth().dR_Ph2_2_FggJet()",
+    "dR_Photon2_J3       := tagTruth().dR_Ph2_3_FggJet()",
+    
+    "dR_dipho_trijet     := tagTruth().dR_DP_123_FggJet()",
+
+    "misPt_dPhi_3J       := tagTruth().missingP4_dPhi_jjj_FggJet()",
+    "misPt_dPhi_2J       := tagTruth().missingP4_dPhi_jj_FggJet()",
+    "misPt_mag_3J        := tagTruth().missingP4_Pt_jjj_FggJet()",
+    "misPt_mag_2J        := tagTruth().missingP4_Pt_jj_FggJet()",
+
+    "misPt_dPhi_d3J2J    := tagTruth().missingP4_dPhi_d3J2J_FggJet()",
+    "misPt_mag_d3J2J     := tagTruth().missingP4_Pt_d3J2J_FggJet()",
+
+    "dPhi_J1_J2          := tagTruth().dPhi_12_FggJet()",
+    "dPhi_J1_J3          := tagTruth().dPhi_13_FggJet()",
+    "dPhi_J2_J3          := tagTruth().dPhi_23_FggJet()",
+
+    "dPhi_max_jets       := tagTruth().dPhi_max_FggJet()",
+    "dPhi_min_jets       := tagTruth().dPhi_min_FggJet()",
+
+    "momentum4Volume     := tagTruth().simplex_volume_DP_12_FggJet()",
+    
+    "dR_min_J12J23       := tagTruth().dR_min_J13J23_FggJet()",
+
+    "dRToNearestPartonJ1 := tagTruth().dR_partonMatchingToJ1()",
+    "dRToNearestPartonJ2 := tagTruth().dR_partonMatchingToJ2()",
+    "dRToNearestPartonJ3 := tagTruth().dR_partonMatchingToJ3()",
+    
+    "numberOfMatches     := tagTruth().numberOfMatchesAfterDRCut(0.5)",
+    
+    # tag truth information
+    "genZ                                 := tagTruth().genPV().z", # try that !!
+    "pt_genJetMatchingToJ1                := tagTruth().pt_genJetMatchingToJ1",
+    "pt_genJetMatchingToJ2                := tagTruth().pt_genJetMatchingToJ2",
+    "pt_genJetMatchingToJ3                := tagTruth().pt_genJetMatchingToJ3",
+    "eta_genJetMatchingToJ1               := tagTruth().eta_genJetMatchingToJ1",
+    "eta_genJetMatchingToJ2               := tagTruth().eta_genJetMatchingToJ2",
+    "eta_genJetMatchingToJ3               := tagTruth().eta_genJetMatchingToJ3",
+    "hasClosestGenJetToLeadingJet         := tagTruth().hasClosestGenJetToLeadingJet",
+    "hasClosestGenJetToSubLeadingJet      := tagTruth().hasClosestGenJetToSubLeadingJet",
+    "hasClosestParticleToLeadingJet       := tagTruth().hasClosestParticleToLeadingJet",
+    "hasClosestParticleToSubLeadingJet    := tagTruth().hasClosestParticleToSubLeadingJet",
+    "hasClosestParticleToLeadingPhoton    := tagTruth().hasClosestParticleToLeadingPhoton",
+    "hasClosestParticleToSubLeadingPhoton := tagTruth().hasClosestParticleToSubLeadingPhoton"
+    
+    ]

--- a/Taggers/python/flashggTags_cff.py
+++ b/Taggers/python/flashggTags_cff.py
@@ -41,8 +41,10 @@ flashggVBFTag = cms.EDProducer("FlashggVBFTagProducer",
                                VBFMVAResultTag=cms.InputTag('flashggVBFMVA'),
                                GenParticleTag=cms.InputTag( "flashggPrunedGenParticles" ),
                                GenJetTag = cms.InputTag("slimmedGenJets"),
-                               Boundaries=cms.untracked.vdouble(0.21,0.6,0.81)
-)
+                               #Boundaries=cms.untracked.vdouble(0.21,0.6,0.81)
+                               #  for the moment we have two categories VBF-0 and VBF-1: to be changed when the diphoton MVA is ready 
+                               Boundaries=cms.untracked.vdouble(0.26,0.79) 
+                               )
 
 
 flashggVHEtTag = cms.EDProducer("FlashggVHEtTagProducer",

--- a/Taggers/python/flashggVBFMVA_cff.py
+++ b/Taggers/python/flashggVBFMVA_cff.py
@@ -9,8 +9,9 @@ flashggVBFMVA = cms.EDProducer('FlashggVBFMVAProducer',
                                inputTagJets= UnpackedJetCollectionVInputTag,
                                UseLegacyMVA = cms.untracked.bool(True),
                                MinDijetMinv = cms.double(0.0),
-                               vbfMVAweightfile = cms.FileInPath("flashgg/Taggers/data/TMVA_dijet_sherpa_scalewt50_2evenb_powheg200_maxdPhi_oct9_Gradient.weights.xml"),
-		)
+                               #vbfMVAweightfile = cms.FileInPath("flashgg/Taggers/data/TMVA_dijet_sherpa_scalewt50_2evenb_powheg200_maxdPhi_oct9_Gradient.weights.xml"),
+                               vbfMVAweightfile = cms.FileInPath("flashgg/Taggers/data/Flashgg_VBF_CHS_STD_BDTG.weights.xml"),
+                               )
 
 # Legacy DiPhoDiJet MVA
 flashggVBFDiPhoDiJetMVA = cms.EDProducer('FlashggVBFDiPhoDiJetMVAProducer',
@@ -19,7 +20,7 @@ flashggVBFDiPhoDiJetMVA = cms.EDProducer('FlashggVBFDiPhoDiJetMVAProducer',
                                          MVAResultTag=cms.InputTag('flashggDiPhotonMVA'),
                                          UseLegacyMVA = cms.untracked.bool(True),
                                          vbfDiPhoDiJetMVAweightfile = cms.FileInPath("flashgg/Taggers/data/TMVA_vbf_dijet_dipho_evenbkg_scaledwt50_maxdPhi_Gradient.weights.xml"),
-		)
+                                         )
 
 
 # new test VBF MVA

--- a/Taggers/src/TagsDumpers.cc
+++ b/Taggers/src/TagsDumpers.cc
@@ -6,6 +6,7 @@ namespace flashgg {
     namespace fwlite {
         PLUGGABLE_ANALYZER( CutBasedTTHHadronicTagDumper );
         PLUGGABLE_ANALYZER( CutBasedTTHLeptonicTagDumper );
+        PLUGGABLE_ANALYZER( CutBasedVBFTagDumper );
     }
 }
 

--- a/Taggers/test/VBFTagDumper_standard_cfg.py
+++ b/Taggers/test/VBFTagDumper_standard_cfg.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env cmsRun
+
+import FWCore.ParameterSet.Config as cms
+import FWCore.Utilities.FileUtils as FileUtils
+from FWCore.ParameterSet.VarParsing import VarParsing
+from flashgg.MetaData.samples_utils import SamplesManager
+
+process = cms.Process("VBFTagsDumper")
+
+process.load("FWCore.MessageService.MessageLogger_cfi")
+process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(-1))
+process.MessageLogger.cerr.FwkReport.reportEvery = cms.untracked.int32( 1 )
+process.source = cms.Source ("PoolSource",
+                             fileNames = cms.untracked.vstring("/store/group/phys_higgs/cmshgg/sethzenz/flashgg/RunIISpring15-ReMiniAOD-BetaV7-25ns/Spring15BetaV7/VBFHToGG_M-125_13TeV_powheg_pythia8/RunIISpring15-ReMiniAOD-BetaV7-25ns-Spring15BetaV7-v0-RunIISpring15MiniAODv2-74X_mcRun2_asymptotic_v2-v1/151021_152809/0000/myMicroAODOutputFile_1.root"))
+
+process.TFileService = cms.Service("TFileService",
+                                   fileName = cms.string("VBFTagsDump.root"),
+                                   closeFileFast = cms.untracked.bool(True))
+
+
+from flashgg.Taggers.flashggTagOutputCommands_cff import tagDefaultOutputCommand
+import flashgg.Taggers.dumperConfigTools as cfgTools
+from  flashgg.Taggers.tagsDumpers_cfi import createTagDumper
+
+process.load("flashgg.Taggers.flashggTagSequence_cfi")
+process.load("flashgg.Taggers.flashggTagTester_cfi")
+
+# Use JetID
+process.flashggVBFMVA.UseJetID      = cms.untracked.bool(True)
+process.flashggVBFMVA.JetIDLevel    = cms.untracked.string("Loose")
+
+# use custum TMVA weights
+process.flashggVBFMVA.vbfMVAweightfile = cms.FileInPath("flashgg/Taggers/data/Flashgg_VBF_CHS_STD_BDTG.weights.xml")
+process.flashggVBFMVA.MVAMethod        = cms.untracked.string("BDTG")
+
+# QCD Recovery 
+# process.flashggVBFMVA.merge3rdJet   = cms.untracked.bool(False)
+# process.flashggVBFMVA.thirdJetDRCut = cms.untracked.double(1.5)
+
+# combined MVA boundary set
+process.flashggVBFTag.Boundaries    = cms.untracked.vdouble(-2,0,2)
+
+# set the VBF dumper
+process.vbfTagDumper = createTagDumper("VBFTag")
+process.vbfTagDumper.dumpTrees     = True
+process.vbfTagDumper.dumpHistos    = True
+process.vbfTagDumper.dumpWorkspace = False
+
+# use the trigger-diphoton-preselection
+from PhysicsTools.PatAlgos.tools.helpers import massSearchReplaceAnyInputTag
+massSearchReplaceAnyInputTag(process.flashggTagSequence,cms.InputTag("flashggDiPhotons"),cms.InputTag("flashggPreselectedDiPhotons"))
+
+# get the variable list
+import flashgg.Taggers.VBFTagVariables as var
+all_variables = var.dijet_variables + var.dipho_variables + var.truth_variables
+
+cfgTools.addCategories(process.vbfTagDumper,
+                       [
+                           ("VBFDiJet","leadingJet.pt>0",0),
+                           ("excluded","1",0)
+                       ],
+                       variables  = all_variables,
+                       histograms = []
+)
+
+#process.vbfTagDumper.nameTemplate ="$PROCESS_$SQRTS_$LABEL_$SUBCAT_$CLASSNAME"
+process.vbfTagDumper.nameTemplate = "$PROCESS_$SQRTS_$CLASSNAME_$SUBCAT_$LABEL"
+
+from flashgg.MetaData.JobConfig import customize
+customize.setDefault("maxEvents" ,1000)    # max-number of events
+customize.setDefault("targetLumi",2.11e+3) # define integrated lumi
+customize(process)
+
+process.p1 = cms.Path(
+    process.flashggTagSequence*
+    #    process.flashggTagTester* # Uncommment if you what to test VBFtag
+    process.vbfTagDumper
+)
+
+print process.p1

--- a/Validation/python/JetValidationTreeProducer.py
+++ b/Validation/python/JetValidationTreeProducer.py
@@ -5,17 +5,17 @@
 
 import FWCore.ParameterSet.Config as cms
 import FWCore.Utilities.FileUtils as FileUtils
-
+from flashgg.MicroAOD.flashggJets_cfi import flashggBTag, maxJetCollections
 process = cms.Process("FLASHggJetValidation")
 process.load("FWCore.MessageService.MessageLogger_cfi")
 
 # +++++ the number of processed events
-process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32( 1000 ) )
+process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32( 50000 ) )
 process.MessageLogger.cerr.FwkReport.reportEvery = cms.untracked.int32( 100 )
 
 # +++++ the source file
 process.source = cms.Source("PoolSource",
-                            fileNames=cms.untracked.vstring("file:/afs/cern.ch/work/y/yhaddad/myMicroAODOutputFile.root")) 
+                            fileNames=cms.untracked.vstring("/store/group/phys_higgs/cmshgg/sethzenz/flashgg/RunIISpring15-JetUpdate-BetaV7J1/Spring15BetaV7J1/VBFHToGG_M-125_13TeV_powheg_pythia8/RunIISpring15-JetUpdate-BetaV7J1-Spring15BetaV7J1-v0-RunIISpring15MiniAODv2-74X_mcRun2_asymptotic_v2-v1/151127_155759/0000/myMicroAODOutputFile_1.root")) 
 
 process.MessageLogger.cerr.threshold = 'ERROR'
 
@@ -28,37 +28,42 @@ process.TFileService = cms.Service("TFileService",fileName  = cms.string("jetVal
 #                                                    )
 #
 
-JetCollectionVInputTagPFCHS = cms.VInputTag()
-JetCollectionVInputTagPUPPI = cms.VInputTag()
-for i in range(0,5):
-    JetCollectionVInputTagPFCHS.append(cms.InputTag('flashggPFCHSJets' + str(i)))
-    JetCollectionVInputTagPUPPI.append(cms.InputTag('flashggPUPPIJets' + str(i)))
+#JetCollectionVInputTagPFCHS = cms.VInputTag()
+#JetCollectionVInputTagPUPPI = cms.VInputTag()
+#for i in range(0,5):
+#    JetCollectionVInputTagPFCHS.append(cms.InputTag('flashggPFCHSJets' + str(i)))
+    #JetCollectionVInputTagPUPPI.append(cms.InputTag('flashggPUPPIJets' + str(i)))
+
+process.flashggUnpackedJets = cms.EDProducer("FlashggVectorVectorJetUnpacker",
+                                             JetsTag = cms.InputTag("flashggFinalJets"),
+                                             NCollections = cms.uint32(maxJetCollections)
+                                     )
+
+UnpackedJetCollectionVInputTag = cms.VInputTag()
+for i in range(0,maxJetCollections):
+    UnpackedJetCollectionVInputTag.append(cms.InputTag('flashggUnpackedJets',str(i)))
     
 process.flashggJetValidationTreeMakerPFCHS = cms.EDAnalyzer('FlashggJetValidationTreeMaker',
-                                                            GenParticleTag  = cms.untracked.InputTag('prunedGenParticles'),
-                                                            #JetTagDz        = cms.InputTag("flashggJetsPFCHS0"),
+                                                            GenParticleTag  = cms.untracked.InputTag('flashggPrunedGenParticles'),
                                                             DiPhotonTag     = cms.InputTag('flashggDiPhotons'),
-                                                            #VertexCandidateMapTag = cms.InputTag('')
-                                                            inputTagJets    = JetCollectionVInputTagPFCHS,
+                                                            inputTagJets    = UnpackedJetCollectionVInputTag,
                                                             StringTag	    = cms.string("PFCHS"),
-                                                        )
-
-process.flashggJetValidationTreeMakerPUPPI = cms.EDAnalyzer('FlashggJetValidationTreeMaker',
-                                                            GenParticleTag = cms.untracked.InputTag('prunedGenParticles'),
-                                                            DiPhotonTag     = cms.InputTag('flashggDiPhotons'),
-                                                            inputTagJets   = JetCollectionVInputTagPUPPI,
-                                                            StringTag      = cms.string("PUPPI"),
-                                                        )
+                                                            )
+#
+#process.flashggJetValidationTreeMakerPUPPI = cms.EDAnalyzer('FlashggJetValidationTreeMaker',
+#                                                            GenParticleTag = cms.untracked.InputTag('prunedGenParticles'),
+#                                                            DiPhotonTag     = cms.InputTag('flashggDiPhotons'),
+#                                                            inputTagJets   = JetCollectionVInputTagPUPPI,
+#                                                            StringTag      = cms.string("PUPPI"),
+#                                                        )
 
 process.out = cms.OutputModule("PoolOutputModule", fileName = cms.untracked.string('testetstestst.root'),
                                outputCommands = cms.untracked.vstring())
 
-process.options = cms.untracked.PSet(
-    allowUnscheduled = cms.untracked.bool(True)
-)
+process.options = cms.untracked.PSet( allowUnscheduled = cms.untracked.bool(True) )
 
-process.p = cms.Path(
-    process.flashggJetValidationTreeMakerPFCHS +
-    process.flashggJetValidationTreeMakerPUPPI 
-)
+process.p = cms.Path( 
+    process.flashggUnpackedJets +  
+    process.flashggJetValidationTreeMakerPFCHS 
+    )
 process.e = cms.EndPath(process.out)

--- a/Validation/python/multi_jets_producer_test.py
+++ b/Validation/python/multi_jets_producer_test.py
@@ -23,13 +23,11 @@ if current_gt.count("::All"):
     process.GlobalTag.globaltag = new_gt
 
 
-
+    
 process.source = cms.Source("PoolSource",
-                            fileNames=cms.untracked.vstring(
-                                #"/store/mc/RunIISpring15DR74/VBFHToGG_M-125_13TeV_powheg_pythia8/MINIAODSIM/Asympt50ns_MCRUN2_74_V9A-v1/50000/049AAFAA-CA2D-E511-93E8-02163E00F402.root"
-                                "/store/mc/RunIISpring15DR74/QCD_Pt-15to7000_TuneCUETP8M1_Flat_13TeV_pythia8/MINIAODSIM/AsymptFlat0to50bx50Reco_MCRUN2_74_V9A-v3/00000/023F427F-0E08-E511-A813-0025905A60EE.root"
+                            fileNames=cms.untracked.vstring("/store/mc/RunIISpring15DR74/QCD_Pt-15to7000_TuneCUETP8M1_Flat_13TeV_pythia8/MINIAODSIM/AsymptFlat0to50bx50Reco_MCRUN2_74_V9A-v3/00000/023F427F-0E08-E511-A813-0025905A60EE.root"
+                                                            )
                             )
-)
 
 process.MessageLogger.cerr.threshold = 'ERROR' 
 # process.MessageLogger.suppressWarning.extend(['SimpleMemoryCheck','MemoryCheck'])


### PR DESCRIPTION
This PR includes : 
* A standard configuration file to run the VBFTag dumper wich create a tree will diphoton, dijet and truth vairbales. see : `flashgg/Taggers/test/VBFTagDumper_standard_cfg.py` 
* Configurable QCD recovery for VBF which can be enabled by:
```python 
# QCD Recovery 
 process.flashggVBFMVA.merge3rdJet   = cms.untracked.bool(True)
 process.flashggVBFMVA.thirdJetDRCut = cms.untracked.double(1.5)

```
* Dijet BDT weights 