### PR TITLE
slight changes for resubmission, notably allow r9 > 1 without binning…

### DIFF
--- a/Systematics/interface/ObjectSystMethodBinnedByFunctor.h
+++ b/Systematics/interface/ObjectSystMethodBinnedByFunctor.h
@@ -116,7 +116,7 @@ namespace flashgg {
                     return std::make_pair( bin.val, bin.unc );
                 }
             }
-            throw cms::Exception( "Binning" ) << " binContents failed and would return a pair of empty vectors";
+            throw cms::Exception( "Binning" ) << " binContents failed and would return a pair of empty vectors - 0th val:" << func_vals[0] << std::endl;
             return std::make_pair( std::vector<double>(), std::vector<double>() ); // this is bad
         }
 

--- a/Systematics/python/flashggDiPhotonSystematics_cfi.py
+++ b/Systematics/python/flashggDiPhotonSystematics_cfi.py
@@ -46,11 +46,11 @@ preselBins = cms.PSet(
     bins = cms.VPSet(
         cms.PSet( lowBounds = cms.vdouble( 0.0, 0.0 ), upBounds = cms.vdouble( 1.5, 0.9 ),
                   values = cms.vdouble( 0.9968 ), uncertainties = cms.vdouble( 0.0227 ) ),
-        cms.PSet( lowBounds = cms.vdouble( 0.0, 0.9 ), upBounds = cms.vdouble( 1.5, 1.0 ),
+        cms.PSet( lowBounds = cms.vdouble( 0.0, 0.9 ), upBounds = cms.vdouble( 1.5, 999. ),
                   values = cms.vdouble(0.9978 ), uncertainties= cms.vdouble( 0.0029 ) ),
         cms.PSet( lowBounds = cms.vdouble( 1.5, 0.0 ), upBounds = cms.vdouble( 2.5, 0.9),
                   values = cms.vdouble( 1.0115 ), uncertainties= cms.vdouble( 0.0297 ) ),
-        cms.PSet( lowBounds = cms.vdouble( 1.5, 0.9 ), upBounds = cms.vdouble( 2.5, 1.0 ),
+        cms.PSet( lowBounds = cms.vdouble( 1.5, 0.9 ), upBounds = cms.vdouble( 2.5, 999. ),
                   values = cms.vdouble(0.9963 ), uncertainties= cms.vdouble( 0.0044 ) )
         )
     )
@@ -61,11 +61,11 @@ looseMvaBins = cms.PSet(
     bins = cms.VPSet(
         cms.PSet( lowBounds = cms.vdouble( 0.0, 0.0 ), upBounds = cms.vdouble( 1.5, 0.9 ),
                   values = cms.vdouble( 1.0001 ), uncertainties = cms.vdouble( 0.0022 ) ),
-        cms.PSet( lowBounds = cms.vdouble( 0.0, 0.9 ), upBounds = cms.vdouble( 1.5, 1.0 ),
+        cms.PSet( lowBounds = cms.vdouble( 0.0, 0.9 ), upBounds = cms.vdouble( 1.5, 999.0 ),
                   values = cms.vdouble( 1.000 ), uncertainties= cms.vdouble( 0.0001 ) ),
         cms.PSet( lowBounds = cms.vdouble( 1.5, 0.0 ), upBounds = cms.vdouble( 2.5, 0.9),
                   values = cms.vdouble( 0.9851 ), uncertainties= cms.vdouble( 0.0016 ) ),
-        cms.PSet( lowBounds = cms.vdouble( 1.5, 0.9 ), upBounds = cms.vdouble( 2.5, 1.0 ),
+        cms.PSet( lowBounds = cms.vdouble( 1.5, 0.9 ), upBounds = cms.vdouble( 2.5, 999.0 ),
                   values = cms.vdouble( 1.0001 ), uncertainties= cms.vdouble( 0.0009 ) )
         )
     )
@@ -147,7 +147,7 @@ flashggDiPhotonSystematics = cms.EDProducer('FlashggDiPhotonSystematicProducer',
                                                   MethodName = cms.string("FlashggDiPhotonFromPhoton"),
                                                   Label = cms.string("MCSmearHighR9EB"),
                                                   NSigmas = cms.vint32(-1,1),
-                                                  OverallRange = cms.string("r9>0.94&&abs(eta)<1.5"),
+                                                  OverallRange = cms.string("r9>0.94&&abs(superCluster.eta)<1.5"),
                                                   BinList = smearBins,
                                                   Debug = cms.untracked.bool(False),
                                                   ExaggerateShiftUp = cms.untracked.bool(False),
@@ -156,7 +156,7 @@ flashggDiPhotonSystematics = cms.EDProducer('FlashggDiPhotonSystematicProducer',
                                                   MethodName = cms.string("FlashggDiPhotonFromPhoton"),
                                                   Label = cms.string("MCSmearLowR9EB"),
                                                   NSigmas = cms.vint32(-1,1),
-                                                  OverallRange = cms.string("r9<=0.94&&abs(eta)<1.5"),
+                                                  OverallRange = cms.string("r9<=0.94&&abs(superCluster.eta)<1.5"),
                                                   BinList = smearBins,
                                                   Debug = cms.untracked.bool(False),
                                                   ExaggerateShiftUp = cms.untracked.bool(False),

--- a/Systematics/test/MicroAODtoWorkspace.py
+++ b/Systematics/test/MicroAODtoWorkspace.py
@@ -126,7 +126,7 @@ from flashgg.MetaData.samples_utils import SamplesManager
 process.source = cms.Source ("PoolSource",
                              fileNames = cms.untracked.vstring("file:myMicroAODOutputFile.root"))
 #process.source = cms.Source("PoolSource",fileNames = cms.untracked.vstring("/store/group/phys_higgs/cmshgg/sethzenz/flashgg/RunIISpring15-FinalPrompt-BetaV7-25ns/Spring15#BetaV7/DoubleEG/RunIISpring15-FinalPrompt-BetaV7-25ns-Spring15BetaV7-v0-Run2015D-PromptReco-v4/151124_234634/0000/myMicroAODOutputFile_1.root"))
-
+#process.source = cms.Source("PoolSource",fileNames=cms.untracked.vstring("root://eoscms.cern.ch//eos/cms/store/group/phys_higgs/cmshgg/sethzenz/flashgg/RunIISpring15-ReMiniAOD-BetaV7-25ns/Spring15BetaV7/GluGluHToGG_M-125_13TeV_powheg_pythia8/RunIISpring15-ReMiniAOD-BetaV7-25ns-Spring15BetaV7-v0-RunIISpring15MiniAODv2-74X_mcRun2_asymptotic_v2-v1/151021_152108/0000/myMicroAODOutputFile_2.root"))
 
 #if options.maxEvents > 0:
 #    process.source.eventsToProcess = cms.untracked.VEventRange('1:1-1:'+str(options.maxEvents))


### PR DESCRIPTION
Workspaces submitted, and a few final changes that were done:

   * May not matter, but use superCluster.eta consistently rather than eta
   * Allow r9 to be bigger than 1 in photon weight systematics.  When bin ended at 1 we occasionally got a binning exception.  Oops!