### PR TITLE
machinery for sigmaE/E shift

### DIFF
--- a/DataFormats/interface/Photon.h
+++ b/DataFormats/interface/Photon.h
@@ -62,6 +62,7 @@ namespace flashgg {
         void setPhoIdMvaD( std::map<edm::Ptr<reco::Vertex>, float> valmap ) {  phoIdMvaD_ = valmap; };  // concept: pass the pre-computed map when calling this in the producer
         void updateEnergy( std::string key, float val );
         void shiftAllMvaValuesBy( float val );
+        void shiftSigmaEOverEValueBy( float val );
         //    void setSigEOverE(float val) { sigEOverE_ = val; };
 
         // define which regression from reco we use - only this one is valid as of 74X

--- a/DataFormats/src/Photon.cc
+++ b/DataFormats/src/Photon.cc
@@ -271,6 +271,22 @@ void Photon::shiftAllMvaValuesBy( float val ) {
     }
 }
 
+//sigmaEOverE systematycs
+void Photon::shiftSigmaEOverEValueBy( float val ) {
+    const LorentzVector pho_p4 = p4(regression_type);
+    float energyError = getCorrectedEnergyError(regression_type);
+    setP4(regression_type, pho_p4, energyError*(1.+val), false);
+}
+
+
+
+//void Photon::setSigEOverE(){
+//        sigEOverE_ = getCorrectedEnergyError( regression_type ) / getCorrectedEnergy( regression_type ) ;
+//}
+    
+
+
+
 float const Photon::sigEOverE() const
 {
     // Use uncertainty and error stored from reco because we want this fraction to be constant

--- a/Systematics/plugins/PhotonSigEoverEShift.cc
+++ b/Systematics/plugins/PhotonSigEoverEShift.cc
@@ -1,0 +1,83 @@
+#include "flashgg/Systematics/interface/ObjectSystMethodBinnedByFunctor.h"
+#include "DataFormats/Common/interface/Handle.h"
+#include "DataFormats/Common/interface/PtrVector.h"
+#include "flashgg/DataFormats/interface/Photon.h"
+#include "CommonTools/Utils/interface/StringCutObjectSelector.h"
+
+namespace flashgg {
+
+    class PhotonSigEOverEShift: public ObjectSystMethodBinnedByFunctor<flashgg::Photon, int>
+    {
+
+    public:
+        typedef StringCutObjectSelector<Photon, true> selector_type;
+
+        PhotonSigEOverEShift( const edm::ParameterSet &conf );
+        void applyCorrection( flashgg::Photon &y, int syst_shift ) override;
+        std::string shiftLabel( int ) const override;
+
+    private:
+        selector_type overall_range_;
+    };
+
+    PhotonSigEOverEShift::PhotonSigEOverEShift( const edm::ParameterSet &conf ) :
+        ObjectSystMethodBinnedByFunctor( conf ),
+        overall_range_( conf.getParameter<std::string>( "OverallRange" ) )
+    {
+    }
+
+    std::string PhotonSigEOverEShift::shiftLabel( int syst_value ) const
+    {
+        std::string result;
+        if( syst_value == 0 ) {
+            result = Form( "%sCentral", label().c_str() );
+        } else if( syst_value > 0 ) {
+            result = Form( "%sUp%.2dsigma", label().c_str(), syst_value );
+        } else {
+            result = Form( "%sDown%.2dsigma", label().c_str(), -1 * syst_value );
+        }
+        return result;
+    }
+
+    void PhotonSigEOverEShift::applyCorrection( flashgg::Photon &y, int syst_shift )
+    {
+        if( overall_range_( y ) ) {
+            auto val_err = binContents( y );
+            if( val_err.first.size() == 1 && val_err.second.size() == 1 ) { // otherwise no-op because we don't have an entry
+                float shift_val = val_err.first[0];  // e.g. 0 if no central value change
+                float shift_err = val_err.second[0]; // e.g. 0.1
+                float shift = shift_val + syst_shift * shift_err;
+                //              std::vector<edm::Ptr<reco::Vertex> > keys;
+                if( debug_ ) {
+                    std::cout << "  " << shiftLabel( syst_shift ) << ": Photon has pt= " << y.pt() << " eta=" << y.eta()
+                              << " and we apply a sigmaEoverE shift of " << shift << "%" << std::endl;
+                    std::cout << "     sigE/E VALUE BEFORE: ";
+                    auto beforeSigEoE = y.sigEOverE();
+                    std::cout << beforeSigEoE << " ";
+                    std::cout << std::endl;
+                }
+                y.shiftSigmaEOverEValueBy( shift ); 
+                // the others are no longer used at this stage anyway, so it cannot hurt
+                if ( debug_) {
+                    auto afterSigEoE = y.sigEOverE();
+                    std::cout << "     sigE/E VALUE AFTER: ";
+                    std::cout << afterSigEoE << " ";
+                    std::cout << std::endl;
+                }
+            }
+        }
+    }
+    
+}
+    
+DEFINE_EDM_PLUGIN( FlashggSystematicPhotonMethodsFactory,
+                   flashgg::PhotonSigEOverEShift,
+                   "FlashggPhotonSigEOverEShift" );
+// Local Variables:
+// mode:c++
+// indent-tabs-mode:nil
+// tab-width:4
+// c-basic-offset:4
+// End:
+// vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4
+

--- a/Systematics/python/flashggDiPhotonSystematics_cfi.py
+++ b/Systematics/python/flashggDiPhotonSystematics_cfi.py
@@ -83,7 +83,7 @@ looseMvaBins = cms.PSet(
 
 
 
-
+# RELATIVE shift of sigmaE/E --> 0.05 corresponds to a shift of 5%
 sigmaEOverEShiftBins = cms.PSet(
     variables = cms.vstring("abs(superCluster.eta)"),
     bins = cms.VPSet(
@@ -246,7 +246,7 @@ flashggDiPhotonSystematics = cms.EDProducer('FlashggDiPhotonSystematicProducer',
                                                   NSigmas = cms.vint32(-1,1),
                                                   OverallRange = cms.string("1"),
                                                   BinList = sigmaEOverEShiftBins,
-                                                  Debug = cms.untracked.bool(True)
+                                                  Debug = cms.untracked.bool(False)
                                                   )
 
                                         )

--- a/Systematics/python/flashggDiPhotonSystematics_cfi.py
+++ b/Systematics/python/flashggDiPhotonSystematics_cfi.py
@@ -238,6 +238,8 @@ flashggDiPhotonSystematics = cms.EDProducer('FlashggDiPhotonSystematicProducer',
                                                   NSigmas = cms.vint32(-1,1),
                                                   OverallRange = cms.string("r9>=0.9&&abs(superCluster.eta)<1.5"),
                                                   BinList = looseMvaBins,
+                                                  Debug = cms.untracked.bool(False)
+                                                  ),
                                         cms.PSet( PhotonMethodName = cms.string("FlashggPhotonSigEOverEShift"),
                                                   MethodName = cms.string("FlashggDiPhotonFromPhoton"),
                                                   Label = cms.string("SigmaEOverEShift"),

--- a/Systematics/python/flashggDiPhotonSystematics_cfi.py
+++ b/Systematics/python/flashggDiPhotonSystematics_cfi.py
@@ -84,6 +84,15 @@ looseMvaBins = cms.PSet(
 
 
 
+sigmaEOverEShiftBins = cms.PSet(
+    variables = cms.vstring("abs(superCluster.eta)"),
+    bins = cms.VPSet(
+                     cms.PSet( lowBounds = cms.vdouble(0.000), upBounds = cms.vdouble(999.),
+                               values = cms.vdouble( 0.0 ), uncertainties = cms.vdouble( 0.05 ))
+                     )
+    )
+
+
 flashggDiPhotonSystematics = cms.EDProducer('FlashggDiPhotonSystematicProducer',
 		src = cms.InputTag("flashggFinalEGamma","finalDiPhotons"),
                 SystMethods2D = cms.VPSet(
@@ -229,7 +238,13 @@ flashggDiPhotonSystematics = cms.EDProducer('FlashggDiPhotonSystematicProducer',
                                                   NSigmas = cms.vint32(-1,1),
                                                   OverallRange = cms.string("r9>=0.9&&abs(superCluster.eta)<1.5"),
                                                   BinList = looseMvaBins,
-                                                  Debug = cms.untracked.bool(False)
+                                        cms.PSet( PhotonMethodName = cms.string("FlashggPhotonSigEOverEShift"),
+                                                  MethodName = cms.string("FlashggDiPhotonFromPhoton"),
+                                                  Label = cms.string("SigmaEOverEShift"),
+                                                  NSigmas = cms.vint32(-1,1),
+                                                  OverallRange = cms.string("1"),
+                                                  BinList = sigmaEOverEShiftBins,
+                                                  Debug = cms.untracked.bool(True)
                                                   )
 
                                         )

--- a/Systematics/test/MicroAODtoWorkspace.py
+++ b/Systematics/test/MicroAODtoWorkspace.py
@@ -62,6 +62,7 @@ if customize.processId.count("h_") or customize.processId.count("vbf_"): # conve
     variablesToUse = minimalVariables
     for direction in ["Up","Down"]:
         phosystlabels.append("MvaShift%s01sigma" % direction)
+        phosystlabels.append("SigmaEOverEShift%s01sigma" % direction)
         jetsystlabels.append("JEC%s01sigma" % direction)
         jetsystlabels.append("JER%s01sigma" % direction)
         for r9 in ["HighR9","LowR9"]:


### PR DESCRIPTION
in the same style of PR #412 , machinery to shift sigmaE/E:
- Photon method to apply shift
- method used in systematics producer
- new syst added to MicroAODToWorkspace.py 

The shift has to be interpreted as a relative shift, so specifying a shift for sigmaE/E of 0.05 in Systematics/python/flashggDiPhotonSystematics_cfi.py corresponds to an applied shift of 5%.