### PR TITLE
Topic develop rv syst technicalities

### DIFF
--- a/DataFormats/interface/DiPhotonCandidate.h
+++ b/DataFormats/interface/DiPhotonCandidate.h
@@ -103,7 +103,8 @@ namespace flashgg {
         unsigned int jetCollectionIndex() const { return jetCollectionIndex_; }
 
         LorentzVector genP4() const; 
-    private:
+
+        DiPhotonCandidate *clone() const { return ( new DiPhotonCandidate( *this ) ); }
 
     private:
         

--- a/DataFormats/interface/DiPhotonTagBase.h
+++ b/DataFormats/interface/DiPhotonTagBase.h
@@ -29,7 +29,7 @@ namespace flashgg {
         void setSystLabel( const std::string label ) { systLabel_ = label; }
         std::string systLabel() const { return systLabel_; }
         bool hasSyst( const string &label ) const { return ( systLabel_ == label );}
-        private:
+    private:
         DiPhotonMVAResult mva_result_;
         int category_number_;
         int diPhotonIndex_;

--- a/DataFormats/interface/Electron.h
+++ b/DataFormats/interface/Electron.h
@@ -24,6 +24,8 @@ namespace flashgg {
         bool hasMatchedConversion() const { return hasMatchedConversion_; }
         void setHasMatchedConversion( bool val ) { hasMatchedConversion_ = val;}
 
+        Electron *clone() const { return ( new Electron( *this ) ); }
+
     private:
         float nontrigmva_;
         float PfRhoAreaCorrectedIso_;

--- a/DataFormats/interface/Jet.h
+++ b/DataFormats/interface/Jet.h
@@ -32,6 +32,7 @@ namespace flashgg {
         bool passesPuJetId( const edm::Ptr<DiPhotonCandidate> dipho, PileupJetIdentifier::Id level = PileupJetIdentifier::kLoose )const;
         float rms( const edm::Ptr<DiPhotonCandidate> dipho ) const;
         float betaStar( const edm::Ptr<DiPhotonCandidate> dipho ) const;
+        Jet *clone() const { return ( new Jet( *this ) ); }
         
         bool passesJetID( JetIDLevel level = Loose ) const; 
     private:

--- a/DataFormats/interface/Muon.h
+++ b/DataFormats/interface/Muon.h
@@ -14,6 +14,7 @@ namespace flashgg {
         Muon();
         Muon( const pat::Muon & );
         ~Muon();
+        Muon *clone() const { return ( new Muon( *this ) ); }
     };
 }
 

--- a/Systematics/interface/BaseSystMethod.h
+++ b/Systematics/interface/BaseSystMethod.h
@@ -81,6 +81,7 @@ namespace flashgg {
 #include "flashgg/DataFormats/interface/Electron.h"
 #include "flashgg/DataFormats/interface/Muon.h"
 #include "flashgg/DataFormats/interface/Jet.h"
+#include "flashgg/DataFormats/interface/DiPhotonTagBase.h"
 //template <class T, class U> struct A {
 //    typedef edmplugin::PluginFactory< flashgg::BaseSystMethod<T,U>* (const edm::ParameterSet & ) > FlashggSystematicMethodsFactory;
 //}
@@ -97,6 +98,8 @@ typedef FlashggSystematicMethodsFactory<flashgg::Electron, std::pair<int, int> >
 typedef FlashggSystematicMethodsFactory<flashgg::Muon, std::pair<int, int> > FlashggSystematicMuonMethodsFactory2D;
 typedef FlashggSystematicMethodsFactory<flashgg::Jet, int > FlashggSystematicJetMethodsFactory;
 typedef FlashggSystematicMethodsFactory<flashgg::Jet, std::pair<int,int> > FlashggSystematicJetMethodsFactory2D;
+typedef FlashggSystematicMethodsFactory<flashgg::DiPhotonTagBase, int> FlashggSystematicTagMethodsFactory;
+typedef FlashggSystematicMethodsFactory<flashgg::DiPhotonTagBase, std::pair<int,int> > FlashggSystematicTagMethodsFactory2D;
 //typedef edmplugin::PluginFactory< flashgg::BaseSystMethod<flashgg::Photon, int>* ( const edm::ParameterSet & ) > FlashggSystematicPhotonMethodsFactory;
 //typedef edmplugin::PluginFactory< flashgg::BaseSystMethod<flashgg::Photon,float>* ( const edm::ParameterSet&) > FlashggSystematicPhotonMethodsFactory;
 //typedef edmplugin::PluginFactory< flashgg::BaseSystMethod<flashgg::DiPhotonCandidate>* ( const edm::ParameterSet&) > FlashggSystematicDiPhotonMethodsFactory;

--- a/Systematics/interface/ObjectSystematicProducer.h
+++ b/Systematics/interface/ObjectSystematicProducer.h
@@ -23,7 +23,7 @@ using namespace std;
 
 namespace flashgg {
 
-    template <typename flashgg_object, typename param_var>
+    template <typename flashgg_object, typename param_var, template <typename...> class output_container>
     class ObjectSystematicProducer : public edm::EDProducer
     {
     public:
@@ -50,8 +50,8 @@ namespace flashgg {
         std::vector<std::vector<pair<param_var, param_var> > > sigmas2D_;
     };
 
-    template <typename flashgg_object, typename param_var>
-    ObjectSystematicProducer<flashgg_object, param_var>::ObjectSystematicProducer( const ParameterSet &iConfig ) :
+    template <typename flashgg_object, typename param_var, template <typename...> class output_container>
+    ObjectSystematicProducer<flashgg_object, param_var, output_container>::ObjectSystematicProducer( const ParameterSet &iConfig ) :
         ObjectToken_( consumes<View<flashgg_object> >( iConfig.getParameter<InputTag>( "src" ) ) )
     {
         edm::Service<edm::RandomNumberGenerator> rng;
@@ -59,7 +59,7 @@ namespace flashgg {
             throw cms::Exception( "Configuration" ) << "ObjectSystematicProducer requires the RandomNumberGeneratorService  - please add to configuration";
         }
 
-        produces<std::vector<flashgg_object> >(); // Central value
+        produces<output_container<flashgg_object> >(); // Central value
         std::vector<edm::ParameterSet> vpset = iConfig.getParameter<std::vector<edm::ParameterSet> >( "SystMethods" );
         std::vector<edm::ParameterSet> vpset2D = iConfig.getParameter<std::vector<edm::ParameterSet> >( "SystMethods2D" );
 
@@ -90,7 +90,7 @@ namespace flashgg {
             if( !Corrections_.at( ipset )->makesWeight() ) {
                 for( const auto &sig : sigmas_.at( ipset ) ) {
                     std::string collection_label = Corrections_.at( ipset )->shiftLabel( sig );
-                    produces<vector<flashgg_object> >( collection_label );
+                    produces<output_container<flashgg_object> >( collection_label );
                     collectionLabelsNonCentral_.push_back( collection_label ); // 2N elements, current code gets labels right only if loops are consistent
                 }
             } else {
@@ -126,7 +126,7 @@ namespace flashgg {
             if( !Corrections_.at( ipset2D )->makesWeight() ) {
                 for( const auto &sig : sigmas2D_.at( ipset2D ) ) {
                     std::string collection_label = Corrections2D_.at( ipset2D )->shiftLabel( sig );
-                    produces<vector<flashgg_object> >( collection_label );
+                    produces<output_container<flashgg_object> >( collection_label );
                     collectionLabelsNonCentral_.push_back( collection_label );
                 }
             } else {
@@ -138,8 +138,8 @@ namespace flashgg {
     }
 
     ///fucntion takes in the current corection one is looping through and compares with its own internal loop, given that this will be within the corr and sys loop it takes care of the 2n+1 collection number////
-    template <typename flashgg_object, typename param_var>
-    void ObjectSystematicProducer<flashgg_object, param_var>::ApplyCorrections( flashgg_object &y,
+    template <typename flashgg_object, typename param_var, template <typename...> class output_container>
+    void ObjectSystematicProducer<flashgg_object, param_var, output_container>::ApplyCorrections( flashgg_object &y,
             shared_ptr<BaseSystMethod<flashgg_object, param_var> > CorrToShift,
             param_var syst_shift )
     {
@@ -178,8 +178,8 @@ namespace flashgg {
         //        std::cout << " 1d end " << std::endl;
     }
 
-    template <typename flashgg_object, typename param_var>
-    void ObjectSystematicProducer<flashgg_object, param_var>::ApplyCorrections( flashgg_object &y,
+    template <typename flashgg_object, typename param_var, template <typename...> class output_container>
+    void ObjectSystematicProducer<flashgg_object, param_var, output_container>::ApplyCorrections( flashgg_object &y,
             shared_ptr<BaseSystMethod<flashgg_object, pair<param_var, param_var> > > CorrToShift,
             pair<param_var, param_var>  syst_shift )
     {
@@ -207,8 +207,8 @@ namespace flashgg {
         //        std::cout << " Applied a central weight of " << theWeight << " - as part of 2d shift" << std::endl;
     }
 
-    template <typename flashgg_object, typename param_var>
-    void ObjectSystematicProducer<flashgg_object, param_var>::ApplyNonCentralWeights( flashgg_object &y )
+    template <typename flashgg_object, typename param_var, template <typename...> class output_container>
+    void ObjectSystematicProducer<flashgg_object, param_var, output_container>::ApplyNonCentralWeights( flashgg_object &y )
     {
         for( unsigned int ncorr = 0; ncorr < Corrections_.size(); ncorr++ ) {
             if( Corrections_.at( ncorr )->makesWeight() ) {
@@ -232,8 +232,8 @@ namespace flashgg {
         }
     }
 
-    template <typename flashgg_object, typename param_var>
-    void ObjectSystematicProducer<flashgg_object, param_var>::produce( Event &evt, const EventSetup & )
+    template <typename flashgg_object, typename param_var, template <typename...> class output_container>
+    void ObjectSystematicProducer<flashgg_object, param_var, output_container>::produce( Event &evt, const EventSetup & )
     {
 
         Handle<View<flashgg_object> > objects;
@@ -281,11 +281,11 @@ namespace flashgg {
         // although I think I have done it correctly - the delete[] statement below is vital
         // Problem: vector<auto_ptr> is not allowed
         // Possible alternate solutions: map, multimap, vector<unique_ptr> + std::move ??
-        std::auto_ptr<std::vector<flashgg_object> > *all_shifted_collections;
+        std::auto_ptr<output_container<flashgg_object> > *all_shifted_collections;
         unsigned int total_shifted_collections = collectionLabelsNonCentral_.size();
-        all_shifted_collections = new std::auto_ptr<std::vector<flashgg_object> >[total_shifted_collections];
+        all_shifted_collections = new std::auto_ptr<output_container<flashgg_object> >[total_shifted_collections];
         for( unsigned int ncoll = 0 ; ncoll < total_shifted_collections ; ncoll++ ) {
-            all_shifted_collections[ncoll].reset( new std::vector<flashgg_object> );
+            all_shifted_collections[ncoll].reset( new output_container<flashgg_object> );
         }
         for( unsigned int i = 0; i < objects->size(); i++ ) {
             unsigned int ncoll = 0;

--- a/Systematics/interface/ObjectSystematicProducer.h
+++ b/Systematics/interface/ObjectSystematicProducer.h
@@ -264,7 +264,7 @@ namespace flashgg {
         //        std::cout << "Engines set!" << std::endl;
 
         // Build central collection
-        auto_ptr<vector<flashgg_object> > centralObjectColl( new vector<flashgg_object> );
+        auto_ptr<output_container<flashgg_object> > centralObjectColl( new output_container<flashgg_object> );
         for( unsigned int i = 0; i < objects->size(); i++ ) {
             flashgg_object *p_obj = objects->ptrAt( i )->clone();
             flashgg_object obj = *p_obj;

--- a/Systematics/interface/ObjectSystematicProducer.h
+++ b/Systematics/interface/ObjectSystematicProducer.h
@@ -266,7 +266,8 @@ namespace flashgg {
         // Build central collection
         auto_ptr<vector<flashgg_object> > centralObjectColl( new vector<flashgg_object> );
         for( unsigned int i = 0; i < objects->size(); i++ ) {
-            flashgg_object obj = flashgg_object( *objects->ptrAt( i ) );
+            flashgg_object *p_obj = objects->ptrAt( i )->clone();
+            flashgg_object obj = *p_obj;
             ApplyCorrections( obj, nullptr, param_var( 0 ) );
             ApplyNonCentralWeights( obj );
             centralObjectColl->push_back( obj );
@@ -292,7 +293,8 @@ namespace flashgg {
                 for( const auto &sig : sigmas_.at( ncorr ) ) {
                     //                    std::cout << i << " " << ncoll << " " << sig << std::endl;
                     if( !Corrections_.at( ncorr )->makesWeight() ) {
-                        flashgg_object obj = flashgg_object( *objects->ptrAt( i ) );
+                        flashgg_object *p_obj = objects->ptrAt( i )->clone();
+                        flashgg_object obj = *p_obj;
                         ApplyCorrections( obj, Corrections_.at( ncorr ), sig );
                         all_shifted_collections[ncoll]->push_back( obj );
                         ncoll++;
@@ -303,7 +305,8 @@ namespace flashgg {
                 for( const auto &sig : sigmas2D_.at( ncorr ) ) {
                     //                    std::cout << i << " " << ncoll << " " << sig.first << " " << sig.second << std::endl;
                     if( !Corrections_.at( ncorr )->makesWeight() ) {
-                        flashgg_object obj = flashgg_object( *objects->ptrAt( i ) );
+                        flashgg_object *p_obj = objects->ptrAt( i )->clone();
+                        flashgg_object obj = *p_obj;
                         ApplyCorrections( obj, Corrections2D_.at( ncorr ), sig );
                         all_shifted_collections[ncoll]->push_back( obj );
                         ncoll++;

--- a/Systematics/plugins/BuildFile.xml
+++ b/Systematics/plugins/BuildFile.xml
@@ -5,6 +5,7 @@
 <use name="CondFormats/JetMETObjects"/>
 <use name="JetMETCorrections/Objects"/>
 <use name="flashgg/Systematics"/>
+<use name="flashgg/DataFormats"/>
 <use name="roottmva"/>
 <use name="clhep"/>
 <flags  EDM_PLUGIN="1"/>

--- a/Systematics/plugins/DiPhotonSystematicProducer.cc
+++ b/Systematics/plugins/DiPhotonSystematicProducer.cc
@@ -4,7 +4,7 @@
 
 namespace flashgg {
 
-    typedef ObjectSystematicProducer<DiPhotonCandidate, int> DiPhotonSystematicProducer;
+    typedef ObjectSystematicProducer<DiPhotonCandidate, int, std::vector> DiPhotonSystematicProducer;
 
 }
 

--- a/Systematics/plugins/JetSystematicProducer.cc
+++ b/Systematics/plugins/JetSystematicProducer.cc
@@ -20,7 +20,7 @@
 
 namespace flashgg {
 
-    class JetSystematicProducer : public ObjectSystematicProducer<flashgg::Jet,int>
+    class JetSystematicProducer : public ObjectSystematicProducer<flashgg::Jet,int,std::vector>
     {
         
     public:
@@ -31,7 +31,7 @@ namespace flashgg {
         bool correctionsSet_;
     };
 
-    JetSystematicProducer::JetSystematicProducer ( const edm::ParameterSet &iConfig ) : ObjectSystematicProducer<flashgg::Jet,int>( iConfig ) {
+    JetSystematicProducer::JetSystematicProducer ( const edm::ParameterSet &iConfig ) : ObjectSystematicProducer<flashgg::Jet,int,std::vector>( iConfig ) {
         correctionsSet_ = false;
     }
     
@@ -47,7 +47,7 @@ namespace flashgg {
                 this->Corrections2D_.at( ncorr )->setEnergyCorrections(JetCorPar);
             }
         }
-        ObjectSystematicProducer<flashgg::Jet,int>::produce( iEvent, iSetup );
+        ObjectSystematicProducer<flashgg::Jet,int,std::vector>::produce( iEvent, iSetup );
     }
 
 }

--- a/Systematics/plugins/LeptonEffSystematicProducer.cc
+++ b/Systematics/plugins/LeptonEffSystematicProducer.cc
@@ -5,8 +5,8 @@
 
 namespace flashgg {
 
-    typedef ObjectSystematicProducer<flashgg::Electron, int> ElectronEffSystematicProducer;
-    typedef ObjectSystematicProducer<flashgg::Muon, int> MuonEffSystematicProducer;
+    typedef ObjectSystematicProducer<flashgg::Electron, int, std::vector> ElectronEffSystematicProducer;
+    typedef ObjectSystematicProducer<flashgg::Muon, int, std::vector> MuonEffSystematicProducer;
 
 }
 

--- a/Systematics/plugins/PhotonSystematicProducer.cc
+++ b/Systematics/plugins/PhotonSystematicProducer.cc
@@ -4,7 +4,7 @@
 
 namespace flashgg {
 
-    typedef ObjectSystematicProducer<flashgg::Photon, int> PhotonSystematicProducer;
+    typedef ObjectSystematicProducer<flashgg::Photon, int, std::vector> PhotonSystematicProducer;
 
 }
 

--- a/Systematics/plugins/TagSystematicProducer.cc
+++ b/Systematics/plugins/TagSystematicProducer.cc
@@ -4,7 +4,7 @@
 
 namespace flashgg {
 
-    typedef ObjectSystematicProducer<flashgg::DiPhotonTagBase, int> TagSystematicProducer;
+    typedef ObjectSystematicProducer<flashgg::DiPhotonTagBase, int, edm::OwnVector> TagSystematicProducer;
 
 }
 

--- a/Systematics/plugins/TagSystematicProducer.cc
+++ b/Systematics/plugins/TagSystematicProducer.cc
@@ -1,0 +1,20 @@
+#include "flashgg/DataFormats/interface/DiPhotonTagBase.h"
+#include "flashgg/Systematics/interface/BaseSystMethod.h"
+#include "flashgg/Systematics/interface/ObjectSystematicProducer.h"
+
+namespace flashgg {
+
+    typedef ObjectSystematicProducer<flashgg::DiPhotonTagBase, int> TagSystematicProducer;
+
+}
+
+typedef flashgg::TagSystematicProducer FlashggTagSystematicProducer;
+DEFINE_FWK_MODULE( FlashggTagSystematicProducer );
+
+// Local Variables:
+// mode:c++
+// indent-tabs-mode:nil
+// tab-width:4
+// c-basic-offset:4
+// End:
+// vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4

--- a/Systematics/plugins/TagWeightFromFracRV.cc
+++ b/Systematics/plugins/TagWeightFromFracRV.cc
@@ -1,0 +1,74 @@
+#include "flashgg/Systematics/interface/ObjectSystMethodBinnedByFunctor.h"
+#include "DataFormats/Common/interface/Handle.h"
+#include "DataFormats/Common/interface/PtrVector.h"
+#include "flashgg/DataFormats/interface/DiPhotonTagBase.h"
+#include "CommonTools/Utils/interface/StringCutObjectSelector.h"
+
+namespace flashgg {
+
+    class TagWeightFromFracRV: public ObjectSystMethodBinnedByFunctor<flashgg::DiPhotonTagBase, int>
+    {
+
+    public:
+        typedef StringCutObjectSelector<DiPhotonTagBase, true> selector_type;
+
+        TagWeightFromFracRV( const edm::ParameterSet &conf );
+        float makeWeight( const flashgg::DiPhotonTagBase &y, int syst_shift ) override;
+        std::string shiftLabel( int ) const override;
+
+    private:
+        selector_type overall_range_;
+        bool debug_;
+    };
+
+    TagWeightFromFracRV::TagWeightFromFracRV( const edm::ParameterSet &conf ) :
+        ObjectSystMethodBinnedByFunctor( conf ),
+        overall_range_( conf.getParameter<std::string>( "OverallRange" ) ),
+        debug_( conf.getUntrackedParameter<bool>( "Debug", false ) )
+    {
+    }
+
+    std::string TagWeightFromFracRV::shiftLabel( int syst_value ) const
+    {
+        std::string result;
+        if( syst_value == 0 ) {
+            result = Form( "%sCentral", label().c_str() );
+        } else if( syst_value > 0 ) {
+            result = Form( "%sUp%.2dsigma", label().c_str(), syst_value );
+        } else {
+            result = Form( "%sDown%.2dsigma", label().c_str(), -1 * syst_value );
+        }
+        return result;
+    }
+
+    float TagWeightFromFracRV::makeWeight( const DiPhotonTagBase &obj, int syst_shift )
+    {
+        float theWeight = 1.;
+        if( overall_range_( obj ) ) {
+            auto val_err = this->binContents( obj );
+
+            // Do the interpretation here!  See ObjectWeight for an example
+
+            if( this->debug_ ) {
+                std::cout << "  " << shiftLabel( syst_shift ) << ": Tag has diphoton pt " << obj.diPhoton()->pt() 
+                          << " and we apply a weight of " << theWeight << std::endl;
+            }
+        }
+        return theWeight;
+    }
+
+
+}
+
+DEFINE_EDM_PLUGIN( FlashggSystematicTagMethodsFactory,
+                   flashgg::TagWeightFromFracRV,
+                   "FlashggTagWeightFromFracRV" );
+
+// Local Variables:
+// mode:c++
+// indent-tabs-mode:nil
+// tab-width:4
+// c-basic-offset:4
+// End:
+// vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4
+

--- a/Systematics/plugins/TagWeightFromFracRV.cc
+++ b/Systematics/plugins/TagWeightFromFracRV.cc
@@ -26,6 +26,7 @@ namespace flashgg {
         overall_range_( conf.getParameter<std::string>( "OverallRange" ) ),
         debug_( conf.getUntrackedParameter<bool>( "Debug", false ) )
     {
+        this->setMakesWeight( true );
     }
 
     std::string TagWeightFromFracRV::shiftLabel( int syst_value ) const

--- a/Systematics/plugins/TagWeightFromFracRV.cc
+++ b/Systematics/plugins/TagWeightFromFracRV.cc
@@ -179,7 +179,6 @@ EXAMPLE2:
                 y.updateEnergy( shiftLabel( syst_shift ), newe );
  */
 
->>>>>>> malcles/master
 DEFINE_EDM_PLUGIN( FlashggSystematicTagMethodsFactory,
                    flashgg::TagWeightFromFracRV,
                    "FlashggTagWeightFromFracRV" );
@@ -191,7 +190,4 @@ DEFINE_EDM_PLUGIN( FlashggSystematicTagMethodsFactory,
 // c-basic-offset:4
 // End:
 // vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4
-<<<<<<< HEAD
 
-=======
->>>>>>> malcles/master

--- a/Systematics/python/flashggTagSystematics_cfi.py
+++ b/Systematics/python/flashggTagSystematics_cfi.py
@@ -1,0 +1,22 @@
+import FWCore.ParameterSet.Config as cms
+
+fakeBins = cms.PSet(
+    variables = cms.vstring("abs(eta)"),
+    bins = cms.VPSet(
+                     cms.PSet( lowBounds = cms.vdouble(0.0), upBounds = cms.vdouble(0.8),
+                               values = cms.vdouble( 1. ), uncertainties = cms.vdouble( 0. ) ),
+                    ))
+
+flashggTagSystematics = cms.EDProducer('FlashggTagSystematicProducer',
+                                       src = cms.InputTag("flashggTagMerger"),
+                                       SystMethods2D = cms.VPSet(),
+                                       SystMethods = cms.VPSet(cms.PSet( MethodName = cms.string("TagWeightFromFracRV"),
+                                                                          Label = cms.string("FracRVWeight"),
+                                                                          NSigmas = cms.vint32(-1,1),
+                                                                          OverallRange = cms.string("1"),
+                                                                          BinList = fakeBins,
+                                                                          Debug = cms.untracked.bool(True)
+                                                                         )
+                                                               )
+                                       )
+

--- a/Systematics/python/flashggTagSystematics_cfi.py
+++ b/Systematics/python/flashggTagSystematics_cfi.py
@@ -1,16 +1,16 @@
 import FWCore.ParameterSet.Config as cms
 
 fakeBins = cms.PSet(
-    variables = cms.vstring("abs(eta)"),
+    variables = cms.vstring("diPhoton().pt"),
     bins = cms.VPSet(
-                     cms.PSet( lowBounds = cms.vdouble(0.0), upBounds = cms.vdouble(0.8),
+                     cms.PSet( lowBounds = cms.vdouble(0.0), upBounds = cms.vdouble(999999.),
                                values = cms.vdouble( 1. ), uncertainties = cms.vdouble( 0. ) ),
                     ))
 
 flashggTagSystematics = cms.EDProducer('FlashggTagSystematicProducer',
-                                       src = cms.InputTag("flashggTagMerger"),
+                                       src = cms.InputTag("flashggSystTagMerger"),
                                        SystMethods2D = cms.VPSet(),
-                                       SystMethods = cms.VPSet(cms.PSet( MethodName = cms.string("TagWeightFromFracRV"),
+                                       SystMethods = cms.VPSet(cms.PSet( MethodName = cms.string("FlashggTagWeightFromFracRV"),
                                                                           Label = cms.string("FracRVWeight"),
                                                                           NSigmas = cms.vint32(-1,1),
                                                                           OverallRange = cms.string("1"),

--- a/Systematics/python/flashggTagSystematics_cfi.py
+++ b/Systematics/python/flashggTagSystematics_cfi.py
@@ -11,7 +11,8 @@ cms.PSet(lowBounds = cms.vdouble(40), upBounds = cms.vdouble(50), values = cms.v
 cms.PSet(lowBounds = cms.vdouble(50), upBounds = cms.vdouble(70), values = cms.vdouble(0.998695,1.02067), uncertainties = cms.vdouble(0.00137969,0.00137969,0.021848,0.021848)),
 cms.PSet(lowBounds = cms.vdouble(70), upBounds = cms.vdouble(110), values = cms.vdouble(1.00354,0.899309), uncertainties = cms.vdouble(0.00105337,0.00105337,0.0299365,0.0299365)),
 cms.PSet(lowBounds = cms.vdouble(110), upBounds = cms.vdouble(170), values = cms.vdouble(1.00369,0.786148), uncertainties = cms.vdouble(0.00105199,0.00105199,0.0609889,0.0609889)),
-cms.PSet(lowBounds = cms.vdouble(170), upBounds = cms.vdouble(400), values = cms.vdouble(1,1), uncertainties = cms.vdouble(0.00383577,0.00383577,0.47521,0.47521))
+cms.PSet(lowBounds = cms.vdouble(170), upBounds = cms.vdouble(400), values = cms.vdouble(1,1), uncertainties = cms.vdouble(0.00383577,0.00383577,0.47521,0.47521)),
+cms.PSet(lowBounds = cms.vdouble(400), upBounds = cms.vdouble(7000), values = cms.vdouble(1,1), uncertainties = cms.vdouble(0.,0.,0.,0.))
 )
 )
 

--- a/Systematics/src/BaseSystMethod.cc
+++ b/Systematics/src/BaseSystMethod.cc
@@ -20,6 +20,11 @@ EDM_REGISTER_PLUGINFACTORY( FlashggSystematicJetMethodsFactory,
                             "SystematicJetMethodsFactory" );
 EDM_REGISTER_PLUGINFACTORY( FlashggSystematicJetMethodsFactory2D,
                             "SystematicJetMethodsFactory2D" );
+EDM_REGISTER_PLUGINFACTORY( FlashggSystematicTagMethodsFactory,
+                            "SystematicTagMethodsFactory" );
+EDM_REGISTER_PLUGINFACTORY( FlashggSystematicTagMethodsFactory2D,
+                            "SystematicTagMethodsFactory2D" );
+
 
 //EDM_REGISTER_PLUGINFACTORY(FlashggSystematicDiPhotonMethodsFactory,
 //				"SystematicDiPhotonMethodsFactory");

--- a/Systematics/test/MicroAODtoWorkspace.py
+++ b/Systematics/test/MicroAODtoWorkspace.py
@@ -21,7 +21,8 @@ process.MessageLogger.cerr.FwkReport.reportEvery = cms.untracked.int32( 10 )
 process.RandomNumberGeneratorService = cms.Service("RandomNumberGeneratorService",
                                                    flashggDiPhotonSystematics = cms.PSet(initialSeed = cms.untracked.uint32(664)),
                                                    flashggElectronSystematics = cms.PSet(initialSeed = cms.untracked.uint32(11)),
-                                                   flashggMuonSystematics = cms.PSet(initialSeed = cms.untracked.uint32(13))
+                                                   flashggMuonSystematics = cms.PSet(initialSeed = cms.untracked.uint32(13)),
+                                                   flashggTagSystematics = cms.PSet(initialSeed = cms.untracked.uint32(999))
                                                   )
 
 process.load("flashgg.Systematics.flashggDiPhotonSystematics_cfi")
@@ -134,6 +135,7 @@ process.load("flashgg.Taggers.diphotonTagDumper_cfi") ##  import diphotonTagDump
 import flashgg.Taggers.dumperConfigTools as cfgTools
 
 process.tagsDumper.className = "DiPhotonTagDumper"
+#process.tagsDumper.src = "flashggSystTagMerger"
 process.tagsDumper.src = "flashggTagSystematics"
 process.tagsDumper.processId = "test"
 process.tagsDumper.dumpTrees = True # TODO CHANGE THIS BACK TO FALSE
@@ -191,8 +193,9 @@ for tag in tagList:
 process.p = cms.Path((process.flashggDiPhotonSystematics+process.flashggMuonSystematics+process.flashggElectronSystematics)*
                      (process.flashggUnpackedJets*process.jetSystematicsSequence)*
                      (process.flashggTagSequence+process.systematicsTagSequences)*
-                     process.flashggSystTagMerger
-                     * process.tagsDumper)
+                     process.flashggSystTagMerger*
+                     process.flashggTagSystematics*
+                     process.tagsDumper)
 
 ################################
 ## Dump merged tags to screen ##

--- a/Systematics/test/MicroAODtoWorkspace.py
+++ b/Systematics/test/MicroAODtoWorkspace.py
@@ -46,6 +46,7 @@ for i in range(len(UnpackedJetCollectionVInputTag)):
     massSearchReplaceAnyInputTag(process.flashggTagSequence,UnpackedJetCollectionVInputTag[i],jetSystematicsInputTags[i])
 
 process.flashggSystTagMerger = cms.EDProducer("TagMerger",src=cms.VInputTag("flashggTagSorter"))
+process.load("flashgg.Systematics.flashggTagSystematics_cfi")
 
 process.systematicsTagSequences = cms.Sequence()
 systlabels = [""]
@@ -64,6 +65,7 @@ if customize.processId.count("h_") or customize.processId.count("vbf_"): # conve
         phosystlabels.append("MvaShift%s01sigma" % direction)
         jetsystlabels.append("JEC%s01sigma" % direction)
         jetsystlabels.append("JER%s01sigma" % direction)
+        variablesToUse.append("FracRVWeight%s01sigma := weight(\"FracRVWeight%s01sigma\")" % (direction,direction))
         for r9 in ["HighR9","LowR9"]:
             phosystlabels.append("MCSmear%sEE%s01sigma" % (r9,direction))
             for var in ["Rho","Phi"]:
@@ -132,7 +134,7 @@ process.load("flashgg.Taggers.diphotonTagDumper_cfi") ##  import diphotonTagDump
 import flashgg.Taggers.dumperConfigTools as cfgTools
 
 process.tagsDumper.className = "DiPhotonTagDumper"
-process.tagsDumper.src = "flashggSystTagMerger"
+process.tagsDumper.src = "flashggTagSystematics"
 process.tagsDumper.processId = "test"
 process.tagsDumper.dumpTrees = True # TODO CHANGE THIS BACK TO FALSE
 process.tagsDumper.dumpWorkspace = True

--- a/Taggers/plugins/TagTestAnalyzer.cc
+++ b/Taggers/plugins/TagTestAnalyzer.cc
@@ -56,7 +56,7 @@ namespace flashgg {
         virtual void analyze( const edm::Event &, const edm::EventSetup & ) override;
         virtual void endJob() override;
 
-        edm::EDGetTokenT<edm::OwnVector<flashgg::DiPhotonTagBase> > TagSorterToken_;
+        edm::EDGetTokenT<edm::View<flashgg::DiPhotonTagBase> > TagSorterToken_;
         bool expectMultiples_;
     };
 
@@ -75,7 +75,7 @@ namespace flashgg {
 // constructors and destructor
 //
     TagTestAnalyzer::TagTestAnalyzer( const edm::ParameterSet &iConfig ):
-        TagSorterToken_( consumes<edm::OwnVector<flashgg::DiPhotonTagBase> >( iConfig.getParameter<InputTag> ( "TagSorter" ) ) ),
+        TagSorterToken_( consumes<edm::View<flashgg::DiPhotonTagBase> >( iConfig.getParameter<InputTag> ( "TagSorter" ) ) ),
         expectMultiples_( iConfig.getUntrackedParameter<bool>( "ExpectMultiples", false) )
     {
     }
@@ -92,7 +92,7 @@ namespace flashgg {
         // ********************************************************************************
         // access edm objects
 
-        Handle<edm::OwnVector<flashgg::DiPhotonTagBase> > TagSorter;
+        Handle<edm::View<flashgg::DiPhotonTagBase> > TagSorter;
         iEvent.getByToken( TagSorterToken_, TagSorter );
 
         if (!expectMultiples_) {


### PR DESCRIPTION
Actual physics content, put in by @malcles, provides the correct RV/WV reweighting SFs.

This PR develops the machinery to apply systematics to the CombinedMVA plots, which had a few technicalities relating to collection templating and base class cloning and some tweaks required to the Systematics sequence in MicroAODToWorkspace.py.  I thought this was necessary because DiPhotonCandidate does not know the true vertex z, which was needed for determining the RV/WV reweight. In the longer term, several people expressed a preference to store the true vertex position in the DiPhotonCandidate (MicroAOD change) and convert this systematic back into a DiPhoton systematic.  But I keep this one for the Dry Run because it works and I already did it.