### PR TITLE
Update flashggPrunedGenParticles_cfi.py to include top quarks and daughters from top decay for ttH analysis

### DIFF
--- a/MicroAOD/python/flashggPrunedGenParticles_cfi.py
+++ b/MicroAOD/python/flashggPrunedGenParticles_cfi.py
@@ -3,6 +3,8 @@ import FWCore.ParameterSet.Config as cms
 flashggPrunedGenParticles = cms.EDProducer("GenParticlePruner",
                                     src = cms.InputTag("prunedGenParticles"),
                                     select = cms.vstring("drop  *  ", # this is the default
+                                                         "keep++ abs(pdgId) = 6",
+                                                         "drop abs(pdgId) > 25",
                                                          "keep status = 3",
                                                          "keep status = 23",
                                                          "keep status = 22",


### PR DESCRIPTION
Updates flashggPrunedGenParticles_cfi.py so that the gen level information for the top quark, its subsequent decay candidates is also stored. This is useful for ttH analysis to check the channel (hadronic or leptonic etc) at the gen level and check the selection efficiency in MC for different channels and also for b quark matching. The gen particles with pdgId > 25 are dropped to reduce file size, while keeping the original chain from the top quark to the b, W and the immediate daughters of the subsequent W decay as well.