### PR TITLE
Include QGL in flashgg::jet 

### DIFF
--- a/DataFormats/interface/Jet.h
+++ b/DataFormats/interface/Jet.h
@@ -34,9 +34,13 @@ namespace flashgg {
         float betaStar( const edm::Ptr<DiPhotonCandidate> dipho ) const;
         Jet *clone() const { return ( new Jet( *this ) ); }
         
+        void  setQGL(const float qglikelihood=-99) {qglikelihood_ = qglikelihood;}
+        float QGL(){return qglikelihood_;}
+        
         bool passesJetID( JetIDLevel level = Loose ) const; 
     private:
         std::map<edm::Ptr<reco::Vertex>, MinimalPileupJetIdentifier> puJetId_;
+        float qglikelihood_;
     };
 }
 

--- a/DataFormats/src/classes_def.xml
+++ b/DataFormats/src/classes_def.xml
@@ -154,8 +154,8 @@
 </class>
 <class name="std::pair<edm::Ptr<reco::Vertex>,flashgg::MinimalPileupJetIdentifier>"/>
 <class name="std::map<edm::Ptr<reco::Vertex>,flashgg::MinimalPileupJetIdentifier>"/>
-<class name="flashgg::Jet" ClassVersion="10">
-  <version ClassVersion="10" checksum="2045570510"/>
+<class name="flashgg::Jet" ClassVersion="11">
+  <version ClassVersion="11" checksum="3459570589"/>
 </class>
 <class name="std::vector<flashgg::Jet>"/>
 <class name="edm::Ptr<flashgg::Jet>"/>

--- a/MicroAOD/plugins/JetProducer.cc
+++ b/MicroAOD/plugins/JetProducer.cc
@@ -101,7 +101,8 @@ namespace flashgg {
             //--- Retrieve the q/g likelihood
             float qgLikelihood = -99.0;
             if(qgHandle.isValid()) qgLikelihood = ( *qgHandle )[jets->refAt( i )];;
-            std::cout << "QGL jet["<< i << "] == " << qgLikelihood << std::endl;
+            fjet.setQGL(qgLikelihood);
+            //std::cout << "QGL jet["<< i << "] == " << qgLikelihood << std::endl;
             /*
             for( unsigned int j = 0 ; j < diPhotons->size() ; j++ ) {
                 Ptr<DiPhotonCandidate> diPhoton = diPhotons->ptrAt( j );

--- a/MicroAOD/plugins/JetProducer.cc
+++ b/MicroAOD/plugins/JetProducer.cc
@@ -30,6 +30,10 @@ namespace flashgg {
         EDGetTokenT<View<DiPhotonCandidate> > diPhotonToken_;
         EDGetTokenT<View<reco::Vertex> >  vertexToken_;
         EDGetTokenT< VertexCandidateMap > vertexCandidateMapToken_;
+        //EDGetTokenT<edm::ValueMap<float> > qgToken_; 
+        //edm::InputTag qgToken_;
+        edm::InputTag qgVariablesInputTag;
+        edm::EDGetTokenT<edm::ValueMap<float> > qgToken;
         //        unique_ptr<PileupJetIdAlgo>  pileupJetIdAlgo_;
         //        ParameterSet pileupJetIdParameters_;
         bool usePuppi;
@@ -39,24 +43,28 @@ namespace flashgg {
     JetProducer::JetProducer( const ParameterSet &iConfig ) :
         jetToken_( consumes<View<pat::Jet> >( iConfig.getParameter<InputTag> ( "JetTag" ) ) ),
         diPhotonToken_( consumes<View<DiPhotonCandidate> >( iConfig.getParameter<InputTag>( "DiPhotonTag" ) ) ),
-        vertexToken_( consumes<View<reco::Vertex> >( iConfig.getParameter<InputTag> ( "VertexTag" ) ) ),
-        vertexCandidateMapToken_( consumes<VertexCandidateMap>( iConfig.getParameter<InputTag>( "VertexCandidateMapTag" ) ) )
+        vertexToken_  ( consumes<View<reco::Vertex> >( iConfig.getParameter<InputTag> ( "VertexTag" ) ) ),
+        vertexCandidateMapToken_( consumes<VertexCandidateMap>( iConfig.getParameter<InputTag>( "VertexCandidateMapTag" ) )),
+        qgVariablesInputTag( iConfig.getParameter<edm::InputTag>( "qgVariablesInputTag" ) )
+        //GluonTagSrc_  (iConfig.getParameter<edm::InputTag>("GluonTagSrc") )
         //        pileupJetIdParameters_( iConfig.getParameter<ParameterSet>( "PileupJetIdParameters" ) ),
         //        usePuppi( iConfig.getUntrackedParameter<bool>( "UsePuppi", false ) )
     {
         //        pileupJetIdAlgo_.reset( new PileupJetIdAlgo( pileupJetIdParameters_ ) );
-
+        //qgToken_ = consumes<edm::ValueMap<float> >(edm::InputTag("GluonTagSrc", "qgLikelihood"));
+        qgToken  = consumes<edm::ValueMap<float>>( edm::InputTag( qgVariablesInputTag.label(), "qgLikelihood" ) );
+        
         produces<vector<flashgg::Jet> >();
     }
-
+    
     void JetProducer::produce( Event &evt, const EventSetup & )
     {
-
+        
         // input jets
         Handle<View<pat::Jet> > jets;
         evt.getByToken( jetToken_, jets );
         // const PtrVector<pat::Jet>& jetPointers = jets->ptrVector();
-
+        
         // input DiPhoton candidates
         Handle<View<DiPhotonCandidate> > diPhotons;
         evt.getByToken( diPhotonToken_, diPhotons );
@@ -71,12 +79,29 @@ namespace flashgg {
         evt.getByToken( vertexCandidateMapToken_, vertexCandidateMap );
         // std::cout << " vtx map ==" << vertexCandidateMap->size() <<  std::endl;
         // output jets
+        
+        //edm::Handle<edm::ValueMap<float> > qgHandle; 
+        //evt.getByToken(qgToken_, qgHandle);
+        
+        // input QGL
+        //edm::Handle<edm::ValueMap<float> >  qgHandle; 
+        //evt.getByToken(GluonTagSrc_, qgHandle);
+        edm::Handle<edm::ValueMap<float>> qgHandle;
+        evt.getByToken( qgToken, qgHandle );
+        
         auto_ptr<vector<flashgg::Jet> > jetColl( new vector<flashgg::Jet> );
-
+        
         for( unsigned int i = 0 ; i < jets->size() ; i++ ) {
             Ptr<pat::Jet> pjet = jets->ptrAt( i );
             flashgg::Jet fjet = flashgg::Jet( *pjet );
+            
+            
 
+            
+            //--- Retrieve the q/g likelihood
+            float qgLikelihood = -99.0;
+            if(qgHandle.isValid()) qgLikelihood = ( *qgHandle )[jets->refAt( i )];;
+            std::cout << "QGL jet["<< i << "] == " << qgLikelihood << std::endl;
             /*
             for( unsigned int j = 0 ; j < diPhotons->size() ; j++ ) {
                 Ptr<DiPhotonCandidate> diPhoton = diPhotons->ptrAt( j );

--- a/MicroAOD/python/MicroAODCustomize.py
+++ b/MicroAOD/python/MicroAODCustomize.py
@@ -185,7 +185,7 @@ class MicroAODCustomize(object):
         for vtx in range(0,maxJetCollections):
             addFlashggPFCHSJets (process = process,
                                  vertexIndex =vtx,
-                                 doQGTagging = True,
+                                 #doQGTagging = True,
                                  label = '' + str(vtx))
             
     def customizePuppi(self,process):

--- a/MicroAOD/python/flashggJets_cfi.py
+++ b/MicroAOD/python/flashggJets_cfi.py
@@ -58,10 +58,8 @@ def addFlashggPFCHSJets(process, vertexIndex = 0, doQGTagging = True, label ='',
   
   #Import RECO jet producer for ak4 PF and GEN jet
   from RecoJets.JetProducers.ak4PFJets_cfi  import ak4PFJets
-  #from RecoJets.JetProducers.ak4GenJets_cfi import ak4GenJets
   setattr(process, 'ak4PFJetsCHSLeg' + label, ak4PFJets.clone ( src = 'pfNoElectronsCHSLeg' + label, doAreaFastjet = True))
-  #process.ak4GenJetsLeg   = ak4GenJets.clone( src = 'packedGenParticles')
-  
+    
   # NOTE: this is the 74X recipe for the jet clustering
   addJetCollection(
     process,
@@ -82,21 +80,18 @@ def addFlashggPFCHSJets(process, vertexIndex = 0, doQGTagging = True, label ='',
   #adjust PV used for Jet Corrections
   #process.patJetCorrFactorsAK4PFCHSLeg.primaryVertices = "offlineSlimmedPrimaryVertices"
   getattr(process, 'patJetCorrFactorsAK4PFCHSLeg' + label).primaryVertices = "offlineSlimmedPrimaryVertices"
-
-  # Flashgg Jet producer using the collection created with function above.
+  #if doQGTagging:
+  from RecoJets.JetProducers.QGTagger_cfi import QGTagger
+  setattr( process, 'QGTaggerPFCHS' + label,  QGTagger.clone( srcJets   = 'patJetsAK4PFCHSLeg' + label ,jetsLabel = 'ak4PFJetsCHS'))
+  
   flashggJets = cms.EDProducer('FlashggJetProducer',
                                DiPhotonTag = cms.InputTag('flashggDiPhotons'),
                                VertexTag   = cms.InputTag('offlineSlimmedPrimaryVertices'),
                                JetTag      = cms.InputTag('patJetsAK4PFCHSLeg' + label),
                                VertexCandidateMapTag = cms.InputTag("flashggVertexMapForCHS"),
-#                               PileupJetIdParameters = cms.PSet(pu_jetid)
-                             )
+                               qgVariablesInputTag   = cms.InputTag('QGTaggerPFCHS'+label, 'qgLikelihood'),
+                               )
   setattr( process, 'flashggPFCHSJets'+ label, flashggJets)
-  
-  if doQGTagging:
-    from RecoJets.JetProducers.QGTagger_cfi import QGTagger
-    setattr( process, 'QGTaggerPFCHS' + label,  QGTagger.clone( srcJets   = 'flashggPFCHSJets' + label ,jetsLabel = 'ak4PFJetsCHS'))
-
   flashggSelectedJets = cms.EDFilter("FLASHggJetSelector",
                                      src = cms.InputTag( 'flashggPFCHSJets'+ label ),
                                      cut = cms.string("pt > 15.")

--- a/MicroAOD/python/flashggJets_cfi.py
+++ b/MicroAOD/python/flashggJets_cfi.py
@@ -5,6 +5,8 @@ import FWCore.ParameterSet.Config as cms
 
 #from RecoJets.JetProducers.PileupJetIDParams_cfi import cutbased_new as pu_jetid
 from PhysicsTools.PatAlgos.tools.jetTools        import addJetCollection
+from CondCore.DBCommon.CondDBSetup_cfi import *
+
 import os
 
 flashggBTag = 'pfCombinedInclusiveSecondaryVertexV2BJetTags'
@@ -87,8 +89,6 @@ def addFlashggPFCHSJets(process,
   getattr(process, 'patJetCorrFactorsAK4PFCHSLeg' + label).primaryVertices = "offlineSlimmedPrimaryVertices"
   
   #== QGTagging
-  
-  from CondCore.DBCommon.CondDBSetup_cfi import *
   process.QGPoolDBESSource = cms.ESSource("PoolDBESSource",
                                           CondDBSetup,
                                           toGet = cms.VPSet(),

--- a/MicroAOD/python/flashggJets_cfi.py
+++ b/MicroAOD/python/flashggJets_cfi.py
@@ -81,8 +81,22 @@ def addFlashggPFCHSJets(process, vertexIndex = 0, doQGTagging = True, label ='',
   #process.patJetCorrFactorsAK4PFCHSLeg.primaryVertices = "offlineSlimmedPrimaryVertices"
   getattr(process, 'patJetCorrFactorsAK4PFCHSLeg' + label).primaryVertices = "offlineSlimmedPrimaryVertices"
   #if doQGTagging:
+  qgDatabaseVersion = 'v1' # check https://twiki.cern.ch/twiki/bin/viewauth/CMS/QGDataBaseVersion
+  from CondCore.DBCommon.CondDBSetup_cfi import *
+  process.QGPoolDBESSource = cms.ESSource("PoolDBESSource",
+                                          CondDBSetup,
+                                          toGet = cms.VPSet(),
+                                          connect = cms.string('frontier://FrontierProd/CMS_COND_PAT_000'),)
+  
+  for type in ['AK4PFchs','AK4PFchs_antib']:
+    process.QGPoolDBESSource.toGet.extend(cms.VPSet(cms.PSet(
+          record = cms.string('QGLikelihoodRcd'),
+          tag    = cms.string('QGLikelihoodObject_'+qgDatabaseVersion+'_'+type),
+          label  = cms.untracked.string('QGL_'+type)
+          )))
+  
   from RecoJets.JetProducers.QGTagger_cfi import QGTagger
-  setattr( process, 'QGTaggerPFCHS' + label,  QGTagger.clone( srcJets   = 'patJetsAK4PFCHSLeg' + label ,jetsLabel = 'ak4PFJetsCHS'))
+  setattr( process, 'QGTaggerPFCHS' + label,  QGTagger.clone( srcJets   = 'patJetsAK4PFCHSLeg' + label ,jetsLabel = 'QGL_AK4PFchs'))
   
   flashggJets = cms.EDProducer('FlashggJetProducer',
                                DiPhotonTag = cms.InputTag('flashggDiPhotons'),

--- a/MicroAOD/python/flashggJets_cfi.py
+++ b/MicroAOD/python/flashggJets_cfi.py
@@ -9,8 +9,13 @@ import os
 
 flashggBTag = 'pfCombinedInclusiveSecondaryVertexV2BJetTags'
 maxJetCollections = 8
+qgDatabaseVersion = 'v1' # check https://twiki.cern.ch/twiki/bin/viewauth/CMS/QGDataBaseVersion
 
-def addFlashggPFCHSJets(process, vertexIndex = 0, doQGTagging = True, label ='', debug = False):
+def addFlashggPFCHSJets(process, 
+                        vertexIndex = 0, 
+                        #doQGTagging = True, 
+                        label ='', 
+                        debug = False):
   setattr(process, 'selectedMuons' + label, cms.EDFilter("CandPtrSelector", 
                                                          src = cms.InputTag("slimmedMuons"), 
                                                          cut = cms.string('''abs(eta)<2.5 && pt>10. &&
@@ -80,8 +85,9 @@ def addFlashggPFCHSJets(process, vertexIndex = 0, doQGTagging = True, label ='',
   #adjust PV used for Jet Corrections
   #process.patJetCorrFactorsAK4PFCHSLeg.primaryVertices = "offlineSlimmedPrimaryVertices"
   getattr(process, 'patJetCorrFactorsAK4PFCHSLeg' + label).primaryVertices = "offlineSlimmedPrimaryVertices"
-  #if doQGTagging:
-  qgDatabaseVersion = 'v1' # check https://twiki.cern.ch/twiki/bin/viewauth/CMS/QGDataBaseVersion
+  
+  #== QGTagging
+  
   from CondCore.DBCommon.CondDBSetup_cfi import *
   process.QGPoolDBESSource = cms.ESSource("PoolDBESSource",
                                           CondDBSetup,

--- a/MicroAOD/test/microAODstd.py
+++ b/MicroAOD/test/microAODstd.py
@@ -13,7 +13,7 @@ process.load("Configuration.StandardSequences.MagneticField_cff")
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_condDBv2_cff")
 from Configuration.AlCa.GlobalTag import GlobalTag
 
-process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32( 1000) )
+process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32( 100) )
 process.MessageLogger.cerr.FwkReport.reportEvery = cms.untracked.int32( 1000 )
 
 process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:run2_mc')

--- a/Validation/plugins/JetValidationTreeMaker.cc
+++ b/Validation/plugins/JetValidationTreeMaker.cc
@@ -594,7 +594,8 @@ JetValidationTreeMaker::analyze( const edm::Event &iEvent, const edm::EventSetup
             jInfo.diphotonIndex  = diphoIndex;
             jInfo.JetIndex       = jdz;
             //jInfo.jet_qgLikelihood = ( *qgHandle )[Jets[jetCollectionIndex]->refAt( jdz )];
-
+            jInfo.jet_qgLikelihood = Jets[jetCollectionIndex]->ptrAt( jdz )->userFloat("QGTagger:qgLikelihood");
+            std::cout << "QGL::"<< jInfo.jet_qgLikelihood << std::endl;
             GenPhotonInfo tmp_info = photonJet_id.find( jdz )->second; // call find ones
 
             jInfo.GenPhotonPt  = tmp_info.pt   ;

--- a/Validation/python/multi_jets_producer_test.py
+++ b/Validation/python/multi_jets_producer_test.py
@@ -21,8 +21,6 @@ if current_gt.count("::All"):
     new_gt = current_gt.replace("::All","")
     print 'Removing "::All" from GlobalTag by hand for condDBv2: was %s, now %s' % (current_gt,new_gt)
     process.GlobalTag.globaltag = new_gt
-
-
     
 process.source = cms.Source("PoolSource",
                             fileNames=cms.untracked.vstring("/store/mc/RunIISpring15DR74/QCD_Pt-15to7000_TuneCUETP8M1_Flat_13TeV_pythia8/MINIAODSIM/AsymptFlat0to50bx50Reco_MCRUN2_74_V9A-v3/00000/023F427F-0E08-E511-A813-0025905A60EE.root"
@@ -55,31 +53,31 @@ process.options = cms.untracked.PSet(
     )
 # import function which takes care of reclustering the jets using legacy vertex		
 from flashgg.MicroAOD.flashggJets_cfi import addFlashggPFCHSJets 
-from flashgg.MicroAOD.flashggJets_cfi import addFlashggPuppiJets
+#from flashgg.MicroAOD.flashggJets_cfi import addFlashggPuppiJets
 from flashgg.MicroAOD.flashggJets_cfi import maxJetCollections
-from flashgg.MicroAOD.flashggJets_cfi import PuppiJetCollectionVInputTag, JetCollectionVInputTag
+from flashgg.MicroAOD.flashggJets_cfi import JetCollectionVInputTag#PuppiJetCollectionVInputTag, 
 # call the function, it takes care of everything else.
 
 
 for vtx in range(0,maxJetCollections):
     addFlashggPFCHSJets (process = process,
                          vertexIndex =vtx,
-                         doQGTagging = False,
+                         doQGTagging = True,
                          label = '' + str(vtx))    
-    addFlashggPuppiJets (process     = process,
-                         vertexIndex = vtx,
-                         debug       = False,
-                         label = '' + str(vtx))
+#    addFlashggPuppiJets (process     = process,
+#                         vertexIndex = vtx,
+#                         debug       = False,
+#                         label = '' + str(vtx))
 
 #------------------------------------------------------------------------------------------------    
 # run a standard puppi with the default seeting
-from flashgg.MicroAOD.flashggExtraJets_cfi import addStandardPuppiJets
-addStandardPuppiJets(process,
-                     label = '',
-                     debug = True)
+#from flashgg.MicroAOD.flashggExtraJets_cfi import addStandardPuppiJets
+#addStandardPuppiJets(process,
+#                     label = '',
+#                     debug = True)
 
 from flashgg.Taggers.flashggTags_cff       import UnpackedJetCollectionVInputTag   
-from flashgg.MicroAOD.flashggExtraJets_cfi import StandardPUPIJetVInputTag
+#from flashgg.MicroAOD.flashggExtraJets_cfi import StandardPUPIJetVInputTag
 
 process.flashggJetTreeMakerPFCHS = cms.EDAnalyzer('FlashggJetValidationTreeMaker',
                                                   GenParticleTag = cms.untracked.InputTag('prunedGenParticles'),
@@ -87,24 +85,24 @@ process.flashggJetTreeMakerPFCHS = cms.EDAnalyzer('FlashggJetValidationTreeMaker
                                                   inputTagJets   = JetCollectionVInputTag,
                                                   StringTag      = cms.string("PFCHS"))
 
-process.flashggJetTreeMakerPUPPI = cms.EDAnalyzer('FlashggJetValidationTreeMaker',
-                                                  GenParticleTag = cms.untracked.InputTag('prunedGenParticles'),
-                                                  DiPhotonTag    = cms.InputTag('flashggDiPhotons'),
-                                                  inputTagJets   = PuppiJetCollectionVInputTag,
-                                                  StringTag      = cms.string("PUPPI"))
-
-process.flashggJetTreeMakerSTDPUPPI = cms.EDAnalyzer('FlashggJetValidationTreeMaker',
-                                                     GenParticleTag = cms.untracked.InputTag('prunedGenParticles'),
-                                                     DiPhotonTag    = cms.InputTag('flashggDiPhotons'),
-                                                     inputTagJets   = StandardPUPIJetVInputTag,#TmpJetVInputTag,
-                                                     debug          = cms.untracked.bool(True),
-                                                     ZeroVertexOnly = cms.untracked.bool(True),
-                                                     StringTag      = cms.string("PUPPI"))
-
+#process.flashggJetTreeMakerPUPPI = cms.EDAnalyzer('FlashggJetValidationTreeMaker',
+#                                                  GenParticleTag = cms.untracked.InputTag('prunedGenParticles'),
+#                                                  DiPhotonTag    = cms.InputTag('flashggDiPhotons'),
+#                                                  inputTagJets   = PuppiJetCollectionVInputTag,
+#                                                  StringTag      = cms.string("PUPPI"))
+#
+#process.flashggJetTreeMakerSTDPUPPI = cms.EDAnalyzer('FlashggJetValidationTreeMaker',
+#                                                     GenParticleTag = cms.untracked.InputTag('prunedGenParticles'),
+#                                                     DiPhotonTag    = cms.InputTag('flashggDiPhotons'),
+#                                                     inputTagJets   = StandardPUPIJetVInputTag,#TmpJetVInputTag,
+#                                                     debug          = cms.untracked.bool(True),
+#                                                     ZeroVertexOnly = cms.untracked.bool(True),
+#                                                     StringTag      = cms.string("PUPPI"))
+#
 process.p = cms.Path(process.flashggMicroAODSequence +
-                     process.flashggJetTreeMakerPFCHS +
-                     process.flashggJetTreeMakerPUPPI  +
-                     process.flashggJetTreeMakerSTDPUPPI  )
+                     process.flashggJetTreeMakerPFCHS )
+#                     process.flashggJetTreeMakerPUPPI  +
+#                     process.flashggJetTreeMakerSTDPUPPI  )
 process.e = cms.EndPath(process.out)
 
 


### PR DESCRIPTION
This PR contains an implementation of the QGTagger in the `flashgg::Jet`, the likelihood can be accessed by using `jet->QGL()`