### PR TITLE
Topic add gen vtx to diphoton

### DIFF
--- a/DataFormats/interface/DiPhotonCandidate.h
+++ b/DataFormats/interface/DiPhotonCandidate.h
@@ -8,6 +8,8 @@
 #include "flashgg/DataFormats/interface/SinglePhotonView.h"
 #include "DataFormats/VertexReco/interface/Vertex.h"
 #include "flashgg/DataFormats/interface/WeightedObject.h"
+#include "DataFormats/Math/interface/Point3D.h"
+
 
 
 namespace flashgg {
@@ -106,6 +108,9 @@ namespace flashgg {
 
         DiPhotonCandidate *clone() const { return ( new DiPhotonCandidate( *this ) ); }
 
+        Point genPV() const { return genPV_; }
+        void setGenPV( const Point genpv ) { genPV_ = genpv; }
+
     private:
         
         edm::Ptr<reco::Vertex> vertex_;
@@ -137,6 +142,8 @@ namespace flashgg {
         flashgg::SinglePhotonView viewPho2_;
 
         unsigned int jetCollectionIndex_; // index for which jet collection corresponds to the vertex choice in this diphoton
+
+        Point genPV_;
     };
 
 

--- a/DataFormats/src/classes_def.xml
+++ b/DataFormats/src/classes_def.xml
@@ -90,8 +90,9 @@
 <class name="edm::Ptr<flashgg::Photon>"/>
 <class name="std::vector<flashgg::Photon>"/>
 <class name="edm::Wrapper<std::vector<flashgg::Photon> >"/>
-<class name="flashgg::DiPhotonCandidate" ClassVersion="10">
+<class name="flashgg::DiPhotonCandidate" ClassVersion="11">
   <version ClassVersion="10" checksum="2243573479"/>
+  <version ClassVersion="11" checksum="3086156793"/>
 </class>
 <class name="std::vector<flashgg::DiPhotonCandidate>"/>
 <class name="edm::Wrapper<std::vector<flashgg::DiPhotonCandidate> >"/>

--- a/MicroAOD/plugins/DiPhotonGenZProducer.cc
+++ b/MicroAOD/plugins/DiPhotonGenZProducer.cc
@@ -1,0 +1,86 @@
+#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "DataFormats/Common/interface/Handle.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/EDMException.h"
+#include "CommonTools/UtilAlgos/interface/TFileService.h"
+#include "flashgg/DataFormats/interface/DiPhotonCandidate.h"
+#include "flashgg/MicroAOD/interface/PhotonIdUtils.h"
+#include "DataFormats/VertexReco/interface/Vertex.h"
+#include "flashgg/MicroAOD/interface/VertexSelectorBase.h"
+#include "DataFormats/PatCandidates/interface/PackedCandidate.h"
+#include "flashgg/DataFormats/interface/VertexCandidateMap.h"
+#include "DataFormats/EgammaCandidates/interface/Conversion.h"
+#include "DataFormats/BeamSpot/interface/BeamSpot.h"
+#include "DataFormats/PatCandidates/interface/PackedGenParticle.h"
+
+#include <map>
+
+using namespace edm;
+using namespace std;
+
+namespace flashgg {
+
+    class DiPhotonGenZProducer : public EDProducer
+    {
+
+    public:
+        DiPhotonGenZProducer( const ParameterSet & );
+    private:
+        void produce( Event &, const EventSetup & ) override;
+        EDGetTokenT<View<flashgg::DiPhotonCandidate> > diPhotonToken_;
+        EDGetTokenT<View<reco::GenParticle> >      genPartToken_;
+    };
+
+    DiPhotonGenZProducer::DiPhotonGenZProducer( const ParameterSet &iConfig ) :
+        diPhotonToken_( consumes<View<flashgg::DiPhotonCandidate> >( iConfig.getParameter<InputTag> ( "DiPhotonTag" ) ) ),
+        genPartToken_( consumes<View<reco::GenParticle> >( iConfig.getParameter<InputTag> ( "GenParticleTag" ) ) )
+    {
+        produces<vector<flashgg::DiPhotonCandidate> >();
+    }
+
+    void DiPhotonGenZProducer::produce( Event &evt, const EventSetup & )
+    {
+        Handle<View<flashgg::DiPhotonCandidate> > diphotons;
+        evt.getByToken( diPhotonToken_, diphotons );
+
+        math::XYZPoint higgsVtx;
+        if( ! evt.isRealData() ) {
+            Handle<View<reco::GenParticle> > genParticles;
+            evt.getByToken( genPartToken_, genParticles );
+            for( unsigned int genLoop = 0 ; genLoop < genParticles->size(); genLoop++ ) {
+                int pdgid = genParticles->ptrAt( genLoop )->pdgId();
+                if( pdgid == 25 || pdgid == 22 ) {
+                    higgsVtx = genParticles->ptrAt( genLoop )->vertex();
+                    break;
+                }
+            }
+        }
+
+        auto_ptr<vector<DiPhotonCandidate> > diPhotonColl( new vector<DiPhotonCandidate> );
+
+        for( unsigned int i = 0 ; i < diphotons->size() ; i++ ) {
+
+            DiPhotonCandidate dipho( diphotons->at(i) );
+            dipho.setGenPV( higgsVtx );
+            diPhotonColl->push_back( dipho );
+        }
+
+        evt.put( diPhotonColl );
+    }
+}
+
+typedef flashgg::DiPhotonGenZProducer FlashggDiPhotonGenZProducer;
+DEFINE_FWK_MODULE( FlashggDiPhotonGenZProducer );
+
+// Local Variables:
+// mode:c++
+// indent-tabs-mode:nil
+// tab-width:4
+// c-basic-offset:4
+// End:
+// vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4
+

--- a/MicroAOD/python/flashggDiPhotons_cfi.py
+++ b/MicroAOD/python/flashggDiPhotons_cfi.py
@@ -9,6 +9,7 @@ flashggDiPhotons = cms.EDProducer('FlashggDiPhotonProducer',
                                   ConversionTag=cms.InputTag("reducedEgamma","reducedConversions"),             
                                   ConversionTagSingleLeg=cms.InputTag("reducedEgamma","reducedSingleLegConversions"),
                                   beamSpotTag = cms.InputTag( "offlineBeamSpot" ),
+                                  GenParticleTag=cms.InputTag( "flashggPrunedGenParticles" ),
 
                                   ##Parameters for Legacy Vertex Selector                                                
                                   #vtxId 2012

--- a/Taggers/plugins/TagTestAnalyzer.cc
+++ b/Taggers/plugins/TagTestAnalyzer.cc
@@ -110,7 +110,7 @@ namespace flashgg {
                 std::cout << "[UNTAGGED] category " << untagged->categoryNumber() << " mass=" << untagged->diPhoton()->mass() <<
                           ", systLabel " << untagged->systLabel() <<  std::endl;
                 if( untagged->tagTruth().isNonnull() ) {
-                    std::cout << "\t[UNTAGGED TRUTH]: genPV=" << untagged->tagTruth()->genPV() << std::endl;
+                    std::cout << "\t[UNTAGGED TRUTH]: genPV=" << untagged->diPhoton()->genPV() << std::endl;
                 }
             }
 
@@ -124,6 +124,7 @@ namespace flashgg {
                     const VBFTagTruth *truth = dynamic_cast<const VBFTagTruth *>( &*vbftag->tagTruth() );
                     assert( truth != NULL );  // If we stored a VBFTag with a nonnull pointer, we either have VBFTagTruth or a nutty bug
                     std::cout << "\t[VBF TRUTH]: genPV=" << truth->genPV() << std::endl;
+                    std::cout << "\t[VBF DIPHOTON]: genPV=" << vbftag->diPhoton()->genPV() << std::endl;
                     std::cout << "\t\t------------------------------------------" << std::endl;
                     if( truth->closestGenJetToLeadingJet().isNonnull() ) {
                         std::cout << "\t\tclosestGenJetToLeadingJet pt eta " << truth->closestGenJetToLeadingJet()->pt() << " " << truth->closestGenJetToLeadingJet()->eta() <<

--- a/Taggers/test/simple_Tag_test.py
+++ b/Taggers/test/simple_Tag_test.py
@@ -31,7 +31,21 @@ process.load("flashgg/Taggers/flashggTagTester_cfi")
 switchToUnPreselected = False
 switchToFinal = False
 switchToPuppi = False
+switchToReadOld = False
 assert(not switchToUnPreselected or not switchToFinal)
+assert(not switchToReadOld or not switchToUnPreselected)
+assert(not switchToReadOld or not switchToFinal)
+
+if switchToReadOld:
+    from PhysicsTools.PatAlgos.tools.helpers import massSearchReplaceAnyInputTag
+    massSearchReplaceAnyInputTag(process.flashggTagSequence,cms.InputTag("flashggPreselectedDiPhotons"),cms.InputTag("flashggDiPhotonsWithAddedDz"))
+    process.flashggDiPhotonsWithAddedDz = cms.EDProducer('FlashggDiPhotonGenZProducer',
+                                                 DiPhotonTag=cms.InputTag('flashggPreselectedDiPhotons'),
+                                                 GenParticleTag=cms.InputTag( "flashggPrunedGenParticles" ))
+    process.flashggNewPreselectedDiPhotons = cms.Sequence(process.flashggPreselectedDiPhotons*process.flashggDiPhotonsWithAddedDz)
+    process.flashggTagSequence.replace(process.flashggPreselectedDiPhotons,process.flashggNewPreselectedDiPhotons)
+    process.source.fileNames=cms.untracked.vstring("root://eoscms.cern.ch//eos/cms/store/group/phys_higgs/cmshgg/sethzenz/flashgg/RunIISpring15-ReMiniAOD-BetaV7-25ns/Spring15BetaV7/GluGluHToGG_M-125_13TeV_powheg_pythia8/RunIISpring15-ReMiniAOD-BetaV7-25ns-Spring15BetaV7-v0-RunIISpring15MiniAODv2-74X_mcRun2_asymptotic_v2-v1/151021_152108/0000/myMicroAODOutputFile_2.root")
+    print process.flashggTagSequence
 
 if switchToUnPreselected:
     from PhysicsTools.PatAlgos.tools.helpers import massSearchReplaceAnyInputTag


### PR DESCRIPTION
Add gen vtx to diphoton.  Put into DiPhoton producer and also an ad hoc one to modify the existing DiPhotons.  Appropriate tests.

This will let us recast the RV/WV weight producer as a DiPhoton systematic, which is technically and logically easier to follow.  But that's not yet done in this PR.