### PR TITLE
Jet updates for reading 1_1_0

### DIFF
--- a/Systematics/BuildFile.xml
+++ b/Systematics/BuildFile.xml
@@ -2,6 +2,7 @@
 <use name="CommonTools/Utils"/>
 <use name="flashgg/DataFormats"/>
 <use name="rootrflx"/>
+<use name="root"/>
 <export>
   <lib  name="1"/>
 </export>

--- a/Systematics/plugins/JetSmearConstant.cc
+++ b/Systematics/plugins/JetSmearConstant.cc
@@ -66,9 +66,10 @@ namespace flashgg {
                     y.setP4((newpt/recpt)*y.p4());
                 } else {
                     if (!y.hasUserFloat(random_label_)) {
-                        throw cms::Exception("Missing embedded random number") << "Could not find key " << random_label_ << " for random numbers embedded in the photon object, please make sure to read the appropriate version of MicroAOD and/or access the correct label and/or run the PerPhotonDiPhoton randomizer on-the-fly";
+                        throw cms::Exception("Missing embedded random number") << "Could not find key " << random_label_ << " for random numbers embedded in the jet object, please make sure to read the appropriate version of MicroAOD and/or access the correct label and/or run the randomizer on-the-fly";
                     }
-                    float rnd = y.userFloat(random_label_);                        
+                    float rnd = y.userFloat(random_label_);       
+                    
                     std::cout << " We do not use it yet, but we have a random number for " << random_label_ << ": " << rnd << std::endl;
                     if ( debug_ ) {
                         std::cout << "  " << shiftLabel( syst_shift ) << ": Jet has pt=" << y.pt() << " eta=" << y.eta() << " AND NO GENJET! "

--- a/Systematics/plugins/JetSmearConstant.cc
+++ b/Systematics/plugins/JetSmearConstant.cc
@@ -70,7 +70,9 @@ namespace flashgg {
                     }
                     float rnd = y.userFloat(random_label_);       
                     
-                    std::cout << " We do not use it yet, but we have a random number for " << random_label_ << ": " << rnd << std::endl;
+                    if ( debug_ ) {
+                        std::cout << " We do not use it yet, but we have a random number for " << random_label_ << ": " << rnd << std::endl;
+                    }
                     if ( debug_ ) {
                         std::cout << "  " << shiftLabel( syst_shift ) << ": Jet has pt=" << y.pt() << " eta=" << y.eta() << " AND NO GENJET! "
                                   << " ... so we do nothing" << std::endl;

--- a/Systematics/plugins/JetSystematicProducer.cc
+++ b/Systematics/plugins/JetSystematicProducer.cc
@@ -30,19 +30,23 @@ namespace flashgg {
     private:
         void produce( edm::Event &, const edm::EventSetup & ) override;
         bool correctionsSet_;
+        bool doCentralJEC_;
     };
 
     JetSystematicProducer::JetSystematicProducer ( const edm::ParameterSet &iConfig ) : ObjectSystematicProducer<flashgg::Jet,int,std::vector>( iConfig ) {
         correctionsSet_ = false;
+        doCentralJEC_ = iConfig.getParameter<bool>("DoCentralJEC");
     }
     
     void JetSystematicProducer::produce( edm::Event &iEvent, const edm::EventSetup & iSetup ) {
-        const JetCorrector* corrector = JetCorrector::getJetCorrector ("ak4PFCHSL1FastL2L3",iSetup); 
-        for( unsigned int ncorr = 0; ncorr < this->Corrections_.size(); ncorr++ ) {
-            this->Corrections_.at( ncorr )->setJEC(corrector,iEvent,iSetup);
-        }
-        for( unsigned int ncorr = 0; ncorr < this->Corrections2D_.size(); ncorr++ ) {
-            this->Corrections2D_.at( ncorr )->setJEC(corrector,iEvent,iSetup);
+        if (doCentralJEC_) {
+            const JetCorrector* corrector = JetCorrector::getJetCorrector ("ak4PFCHSL1FastL2L3",iSetup); 
+            for( unsigned int ncorr = 0; ncorr < this->Corrections_.size(); ncorr++ ) {
+                this->Corrections_.at( ncorr )->setJEC(corrector,iEvent,iSetup);
+            }
+            for( unsigned int ncorr = 0; ncorr < this->Corrections2D_.size(); ncorr++ ) {
+                this->Corrections2D_.at( ncorr )->setJEC(corrector,iEvent,iSetup);
+            }
         }
         if (!correctionsSet_) {
             edm::ESHandle<JetCorrectorParametersCollection> JetCorParColl;

--- a/Systematics/python/flashggJetSystematics_cfi.py
+++ b/Systematics/python/flashggJetSystematics_cfi.py
@@ -33,7 +33,7 @@ def createJetSystematicsForTag(process,jetInputTag):
                                                            Label = cms.string("JEC"),
                                                            NSigmas = cms.vint32(-1,1),
                                                            OverallRange = cms.string("abs(eta)<5.0"),
-                                                           Debug = cms.untracked.bool(True)
+                                                           Debug = cms.untracked.bool(False)
                                                            ),
                                                  cms.PSet( MethodName = cms.string("FlashggJetSmearConstant"),
                                                            Label = cms.string("JER"),
@@ -41,7 +41,7 @@ def createJetSystematicsForTag(process,jetInputTag):
                                                            OverallRange = cms.string("abs(eta)<5.0"),
                                                            RandomLabel = cms.string("rnd_g_JER"), # for no-match case
                                                            BinList = smearBins,
-                                                           Debug = cms.untracked.bool(True),
+                                                           Debug = cms.untracked.bool(False),
                                                            )
                                                  )
                          

--- a/Systematics/python/flashggJetSystematics_cfi.py
+++ b/Systematics/python/flashggJetSystematics_cfi.py
@@ -27,12 +27,13 @@ def createJetSystematicsForTag(process,jetInputTag):
   setattr(process,newName,
           cms.EDProducer('FlashggJetSystematicProducer',
                          src = jetInputTag,
+                         DoCentralJEC = cms.bool(False),
                          SystMethods2D = cms.VPSet(),
                          SystMethods = cms.VPSet(cms.PSet( MethodName = cms.string("FlashggJetEnergyCorrector"),
                                                            Label = cms.string("JEC"),
                                                            NSigmas = cms.vint32(-1,1),
                                                            OverallRange = cms.string("abs(eta)<5.0"),
-                                                           Debug = cms.untracked.bool(False)
+                                                           Debug = cms.untracked.bool(True)
                                                            ),
                                                  cms.PSet( MethodName = cms.string("FlashggJetSmearConstant"),
                                                            Label = cms.string("JER"),
@@ -40,7 +41,7 @@ def createJetSystematicsForTag(process,jetInputTag):
                                                            OverallRange = cms.string("abs(eta)<5.0"),
                                                            RandomLabel = cms.string("rnd_g_JER"), # for no-match case
                                                            BinList = smearBins,
-                                                           Debug = cms.untracked.bool(False),
+                                                           Debug = cms.untracked.bool(True),
                                                            )
                                                  )
                          

--- a/Systematics/test/VBFTagDumper_standard_wsys_cfg.py
+++ b/Systematics/test/VBFTagDumper_standard_wsys_cfg.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env cmsRun
+
+doSystematics = True
+requireTriggerOnData = True
+
+import FWCore.ParameterSet.Config as cms
+import FWCore.Utilities.FileUtils as FileUtils
+from FWCore.ParameterSet.VarParsing import VarParsing
+from flashgg.MetaData.samples_utils import SamplesManager
+from PhysicsTools.PatAlgos.tools.helpers import massSearchReplaceAnyInputTag,cloneProcessingSnippet
+from flashgg.MetaData.JobConfig import customize
+
+process = cms.Process("VBFTagsDumper")
+
+if doSystematics:
+    process.load("Configuration.StandardSequences.GeometryDB_cff")
+    process.load("Configuration.StandardSequences.MagneticField_cff")
+    process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_condDBv2_cff")
+    from Configuration.AlCa.GlobalTag import GlobalTag
+    process.GlobalTag.globaltag = '74X_mcRun2_asymptotic_v4' # keep updated for JEC
+
+process.load("FWCore.MessageService.MessageLogger_cfi")
+process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(-1))
+process.MessageLogger.cerr.FwkReport.reportEvery = cms.untracked.int32( 1 )
+process.source = cms.Source ("PoolSource",
+                             fileNames = cms.untracked.vstring(
+#        "root://eoscms.cern.ch//eos/cms/store/group/phys_higgs/cmshgg/sethzenz/flashgg/RunIISpring15-ReMiniAOD-1_1_0-25ns/1_1_0/VBFHToGG_M-125_13TeV_powheg_pythia8/RunIISpring15-ReMiniAOD-1_1_0-25ns-1_1_0-v0-RunIISpring15MiniAODv2-74X_mcRun2_asymptotic_v2-v1/160105_224017/0000/myMicroAODOutputFile_1.root"
+        "root://eoscms.cern.ch//eos/cms/store/group/phys_higgs/cmshgg/sethzenz/flashgg/RunIISpring15-ReMiniAOD-1_1_0-25ns/1_1_0/DoubleEG/RunIISpring15-ReMiniAOD-1_1_0-25ns-1_1_0-v0-Run2015C_25ns-05Oct2015-v1/160105_222657/0000/myMicroAODOutputFile_41.root"
+                             ))
+
+process.TFileService = cms.Service("TFileService",
+                                   fileName = cms.string("VBFTagsDump.root"),
+                                   closeFileFast = cms.untracked.bool(True))
+
+
+from flashgg.Taggers.flashggTagOutputCommands_cff import tagDefaultOutputCommand
+import flashgg.Taggers.dumperConfigTools as cfgTools
+from  flashgg.Taggers.tagsDumpers_cfi import createTagDumper
+
+if doSystematics:
+    from flashgg.Taggers.flashggTags_cff import UnpackedJetCollectionVInputTag
+    from flashgg.Systematics.flashggJetSystematics_cfi import createJetSystematics
+    process.RandomNumberGeneratorService = cms.Service("RandomNumberGeneratorService")
+    jetSystematicsInputTags = createJetSystematics(process,UnpackedJetCollectionVInputTag)
+
+process.load("flashgg.Taggers.flashggTagSequence_cfi")
+process.load("flashgg.Taggers.flashggTagTester_cfi")
+
+if doSystematics:
+    process.flashggTagSequence.remove(process.flashggUnpackedJets)
+    for i in range(len(UnpackedJetCollectionVInputTag)):
+        massSearchReplaceAnyInputTag(process.flashggTagSequence,UnpackedJetCollectionVInputTag[i],jetSystematicsInputTags[i])
+    process.flashggVBFTagMerger = cms.EDProducer("VBFTagMerger",src=cms.VInputTag("flashggVBFTag"))
+
+# Use JetID
+process.flashggVBFMVA.UseJetID      = cms.untracked.bool(True)
+process.flashggVBFMVA.JetIDLevel    = cms.untracked.string("Loose")
+
+# use custum TMVA weights
+process.flashggVBFMVA.vbfMVAweightfile = cms.FileInPath("flashgg/Taggers/data/Flashgg_VBF_CHS_STD_BDTG.weights.xml")
+process.flashggVBFMVA.MVAMethod        = cms.untracked.string("BDTG")
+
+# QCD Recovery 
+# process.flashggVBFMVA.merge3rdJet   = cms.untracked.bool(False)
+# process.flashggVBFMVA.thirdJetDRCut = cms.untracked.double(1.5)
+
+# combined MVA boundary set
+process.flashggVBFTag.Boundaries    = cms.untracked.vdouble(-2,0,2)
+
+process.systematicsTagSequences = cms.Sequence()
+
+from flashgg.MetaData.JobConfig import customize
+customize.parse()
+print "customize.processId:",customize.processId
+
+# Do systematics on all MC (n.b. different from ordinary workspaces) but not on data
+if doSystematics:
+    systlabels = [""]
+    jetsystlabels = []
+    if customize.processId == "Data":
+        systprodlist = [getattr(process,"flashggJetSystematics%i"%i) for i in range(len(UnpackedJetCollectionVInputTag))]
+        for systprod in systprodlist:
+            systprod.SystMethods = cms.VPSet() # empty everything
+    else:
+        for direction in ["Up","Down"]:
+            jetsystlabels.append("JEC%s01sigma" % direction)
+            jetsystlabels.append("JER%s01sigma" % direction)
+        systlabels += jetsystlabels
+
+    for systlabel in systlabels:
+        if systlabel == "":
+            continue
+        newseq = cloneProcessingSnippet(process,process.flashggTagSequence,systlabel)
+        if systlabel in jetsystlabels:    
+            for i in range(len(jetSystematicsInputTags)):
+                massSearchReplaceAnyInputTag(newseq,jetSystematicsInputTags[i],cms.InputTag(jetSystematicsInputTags[i].moduleLabel,systlabel))
+        for name in newseq.moduleNames():
+            module = getattr(process,name)
+            if hasattr(module,"SystLabel"):
+                module.SystLabel = systlabel
+        process.systematicsTagSequences += newseq
+        process.flashggVBFTagMerger.src.append(cms.InputTag("flashggVBFTag" + systlabel))
+        
+        
+# set the VBF dumper
+process.vbfTagDumper = createTagDumper("VBFTag")
+process.vbfTagDumper.dumpTrees     = True
+process.vbfTagDumper.dumpHistos    = True
+process.vbfTagDumper.dumpWorkspace = False
+       
+
+if doSystematics:
+    process.vbfTagDumper.src = "flashggVBFTagMerger"
+else:
+    # use the trigger-diphoton-preselection
+    massSearchReplaceAnyInputTag(process.flashggTagSequence,cms.InputTag("flashggDiPhotons"),cms.InputTag("flashggPreselectedDiPhotons"))
+
+# get the variable list
+import flashgg.Taggers.VBFTagVariables as var
+new_variables = [
+    "prompt_pho_1  := diPhoton.leadingPhoton.genMatchType()",
+    "prompt_pho_2  := diPhoton.subLeadingPhoton.genMatchType()",
+    "n_jets        := VBFMVA.n_rec_jets"
+    #"jet1_btag := leadingJet_ptr.bDiscriminator(\"pfCombinedInclusiveSecondaryVertexV2BJetTags\")",
+    #"jet2_btag := subLeadingJet_ptr.bDiscriminator(\"pfCombinedInclusiveSecondaryVertexV2BJetTags\")"
+    ]
+all_variables = var.dijet_variables + var.dipho_variables + new_variables #var.truth_variables
+if customize.processId != "Data":
+    all_variables += var.truth_variables
+
+
+cats = []
+if doSystematics:
+    for syst in jetsystlabels:
+        systcutstring = "hasSyst(\"%s\") "%syst
+        cats += [("VBFDiJet_%s"%syst,"leadingJet.pt>0&&%s"%systcutstring,0),
+                 ("excluded_%s"%syst,systcutstring,0)]
+else:
+    cats = [
+                    ("VBFDiJet","leadingJet.pt>0",0),
+                    ("excluded","1",0)
+                    ]
+
+cats += [
+    ("VBFDiJet","leadingJet.pt>0",0),
+    ("excluded","1",0)
+    ]
+
+cfgTools.addCategories(process.vbfTagDumper,
+                       cats,
+                       variables  = all_variables,
+                       histograms = []
+)
+
+print cats
+
+
+#process.vbfTagDumper.nameTemplate ="$PROCESS_$SQRTS_$LABEL_$SUBCAT_$CLASSNAME"
+process.vbfTagDumper.nameTemplate = "$PROCESS_$SQRTS_$CLASSNAME_$SUBCAT_$LABEL"
+
+customize.setDefault("maxEvents" , 1000     ) # max-number of events
+customize.setDefault("targetLumi", 2.56e+3  ) # define integrated lumi
+customize(process)
+
+from HLTrigger.HLTfilters.hltHighLevel_cfi import hltHighLevel
+process.hltHighLevel = hltHighLevel.clone(HLTPaths = cms.vstring("HLT_Diphoton30_18_R9Id_OR_IsoCaloId_AND_HE_R9Id_Mass95_v1") )
+process.options      = cms.untracked.PSet( wantSummary = cms.untracked.bool(True) )
+
+process.hltRequirement = cms.Sequence()
+if customize.processId == "Data" and requireTriggerOnData:
+        process.hltRequirement += process.hltHighLevel
+
+if doSystematics:
+    process.p1 = cms.Path(
+        process.hltRequirement*
+        (process.flashggUnpackedJets*process.jetSystematicsSequence)*
+        (process.flashggTagSequence+process.systematicsTagSequences)*
+        process.flashggVBFTagMerger*
+        process.vbfTagDumper
+        )
+else:
+    process.p1 = cms.Path(
+        process.hltRequirement*
+        process.flashggTagSequence*
+        # process.flashggTagTester* # Uncommment if you what to test VBFtag
+        process.vbfTagDumper
+        )
+
+print process.p1

--- a/Taggers/plugins/TagMerger.cc
+++ b/Taggers/plugins/TagMerger.cc
@@ -2,10 +2,13 @@
 #include "CommonTools/UtilAlgos/interface/Merger.h"
 #include "DataFormats/Candidate/interface/Candidate.h"
 #include "flashgg/DataFormats/interface/DiPhotonTagBase.h"
+#include "flashgg/DataFormats/interface/VBFTag.h"
 
 typedef Merger<edm::OwnVector<flashgg::DiPhotonTagBase> > TagMerger;
+typedef Merger<std::vector<flashgg::VBFTag> > VBFTagMerger;
 
 DEFINE_FWK_MODULE( TagMerger );
+DEFINE_FWK_MODULE( VBFTagMerger );
 
 // Local Variables:
 // mode:c++


### PR DESCRIPTION
* Option to turn of central JEC recalculation; already ok for 1_1_0, so this is default.
* Some ground work for JES when no match is present (not done)
* Turn off debug messages
* Dumper for VBF Tag in order to check jet resolutions