### PR TITLE
added hessian uncertainty calculation to flashgg pdf

### DIFF
--- a/DataFormats/interface/PDFWeightObject.h
+++ b/DataFormats/interface/PDFWeightObject.h
@@ -17,8 +17,10 @@ namespace flashgg {
         ~PDFWeightObject();
         
         vector<uint16_t> pdf_weight_container;
-        
-        vector<float> uncompress() const;
+       
+	vector<uint16_t> alpha_s_container;
+ 
+        vector<float> uncompress( vector<uint16_t> ) const;
         
       };
  }

--- a/DataFormats/src/PDFWeightObject.cc
+++ b/DataFormats/src/PDFWeightObject.cc
@@ -12,15 +12,15 @@ PDFWeightObject::PDFWeightObject()
 PDFWeightObject::~PDFWeightObject()
 {}
 
-vector<float> PDFWeightObject::uncompress() const {
+vector<float> PDFWeightObject::uncompress( vector<uint16_t> vec ) const {
 
 	vector<float> uncompressed_vector;
 
-	int size = PDFWeightObject::pdf_weight_container.size();	
+	int size = vec.size();	
 
 	for(int i = 0; i<size; i++ ){
 
-		uint16_t compressed_weight = PDFWeightObject::pdf_weight_container[i];
+		uint16_t compressed_weight = vec[i];
 
 		float uncompressed_weight = MiniFloatConverter::float16to32( compressed_weight );	
 

--- a/DataFormats/src/classes_def.xml
+++ b/DataFormats/src/classes_def.xml
@@ -2,7 +2,8 @@
 <class name="flashgg::WeightedObject" ClassVersion="10">
   <version ClassVersion="10" checksum="1340095011"/>
 </class>
-<class name="flashgg::PDFWeightObject" ClassVersion="11">
+<class name="flashgg::PDFWeightObject" ClassVersion="12">
+  <version ClassVersion="12" checksum="3929296232"/>
   <version ClassVersion="11" checksum="103726048"/>
   <version ClassVersion="10" checksum="92077144"/>
 </class>

--- a/MicroAOD/BuildFile.xml
+++ b/MicroAOD/BuildFile.xml
@@ -7,7 +7,7 @@
 <use name="RecoEcal/EgammaCoreTools" />
 <use name="FWCore/Utilities"/>
 <use name="CommonTools/Utils"/>
-<use name="PhysicsTools/HepMCCandAlgos">
+<use name="PhysicsTools/HepMCCandAlgos"/>
 <use name="roottmva"/>
 <!-- Flags CXXFLAGS="-ggdb"/ -->
 <export>

--- a/MicroAOD/BuildFile.xml
+++ b/MicroAOD/BuildFile.xml
@@ -7,6 +7,7 @@
 <use name="RecoEcal/EgammaCoreTools" />
 <use name="FWCore/Utilities"/>
 <use name="CommonTools/Utils"/>
+<use name="PhysicsTools/HepMCCandAlgos">
 <use name="roottmva"/>
 <!-- Flags CXXFLAGS="-ggdb"/ -->
 <export>

--- a/MicroAOD/plugins/PDFWeightObjectProducer.cc
+++ b/MicroAOD/plugins/PDFWeightObjectProducer.cc
@@ -37,8 +37,9 @@ namespace flashgg {
 			string delimiter_2_;
 			void beginRun( edm::Run const &, edm::EventSetup const &iSetup );
 			vector<int> weight_indices;
+			vector<int> alpha_indices;
 			string removeSpace( string line );
-			PDFWeightsHelper pdfweightshelper_;
+			PDFWeightsHelper pdfweightshelper_;//tool from HepMCCandAlgos/interface/PDFWeightsHelper
 		        unsigned int nPdfEigWeights_;
 //		        std::vector<float> pdfeigweights_;
 	                edm::FileInPath mc2hessianCSV;
@@ -192,16 +193,27 @@ namespace flashgg {
 
 					}
 
-					//if (generator == "ph"){
+//					if (generator == "ph"){
+
+						int alphas_1 = PDFWeightProducer::weight_indices.back() + 1;
+						int alphas_2 = PDFWeightProducer::weight_indices.back() + 2;
+
+					//	cout << "alpha 2 " << alphas_2 << endl; 
+
+						PDFWeightProducer::alpha_indices.push_back(alphas_1);
+						PDFWeightProducer::alpha_indices.push_back(alphas_2);
+			
+//					}
+
+					//if (generator == "mg"){
 
 					//	int alphas_1 = PDFWeightProducer::weight_indices.back() + 1;
 					//	int alphas_2 = PDFWeightProducer::weight_indices.back() + 2;
 
-					//	PDFWeightProducer::weight_indices.push_back(alphas_1);
-					//	PDFWeightProducer::weight_indices.push_back(alphas_2);
+					//	PDFWeightProducer::alpha_indices.push_back(alphas_1);
+					//	PDFWeightProducer::alpha_indices.push_back(alphas_2);
 			
 					//}
-
 
 			}	
 
@@ -228,17 +240,19 @@ namespace flashgg {
 
 		float weight = 1;
 		uint16_t weight_16 =1;
+		float alpha = 1;
 
 		//cout << "weight_container size " << LHEEventHandle->weights().size() << " num_weight " << PDFWeightProducer::weight_indices.size() << endl;
 		//int lower_bound = LHEEventHandle->weights().size() - PDFWeightProducer::weight_indices.size();
 		int upper_bound = LHEEventHandle->weights().size();
-		int size = PDFWeightProducer::weight_indices.size();
+		int size_weight = PDFWeightProducer::weight_indices.size();
+		int size_alpha = PDFWeightProducer::alpha_indices.size();
 		//cout << "lower_bound " << lower_bound << " upper_bound " << upper_bound << endl;
 		for( int i = 0; i < upper_bound; i++ ) {
 
 			int id_i = stoi( LHEEventHandle->weights()[i].id );
 
-			for( int j = 0; j<size; j++ ){
+			for( int j = 0; j<size_weight; j++ ){
 
 				int id_j = PDFWeightProducer::weight_indices[j];	
 //				cout << "id_i " << id_i << " id_j " << id_j << endl;
@@ -253,11 +267,30 @@ namespace flashgg {
 				}
 
 			}
+
+			for( int k = 0; k<size_alpha; k++ ){
+
+				int id_k = PDFWeightProducer::alpha_indices[k];
+
+			if(id_i == id_k ){
+			
+				//cout << " in here " << endl;
+	
+				alpha = LHEEventHandle->weights()[i].wgt;
+			
+				//cout << " alpha " << alpha  << endl;
+
+				uint16_t alpha_16 = MiniFloatConverter::float32to16( alpha );
+				pdfWeight.alpha_s_container.push_back(alpha_16);	
+			}
+		
+		   }
+
 		}
 
 		//cout << "should be 100   " << lhe_weights.size() << endl;
 
-		pdfweightshelper_.Init(size,nPdfEigWeights_,mc2hessianCSV);
+		pdfweightshelper_.Init(size_weight,nPdfEigWeights_,mc2hessianCSV);
 
 	        std::vector<double> outpdfweights(nPdfEigWeights_);
 

--- a/MicroAOD/python/flashggPDFWeightObject_cfi.py
+++ b/MicroAOD/python/flashggPDFWeightObject_cfi.py
@@ -2,9 +2,9 @@ import FWCore.ParameterSet.Config as cms
 
 flashggPDFWeightObject = cms.EDProducer('FlashggPDFWeightProducer',
 		tag = cms.untracked.string("initrwgt"),
-		pdfset = cms.untracked.string("PDF_variation"),
+		nPdfEigWeights = cms.uint32(60),
 		delimiter_1 = cms.untracked.string("id=\""),
 		delimiter_2 = cms.untracked.string("\">"),
-		delimiter_3 = cms.untracked.string("</weightgroup>"),
 		LHEEventTag = cms.untracked.InputTag('externalLHEProducer'),
-		)
+		mc2hessianCSV = cms.FileInPath('PhysicsTools/HepMCCandAlgos/data/NNPDF30_lo_as_0130_hessian_60.csv')
+	)

--- a/Taggers/interface/CollectionDumper.h
+++ b/Taggers/interface/CollectionDumper.h
@@ -293,9 +293,12 @@ namespace flashgg {
             edm::Handle<vector<flashgg::PDFWeightObject> > WeightHandle;
             event.getByLabel( pdfWeightToken_, WeightHandle );
 
-
             for( unsigned int weight_index = 0; weight_index < (*WeightHandle).size(); weight_index++ ){
-                std::vector<float> uncompressed = (*WeightHandle)[weight_index].uncompress();
+
+                vector<uint16_t> compressed_weights = (*WeightHandle)[weight_index].pdf_weight_container; 
+
+                std::vector<float> uncompressed = (*WeightHandle)[weight_index].uncompress( compressed_weights );
+
                 for( unsigned int j=0; j<(*WeightHandle)[weight_index].pdf_weight_container.size();j++ ) {
                     pdfWeights.push_back(uncompressed[j]);
                 }

--- a/Validation/plugins/PDFValidation.cc
+++ b/Validation/plugins/PDFValidation.cc
@@ -65,19 +65,20 @@ PDFWeight::analyze( const edm::Event &evt, const edm::EventSetup &iSetup )
 	//    Handle<LHEEventProduct> LHEHandle;
 	//    evt.getByToken( LHEEventToken_, LHEHandle );
 
-	//    Handle<vector<flashgg::PDFWeightObject> > WeightHandle;
-	//    evt.getByToken( WeightToken_, WeightHandle );
-	//    const PtrVector<flashgg::PDFWeightObject> mcWeightPointers = WeightHandle->ptrVector();
+	    Handle<vector<flashgg::PDFWeightObject> > WeightHandle;
+	    evt.getByToken( WeightToken_, WeightHandle );
+//	    const PtrVector<flashgg::PDFWeightObject> mcWeightPointers = WeightHandle->ptrVector();
 
 	//cout << "XS  " << LHEHandle->originalXWGTUP() << endl;
 
-	//        for( unsigned int weight_index = 0; weight_index < (*WeightHandle).size(); weight_index++ ){
-	//            std::vector<float> uncompressed = (*WeightHandle)[weight_index].uncompress();
-	//            for( unsigned int j=0; j<(*WeightHandle)[weight_index].pdf_weight_container.size();j++ ) {
-	//                    cout << "compresed weight " << (*WeightHandle)[weight_index].pdf_weight_container[j] << endl;
-	//                    cout << "uncompressed weight " << uncompressed[j] << endl;
-	//       }
-	//    }
+	        for( unsigned int weight_index = 0; weight_index < (*WeightHandle).size(); weight_index++ ){
+	            vector<uint16_t> compressed_weights = (*WeightHandle)[weight_index].pdf_weight_container; 
+                std::vector<float> uncompressed = (*WeightHandle)[weight_index].uncompress( compressed_weights );
+	            for( unsigned int j=0; j<(*WeightHandle)[weight_index].pdf_weight_container.size();j++ ) {
+	                    cout << "compresed weight " << (*WeightHandle)[weight_index].pdf_weight_container[j] << endl;
+	                    cout << "uncompressed weight " << uncompressed[j] << endl;
+	       }
+	    }
 }
 
 
@@ -95,20 +96,20 @@ PDFWeight::endJob()
 	void
 PDFWeight::beginRun( edm::Run const &iRun, edm::EventSetup const &iSetup )
 {
-	Handle<LHERunInfoProduct> run;
-	typedef vector<LHERunInfoProduct::Header>::const_iterator headers_const_iterator;
-
-	iRun.getByLabel( "externalLHEProducer", run );
-	LHERunInfoProduct myLHERunInfoProduct = *( run.product() );
-
-	for( headers_const_iterator iter = myLHERunInfoProduct.headers_begin(); iter != myLHERunInfoProduct.headers_end(); iter++ ) {
-		if( iter->tag() == "init" )
-		{ cout << iter->tag() << endl; }
-		vector<string> lines = iter->lines();
-		for( unsigned int iLine = 0; iLine < lines.size(); iLine++ ) {
-			cout << lines.at( iLine );
-		}
-	}
+//	Handle<LHERunInfoProduct> run;
+//	typedef vector<LHERunInfoProduct::Header>::const_iterator headers_const_iterator;
+//
+//	iRun.getByLabel( "externalLHEProducer", run );
+//	LHERunInfoProduct myLHERunInfoProduct = *( run.product() );
+//
+//	for( headers_const_iterator iter = myLHERunInfoProduct.headers_begin(); iter != myLHERunInfoProduct.headers_end(); iter++ ) {
+//		if( iter->tag() == "init" )
+//		{ cout << iter->tag() << endl; }
+//		vector<string> lines = iter->lines();
+//		for( unsigned int iLine = 0; iLine < lines.size(); iLine++ ) {
+//			cout << lines.at( iLine );
+//		}
+//	}
 }
 
 

--- a/setup.sh
+++ b/setup.sh
@@ -110,6 +110,8 @@ git cms-addpkg DataFormats/RecoCandidate
 git cms-addpkg PhysiscsTools/TagAndProbe
 git cms-merge-topic -u matteosan1:egm_tnp
 
+echo "Setting up PDF weight tool..."
+git-cms-merge-topic bendavid:pdfweights_74x
 
 echo "adding hook for indentation"
 ln -s $CMSSW_BASE/src/flashgg/Validation/scripts/flashgg_indent_check.sh $CMSSW_BASE/src/flashgg/.git/hooks/pre-commit


### PR DESCRIPTION
This implements Josh's tool to calculate the uncertainties for the 100 replicas along the 60 eigenvectors of the hessian matrix. A couple questions remain, do we not have to divide the lhe->weights()[x] by lhe-> originalXWGTUP()  ?  What do we do with the alpha(s) variations ? At the moment they are not stored, only the 100 replicas are. Do we store them in a different vector ?

Besides these points, the machinery works well, it identifies if we are either using a madgraph or powheg generator and from here it sets hardcoded ranges for the pdf_id.    