### PR TITLE
Topic apply central weight to dumper

### DIFF
--- a/DataFormats/interface/DiPhotonMVAResult.h
+++ b/DataFormats/interface/DiPhotonMVAResult.h
@@ -12,7 +12,7 @@ namespace flashgg {
     public:
         DiPhotonMVAResult();
         //    DiPhotonMVAResult(const DiPhotonMVAResult&) = default;  // C++11 only? Should happen automagically anyway
-
+        virtual ~DiPhotonMVAResult () {}
         // Input variables
         float leadptom;
         float subleadptom;

--- a/DataFormats/interface/SinglePhotonView.h
+++ b/DataFormats/interface/SinglePhotonView.h
@@ -16,7 +16,8 @@ namespace flashgg {
         typedef edm::Ptr<flashgg::Photon> pho_ptr_type;
         typedef edm::Ptr<reco::Vertex> vtx_ptr_type;
         typedef Photon cand_type;
-
+        
+        virtual ~SinglePhotonView() {}
         SinglePhotonView() : hasPhoton_( 0 ) {}
         SinglePhotonView( edm::Ptr<flashgg::Photon> pho, edm::Ptr<reco::Vertex> vtx ) : phoPtr_( pho ), vtxRef_( vtx ), hasPhoton_( 0 ), hasVtx_( 1 ) {}
         SinglePhotonView( edm::Ptr<flashgg::Photon> pho ) : phoPtr_( pho ), hasPhoton_( 0 ), hasVtx_( 0 ) {}

--- a/DataFormats/interface/SingleVertexView.h
+++ b/DataFormats/interface/SingleVertexView.h
@@ -15,6 +15,8 @@ namespace flashgg {
         typedef edm::Ptr<DiPhotonCandidate> dipho_ptr_type;
         typedef reco::Vertex cand_type;
 
+        virtual ~SingleVertexView() {}
+
         SingleVertexView() : isClosestToGen_( false ), dZtoGen_( 0. ), vtx_( 0 ), dipho_( 0 ) {}
         SingleVertexView( dipho_ptr_type dipho, int ivtx ) : isClosestToGen_( false ), dZtoGen_( 0. ), edmdipho_( dipho ), ivtx_( ivtx ), vtx_( 0 ), dipho_( 0 ) {}
         SingleVertexView( const DiPhotonCandidate *dipho, int ivtx ) : isClosestToGen_( false ), dZtoGen_( 0. ), ivtx_( ivtx ), vtx_( 0 ), dipho_( dipho ) {}

--- a/DataFormats/interface/VBFDiPhoDiJetMVAResult.h
+++ b/DataFormats/interface/VBFDiPhoDiJetMVAResult.h
@@ -14,7 +14,7 @@ namespace flashgg {
         VBFDiPhoDiJetMVAResult();
 //    VBFDiPhoDiJetMVAResult(VBFMVAResult);
         //    VBFDiPhoDiJetMVAResult(const VBFDiPhoDiJetMVAResult&) = default;  // C++11 only? Should happen automagically anyway
-
+        virtual ~VBFDiPhoDiJetMVAResult() {}
         // Input variables
         float dijet_mva;
         float dipho_mva;

--- a/DataFormats/interface/VBFMVAResult.h
+++ b/DataFormats/interface/VBFMVAResult.h
@@ -13,7 +13,7 @@ namespace flashgg {
     public:
         VBFMVAResult();
         VBFMVAResult( edm::Ptr<VBFMVAResult> );
-        
+        virtual ~VBFMVAResult() {}
         // diJet Info
         //flashgg::Jet leadJet;
         //flashgg::Jet subleadJet;

--- a/DataFormats/src/WeightedObject.cc
+++ b/DataFormats/src/WeightedObject.cc
@@ -30,7 +30,7 @@ namespace flashgg {
     {
         auto found_label = std::lower_bound( _labels.begin(), _labels.end(), key );
         if( found_label == _labels.end() || *found_label != key ) {
-            return -1.;
+            return 1.;
         }
         return _weights[std::distance( _labels.begin(), found_label )];
     }

--- a/Taggers/interface/CollectionDumper.h
+++ b/Taggers/interface/CollectionDumper.h
@@ -345,13 +345,16 @@ namespace flashgg {
 
                 if( which != dumpers_.end() ) {
                     int isub = ( hasSubcat_[cat.first] ? cat.second : 0 );
+                   double fillWeight =weight_;
                    const  WeightedObject* tag = dynamic_cast<const WeightedObject* >( &cand );
                     if ( tag != NULL ){
 
-                    weight_=weight_*(tag->centralWeight());
+                    //std::cout << "TEST  weight_  " << fillWeight << std::endl;
+                    fillWeight =fillWeight*(tag->centralWeight());
                     //std::cout << "TEST cand centralWeight " << tag->centralWeight() << std::endl;
+                    //std::cout << "TEST  weight  " << fillWeight << std::endl;
                     }
-                    which->second[isub].fill( cand, weight_, pdfWeights_, maxCandPerEvent_ - nfilled );
+                    which->second[isub].fill( cand, fillWeight, pdfWeights_, maxCandPerEvent_ - nfilled );
                     --nfilled;
                 } else if( throwOnUnclassified_ ) {
                     throw cms::Exception( "Runtime error" ) << "could not find dumper for category [" << cat.first << "," << cat.second << "]"

--- a/Taggers/interface/CollectionDumper.h
+++ b/Taggers/interface/CollectionDumper.h
@@ -345,7 +345,12 @@ namespace flashgg {
 
                 if( which != dumpers_.end() ) {
                     int isub = ( hasSubcat_[cat.first] ? cat.second : 0 );
-                    // FIXME per-candidate weights
+                   const  WeightedObject* tag = dynamic_cast<const WeightedObject* >( &cand );
+                    if ( tag != NULL ){
+
+                    weight_=weight_*(tag->centralWeight());
+                    //std::cout << "TEST cand centralWeight " << tag->centralWeight() << std::endl;
+                    }
                     which->second[isub].fill( cand, weight_, pdfWeights_, maxCandPerEvent_ - nfilled );
                     --nfilled;
                 } else if( throwOnUnclassified_ ) {


### PR DESCRIPTION
This PR applies the centralWeight of weightedObject candidates as a factor to the overall weight used to fill trees/workspaces by the dumper. The purpose of this is that in our final workspaces, the weight is correctly handled as the XS_weight*product(central weight of all systematics).

For object which are not inherited from weightedObject, this does not occur since the dynamic cast fails.
If the central weight is not filled or undefined, the default value used as a factor is 1.

