### PR TITLE
updated loose photon ID cut (>-0.9) scale factors

### DIFF
--- a/Systematics/python/flashggDiPhotonSystematics_cfi.py
+++ b/Systematics/python/flashggDiPhotonSystematics_cfi.py
@@ -55,18 +55,19 @@ preselBins = cms.PSet(
         )
     )
 
-# Slide 11, https://indico.cern.ch/event/367883/contribution/2/attachments/1194817/1736347/egamma_26_11_2015.pdf
+# Slide 9 https://indico.cern.ch/event/464689/session/12/contribution/65/attachments/1204381/1754436/flashgg_14_12_2015.pdf
+# N.B. for lose MVA cut SF the R9 boundary is at 0.94
 looseMvaBins = cms.PSet(
     variables = cms.vstring("abs(superCluster.eta)","r9"),
     bins = cms.VPSet(
-        cms.PSet( lowBounds = cms.vdouble( 0.0, 0.0 ), upBounds = cms.vdouble( 1.5, 0.9 ),
-                  values = cms.vdouble( 1.0001 ), uncertainties = cms.vdouble( 0.0022 ) ),
-        cms.PSet( lowBounds = cms.vdouble( 0.0, 0.9 ), upBounds = cms.vdouble( 1.5, 999.0 ),
-                  values = cms.vdouble( 1.000 ), uncertainties= cms.vdouble( 0.0001 ) ),
-        cms.PSet( lowBounds = cms.vdouble( 1.5, 0.0 ), upBounds = cms.vdouble( 2.5, 0.9),
-                  values = cms.vdouble( 0.9851 ), uncertainties= cms.vdouble( 0.0016 ) ),
-        cms.PSet( lowBounds = cms.vdouble( 1.5, 0.9 ), upBounds = cms.vdouble( 2.5, 999.0 ),
-                  values = cms.vdouble( 1.0001 ), uncertainties= cms.vdouble( 0.0009 ) )
+        cms.PSet( lowBounds = cms.vdouble( 0.0, 0.0 ), upBounds = cms.vdouble( 1.5, 0.94 ),
+                  values = cms.vdouble( 1.0012 ), uncertainties = cms.vdouble( 0.0016 ) ),
+        cms.PSet( lowBounds = cms.vdouble( 0.0, 0.94 ), upBounds = cms.vdouble( 1.5, 999.0 ),
+                  values = cms.vdouble( 0.9999 ), uncertainties= cms.vdouble( 0.0005 ) ),
+        cms.PSet( lowBounds = cms.vdouble( 1.5, 0.0 ), upBounds = cms.vdouble( 2.5, 0.94),
+                  values = cms.vdouble( 1.0018 ), uncertainties= cms.vdouble( 0.0019 ) ),
+        cms.PSet( lowBounds = cms.vdouble( 1.5, 0.94 ), upBounds = cms.vdouble( 2.5, 999.0 ),
+                  values = cms.vdouble( 0.9997 ), uncertainties= cms.vdouble( 0.0008 ) )
         )
     )
 


### PR DESCRIPTION
Loose photon ID cut scale factors updated:
- R9 boundary at 0.94
- scale factors for  idmva > -0.9 (from Matteo's slides https://indico.cern.ch/event/464689/session/12/contribution/65/attachments/1204381/1754436/flashgg_14_12_2015.pdf)


