### PR TITLE
Randomizer - embed random numbers into objects

### DIFF
--- a/MicroAOD/interface/RandomizedObjectProducer.h
+++ b/MicroAOD/interface/RandomizedObjectProducer.h
@@ -1,0 +1,75 @@
+#ifndef FLASHgg_RandomizedObjectProducer_h
+#define FLASHgg_RandomizedObjectProducer_h
+
+#include "DataFormats/Common/interface/Handle.h"
+#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "FWCore/Utilities/interface/RandomNumberGenerator.h"
+#include "CLHEP/Random/RandomEngine.h"
+#include "CLHEP/Random/RandGauss.h"
+
+namespace flashgg {
+
+    template <typename pat_object>
+    class RandomizedObjectProducer : public edm::EDProducer
+    {
+    public:
+        RandomizedObjectProducer( const edm::ParameterSet & );
+        void produce( edm::Event &, const edm::EventSetup & ) override;
+
+    private:
+        edm::EDGetTokenT<edm::View<pat_object> > token_;
+        std::vector<std::string> labels_;
+        //std::string pdf_; // only gaussians with mean 0 and width 1 for the time being
+
+    };
+
+    template <typename pat_object>
+    RandomizedObjectProducer<pat_object>::RandomizedObjectProducer( const edm::ParameterSet &ps ) :
+        token_(consumes<edm::View<pat_object> >(ps.getParameter<edm::InputTag>("src"))),
+        labels_(ps.getParameter<std::vector<std::string> >("labels"))
+        //prefix_(ps.getParameter<std::string>("pdf")
+    {
+        produces<std::vector<pat_object> >();
+    }
+
+    template <typename pat_object>
+    void RandomizedObjectProducer<pat_object>::produce( edm::Event &evt, const edm::EventSetup & )
+    {
+        edm::Service<edm::RandomNumberGenerator> rng;
+        if( ! rng.isAvailable() ) {
+            throw cms::Exception( "Configuration" ) << "ObjectSystematicProducer requires the RandomNumberGeneratorService  - please add to configuration";
+        }
+
+        edm::Handle<edm::View<pat_object> > objects;
+        evt.getByToken( token_, objects );
+
+        CLHEP::HepRandomEngine & engine = rng->getEngine( evt.streamID() );
+        auto_ptr<std::vector<pat_object> > out_obj( new std::vector<pat_object>() );
+        CLHEP::RandGauss::shoot(&engine, 0., 1.);
+
+        for (const auto & obj : *objects) {
+            auto o = obj;
+            for (auto l : labels_) {
+                    o.addUserFloat(l, CLHEP::RandGauss::shoot(&engine, 0., 1.));
+                    out_obj->push_back(o);
+            }
+        }
+        evt.put(out_obj);
+    }
+}
+
+#endif
+
+// Local Variables:
+// mode:c++
+// indent-tabs-mode:nil
+// tab-width:4
+// c-basic-offset:4
+// End:
+// vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4

--- a/MicroAOD/plugins/RandomizedPerPhotonDiPhotonProducer.cc
+++ b/MicroAOD/plugins/RandomizedPerPhotonDiPhotonProducer.cc
@@ -1,0 +1,86 @@
+#ifndef FLASHgg_RandomizedPerPhotonDiPhotonProducer_h
+#define FLASHgg_RandomizedPerPhotonDiPhotonProducer_h
+
+/* This is a *temporary* producer supposed to be replaced by the
+ * RandomizedPhotonProducer run at MicroAOD production time. This producer is
+ * meant to be run on-the-fly on MicroAOD produced already with no random
+ * information attached to the Photon's. It is close to a mere copy-n-paste of
+ * RandomizedObjectProducer.h
+ */
+
+#include "DataFormats/Common/interface/Handle.h"
+#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "FWCore/Utilities/interface/RandomNumberGenerator.h"
+#include "CLHEP/Random/RandomEngine.h"
+#include "CLHEP/Random/RandGauss.h"
+
+#include "flashgg/DataFormats/interface/DiPhotonCandidate.h"
+
+namespace flashgg {
+
+    class RandomizedPerPhotonDiPhotonProducer : public edm::EDProducer
+    {
+    public:
+        RandomizedPerPhotonDiPhotonProducer( const edm::ParameterSet & );
+        void produce( edm::Event &, const edm::EventSetup & ) override;
+
+    private:
+        edm::EDGetTokenT<edm::View<flashgg::DiPhotonCandidate> > token_;
+        edm::Handle<edm::View<flashgg::DiPhotonCandidate> > input;
+        std::vector<std::string> labels_;
+        //std::string pdf_; // only gaussians with mean 0 and width 1 for the time being
+    };
+
+    RandomizedPerPhotonDiPhotonProducer::RandomizedPerPhotonDiPhotonProducer( const edm::ParameterSet &ps ) :
+        token_(consumes<edm::View<flashgg::DiPhotonCandidate> >(ps.getParameter<edm::InputTag>("src"))),
+        labels_(ps.getParameter<std::vector<std::string> >("labels"))
+        //prefix_(ps.getParameter<std::string>("pdf")
+    {
+        produces<std::vector<flashgg::DiPhotonCandidate> >();
+    }
+
+    void RandomizedPerPhotonDiPhotonProducer::produce( edm::Event &evt, const edm::EventSetup & )
+    {
+        edm::Service<edm::RandomNumberGenerator> rng;
+        if( ! rng.isAvailable() ) {
+            throw cms::Exception( "Configuration" ) << "ObjectSystematicProducer requires the RandomNumberGeneratorService  - please add to configuration";
+        }
+
+        edm::Handle<edm::View<flashgg::DiPhotonCandidate> > objects;
+        evt.getByToken( token_, objects );
+
+        CLHEP::HepRandomEngine & engine = rng->getEngine( evt.streamID() );
+        auto_ptr<std::vector<flashgg::DiPhotonCandidate> > out_obj( new std::vector<flashgg::DiPhotonCandidate>() );
+        CLHEP::RandGauss::shoot(&engine, 0., 1.);
+
+        for (const auto & obj : *objects) {
+            auto o = obj;
+            for (auto l : labels_) {
+                    o.makePhotonsPersistent();
+                    o.getLeadingPhoton().addUserFloat(l, CLHEP::RandGauss::shoot(&engine, 0., 1.));
+                    o.getSubLeadingPhoton().addUserFloat(l, CLHEP::RandGauss::shoot(&engine, 0., 1.));
+                    out_obj->push_back(o);
+            }
+        }
+        evt.put(out_obj);
+    }
+}
+
+typedef flashgg::RandomizedPerPhotonDiPhotonProducer FlashggRandomizedPerPhotonDiPhotonProducer;
+DEFINE_FWK_MODULE( FlashggRandomizedPerPhotonDiPhotonProducer );
+
+#endif
+
+// Local Variables:
+// mode:c++
+// indent-tabs-mode:nil
+// tab-width:4
+// c-basic-offset:4
+// End:
+// vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4

--- a/MicroAOD/plugins/RandomizedPhotonProducer.cc
+++ b/MicroAOD/plugins/RandomizedPhotonProducer.cc
@@ -1,0 +1,19 @@
+#include "flashgg/DataFormats/interface/Photon.h"
+#include "flashgg/MicroAOD/interface/RandomizedObjectProducer.h"
+
+namespace flashgg {
+
+    typedef RandomizedObjectProducer<flashgg::Photon> RandomizedPhotonProducer;
+
+}
+
+typedef flashgg::RandomizedPhotonProducer FlashggRandomizedPhotonProducer;
+DEFINE_FWK_MODULE( FlashggRandomizedPhotonProducer );
+
+// Local Variables:
+// mode:c++
+// indent-tabs-mode:nil
+// tab-width:4
+// c-basic-offset:4
+// End:
+// vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4

--- a/MicroAOD/python/flashggRandomizedPerPhotonDiPhotonProducer_cff.py
+++ b/MicroAOD/python/flashggRandomizedPerPhotonDiPhotonProducer_cff.py
@@ -1,0 +1,17 @@
+
+import FWCore.ParameterSet.Config as cms
+
+# add the following lines to the module used to configure the RandomNumberGeneratorService
+# process.RandomNumberGeneratorService.flashggRandomizedPerPhotonDiPhotons = cms.PSet(
+#           initialSeed = cms.untracked.uint32(281765313)
+#         # engineName = cms.untracked.string('TRandom3') # optional, default to HepJamesRandom if absent
+#         )
+
+
+flashggRandomizedPerPhotonDiPhotons = cms.EDProducer("FlashggRandomizedPerPhotonDiPhotonProducer",
+                                    src = cms.InputTag("flashggFinalEGamma", "finalDiPhotons"),
+                                    outputCollectionName = cms.string("flashggFinalRandomizedDiPhotons"),
+                                    # labels of various gaussian random numbers with mean=0, sigma=1
+                                    # to be associated with the photon object
+                                    labels = cms.vstring("smearE")
+                                    )

--- a/MicroAOD/python/flashggRandomizedPhotonProducer_cff.py
+++ b/MicroAOD/python/flashggRandomizedPhotonProducer_cff.py
@@ -1,0 +1,16 @@
+
+import FWCore.ParameterSet.Config as cms
+
+# add the following lines to the module used to configure the RandomNumberGeneratorService
+# process.RandomNumberGeneratorService.flashggRandomizedPhotons = cms.PSet(
+#           initialSeed = cms.untracked.uint32(16253245)
+#         # engineName = cms.untracked.string('TRandom3') # optional, default to HepJamesRandom if absent
+#         )
+
+flashggRandomizedPhotons = cms.EDProducer("FlashggRandomizedPhotons",
+                                    src = cms.InputTag("flashggFinalEGamma"),
+                                    outputCollectionName = cms.string("flashggFinalRandomizedEGamma"),
+                                    # labels of various gaussian random numbers with mean=0, sigma=1
+                                    # to be associated with the photon object
+                                    labels = cms.vstring("smearE")
+                                    )

--- a/Systematics/plugins/BuildFile.xml
+++ b/Systematics/plugins/BuildFile.xml
@@ -7,6 +7,5 @@
 <use name="flashgg/Systematics"/>
 <use name="flashgg/DataFormats"/>
 <use name="roottmva"/>
-<use name="clhep"/>
 <flags  EDM_PLUGIN="1"/>
 </library>

--- a/Systematics/python/flashggDiPhotonSystematics_cfi.py
+++ b/Systematics/python/flashggDiPhotonSystematics_cfi.py
@@ -131,6 +131,10 @@ flashggDiPhotonSystematics = cms.EDProducer('FlashggDiPhotonSystematicProducer',
                                                   NSigmas = cms.vint32(-1,1),
                                                   OverallRange = cms.string("r9>0.94&&abs(superCluster.eta)>=1.5"),
                                                   BinList = smearBins,
+                                                  # has to match the labels embedded in the photon object as
+                                                  # defined e.g. in flashgg/MicroAOD/python/flashggRandomizedPerPhotonDiPhotonProducer_cff.py
+                                                  #           or in flashgg/MicroAOD/python/flashggRandomizedPhotonProducer_cff.py (if at MicroAOD prod.)
+                                                  RandomLabel = cms.string("smearE"),
                                                   Debug = cms.untracked.bool(False),
                                                   ExaggerateShiftUp = cms.untracked.bool(False),
                                                   ),
@@ -140,6 +144,10 @@ flashggDiPhotonSystematics = cms.EDProducer('FlashggDiPhotonSystematicProducer',
                                                   NSigmas = cms.vint32(-1,1),
                                                   OverallRange = cms.string("r9<0.94&&abs(superCluster.eta)>=1.5"),
                                                   BinList = smearBins,
+                                                  # has to match the labels embedded in the photon object as
+                                                  # defined e.g. in flashgg/MicroAOD/python/flashggRandomizedPerPhotonDiPhotonProducer_cff.py
+                                                  #           or in flashgg/MicroAOD/python/flashggRandomizedPhotonProducer_cff.py (if at MicroAOD prod.)
+                                                  RandomLabel = cms.string("smearE"),
                                                   Debug = cms.untracked.bool(False),
                                                   ExaggerateShiftUp = cms.untracked.bool(False),
                                                   ),
@@ -149,6 +157,10 @@ flashggDiPhotonSystematics = cms.EDProducer('FlashggDiPhotonSystematicProducer',
                                                   NSigmas = cms.vint32(-1,1),
                                                   OverallRange = cms.string("r9>0.94&&abs(superCluster.eta)<1.5"),
                                                   BinList = smearBins,
+                                                  # has to match the labels embedded in the photon object as
+                                                  # defined e.g. in flashgg/MicroAOD/python/flashggRandomizedPerPhotonDiPhotonProducer_cff.py
+                                                  #           or in flashgg/MicroAOD/python/flashggRandomizedPhotonProducer_cff.py (if at MicroAOD prod.)
+                                                  RandomLabel = cms.string("smearE"),
                                                   Debug = cms.untracked.bool(False),
                                                   ExaggerateShiftUp = cms.untracked.bool(False),
                                                   ),
@@ -158,6 +170,10 @@ flashggDiPhotonSystematics = cms.EDProducer('FlashggDiPhotonSystematicProducer',
                                                   NSigmas = cms.vint32(-1,1),
                                                   OverallRange = cms.string("r9<=0.94&&abs(superCluster.eta)<1.5"),
                                                   BinList = smearBins,
+                                                  # has to match the labels embedded in the photon object as
+                                                  # defined e.g. in flashgg/MicroAOD/python/flashggRandomizedPerPhotonDiPhotonProducer_cff.py
+                                                  #           or in flashgg/MicroAOD/python/flashggRandomizedPhotonProducer_cff.py (if at MicroAOD prod.)
+                                                  RandomLabel = cms.string("smearE"),
                                                   Debug = cms.untracked.bool(False),
                                                   ExaggerateShiftUp = cms.untracked.bool(False),
                                                   ),
@@ -195,4 +211,3 @@ flashggDiPhotonSystematics = cms.EDProducer('FlashggDiPhotonSystematicProducer',
                                                   )
                                         )
 )
-

--- a/Systematics/python/flashggDiPhotonSystematics_cfi.py
+++ b/Systematics/python/flashggDiPhotonSystematics_cfi.py
@@ -6,14 +6,14 @@ scaleBins = cms.PSet(
             # scale for prompt 2015, values OK, errors as in Run1 (since Run2 stat. only)
             # see Fasanella et al., ECAL DPG 03/12/2015, https://cern.ch/go/zFH8
             # w.r.t. the numbers in slide 3, the scale is computed as 1. / scale(MC) - 1.
-                     cms.PSet( lowBounds = cms.vdouble(0.000,0.940), upBounds = cms.vdouble(1.000,999.000), values = cms.vdouble( 0.00118139404497 ), uncertainties = cms.vdouble( 0.00050 ) ),
-                     cms.PSet( lowBounds = cms.vdouble(0.000,-999.000), upBounds = cms.vdouble(1.000,0.940), values = cms.vdouble( 0.00458088885317 ), uncertainties = cms.vdouble( 0.00050 ) ),
-                     cms.PSet( lowBounds = cms.vdouble(1.000,0.940), upBounds = cms.vdouble(1.500,999.000), values = cms.vdouble( -0.00645802285147 ), uncertainties = cms.vdouble( 0.00060 ) ),
-                     cms.PSet( lowBounds = cms.vdouble(1.000,-999.000), upBounds = cms.vdouble(1.500,0.940), values = cms.vdouble( 0.00339146314543 ), uncertainties = cms.vdouble( 0.00120 ) ),
-                     cms.PSet( lowBounds = cms.vdouble(1.500,-999.000), upBounds = cms.vdouble(2.000,0.940), values = cms.vdouble( 0.0138594588018 ), uncertainties = cms.vdouble( 0.00200 ) ),
-                     cms.PSet( lowBounds = cms.vdouble(1.500,0.940), upBounds = cms.vdouble(2.000,999.000), values = cms.vdouble( 0.00466162996303 ), uncertainties = cms.vdouble( 0.00300 ) ),
-                     cms.PSet( lowBounds = cms.vdouble(2.000,-999.000), upBounds = cms.vdouble(3.000,0.940), values = cms.vdouble( 0.021878416906 ), uncertainties = cms.vdouble( 0.00200 ) ),
-                     cms.PSet( lowBounds = cms.vdouble(2.000,0.940), upBounds = cms.vdouble(3.000,999.000), values = cms.vdouble( 0.014538334331 ), uncertainties = cms.vdouble( 0.00300 ) ),
+            cms.PSet( lowBounds = cms.vdouble(0.000 , 0.940)    , upBounds = cms.vdouble(1.000 , 999.000) , values = cms.vdouble( 0.00118139404497 )  , uncertainties = cms.vdouble( 0.00050 ) ) ,
+            cms.PSet( lowBounds = cms.vdouble(0.000 , -999.000) , upBounds = cms.vdouble(1.000 , 0.940)   , values = cms.vdouble( 0.00458088885317 )  , uncertainties = cms.vdouble( 0.00050 ) ) ,
+            cms.PSet( lowBounds = cms.vdouble(1.000 , 0.940)    , upBounds = cms.vdouble(1.500 , 999.000) , values = cms.vdouble( -0.00645802285147 ) , uncertainties = cms.vdouble( 0.00060 ) ) ,
+            cms.PSet( lowBounds = cms.vdouble(1.000 , -999.000) , upBounds = cms.vdouble(1.500 , 0.940)   , values = cms.vdouble( 0.00339146314543 )  , uncertainties = cms.vdouble( 0.00120 ) ) ,
+            cms.PSet( lowBounds = cms.vdouble(1.500 , -999.000) , upBounds = cms.vdouble(2.000 , 0.940)   , values = cms.vdouble( 0.0138594588018 )   , uncertainties = cms.vdouble( 0.00200 ) ) ,
+            cms.PSet( lowBounds = cms.vdouble(1.500 , 0.940)    , upBounds = cms.vdouble(2.000 , 999.000) , values = cms.vdouble( 0.00466162996303 )  , uncertainties = cms.vdouble( 0.00300 ) ) ,
+            cms.PSet( lowBounds = cms.vdouble(2.000 , -999.000) , upBounds = cms.vdouble(3.000 , 0.940)   , values = cms.vdouble( 0.021878416906 )    , uncertainties = cms.vdouble( 0.00200 ) ) ,
+            cms.PSet( lowBounds = cms.vdouble(2.000 , 0.940)    , upBounds = cms.vdouble(3.000 , 999.000) , values = cms.vdouble( 0.014538334331 )    , uncertainties = cms.vdouble( 0.00300 ) ) ,
                     ))
 
 
@@ -22,21 +22,20 @@ smearBins = cms.PSet(
     bins = cms.VPSet(
             # smearings for prompt 2015, values OK, errors as statistical of Run2 (since Run1 different parametrization)
             # see Fasanella et al., ECAL DPG 03/12/2015, https://cern.ch/go/zFH8
-                     cms.PSet( lowBounds = cms.vdouble(0.000,-999.000), upBounds = cms.vdouble(1.000,0.940), values = cms.vdouble( 0.013654 ), uncertainties = cms.vdouble( 0.00024652 ) ),
-                     cms.PSet( lowBounds = cms.vdouble(0.000,0.940), upBounds = cms.vdouble(1.000,999.000), values = cms.vdouble( 0.014142 ), uncertainties = cms.vdouble( 0.00018319 ) ),
-                     cms.PSet( lowBounds = cms.vdouble(1.000,-999.000), upBounds = cms.vdouble(1.500,0.940), values = cms.vdouble( 0.020859 ), uncertainties = cms.vdouble( 0.00032435 ) ),
-                     cms.PSet( lowBounds = cms.vdouble(1.000,0.940), upBounds = cms.vdouble(1.500,999.000), values = cms.vdouble( 0.017120 ), uncertainties = cms.vdouble( 0.00098551 ) ),
-                     cms.PSet( lowBounds = cms.vdouble(1.500,-999.000), upBounds = cms.vdouble(2.000,0.940), values = cms.vdouble( 0.028083 ), uncertainties = cms.vdouble( 0.00045816 ) ),
-                     cms.PSet( lowBounds = cms.vdouble(1.500,0.940), upBounds = cms.vdouble(2.000,999.000), values = cms.vdouble( 0.027289 ), uncertainties = cms.vdouble( 0.00076386 ) ),
-                     cms.PSet( lowBounds = cms.vdouble(2.000,-999.000), upBounds = cms.vdouble(3.000,0.940), values = cms.vdouble( 0.031793 ), uncertainties = cms.vdouble( 0.00061517 ) ),
-                     cms.PSet( lowBounds = cms.vdouble(2.000,0.940), upBounds = cms.vdouble(3.000,999.000), values = cms.vdouble( 0.030831 ), uncertainties = cms.vdouble( 0.00042066 ) ),
+            cms.PSet( lowBounds = cms.vdouble(0.000 , -999.000) , upBounds = cms.vdouble(1.000 , 0.940)   , values = cms.vdouble( 0.013654 ) , uncertainties = cms.vdouble( 0.00024652 ) ) ,
+            cms.PSet( lowBounds = cms.vdouble(0.000 , 0.940)    , upBounds = cms.vdouble(1.000 , 999.000) , values = cms.vdouble( 0.014142 ) , uncertainties = cms.vdouble( 0.00018319 ) ) ,
+            cms.PSet( lowBounds = cms.vdouble(1.000 , -999.000) , upBounds = cms.vdouble(1.500 , 0.940)   , values = cms.vdouble( 0.020859 ) , uncertainties = cms.vdouble( 0.00032435 ) ) ,
+            cms.PSet( lowBounds = cms.vdouble(1.000 , 0.940)    , upBounds = cms.vdouble(1.500 , 999.000) , values = cms.vdouble( 0.017120 ) , uncertainties = cms.vdouble( 0.00098551 ) ) ,
+            cms.PSet( lowBounds = cms.vdouble(1.500 , -999.000) , upBounds = cms.vdouble(2.000 , 0.940)   , values = cms.vdouble( 0.028083 ) , uncertainties = cms.vdouble( 0.00045816 ) ) ,
+            cms.PSet( lowBounds = cms.vdouble(1.500 , 0.940)    , upBounds = cms.vdouble(2.000 , 999.000) , values = cms.vdouble( 0.027289 ) , uncertainties = cms.vdouble( 0.00076386 ) ) ,
+            cms.PSet( lowBounds = cms.vdouble(2.000 , -999.000) , upBounds = cms.vdouble(3.000 , 0.940)   , values = cms.vdouble( 0.031793 ) , uncertainties = cms.vdouble( 0.00061517 ) ) ,
+            cms.PSet( lowBounds = cms.vdouble(2.000 , 0.940)    , upBounds = cms.vdouble(3.000 , 999.000) , values = cms.vdouble( 0.030831 ) , uncertainties = cms.vdouble( 0.00042066 ) ) ,
                     ))
 
 mvaShiftBins = cms.PSet(
     variables = cms.vstring("abs(superCluster.eta)"),
     bins = cms.VPSet(
-                     cms.PSet( lowBounds = cms.vdouble(0.000), upBounds = cms.vdouble(999.),
-                               values = cms.vdouble( 0.0 ), uncertainties = cms.vdouble( 0.03 ))
+            cms.PSet( lowBounds = cms.vdouble(0.000), upBounds = cms.vdouble(999.), values = cms.vdouble( 0.0 ), uncertainties = cms.vdouble( 0.03 ))
                      )
     )
 
@@ -44,14 +43,10 @@ mvaShiftBins = cms.PSet(
 preselBins = cms.PSet(
     variables = cms.vstring("abs(superCluster.eta)","r9"),
     bins = cms.VPSet(
-        cms.PSet( lowBounds = cms.vdouble( 0.0, 0.0 ), upBounds = cms.vdouble( 1.5, 0.9 ),
-                  values = cms.vdouble( 0.9968 ), uncertainties = cms.vdouble( 0.0227 ) ),
-        cms.PSet( lowBounds = cms.vdouble( 0.0, 0.9 ), upBounds = cms.vdouble( 1.5, 999. ),
-                  values = cms.vdouble(0.9978 ), uncertainties= cms.vdouble( 0.0029 ) ),
-        cms.PSet( lowBounds = cms.vdouble( 1.5, 0.0 ), upBounds = cms.vdouble( 2.5, 0.9),
-                  values = cms.vdouble( 1.0115 ), uncertainties= cms.vdouble( 0.0297 ) ),
-        cms.PSet( lowBounds = cms.vdouble( 1.5, 0.9 ), upBounds = cms.vdouble( 2.5, 999. ),
-                  values = cms.vdouble(0.9963 ), uncertainties= cms.vdouble( 0.0044 ) )
+        cms.PSet( lowBounds = cms.vdouble( 0.0 , 0.0 ) , upBounds = cms.vdouble( 1.5 , 0.9 )  , values = cms.vdouble( 0.9968 ) , uncertainties = cms.vdouble( 0.0227 ) ) ,
+        cms.PSet( lowBounds = cms.vdouble( 0.0 , 0.9 ) , upBounds = cms.vdouble( 1.5 , 999. ) , values = cms.vdouble( 0.9978 ) , uncertainties = cms.vdouble( 0.0029 ) ) ,
+        cms.PSet( lowBounds = cms.vdouble( 1.5 , 0.0 ) , upBounds = cms.vdouble( 2.5 , 0.9)   , values = cms.vdouble( 1.0115 ) , uncertainties = cms.vdouble( 0.0297 ) ) ,
+        cms.PSet( lowBounds = cms.vdouble( 1.5 , 0.9 ) , upBounds = cms.vdouble( 2.5 , 999. ) , values = cms.vdouble( 0.9963 ) , uncertainties = cms.vdouble( 0.0044 ) )
         )
     )
 
@@ -59,14 +54,10 @@ preselBins = cms.PSet(
 looseMvaBins = cms.PSet(
     variables = cms.vstring("abs(superCluster.eta)","r9"),
     bins = cms.VPSet(
-        cms.PSet( lowBounds = cms.vdouble( 0.0, 0.0 ), upBounds = cms.vdouble( 1.5, 0.9 ),
-                  values = cms.vdouble( 1.0001 ), uncertainties = cms.vdouble( 0.0022 ) ),
-        cms.PSet( lowBounds = cms.vdouble( 0.0, 0.9 ), upBounds = cms.vdouble( 1.5, 999.0 ),
-                  values = cms.vdouble( 1.000 ), uncertainties= cms.vdouble( 0.0001 ) ),
-        cms.PSet( lowBounds = cms.vdouble( 1.5, 0.0 ), upBounds = cms.vdouble( 2.5, 0.9),
-                  values = cms.vdouble( 0.9851 ), uncertainties= cms.vdouble( 0.0016 ) ),
-        cms.PSet( lowBounds = cms.vdouble( 1.5, 0.9 ), upBounds = cms.vdouble( 2.5, 999.0 ),
-                  values = cms.vdouble( 1.0001 ), uncertainties= cms.vdouble( 0.0009 ) )
+        cms.PSet( lowBounds = cms.vdouble( 0.0 , 0.0 ) , upBounds = cms.vdouble( 1.5 , 0.9 )   , values = cms.vdouble( 1.0001 ) , uncertainties = cms.vdouble( 0.0022 ) ) ,
+        cms.PSet( lowBounds = cms.vdouble( 0.0 , 0.9 ) , upBounds = cms.vdouble( 1.5 , 999.0 ) , values = cms.vdouble( 1.000 )  , uncertainties = cms.vdouble( 0.0001 ) ) ,
+        cms.PSet( lowBounds = cms.vdouble( 1.5 , 0.0 ) , upBounds = cms.vdouble( 2.5 , 0.9 )   , values = cms.vdouble( 0.9851 ) , uncertainties = cms.vdouble( 0.0016 ) ) ,
+        cms.PSet( lowBounds = cms.vdouble( 1.5 , 0.9 ) , upBounds = cms.vdouble( 2.5 , 999.0 ) , values = cms.vdouble( 1.0001 ) , uncertainties = cms.vdouble( 0.0009 ) )
         )
     )
 
@@ -76,8 +67,7 @@ looseMvaBins = cms.PSet(
 sigmaEOverEShiftBins = cms.PSet(
     variables = cms.vstring("abs(superCluster.eta)"),
     bins = cms.VPSet(
-                     cms.PSet( lowBounds = cms.vdouble(0.000), upBounds = cms.vdouble(999.),
-                               values = cms.vdouble( 0.0 ), uncertainties = cms.vdouble( 0.05 ))
+         cms.PSet( lowBounds = cms.vdouble(0.000), upBounds = cms.vdouble(999.), values = cms.vdouble( 0.0 ), uncertainties = cms.vdouble( 0.05 ))
                      )
     )
 

--- a/Systematics/test/MicroAODtoWorkspace.py
+++ b/Systematics/test/MicroAODtoWorkspace.py
@@ -22,7 +22,8 @@ process.RandomNumberGeneratorService = cms.Service("RandomNumberGeneratorService
                                                    flashggDiPhotonSystematics = cms.PSet(initialSeed = cms.untracked.uint32(664)),
                                                    flashggElectronSystematics = cms.PSet(initialSeed = cms.untracked.uint32(11)),
                                                    flashggMuonSystematics = cms.PSet(initialSeed = cms.untracked.uint32(13)),
-                                                   flashggTagSystematics = cms.PSet(initialSeed = cms.untracked.uint32(999))
+                                                   flashggTagSystematics = cms.PSet(initialSeed = cms.untracked.uint32(999)),
+                                                   flashggRandomizedPerPhotonDiPhotons = cms.PSet(initialSeed = cms.untracked.uint32(281765313))
                                                   )
 
 process.load("flashgg.Systematics.flashggDiPhotonSystematics_cfi")
@@ -47,7 +48,6 @@ for i in range(len(UnpackedJetCollectionVInputTag)):
     massSearchReplaceAnyInputTag(process.flashggTagSequence,UnpackedJetCollectionVInputTag[i],jetSystematicsInputTags[i])
 
 process.flashggSystTagMerger = cms.EDProducer("TagMerger",src=cms.VInputTag("flashggTagSorter"))
-#process.load("flashgg.Systematics.flashggTagSystematics_cfi")
 
 process.systematicsTagSequences = cms.Sequence()
 systlabels = [""]
@@ -194,7 +194,13 @@ for tag in tagList:
                            nPdfWeights=nPdfWeights
                            )
 
-process.p = cms.Path((process.flashggDiPhotonSystematics+process.flashggMuonSystematics+process.flashggElectronSystematics)*
+process.load("flashgg.MicroAOD.flashggRandomizedPerPhotonDiPhotonProducer_cff")
+
+# to be fixed once randomized photons will be produced at MicroAOD level
+process.flashggDiPhotonSystematics.src = "flashggRandomizedPerPhotonDiPhotons"
+
+process.p = cms.Path(process.flashggRandomizedPerPhotonDiPhotons *
+                (process.flashggDiPhotonSystematics+process.flashggMuonSystematics+process.flashggElectronSystematics)*
                      (process.flashggUnpackedJets*process.jetSystematicsSequence)*
                      (process.flashggTagSequence+process.systematicsTagSequences)*
                      process.flashggSystTagMerger*


### PR DESCRIPTION
to ensure reproducibility of results independent of running order and avoid double counting of statistical effects due to finite-size Monte Carlo samples

Features:
* generic templated producer to embed into a PATObject a configurable number of random numbers in the form std::pair<std::string configurable_key, float>
   * random numbers are gaussians with mean=0 and sigma=1
   * can support multiple pdf's if needed
* example of implementation for a randomizer of flashgg::Photon
* temporary patch for already produced MicroAODs: on-the-fly randomizer for DiPhoton objects (embedding random numbers in each of the two photons)
* modification of MicroAODtoWorkspace.py to use the on-the-fly randomizer for DiPhoton in input to the Systematics

Simple test of running the modified MicroAODtoWorkspace passed with correct behaviour.

To do:
* modify MicroAOD production sequence and test the producer works fine
* modify accordingly MicroAODtoWorkspace.py