### PR TITLE
run randomizer on (rerun) preselected collection

### DIFF
--- a/MicroAOD/python/flashggRandomizedPerPhotonDiPhotonProducer_cff.py
+++ b/MicroAOD/python/flashggRandomizedPerPhotonDiPhotonProducer_cff.py
@@ -9,8 +9,8 @@ import FWCore.ParameterSet.Config as cms
 
 
 flashggRandomizedPerPhotonDiPhotons = cms.EDProducer("FlashggRandomizedPerPhotonDiPhotonProducer",
-                                    src = cms.InputTag("flashggFinalEGamma", "finalDiPhotons"),
-                                    outputCollectionName = cms.string("flashggFinalRandomizedDiPhotons"),
+                                    src = cms.InputTag("flashggPreselectedDiPhotons"),
+#                                    outputCollectionName = cms.string("flashggFinalRandomizedDiPhotons"),
                                     # labels of various gaussian random numbers with mean=0, sigma=1
                                     # to be associated with the photon object
                                     labels = cms.vstring("smearE")

--- a/Systematics/python/flashggDiPhotonSystematics_cfi.py
+++ b/Systematics/python/flashggDiPhotonSystematics_cfi.py
@@ -91,7 +91,7 @@ RVBins = cms.PSet(
                 )
 
 flashggDiPhotonSystematics = cms.EDProducer('FlashggDiPhotonSystematicProducer',
-		src = cms.InputTag("flashggFinalEGamma","finalDiPhotons"),
+		src = cms.InputTag("flashggPreselectedDiPhotons"),
                 SystMethods2D = cms.VPSet(),
                 # the number of syst methods matches the number of nuisance parameters
                 # assumed for a given systematic uncertainty and is NOT required

--- a/Systematics/test/MicroAODtoWorkspace.py
+++ b/Systematics/test/MicroAODtoWorkspace.py
@@ -238,6 +238,15 @@ process.p = cms.Path(process.hltRequirement * process.flashggRandomizedPerPhoton
 #                     process.flashggTagSystematics*
                      process.tagsDumper)
 
+print "--- Dumping modules that take diphotons as input: ---"
+mns = process.p.moduleNames()
+for mn in mns:
+    module = getattr(process,mn)
+    if hasattr(module,"src") and type(module.src) == type(cms.InputTag("")) and module.src.value().count("DiPhoton"):
+        print str(module),module.src
+    elif hasattr(module,"DiPhotonTag"):
+        print str(module),module.DiPhotonTag
+
 ################################
 ## Dump merged tags to screen ##
 ################################


### PR DESCRIPTION
Start the tagging and systematics sequences from preselected diphotons rather than "final" ones, because preselected is rerun and "final" is not.  Per email thread, both preselected and "final" will be removed from the next version of MicroAOD to avoid confusion, with preselection being run always at the start of tag/workspace building.  

Also, a few lines to debug which modules get diphotons from where.