### PR TITLE
Machinery for photon weights

### DIFF
--- a/Systematics/interface/DiPhotonFromPhotonBase.h
+++ b/Systematics/interface/DiPhotonFromPhotonBase.h
@@ -19,6 +19,7 @@ namespace flashgg {
         DiPhotonFromPhotonBase( const edm::ParameterSet &conf );
 
         void applyCorrection( DiPhotonCandidate &y, param_var syst_shift ) override;
+        float makeWeight( const DiPhotonCandidate &y, param_var syst_shift ) override;
         std::string shiftLabel( param_var ) const override;
 
         void setRandomEngine( CLHEP::HepRandomEngine &eng ) override
@@ -49,6 +50,24 @@ namespace flashgg {
     std::string DiPhotonFromPhotonBase<param_var>::shiftLabel( param_var syst_value ) const
     {
         return photon_corr_->shiftLabel( syst_value );
+    }
+
+    template<typename param_var>
+    float DiPhotonFromPhotonBase<param_var>::makeWeight( const DiPhotonCandidate &y, param_var syst_shift )
+    {
+        if( debug_ ) {
+            std::cout << "START OF DiPhotonFromPhoton::makeWeight M PT E1 E2 ETA1 ETA2 "
+                      << y.mass() << " " << y.pt() << " " << y.leadingPhoton()->energy() << " " << y.subLeadingPhoton()->energy() << " "
+                      << y.leadingPhoton()->eta() << " " << y.subLeadingPhoton()->eta() << std::endl;
+        }
+        float weight1 = photon_corr_->makeWeight( *(y.leadingPhoton()), syst_shift );
+        float weight2 = photon_corr_->makeWeight( *(y.subLeadingPhoton()), syst_shift );
+        float diphoweight = weight1*weight2;
+        if( debug_ ) {
+            std::cout << "END OF DiPhotonFromPhoton::makeWeight M PT E1 E2 ETA1 ETA2 "
+                      << " weight1=" << weight1 << " weight2=" << weight2 << " diphoweight=" << diphoweight << std::endl;
+        }
+        return diphoweight;
     }
 
     template<class param_var>

--- a/Systematics/interface/ObjectWeight.h
+++ b/Systematics/interface/ObjectWeight.h
@@ -1,0 +1,81 @@
+#ifndef FLASHgg_ObjectEffScale_h
+#define FLASHgg_ObjectEffScale_h
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "flashgg/Systematics/interface/ObjectSystMethodBinnedByFunctor.h"
+#include "CommonTools/Utils/interface/StringCutObjectSelector.h"
+
+namespace flashgg {
+
+    template <typename flashgg_object, typename param_var>
+    class ObjectWeight : public ObjectSystMethodBinnedByFunctor<flashgg_object, param_var>
+    {
+    public:
+        typedef StringCutObjectSelector<flashgg_object, true> selector_type;
+
+        ObjectWeight( const edm::ParameterSet &conf );
+        float makeWeight( const flashgg_object &obj, param_var syst_shift ) override;
+        std::string shiftLabel( param_var syst_shift ) const override;
+        
+    private:
+        selector_type overall_range_;
+
+    };
+
+    template<typename flashgg_object, typename param_var>
+    ObjectWeight<flashgg_object, param_var>::ObjectWeight( const edm::ParameterSet &conf ) : 
+        ObjectSystMethodBinnedByFunctor<flashgg_object, param_var>( conf ),
+        overall_range_( conf.getParameter<std::string>( "OverallRange" ) )
+    {
+        this->setMakesWeight( true );
+    }
+
+    template<typename flashgg_object, typename param_var>
+    std::string ObjectWeight<flashgg_object, param_var>::shiftLabel( param_var syst_value ) const
+    {
+        std::string result;
+        if( syst_value == 0 ) {
+            result = Form( "%sCentral", this->label().c_str() );
+        } else if( syst_value > 0 ) {
+            result = Form( "%sUp%.2dsigma", this->label().c_str(), syst_value );
+        } else {
+            result = Form( "%sDown%.2dsigma", this->label().c_str(), -1 * syst_value );
+        }
+        return result;
+    }
+
+    template<typename flashgg_object, typename param_var>
+    float ObjectWeight<flashgg_object, param_var>::makeWeight( const flashgg_object &obj, param_var syst_shift )
+    {
+        float theWeight = 1.;
+        if( overall_range_( obj ) ) {
+            auto val_err = this->binContents( obj );
+            float central = 1., errup = 0., errdown = 0.;
+            if( val_err.first.size() == 1 && val_err.second.size() == 1 ) { // symmetric
+                central = val_err.first[0];  
+                errup = errdown = val_err.second[0]; 
+            } else if ( val_err.first.size() == 1 && val_err.second.size() == 2 ) { // asymmetric
+                central = val_err.first[0];
+                errup = val_err.second[0];
+                errdown = val_err.second[1];
+            } else {
+                throw cms::Exception("BadConfig") << " We do not recognize the bin format or this object is not in any bin";
+            }
+            theWeight = central;
+            if ( syst_shift < 0 ) theWeight += syst_shift * errdown;
+            if ( syst_shift > 0 ) theWeight += syst_shift * errup;
+            return theWeight;
+        }
+        return theWeight;
+    }
+
+}
+#endif
+
+// Local Variables:
+// mode:c++
+// indent-tabs-mode:nil
+// tab-width:4
+// c-basic-offset:4
+// End:
+// vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4

--- a/Systematics/interface/ObjectWeight.h
+++ b/Systematics/interface/ObjectWeight.h
@@ -64,7 +64,10 @@ namespace flashgg {
             theWeight = central;
             if ( syst_shift < 0 ) theWeight += syst_shift * errdown;
             if ( syst_shift > 0 ) theWeight += syst_shift * errup;
-            return theWeight;
+            if( this->debug_ ) {
+                std::cout << "  " << shiftLabel( syst_shift ) << ": Object has e= " << obj.energy() << " eta=" << obj.eta()
+                          << " and we apply a weight of " << theWeight << std::endl;
+            }
         }
         return theWeight;
     }

--- a/Systematics/plugins/DiPhotonWeight.cc
+++ b/Systematics/plugins/DiPhotonWeight.cc
@@ -1,0 +1,18 @@
+#include "flashgg/Systematics/interface/ObjectWeight.h"
+ 
+namespace flashgg {
+
+    typedef ObjectWeight<flashgg::DiPhotonCandidate, int> DiPhotonWeight;
+}
+
+DEFINE_EDM_PLUGIN( FlashggSystematicDiPhotonMethodsFactory,
+                   flashgg::DiPhotonWeight,
+                   "FlashggDiPhotonWeight" );
+
+// Local Variables:
+// mode:c++
+// indent-tabs-mode:nil
+// tab-width:4
+// c-basic-offset:4
+// End:
+// vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4

--- a/Systematics/plugins/PhotonWeight.cc
+++ b/Systematics/plugins/PhotonWeight.cc
@@ -1,0 +1,18 @@
+#include "flashgg/Systematics/interface/ObjectWeight.h"
+
+namespace flashgg {
+
+    typedef ObjectWeight<flashgg::Photon, int> PhotonWeight;
+}
+
+DEFINE_EDM_PLUGIN( FlashggSystematicPhotonMethodsFactory,
+                   flashgg::PhotonWeight,
+                   "FlashggPhotonWeight" );
+
+// Local Variables:
+// mode:c++
+// indent-tabs-mode:nil
+// tab-width:4
+// c-basic-offset:4
+// End:
+// vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4

--- a/Systematics/python/SystematicDumperDefaultVariables.py
+++ b/Systematics/python/SystematicDumperDefaultVariables.py
@@ -1,11 +1,13 @@
 minimalVariables = ["CMS_hgg_mass[160,100,180]:=diPhoton().mass",
-                    "dZ[2,0,2]:=abs(tagTruth().genPV().z-diPhoton().vtx().z)"] #only need to know if dZ<1 or dz>1
-										#when doing systematics, variables need to have a binning
-										#specified, otherwise the rooDataHist end up empty.
-										#an assert in the code prevents you from doing this.
+                    "dZ[2,0,2]:=abs(tagTruth().genPV().z-diPhoton().vtx().z)", #only need to know if dZ<1 or dz>1
+                                                                               #when doing systematics, variables need to have a binning
+                                                                               #specified, otherwise the rooDataHist end up empty.
+            								       #an assert in the code prevents you from doing this.
+                    "centralObjectWeight := centralWeight"]
+
 minimalHistograms = []
 
-minimalNonSignalVariables = ["CMS_hgg_mass[160,100,180]:=diPhoton().mass"]
+minimalNonSignalVariables = ["CMS_hgg_mass[160,100,180]:=diPhoton().mass"] # do we need centralWeight here?
 
 defaultVariables=["CMS_hgg_mass[160,100,180]:=diPhoton().mass", 
                                     "leadPt                   :=diPhoton().leadingPhoton.pt",

--- a/Systematics/python/SystematicDumperDefaultVariables.py
+++ b/Systematics/python/SystematicDumperDefaultVariables.py
@@ -7,7 +7,7 @@ minimalVariables = ["CMS_hgg_mass[160,100,180]:=diPhoton().mass",
 
 minimalHistograms = []
 
-minimalNonSignalVariables = ["CMS_hgg_mass[160,100,180]:=diPhoton().mass"] # do we need centralWeight here?
+minimalNonSignalVariables = ["CMS_hgg_mass[160,100,180]:=diPhoton().mass"]
 
 defaultVariables=["CMS_hgg_mass[160,100,180]:=diPhoton().mass", 
                                     "leadPt                   :=diPhoton().leadingPhoton.pt",

--- a/Systematics/python/flashggDiPhotonSystematics_cfi.py
+++ b/Systematics/python/flashggDiPhotonSystematics_cfi.py
@@ -47,9 +47,41 @@ mvaShiftBins = cms.PSet(
     variables = cms.vstring("abs(superCluster.eta)"),
     bins = cms.VPSet(
                      cms.PSet( lowBounds = cms.vdouble(0.000), upBounds = cms.vdouble(999.),
-                               values = cms.vdouble( 0.0 ), uncertainties = cms.vdouble( 0.01 ))
+                               values = cms.vdouble( 0.0 ), uncertainties = cms.vdouble( 0.03 ))
                      )
     )
+
+# slide 7 of https://indico.cern.ch/event/367883/contribution/2/attachments/1194817/1736347/egamma_26_11_2015.pdf
+preselBins = cms.PSet(
+    variables = cms.vstring("abs(superCluster.eta)","r9"),
+    bins = cms.VPSet(
+        cms.PSet( lowBounds = cms.vdouble( 0.0, 0.0 ), upBounds = cms.vdouble( 1.5, 0.9 ),
+                  values = cms.vdouble( 0.9968 ), uncertainties = cms.vdouble( 0.0227 ) ),
+        cms.PSet( lowBounds = cms.vdouble( 0.0, 0.9 ), upBounds = cms.vdouble( 1.5, 1.0 ),
+                  values = cms.vdouble(0.9978 ), uncertainties= cms.vdouble( 0.0029 ) ),
+        cms.PSet( lowBounds = cms.vdouble( 1.5, 0.0 ), upBounds = cms.vdouble( 2.5, 0.9),
+                  values = cms.vdouble( 1.0115 ), uncertainties= cms.vdouble( 0.0297 ) ),
+        cms.PSet( lowBounds = cms.vdouble( 1.5, 0.9 ), upBounds = cms.vdouble( 2.5, 1.0 ),
+                  values = cms.vdouble(0.9963 ), uncertainties= cms.vdouble( 0.0044 ) )
+        )
+    )
+
+# Slide 11, https://indico.cern.ch/event/367883/contribution/2/attachments/1194817/1736347/egamma_26_11_2015.pdf
+looseMvaBins = cms.PSet(
+    variables = cms.vstring("abs(superCluster.eta)","r9"),
+    bins = cms.VPSet(
+        cms.PSet( lowBounds = cms.vdouble( 0.0, 0.0 ), upBounds = cms.vdouble( 1.5, 0.9 ),
+                  values = cms.vdouble( 1.0001 ), uncertainties = cms.vdouble( 0.0022 ) ),
+        cms.PSet( lowBounds = cms.vdouble( 0.0, 0.9 ), upBounds = cms.vdouble( 1.5, 1.0 ),
+                  values = cms.vdouble( 1.000 ), uncertainties= cms.vdouble( 0.0001 ) ),
+        cms.PSet( lowBounds = cms.vdouble( 1.5, 0.0 ), upBounds = cms.vdouble( 2.5, 0.9),
+                  values = cms.vdouble( 0.9851 ), uncertainties= cms.vdouble( 0.0016 ) ),
+        cms.PSet( lowBounds = cms.vdouble( 1.5, 0.9 ), upBounds = cms.vdouble( 2.5, 1.0 ),
+                  values = cms.vdouble( 1.0001 ), uncertainties= cms.vdouble( 0.0009 ) )
+        )
+    )
+
+
 
 
 flashggDiPhotonSystematics = cms.EDProducer('FlashggDiPhotonSystematicProducer',
@@ -58,7 +90,7 @@ flashggDiPhotonSystematics = cms.EDProducer('FlashggDiPhotonSystematicProducer',
                                           cms.PSet( PhotonMethodName = cms.string("FlashggPhotonSmearStochastic"),
                                                     MethodName = cms.string("FlashggDiPhotonFromPhoton2D"),
                                                     Label = cms.string("MCSmearHighR9EB"),
-                                                    OverallRange = cms.string("r9>0.94&&abs(eta)<1.5"),
+                                                    OverallRange = cms.string("r9>0.94&&abs(superCluster.eta)<1.5"),
                                                     NSigmas = cms.PSet( firstVar = cms.vint32(1,-1,0,0),
                                                                         secondVar = cms.vint32(0,0,1,-1)),
                                                     BinList = smearBins,
@@ -68,7 +100,7 @@ flashggDiPhotonSystematics = cms.EDProducer('FlashggDiPhotonSystematicProducer',
                                           cms.PSet( PhotonMethodName = cms.string("FlashggPhotonSmearStochastic"),
                                                     MethodName = cms.string("FlashggDiPhotonFromPhoton2D"),
                                                     Label = cms.string("MCSmearLowR9EB"),
-                                                    OverallRange = cms.string("r9<0.94&&abs(eta)<1.5"),
+                                                    OverallRange = cms.string("r9<0.94&&abs(superCluster.eta)<1.5"),
                                                     NSigmas = cms.PSet( firstVar = cms.vint32(1,-1,0,0),
                                                                         secondVar = cms.vint32(0,0,1,-1)),
                                                     BinList = smearBins,
@@ -81,7 +113,7 @@ flashggDiPhotonSystematics = cms.EDProducer('FlashggDiPhotonSystematicProducer',
                                                   MethodName = cms.string("FlashggDiPhotonFromPhoton"),
                                                   Label = cms.string("MCScaleHighR9EB"),
                                                   NSigmas = cms.vint32(-1,1),
-                                                  OverallRange = cms.string("r9>0.94&&abs(eta)<1.5"),
+                                                  OverallRange = cms.string("r9>0.94&&abs(superCluster.eta)<1.5"),
                                                   BinList = scaleBins,
                                                   Debug = cms.untracked.bool(False)
                                                   ),
@@ -89,7 +121,7 @@ flashggDiPhotonSystematics = cms.EDProducer('FlashggDiPhotonSystematicProducer',
                                                   MethodName = cms.string("FlashggDiPhotonFromPhoton"),
                                                   Label = cms.string("MCScaleLowR9EB"),
                                                   NSigmas = cms.vint32(-1,1),
-                                                  OverallRange = cms.string("r9<0.94&&abs(eta)<1.5"),
+                                                  OverallRange = cms.string("r9<0.94&&abs(superCluster.eta)<1.5"),
                                                   BinList = scaleBins,
                                                   Debug = cms.untracked.bool(False)
                                                   ),
@@ -97,7 +129,7 @@ flashggDiPhotonSystematics = cms.EDProducer('FlashggDiPhotonSystematicProducer',
                                                   MethodName = cms.string("FlashggDiPhotonFromPhoton"),
                                                   Label = cms.string("MCScaleHighR9EE"),
                                                   NSigmas = cms.vint32(-1,1),
-                                                  OverallRange = cms.string("r9>0.94&&abs(eta)>=1.5"),
+                                                  OverallRange = cms.string("r9>0.94&&abs(superCluster.eta)>=1.5"),
                                                   BinList = scaleBins,
                                                   Debug = cms.untracked.bool(False)
                                                   ),
@@ -105,7 +137,7 @@ flashggDiPhotonSystematics = cms.EDProducer('FlashggDiPhotonSystematicProducer',
                                                   MethodName = cms.string("FlashggDiPhotonFromPhoton"),
                                                   Label = cms.string("MCScaleLowR9EE"),
                                                   NSigmas = cms.vint32(-1,1),
-                                                  OverallRange = cms.string("r9<0.94&&abs(eta)>=1.5"),
+                                                  OverallRange = cms.string("r9<0.94&&abs(superCluster.eta)>=1.5"),
                                                   BinList = scaleBins,
                                                   Debug = cms.untracked.bool(False)
                                                   ),
@@ -113,7 +145,7 @@ flashggDiPhotonSystematics = cms.EDProducer('FlashggDiPhotonSystematicProducer',
                                                   MethodName = cms.string("FlashggDiPhotonFromPhoton"),
                                                   Label = cms.string("MCSmearHighR9EE"),
                                                   NSigmas = cms.vint32(-1,1),
-                                                  OverallRange = cms.string("r9>0.94&&abs(eta)>=1.5"),
+                                                  OverallRange = cms.string("r9>0.94&&abs(superCluster.eta)>=1.5"),
                                                   BinList = smearBins,
                                                   Debug = cms.untracked.bool(False),
                                                   ExaggerateShiftUp = cms.untracked.bool(False),
@@ -122,7 +154,7 @@ flashggDiPhotonSystematics = cms.EDProducer('FlashggDiPhotonSystematicProducer',
                                                   MethodName = cms.string("FlashggDiPhotonFromPhoton"),
                                                   Label = cms.string("MCSmearLowR9EE"),
                                                   NSigmas = cms.vint32(-1,1),
-                                                  OverallRange = cms.string("r9<0.94&&abs(eta)>=1.5"),
+                                                  OverallRange = cms.string("r9<0.94&&abs(superCluster.eta)>=1.5"),
                                                   BinList = smearBins,
                                                   Debug = cms.untracked.bool(False),
                                                   ExaggerateShiftUp = cms.untracked.bool(False),
@@ -134,7 +166,72 @@ flashggDiPhotonSystematics = cms.EDProducer('FlashggDiPhotonSystematicProducer',
                                                   OverallRange = cms.string("1"),
                                                   BinList = mvaShiftBins,
                                                   Debug = cms.untracked.bool(False)
+                                                  ),
+                                        cms.PSet( PhotonMethodName = cms.string("FlashggPhotonWeight"),
+                                                  MethodName = cms.string("FlashggDiPhotonFromPhoton"),
+                                                  Label = cms.string("PreselSFLowR9EE"),
+                                                  NSigmas = cms.vint32(-1,1),
+                                                  OverallRange = cms.string("r9<0.9&&abs(superCluster.eta)>=1.5"),
+                                                  BinList = preselBins,
+                                                  Debug = cms.untracked.bool(True)
+                                                  ),
+                                        cms.PSet( PhotonMethodName = cms.string("FlashggPhotonWeight"),
+                                                  MethodName = cms.string("FlashggDiPhotonFromPhoton"),
+                                                  Label = cms.string("PreselSFHighR9EE"),
+                                                  NSigmas = cms.vint32(-1,1),
+                                                  OverallRange = cms.string("r9>=0.9&&abs(superCluster.eta)>=1.5"),
+                                                  BinList = preselBins,
+                                                  Debug = cms.untracked.bool(True)
+                                                  ),
+                                        cms.PSet( PhotonMethodName = cms.string("FlashggPhotonWeight"),
+                                                  MethodName = cms.string("FlashggDiPhotonFromPhoton"),
+                                                  Label = cms.string("PreselSFLowR9EB"),
+                                                  NSigmas = cms.vint32(-1,1),
+                                                  OverallRange = cms.string("r9<0.9&&abs(superCluster.eta)<1.5"),
+                                                  BinList = preselBins,
+                                                  Debug = cms.untracked.bool(True)
+                                                  ),
+                                        cms.PSet( PhotonMethodName = cms.string("FlashggPhotonWeight"),
+                                                  MethodName = cms.string("FlashggDiPhotonFromPhoton"),
+                                                  Label = cms.string("PreselSFHighR9EB"),
+                                                  NSigmas = cms.vint32(-1,1),
+                                                  OverallRange = cms.string("r9>=0.9&&abs(superCluster.eta)<1.5"),
+                                                  BinList = preselBins,
+                                                  Debug = cms.untracked.bool(True)
+                                                  ),
+                                        cms.PSet( PhotonMethodName = cms.string("FlashggPhotonWeight"),
+                                                  MethodName = cms.string("FlashggDiPhotonFromPhoton"),
+                                                  Label = cms.string("LooseMvaSFLowR9EE"),
+                                                  NSigmas = cms.vint32(-1,1),
+                                                  OverallRange = cms.string("r9<0.9&&abs(superCluster.eta)>=1.5"),
+                                                  BinList = looseMvaBins,
+                                                  Debug = cms.untracked.bool(True)
+                                                  ),
+                                        cms.PSet( PhotonMethodName = cms.string("FlashggPhotonWeight"),
+                                                  MethodName = cms.string("FlashggDiPhotonFromPhoton"),
+                                                  Label = cms.string("LooseMvaSFHighR9EE"),
+                                                  NSigmas = cms.vint32(-1,1),
+                                                  OverallRange = cms.string("r9>=0.9&&abs(superCluster.eta)>=1.5"),
+                                                  BinList = looseMvaBins,
+                                                  Debug = cms.untracked.bool(True)
+                                                  ),
+                                        cms.PSet( PhotonMethodName = cms.string("FlashggPhotonWeight"),
+                                                  MethodName = cms.string("FlashggDiPhotonFromPhoton"),
+                                                  Label = cms.string("LooseMvaSFLowR9EB"),
+                                                  NSigmas = cms.vint32(-1,1),
+                                                  OverallRange = cms.string("r9<0.9&&abs(superCluster.eta)<1.5"),
+                                                  BinList = looseMvaBins,
+                                                  Debug = cms.untracked.bool(True)
+                                                  ),
+                                        cms.PSet( PhotonMethodName = cms.string("FlashggPhotonWeight"),
+                                                  MethodName = cms.string("FlashggDiPhotonFromPhoton"),
+                                                  Label = cms.string("LooseMvaSFHighR9EB"),
+                                                  NSigmas = cms.vint32(-1,1),
+                                                  OverallRange = cms.string("r9>=0.9&&abs(superCluster.eta)<1.5"),
+                                                  BinList = looseMvaBins,
+                                                  Debug = cms.untracked.bool(True)
                                                   )
+
                                         )
                                      )
 

--- a/Systematics/python/flashggDiPhotonSystematics_cfi.py
+++ b/Systematics/python/flashggDiPhotonSystematics_cfi.py
@@ -173,7 +173,7 @@ flashggDiPhotonSystematics = cms.EDProducer('FlashggDiPhotonSystematicProducer',
                                                   NSigmas = cms.vint32(-1,1),
                                                   OverallRange = cms.string("r9<0.9&&abs(superCluster.eta)>=1.5"),
                                                   BinList = preselBins,
-                                                  Debug = cms.untracked.bool(True)
+                                                  Debug = cms.untracked.bool(False)
                                                   ),
                                         cms.PSet( PhotonMethodName = cms.string("FlashggPhotonWeight"),
                                                   MethodName = cms.string("FlashggDiPhotonFromPhoton"),
@@ -181,7 +181,7 @@ flashggDiPhotonSystematics = cms.EDProducer('FlashggDiPhotonSystematicProducer',
                                                   NSigmas = cms.vint32(-1,1),
                                                   OverallRange = cms.string("r9>=0.9&&abs(superCluster.eta)>=1.5"),
                                                   BinList = preselBins,
-                                                  Debug = cms.untracked.bool(True)
+                                                  Debug = cms.untracked.bool(False)
                                                   ),
                                         cms.PSet( PhotonMethodName = cms.string("FlashggPhotonWeight"),
                                                   MethodName = cms.string("FlashggDiPhotonFromPhoton"),
@@ -189,7 +189,7 @@ flashggDiPhotonSystematics = cms.EDProducer('FlashggDiPhotonSystematicProducer',
                                                   NSigmas = cms.vint32(-1,1),
                                                   OverallRange = cms.string("r9<0.9&&abs(superCluster.eta)<1.5"),
                                                   BinList = preselBins,
-                                                  Debug = cms.untracked.bool(True)
+                                                  Debug = cms.untracked.bool(False)
                                                   ),
                                         cms.PSet( PhotonMethodName = cms.string("FlashggPhotonWeight"),
                                                   MethodName = cms.string("FlashggDiPhotonFromPhoton"),
@@ -197,7 +197,7 @@ flashggDiPhotonSystematics = cms.EDProducer('FlashggDiPhotonSystematicProducer',
                                                   NSigmas = cms.vint32(-1,1),
                                                   OverallRange = cms.string("r9>=0.9&&abs(superCluster.eta)<1.5"),
                                                   BinList = preselBins,
-                                                  Debug = cms.untracked.bool(True)
+                                                  Debug = cms.untracked.bool(False)
                                                   ),
                                         cms.PSet( PhotonMethodName = cms.string("FlashggPhotonWeight"),
                                                   MethodName = cms.string("FlashggDiPhotonFromPhoton"),
@@ -205,7 +205,7 @@ flashggDiPhotonSystematics = cms.EDProducer('FlashggDiPhotonSystematicProducer',
                                                   NSigmas = cms.vint32(-1,1),
                                                   OverallRange = cms.string("r9<0.9&&abs(superCluster.eta)>=1.5"),
                                                   BinList = looseMvaBins,
-                                                  Debug = cms.untracked.bool(True)
+                                                  Debug = cms.untracked.bool(False)
                                                   ),
                                         cms.PSet( PhotonMethodName = cms.string("FlashggPhotonWeight"),
                                                   MethodName = cms.string("FlashggDiPhotonFromPhoton"),
@@ -213,7 +213,7 @@ flashggDiPhotonSystematics = cms.EDProducer('FlashggDiPhotonSystematicProducer',
                                                   NSigmas = cms.vint32(-1,1),
                                                   OverallRange = cms.string("r9>=0.9&&abs(superCluster.eta)>=1.5"),
                                                   BinList = looseMvaBins,
-                                                  Debug = cms.untracked.bool(True)
+                                                  Debug = cms.untracked.bool(False)
                                                   ),
                                         cms.PSet( PhotonMethodName = cms.string("FlashggPhotonWeight"),
                                                   MethodName = cms.string("FlashggDiPhotonFromPhoton"),
@@ -221,7 +221,7 @@ flashggDiPhotonSystematics = cms.EDProducer('FlashggDiPhotonSystematicProducer',
                                                   NSigmas = cms.vint32(-1,1),
                                                   OverallRange = cms.string("r9<0.9&&abs(superCluster.eta)<1.5"),
                                                   BinList = looseMvaBins,
-                                                  Debug = cms.untracked.bool(True)
+                                                  Debug = cms.untracked.bool(False)
                                                   ),
                                         cms.PSet( PhotonMethodName = cms.string("FlashggPhotonWeight"),
                                                   MethodName = cms.string("FlashggDiPhotonFromPhoton"),
@@ -229,7 +229,7 @@ flashggDiPhotonSystematics = cms.EDProducer('FlashggDiPhotonSystematicProducer',
                                                   NSigmas = cms.vint32(-1,1),
                                                   OverallRange = cms.string("r9>=0.9&&abs(superCluster.eta)<1.5"),
                                                   BinList = looseMvaBins,
-                                                  Debug = cms.untracked.bool(True)
+                                                  Debug = cms.untracked.bool(False)
                                                   )
 
                                         )

--- a/Systematics/test/MicroAODtoWorkspace.py
+++ b/Systematics/test/MicroAODtoWorkspace.py
@@ -70,13 +70,20 @@ if customize.processId.count("h_") or customize.processId.count("vbf_"): # conve
                 phosystlabels.append("MCSmear%sEB%s%s01sigma" % (r9,var,direction))
             for region in ["EB","EE"]:
                 phosystlabels.append("MCScale%s%s%s01sigma" % (r9,region,direction))
+                variablesToUse.append("LooseMvaSF%s%s%s01sigma := weight(\"LooseMvaSF%s%s%s01sigma\")" % (r9,region,direction,r9,region,direction))
+                variablesToUse.append("PreselSF%s%s%s01sigma := weight(\"PreselSF%s%s%s01sigma\")" % (r9,region,direction,r9,region,direction))
     systlabels += phosystlabels
     systlabels += jetsystlabels
 else:
     print "Data or background MC, so store mgg and central only"
     variablesToUse = minimalNonSignalVariables
 
+print "--- Systematics  with independent collections ---"
 print systlabels
+print "-------------------------------------------------"
+print "--- Variables to be dumped, including systematic weights ---"
+print variablesToUse
+print "------------------------------------------------------------"
 
 for systlabel in systlabels:
     if systlabel == "":
@@ -111,6 +118,8 @@ from flashgg.MetaData.samples_utils import SamplesManager
 
 process.source = cms.Source ("PoolSource",
                              fileNames = cms.untracked.vstring("file:myMicroAODOutputFile.root"))
+#process.source = cms.Source("PoolSource",fileNames = cms.untracked.vstring("/store/group/phys_higgs/cmshgg/sethzenz/flashgg/RunIISpring15-FinalPrompt-BetaV7-25ns/Spring15#BetaV7/DoubleEG/RunIISpring15-FinalPrompt-BetaV7-25ns-Spring15BetaV7-v0-Run2015D-PromptReco-v4/151124_234634/0000/myMicroAODOutputFile_1.root"))
+
 
 #if options.maxEvents > 0:
 #    process.source.eventsToProcess = cms.untracked.VEventRange('1:1-1:'+str(options.maxEvents))
@@ -125,7 +134,7 @@ import flashgg.Taggers.dumperConfigTools as cfgTools
 process.tagsDumper.className = "DiPhotonTagDumper"
 process.tagsDumper.src = "flashggSystTagMerger"
 process.tagsDumper.processId = "test"
-process.tagsDumper.dumpTrees = False
+process.tagsDumper.dumpTrees = True # TODO CHANGE THIS BACK TO FALSE
 process.tagsDumper.dumpWorkspace = True
 process.tagsDumper.dumpHistos = False
 process.tagsDumper.quietRooFit = True

--- a/Taggers/plugins/TTHHadronicTagProducer.cc
+++ b/Taggers/plugins/TTHHadronicTagProducer.cc
@@ -197,6 +197,7 @@ namespace flashgg {
                 tthhtags_obj.setNBMedium( njets_btagmedium );
                 tthhtags_obj.setDiPhotonIndex( diphoIndex );
                 tthhtags_obj.setSystLabel( systLabel_ );
+                tthhtags_obj.includeWeights( *dipho );
                 tthhtags->push_back( tthhtags_obj );
                 TagTruthBase truth_obj;
                 if( ! evt.isRealData() ) {

--- a/Taggers/plugins/TTHLeptonicTagProducer.cc
+++ b/Taggers/plugins/TTHLeptonicTagProducer.cc
@@ -496,6 +496,7 @@ namespace flashgg {
                     //                    std::cout << "including muon weights" << std::endl;
                     tthltags_obj.includeWeights( *tagMuons[0] );
                 }
+                tthltags_obj.includeWeights( *dipho );
 
                 tthltags_obj.setJets( tagJets );
                 tthltags_obj.setBJets( tagBJets );

--- a/Taggers/plugins/UntaggedTagProducer.cc
+++ b/Taggers/plugins/UntaggedTagProducer.cc
@@ -121,6 +121,8 @@ namespace flashgg {
             int catnum = chooseCategory( mvares->result );
             tag_obj.setCategoryNumber( catnum );
 
+            tag_obj.includeWeights( *dipho );
+
             // Leave in debugging statement temporarily while tag framework is being developed
             // std::cout << "[UNTAGGED] MVA is "<< mvares->result << " and category is " << tag_obj.categoryNumber() << std::endl;
             if( tag_obj.categoryNumber() >= 0 ) {

--- a/Taggers/plugins/VBFTagProducer.cc
+++ b/Taggers/plugins/VBFTagProducer.cc
@@ -151,6 +151,8 @@ namespace flashgg {
             VBFTag tag_obj( dipho, mvares, vbfdipho_mvares );
             tag_obj.setDiPhotonIndex( candIndex );
             tag_obj.setSystLabel    ( systLabel_ );
+
+            tag_obj.includeWeights( *dipho );
             
             int catnum = chooseCategory( vbfdipho_mvares->vbfDiPhoDiJetMvaResult );
             tag_obj.setCategoryNumber( catnum );

--- a/Taggers/plugins/VHEtTagProducer.cc
+++ b/Taggers/plugins/VHEtTagProducer.cc
@@ -127,6 +127,7 @@ namespace flashgg {
 
 
             VHEtTag tag_obj( dipho, mvares );
+            tag_obj.includeWeights( *dipho );
             tag_obj.setDiPhotonIndex( candIndex );
             tag_obj.setSystLabel( systLabel_ );
             tag_obj.setMet( theMET );

--- a/Taggers/plugins/VHHadronicTagProducer.cc
+++ b/Taggers/plugins/VHHadronicTagProducer.cc
@@ -229,6 +229,7 @@ namespace flashgg {
             if( abs( costhetastar ) > cosThetaStarThreshold_ ) { continue; }
 
             VHHadronicTag vhhadtag_obj( dipho, mvares );
+            vhhadtag_obj.includeWeights( *dipho );
             vhhadtag_obj.setJets( goodJets[0], goodJets[1] );
             vhhadtag_obj.setDiPhotonIndex( diphoIndex );
             vhhadtag_obj.setSystLabel( systLabel_ );

--- a/Taggers/plugins/VHLooseTagProducer.cc
+++ b/Taggers/plugins/VHLooseTagProducer.cc
@@ -264,6 +264,7 @@ namespace flashgg {
             edm::Ptr<flashgg::DiPhotonMVAResult> mvares = mvaResults->ptrAt( diphoIndex );
 
             VHLooseTag vhloosetags_obj( dipho, mvares );
+            vhloosetags_obj.includeWeights( *dipho );
 
             if( dipho->leadingPhoton()->pt() < ( dipho->mass() )*leadPhoOverMassThreshold_ ) { continue; }
             if( dipho->subLeadingPhoton()->pt() < ( dipho->mass() )*subleadPhoOverMassThreshold_ ) { continue; }

--- a/Taggers/plugins/VHTightTagProducer.cc
+++ b/Taggers/plugins/VHTightTagProducer.cc
@@ -313,6 +313,7 @@ namespace flashgg {
             edm::Ptr<flashgg::DiPhotonMVAResult> mvares = mvaResults->ptrAt( diphoIndex );
 
             VHTightTag VHTightTags_obj( dipho, mvares );
+            VHTightTags_obj.includeWeights( *dipho );
             if( dipho->leadingPhoton()->pt() < ( dipho->mass() )*leadPhoOverMassThreshold_ ) { continue; }
 
             if( dipho->subLeadingPhoton()->pt() < ( dipho->mass() )*subleadPhoOverMassThreshold_ ) { continue; }


### PR DESCRIPTION
   * Machinery for setting diphoton weights via photons in DiPhotonFromPhoton
   * python configuration for SFs for preselection and loose ID MVA cuts
   * Incorporate diphoton weights into tags
   * Dump tag weights as part of MicroAODtoWorkspace.py
   * ID MVA shift now +/- 0.03 per latest studies by @matteosan1 
   * Use photon supercluster eta in all cases