### PR TITLE
Scale and smearings for prompt reco 2015

### DIFF
--- a/Systematics/python/flashggDiPhotonSystematics_cfi.py
+++ b/Systematics/python/flashggDiPhotonSystematics_cfi.py
@@ -3,44 +3,33 @@ import FWCore.ParameterSet.Config as cms
 scaleBins = cms.PSet(
     variables = cms.vstring("abs(superCluster.eta)","r9"),
     bins = cms.VPSet(
-                     cms.PSet( lowBounds = cms.vdouble(0.000,0.940), upBounds = cms.vdouble(1.000,999.000),
-                              values = cms.vdouble( 0.00000 ), uncertainties = cms.vdouble( 0.00050 ) ),
-                     cms.PSet( lowBounds = cms.vdouble(0.000,-999.000), upBounds = cms.vdouble(1.000,0.940),
-                              values = cms.vdouble( 0.00000 ), uncertainties = cms.vdouble( 0.00050 ) ),
-                     cms.PSet( lowBounds = cms.vdouble(1.000,0.940), upBounds = cms.vdouble(1.500,999.000),
-                              values = cms.vdouble( 0.00000 ), uncertainties = cms.vdouble( 0.00060 ) ),
-                     cms.PSet( lowBounds = cms.vdouble(1.000,-999.000), upBounds = cms.vdouble(1.500,0.940),
-                              values = cms.vdouble( 0.00000 ), uncertainties = cms.vdouble( 0.00120 ) ),
-                     cms.PSet( lowBounds = cms.vdouble(1.500,-999.000), upBounds = cms.vdouble(2.000,0.940),
-                              values = cms.vdouble( 0.00000 ), uncertainties = cms.vdouble( 0.00200 ) ),
-                     cms.PSet( lowBounds = cms.vdouble(1.500,0.940), upBounds = cms.vdouble(2.000,999.000),
-                              values = cms.vdouble( 0.00000 ), uncertainties = cms.vdouble( 0.00300 ) ),
-                     cms.PSet( lowBounds = cms.vdouble(2.000,-999.000), upBounds = cms.vdouble(3.000,0.940),
-                              values = cms.vdouble( 0.00000 ), uncertainties = cms.vdouble( 0.00200 ) ),
-                     cms.PSet( lowBounds = cms.vdouble(2.000,0.940), upBounds = cms.vdouble(3.000,999.000),
-                              values = cms.vdouble( 0.00000 ), uncertainties = cms.vdouble( 0.00300 ) ),
+            # scale for prompt 2015, values OK, errors as in Run1 (since Run2 stat. only)
+            # see Fasanella et al., ECAL DPG 03/12/2015, https://cern.ch/go/zFH8
+            # w.r.t. the numbers in slide 3, the scale is computed as 1. / scale(MC) - 1.
+                     cms.PSet( lowBounds = cms.vdouble(0.000,0.940), upBounds = cms.vdouble(1.000,999.000), values = cms.vdouble( 0.00118139404497 ), uncertainties = cms.vdouble( 0.00050 ) ),
+                     cms.PSet( lowBounds = cms.vdouble(0.000,-999.000), upBounds = cms.vdouble(1.000,0.940), values = cms.vdouble( 0.00458088885317 ), uncertainties = cms.vdouble( 0.00050 ) ),
+                     cms.PSet( lowBounds = cms.vdouble(1.000,0.940), upBounds = cms.vdouble(1.500,999.000), values = cms.vdouble( -0.00645802285147 ), uncertainties = cms.vdouble( 0.00060 ) ),
+                     cms.PSet( lowBounds = cms.vdouble(1.000,-999.000), upBounds = cms.vdouble(1.500,0.940), values = cms.vdouble( 0.00339146314543 ), uncertainties = cms.vdouble( 0.00120 ) ),
+                     cms.PSet( lowBounds = cms.vdouble(1.500,-999.000), upBounds = cms.vdouble(2.000,0.940), values = cms.vdouble( 0.0138594588018 ), uncertainties = cms.vdouble( 0.00200 ) ),
+                     cms.PSet( lowBounds = cms.vdouble(1.500,0.940), upBounds = cms.vdouble(2.000,999.000), values = cms.vdouble( 0.00466162996303 ), uncertainties = cms.vdouble( 0.00300 ) ),
+                     cms.PSet( lowBounds = cms.vdouble(2.000,-999.000), upBounds = cms.vdouble(3.000,0.940), values = cms.vdouble( 0.021878416906 ), uncertainties = cms.vdouble( 0.00200 ) ),
+                     cms.PSet( lowBounds = cms.vdouble(2.000,0.940), upBounds = cms.vdouble(3.000,999.000), values = cms.vdouble( 0.014538334331 ), uncertainties = cms.vdouble( 0.00300 ) ),
                     ))
 
 
 smearBins = cms.PSet(
     variables = cms.vstring("abs(superCluster.eta)","r9"),
     bins = cms.VPSet(
-                     cms.PSet( lowBounds = cms.vdouble(0.000,-999.000), upBounds = cms.vdouble(1.000,0.940),
-                              values = cms.vdouble( 0.00770, 0.00000, 6.73000 ), uncertainties = cms.vdouble( 0.00063, 0.16000 ) ),
-                     cms.PSet( lowBounds = cms.vdouble(0.000,0.940), upBounds = cms.vdouble(1.000,999.000),
-                              values = cms.vdouble( 0.00740, 0.00000, 6.60000 ), uncertainties = cms.vdouble( 0.00065, 0.16000 ) ),
-                     cms.PSet( lowBounds = cms.vdouble(1.000,-999.000), upBounds = cms.vdouble(1.500,0.940),
-                              values = cms.vdouble( 0.01260, 0.00000, 6.73000 ), uncertainties = cms.vdouble( 0.00103, 0.07000 ) ),
-                     cms.PSet( lowBounds = cms.vdouble(1.000,0.940), upBounds = cms.vdouble(1.500,999.000),
-                              values = cms.vdouble( 0.01120, 0.00000, 6.52000 ), uncertainties = cms.vdouble( 0.00132, 0.22000 ) ),
-                     cms.PSet( lowBounds = cms.vdouble(1.500,-999.000), upBounds = cms.vdouble(2.000,0.940),
-                              values = cms.vdouble( 0.01980 ), uncertainties = cms.vdouble( 0.00303 ) ),
-                     cms.PSet( lowBounds = cms.vdouble(1.500,0.940), upBounds = cms.vdouble(2.000,999.000),
-                              values = cms.vdouble( 0.01630 ), uncertainties = cms.vdouble( 0.00122 ) ),
-                     cms.PSet( lowBounds = cms.vdouble(2.000,-999.000), upBounds = cms.vdouble(3.000,0.940),
-                              values = cms.vdouble( 0.01920 ), uncertainties = cms.vdouble( 0.00092 ) ),
-                     cms.PSet( lowBounds = cms.vdouble(2.000,0.940), upBounds = cms.vdouble(3.000,999.000),
-                              values = cms.vdouble( 0.01860 ), uncertainties = cms.vdouble( 0.00078 ) ),
+            # smearings for prompt 2015, values OK, errors as statistical of Run2 (since Run1 different parametrization)
+            # see Fasanella et al., ECAL DPG 03/12/2015, https://cern.ch/go/zFH8
+                     cms.PSet( lowBounds = cms.vdouble(0.000,-999.000), upBounds = cms.vdouble(1.000,0.940), values = cms.vdouble( 0.013654 ), uncertainties = cms.vdouble( 0.00024652 ) ),
+                     cms.PSet( lowBounds = cms.vdouble(0.000,0.940), upBounds = cms.vdouble(1.000,999.000), values = cms.vdouble( 0.014142 ), uncertainties = cms.vdouble( 0.00018319 ) ),
+                     cms.PSet( lowBounds = cms.vdouble(1.000,-999.000), upBounds = cms.vdouble(1.500,0.940), values = cms.vdouble( 0.020859 ), uncertainties = cms.vdouble( 0.00032435 ) ),
+                     cms.PSet( lowBounds = cms.vdouble(1.000,0.940), upBounds = cms.vdouble(1.500,999.000), values = cms.vdouble( 0.017120 ), uncertainties = cms.vdouble( 0.00098551 ) ),
+                     cms.PSet( lowBounds = cms.vdouble(1.500,-999.000), upBounds = cms.vdouble(2.000,0.940), values = cms.vdouble( 0.028083 ), uncertainties = cms.vdouble( 0.00045816 ) ),
+                     cms.PSet( lowBounds = cms.vdouble(1.500,0.940), upBounds = cms.vdouble(2.000,999.000), values = cms.vdouble( 0.027289 ), uncertainties = cms.vdouble( 0.00076386 ) ),
+                     cms.PSet( lowBounds = cms.vdouble(2.000,-999.000), upBounds = cms.vdouble(3.000,0.940), values = cms.vdouble( 0.031793 ), uncertainties = cms.vdouble( 0.00061517 ) ),
+                     cms.PSet( lowBounds = cms.vdouble(2.000,0.940), upBounds = cms.vdouble(3.000,999.000), values = cms.vdouble( 0.030831 ), uncertainties = cms.vdouble( 0.00042066 ) ),
                     ))
 
 mvaShiftBins = cms.PSet(
@@ -54,28 +43,10 @@ mvaShiftBins = cms.PSet(
 
 flashggDiPhotonSystematics = cms.EDProducer('FlashggDiPhotonSystematicProducer',
 		src = cms.InputTag("flashggFinalEGamma","finalDiPhotons"),
-                SystMethods2D = cms.VPSet(
-                                          cms.PSet( PhotonMethodName = cms.string("FlashggPhotonSmearStochastic"),
-                                                    MethodName = cms.string("FlashggDiPhotonFromPhoton2D"),
-                                                    Label = cms.string("MCSmearHighR9EB"),
-                                                    OverallRange = cms.string("r9>0.94&&abs(eta)<1.5"),
-                                                    NSigmas = cms.PSet( firstVar = cms.vint32(1,-1,0,0),
-                                                                        secondVar = cms.vint32(0,0,1,-1)),
-                                                    BinList = smearBins,
-                                                    Debug = cms.untracked.bool(False),
-                                                    ExaggerateShiftUp = cms.untracked.bool(False),
-                                                    ),
-                                          cms.PSet( PhotonMethodName = cms.string("FlashggPhotonSmearStochastic"),
-                                                    MethodName = cms.string("FlashggDiPhotonFromPhoton2D"),
-                                                    Label = cms.string("MCSmearLowR9EB"),
-                                                    OverallRange = cms.string("r9<0.94&&abs(eta)<1.5"),
-                                                    NSigmas = cms.PSet( firstVar = cms.vint32(1,-1,0,0),
-                                                                        secondVar = cms.vint32(0,0,1,-1)),
-                                                    BinList = smearBins,
-                                                    Debug = cms.untracked.bool(False),
-                                                    ExaggerateShiftUp = cms.untracked.bool(False),
-                                                    )
-                                          ),
+                SystMethods2D = cms.VPSet(),
+                # the number of syst methods matches the number of nuisance parameters
+                # assumed for a given systematic uncertainty and is NOT required
+                # to match 1-1 the number of bins above.
 		SystMethods = cms.VPSet(
                                         cms.PSet( PhotonMethodName = cms.string("FlashggPhotonScale"),
                                                   MethodName = cms.string("FlashggDiPhotonFromPhoton"),
@@ -83,7 +54,7 @@ flashggDiPhotonSystematics = cms.EDProducer('FlashggDiPhotonSystematicProducer',
                                                   NSigmas = cms.vint32(-1,1),
                                                   OverallRange = cms.string("r9>0.94&&abs(eta)<1.5"),
                                                   BinList = scaleBins,
-                                                  Debug = cms.untracked.bool(False)
+                                                  Debug = cms.untracked.bool(True)
                                                   ),
                                         cms.PSet( PhotonMethodName = cms.string("FlashggPhotonScale"),
                                                   MethodName = cms.string("FlashggDiPhotonFromPhoton"),
@@ -91,7 +62,7 @@ flashggDiPhotonSystematics = cms.EDProducer('FlashggDiPhotonSystematicProducer',
                                                   NSigmas = cms.vint32(-1,1),
                                                   OverallRange = cms.string("r9<0.94&&abs(eta)<1.5"),
                                                   BinList = scaleBins,
-                                                  Debug = cms.untracked.bool(False)
+                                                  Debug = cms.untracked.bool(True)
                                                   ),
                                         cms.PSet( PhotonMethodName = cms.string("FlashggPhotonScale"),
                                                   MethodName = cms.string("FlashggDiPhotonFromPhoton"),
@@ -99,7 +70,7 @@ flashggDiPhotonSystematics = cms.EDProducer('FlashggDiPhotonSystematicProducer',
                                                   NSigmas = cms.vint32(-1,1),
                                                   OverallRange = cms.string("r9>0.94&&abs(eta)>=1.5"),
                                                   BinList = scaleBins,
-                                                  Debug = cms.untracked.bool(False)
+                                                  Debug = cms.untracked.bool(True)
                                                   ),
                                         cms.PSet( PhotonMethodName = cms.string("FlashggPhotonScale"),
                                                   MethodName = cms.string("FlashggDiPhotonFromPhoton"),
@@ -107,7 +78,7 @@ flashggDiPhotonSystematics = cms.EDProducer('FlashggDiPhotonSystematicProducer',
                                                   NSigmas = cms.vint32(-1,1),
                                                   OverallRange = cms.string("r9<0.94&&abs(eta)>=1.5"),
                                                   BinList = scaleBins,
-                                                  Debug = cms.untracked.bool(False)
+                                                  Debug = cms.untracked.bool(True)
                                                   ),
                                         cms.PSet( PhotonMethodName = cms.string("FlashggPhotonSmearConstant"),
                                                   MethodName = cms.string("FlashggDiPhotonFromPhoton"),
@@ -115,7 +86,7 @@ flashggDiPhotonSystematics = cms.EDProducer('FlashggDiPhotonSystematicProducer',
                                                   NSigmas = cms.vint32(-1,1),
                                                   OverallRange = cms.string("r9>0.94&&abs(eta)>=1.5"),
                                                   BinList = smearBins,
-                                                  Debug = cms.untracked.bool(False),
+                                                  Debug = cms.untracked.bool(True),
                                                   ExaggerateShiftUp = cms.untracked.bool(False),
                                                   ),
                                         cms.PSet( PhotonMethodName = cms.string("FlashggPhotonSmearConstant"),
@@ -124,7 +95,25 @@ flashggDiPhotonSystematics = cms.EDProducer('FlashggDiPhotonSystematicProducer',
                                                   NSigmas = cms.vint32(-1,1),
                                                   OverallRange = cms.string("r9<0.94&&abs(eta)>=1.5"),
                                                   BinList = smearBins,
-                                                  Debug = cms.untracked.bool(False),
+                                                  Debug = cms.untracked.bool(True),
+                                                  ExaggerateShiftUp = cms.untracked.bool(False),
+                                                  ),
+                                        cms.PSet( PhotonMethodName = cms.string("FlashggPhotonSmearConstant"),
+                                                  MethodName = cms.string("FlashggDiPhotonFromPhoton"),
+                                                  Label = cms.string("MCSmearHighR9EB"),
+                                                  NSigmas = cms.vint32(-1,1),
+                                                  OverallRange = cms.string("r9>0.94&&abs(eta)<1.5"),
+                                                  BinList = smearBins,
+                                                  Debug = cms.untracked.bool(True),
+                                                  ExaggerateShiftUp = cms.untracked.bool(False),
+                                                  ),
+                                        cms.PSet( PhotonMethodName = cms.string("FlashggPhotonSmearConstant"),
+                                                  MethodName = cms.string("FlashggDiPhotonFromPhoton"),
+                                                  Label = cms.string("MCSmearLowR9EB"),
+                                                  NSigmas = cms.vint32(-1,1),
+                                                  OverallRange = cms.string("r9<=0.94&&abs(eta)<1.5"),
+                                                  BinList = smearBins,
+                                                  Debug = cms.untracked.bool(True),
                                                   ExaggerateShiftUp = cms.untracked.bool(False),
                                                   ),
                                         cms.PSet( PhotonMethodName = cms.string("FlashggPhotonMvaShift"),
@@ -133,7 +122,7 @@ flashggDiPhotonSystematics = cms.EDProducer('FlashggDiPhotonSystematicProducer',
                                                   NSigmas = cms.vint32(-1,1),
                                                   OverallRange = cms.string("1"),
                                                   BinList = mvaShiftBins,
-                                                  Debug = cms.untracked.bool(False)
+                                                  Debug = cms.untracked.bool(True)
                                                   )
                                         )
                                      )

--- a/Systematics/python/flashggDiPhotonSystematics_cfi.py
+++ b/Systematics/python/flashggDiPhotonSystematics_cfi.py
@@ -46,7 +46,7 @@ flashggDiPhotonSystematics = cms.EDProducer('FlashggDiPhotonSystematicProducer',
                 SystMethods2D = cms.VPSet(),
                 # the number of syst methods matches the number of nuisance parameters
                 # assumed for a given systematic uncertainty and is NOT required
-                # to match 1-1 the number of bins above.
+                # to match 1-to-1 the number of bins above.
 		SystMethods = cms.VPSet(
                                         cms.PSet( PhotonMethodName = cms.string("FlashggPhotonScale"),
                                                   MethodName = cms.string("FlashggDiPhotonFromPhoton"),
@@ -54,7 +54,7 @@ flashggDiPhotonSystematics = cms.EDProducer('FlashggDiPhotonSystematicProducer',
                                                   NSigmas = cms.vint32(-1,1),
                                                   OverallRange = cms.string("r9>0.94&&abs(eta)<1.5"),
                                                   BinList = scaleBins,
-                                                  Debug = cms.untracked.bool(True)
+                                                  Debug = cms.untracked.bool(False)
                                                   ),
                                         cms.PSet( PhotonMethodName = cms.string("FlashggPhotonScale"),
                                                   MethodName = cms.string("FlashggDiPhotonFromPhoton"),
@@ -62,7 +62,7 @@ flashggDiPhotonSystematics = cms.EDProducer('FlashggDiPhotonSystematicProducer',
                                                   NSigmas = cms.vint32(-1,1),
                                                   OverallRange = cms.string("r9<0.94&&abs(eta)<1.5"),
                                                   BinList = scaleBins,
-                                                  Debug = cms.untracked.bool(True)
+                                                  Debug = cms.untracked.bool(False)
                                                   ),
                                         cms.PSet( PhotonMethodName = cms.string("FlashggPhotonScale"),
                                                   MethodName = cms.string("FlashggDiPhotonFromPhoton"),
@@ -70,7 +70,7 @@ flashggDiPhotonSystematics = cms.EDProducer('FlashggDiPhotonSystematicProducer',
                                                   NSigmas = cms.vint32(-1,1),
                                                   OverallRange = cms.string("r9>0.94&&abs(eta)>=1.5"),
                                                   BinList = scaleBins,
-                                                  Debug = cms.untracked.bool(True)
+                                                  Debug = cms.untracked.bool(False)
                                                   ),
                                         cms.PSet( PhotonMethodName = cms.string("FlashggPhotonScale"),
                                                   MethodName = cms.string("FlashggDiPhotonFromPhoton"),
@@ -78,7 +78,7 @@ flashggDiPhotonSystematics = cms.EDProducer('FlashggDiPhotonSystematicProducer',
                                                   NSigmas = cms.vint32(-1,1),
                                                   OverallRange = cms.string("r9<0.94&&abs(eta)>=1.5"),
                                                   BinList = scaleBins,
-                                                  Debug = cms.untracked.bool(True)
+                                                  Debug = cms.untracked.bool(False)
                                                   ),
                                         cms.PSet( PhotonMethodName = cms.string("FlashggPhotonSmearConstant"),
                                                   MethodName = cms.string("FlashggDiPhotonFromPhoton"),
@@ -86,7 +86,7 @@ flashggDiPhotonSystematics = cms.EDProducer('FlashggDiPhotonSystematicProducer',
                                                   NSigmas = cms.vint32(-1,1),
                                                   OverallRange = cms.string("r9>0.94&&abs(eta)>=1.5"),
                                                   BinList = smearBins,
-                                                  Debug = cms.untracked.bool(True),
+                                                  Debug = cms.untracked.bool(False),
                                                   ExaggerateShiftUp = cms.untracked.bool(False),
                                                   ),
                                         cms.PSet( PhotonMethodName = cms.string("FlashggPhotonSmearConstant"),
@@ -95,7 +95,7 @@ flashggDiPhotonSystematics = cms.EDProducer('FlashggDiPhotonSystematicProducer',
                                                   NSigmas = cms.vint32(-1,1),
                                                   OverallRange = cms.string("r9<0.94&&abs(eta)>=1.5"),
                                                   BinList = smearBins,
-                                                  Debug = cms.untracked.bool(True),
+                                                  Debug = cms.untracked.bool(False),
                                                   ExaggerateShiftUp = cms.untracked.bool(False),
                                                   ),
                                         cms.PSet( PhotonMethodName = cms.string("FlashggPhotonSmearConstant"),
@@ -104,7 +104,7 @@ flashggDiPhotonSystematics = cms.EDProducer('FlashggDiPhotonSystematicProducer',
                                                   NSigmas = cms.vint32(-1,1),
                                                   OverallRange = cms.string("r9>0.94&&abs(eta)<1.5"),
                                                   BinList = smearBins,
-                                                  Debug = cms.untracked.bool(True),
+                                                  Debug = cms.untracked.bool(False),
                                                   ExaggerateShiftUp = cms.untracked.bool(False),
                                                   ),
                                         cms.PSet( PhotonMethodName = cms.string("FlashggPhotonSmearConstant"),
@@ -113,7 +113,7 @@ flashggDiPhotonSystematics = cms.EDProducer('FlashggDiPhotonSystematicProducer',
                                                   NSigmas = cms.vint32(-1,1),
                                                   OverallRange = cms.string("r9<=0.94&&abs(eta)<1.5"),
                                                   BinList = smearBins,
-                                                  Debug = cms.untracked.bool(True),
+                                                  Debug = cms.untracked.bool(False),
                                                   ExaggerateShiftUp = cms.untracked.bool(False),
                                                   ),
                                         cms.PSet( PhotonMethodName = cms.string("FlashggPhotonMvaShift"),
@@ -122,7 +122,7 @@ flashggDiPhotonSystematics = cms.EDProducer('FlashggDiPhotonSystematicProducer',
                                                   NSigmas = cms.vint32(-1,1),
                                                   OverallRange = cms.string("1"),
                                                   BinList = mvaShiftBins,
-                                                  Debug = cms.untracked.bool(True)
+                                                  Debug = cms.untracked.bool(False)
                                                   )
                                         )
                                      )


### PR DESCRIPTION
* works from initial tests
* *pending validation* from Martina (expected some time tomorrow if everything smooth)

#### Notes

* scale for prompt 2015, values OK, errors as in Run1 (since Run2 stat. only)
w.r.t. the numbers in slide 3, the scale is computed as 1. / scale(MC) - 1.

* smearings for prompt 2015, values OK, errors as statistical of Run2 (since Run1 different parametrization)

* numbers from Fasanella et al., ECAL DPG 03/12/2015, https://cern.ch/go/zFH8
