### PR TITLE
Randomize jets

### DIFF
--- a/MicroAOD/plugins/RandomizedJetProducer.cc
+++ b/MicroAOD/plugins/RandomizedJetProducer.cc
@@ -1,0 +1,20 @@
+#include "flashgg/DataFormats/interface/Jet.h"
+#include "flashgg/MicroAOD/interface/RandomizedObjectProducer.h"
+
+namespace flashgg {
+
+    typedef RandomizedObjectProducer<flashgg::Jet> RandomizedJetProducer;
+
+}
+
+typedef flashgg::RandomizedJetProducer FlashggRandomizedJetProducer;
+DEFINE_FWK_MODULE( FlashggRandomizedJetProducer );
+
+// Local Variables:
+// mode:c++
+// indent-tabs-mode:nil
+// tab-width:4
+// c-basic-offset:4
+// End:
+// vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4
+

--- a/MicroAOD/python/flashggJets_cfi.py
+++ b/MicroAOD/python/flashggJets_cfi.py
@@ -112,8 +112,16 @@ def addFlashggPFCHSJets(process,
                                qgVariablesInputTag   = cms.InputTag('QGTaggerPFCHS'+label, 'qgLikelihood'),
                                )
   setattr( process, 'flashggPFCHSJets'+ label, flashggJets)
+
+  # randomize Jets
+  from flashgg.MicroAOD.flashggRandomizedJetProducer_cfi import flashggRandomizedJets
+  flashggRandomizedPFCHSJets = flashggRandomizedJets.clone()
+  flashggRandomizedPFCHSJets.src = "flashggPFCHSJets" + label
+  setattr(process.RandomNumberGeneratorService, 'flashggRandomizedPFCHSJets' + label, cms.PSet(initialSeed = cms.untracked.uint32(36423784 + int(label))))
+  setattr( process, 'flashggRandomizedPFCHSJets' + label, flashggRandomizedPFCHSJets )
+
   flashggSelectedJets = cms.EDFilter("FLASHggJetSelector",
-                                     src = cms.InputTag( 'flashggPFCHSJets'+ label ),
+                                     src = cms.InputTag( 'flashggRandomizedPFCHSJets' + label ),
                                      cut = cms.string("pt > 15.")
   )
   setattr( process, 'flashggSelectedPFCHSJets'+label, flashggSelectedJets )
@@ -185,9 +193,17 @@ def addFlashggPuppiJets(process,
                           UsePuppi              = cms.untracked.bool(True),
 #                          PileupJetIdParameters = cms.PSet(pu_jetid)
                         ))
+
+  # randomize Jets
+  from flashgg.MicroAOD.flashggRandomizedJetProducer_cfi import flashggRandomizedJets
+  flashggRandomizedPUPPIJets = flashggRandomizedJets.clone()
+  flashggRandomizedPUPPIJets.src = "flashggPUPPIJets" + label
+  setattr(process.RandomNumberGeneratorService, 'flashggRandomizedPUPPIJets' + label, cms.PSet(initialSeed = cms.untracked.uint32(36421523 + int(label))))
+  setattr( process, 'flashggRandomizedPUPPIJets' + label, flashggRandomizedPUPPIJets )
+
   setattr( process, 'selectedFlashggPUPPIJets'+ label,
            cms.EDFilter("FLASHggJetSelector",
-                        src = cms.InputTag( 'flashggPUPPIJets'+ label ),
+                        src = cms.InputTag( 'flashggRandomizedPUPPIJets'+ label ),
                         cut = cms.string("pt > 15.")
                       ))
   

--- a/MicroAOD/python/flashggRandomizedJetProducer_cfi.py
+++ b/MicroAOD/python/flashggRandomizedJetProducer_cfi.py
@@ -1,0 +1,14 @@
+import FWCore.ParameterSet.Config as cms
+
+# add the following lines to the module used to configure the RandomNumberGeneratorService
+# process.RandomNumberGeneratorService.flashggRandomizedJets = cms.PSet(
+#           initialSeed = cms.untracked.uint32(2837641)
+#         # engineName = cms.untracked.string('TRandom3') # optional, default to HepJamesRandom if absent
+#         )
+
+flashggRandomizedJets = cms.EDProducer("FlashggRandomizedJetProducer",
+                                    src = cms.InputTag("flashggJets"),
+                                    # labels of various gaussian random numbers with mean=0, sigma=1
+                                    # to be associated with the photon object
+                                    labels = cms.vstring("smearJER")
+                                    )

--- a/MicroAOD/python/flashggRandomizedPhotonProducer_cff.py
+++ b/MicroAOD/python/flashggRandomizedPhotonProducer_cff.py
@@ -1,4 +1,3 @@
-
 import FWCore.ParameterSet.Config as cms
 
 # add the following lines to the module used to configure the RandomNumberGeneratorService


### PR DESCRIPTION
   * tested with `microAODstd.py`
   * verified that in the produced microAOD each jet has a new userFloat `smearJER`, overall distributed as a gaussian with mean 0 and sigma 1

Minor detail: the labels `smearE` for photons and `smearJER` for jets will be changed into a more general and intuitive notation in an incoming PR.