### PR TITLE
Add PhotonRandomizedPhoton producer in the default MicroAOD sequence

### DIFF
--- a/MicroAOD/python/flashggDiPhotons_cfi.py
+++ b/MicroAOD/python/flashggDiPhotons_cfi.py
@@ -2,7 +2,7 @@ import FWCore.ParameterSet.Config as cms
 from flashgg.MicroAOD.flashggJets_cfi import maxJetCollections
 
 flashggDiPhotons = cms.EDProducer('FlashggDiPhotonProducer',
-                                  PhotonTag=cms.InputTag('flashggPhotons'),
+                                  PhotonTag=cms.InputTag('flashggRandomizedPhotons'),
                                   VertexTag=cms.InputTag('offlineSlimmedPrimaryVertices'),
                                   VertexSelectorName=cms.string("FlashggLegacyVertexSelector"),
                                   VertexCandidateMapTag=cms.InputTag("flashggVertexMapUnique"),

--- a/MicroAOD/python/flashggMicroAODSequence_cff.py
+++ b/MicroAOD/python/flashggMicroAODSequence_cff.py
@@ -1,7 +1,10 @@
 import FWCore.ParameterSet.Config as cms
 from flashgg.MicroAOD.flashggTkVtxMap_cfi import flashggVertexMapUnique,flashggVertexMapNonUnique,flashggVertexMapForCHS,flashggVertexMapForPUPPI
+
 from flashgg.MicroAOD.flashggPhotons_cfi import flashggPhotons
+from flashgg.MicroAOD.flashggRandomizedPhotonProducer_cff import flashggRandomizedPhotons
 from flashgg.MicroAOD.flashggDiPhotons_cfi import flashggDiPhotons
+
 from flashgg.MicroAOD.flashggPreselectedDiPhotons_cfi import flashggPreselectedDiPhotons
 from flashgg.MicroAOD.flashggJets_cfi import flashggFinalJets,flashggFinalPuppiJets
 from flashgg.MicroAOD.flashggElectrons_cfi import flashggElectrons
@@ -35,7 +38,7 @@ flashggMicroAODSequence = cms.Sequence(eventCount+weightsCount
                                        +electronMVAValueMapProducer*flashggElectrons*flashggSelectedElectrons
                                        +flashggMuons*flashggSelectedMuons
                                        +flashggMicroAODGenSequence
-                                       +flashggPhotons*flashggDiPhotons*flashggPreselectedDiPhotons
+                                       +flashggPhotons * flashggRandomizedPhotons * flashggDiPhotons*flashggPreselectedDiPhotons
                                        +flashggFinalEGamma
                                        +flashggVertexMapForCHS*flashggFinalJets
                                        +flashggVertexMapForPUPPI*flashggFinalPuppiJets

--- a/MicroAOD/python/flashggRandomizedPhotonProducer_cff.py
+++ b/MicroAOD/python/flashggRandomizedPhotonProducer_cff.py
@@ -7,9 +7,8 @@ import FWCore.ParameterSet.Config as cms
 #         # engineName = cms.untracked.string('TRandom3') # optional, default to HepJamesRandom if absent
 #         )
 
-flashggRandomizedPhotons = cms.EDProducer("FlashggRandomizedPhotons",
-                                    src = cms.InputTag("flashggFinalEGamma"),
-                                    outputCollectionName = cms.string("flashggFinalRandomizedEGamma"),
+flashggRandomizedPhotons = cms.EDProducer("FlashggRandomizedPhotonProducer",
+                                    src = cms.InputTag("flashggPhotons"),
                                     # labels of various gaussian random numbers with mean=0, sigma=1
                                     # to be associated with the photon object
                                     labels = cms.vstring("smearE")

--- a/MicroAOD/test/microAODstd.py
+++ b/MicroAOD/test/microAODstd.py
@@ -26,6 +26,11 @@ if current_gt.count("::All"):
     process.GlobalTag.globaltag = new_gt
 
 
+process.RandomNumberGeneratorService = cms.Service("RandomNumberGeneratorService")
+process.RandomNumberGeneratorService.flashggRandomizedPhotons = cms.PSet(
+          initialSeed = cms.untracked.uint32(16253245)
+        )
+
 # 2012 data
 #process.GlobalTag = GlobalTag(process.GlobalTag, 'GR_R_74_V8A::All')
 #process.source = cms.Source("PoolSource",fileNames=cms.untracked.vstring(


### PR DESCRIPTION
   * right after flashggPhotons
   * adjust defaults InputTags
   * add RandomNumberGeneratorService

MicroAOD production tested, output collection seems OK.

MicroAODtoWorkspace.py does not complain about missing products once sequences tweaked, although it fails with `binContents failed and would return a pair of empty vectors - 0th val:2.56093`. Since the error seems unrelated to this PR, I am submitting it anyway and I will debug in parallel the error.