### PR TITLE
restored some old functionality to be able to handle mc samples outside of flashgg

### DIFF
--- a/MicroAOD/plugins/PDFWeightObjectProducer.cc
+++ b/MicroAOD/plugins/PDFWeightObjectProducer.cc
@@ -35,6 +35,7 @@ namespace flashgg {
         string tag_;
         string delimiter_1_;
         string delimiter_2_;
+        string delimiter_3_;
         void beginRun( edm::Run const &, edm::EventSetup const &iSetup );
         vector<int> weight_indices;
         vector<int> alpha_indices;
@@ -46,20 +47,30 @@ namespace flashgg {
         edm::FileInPath mc2hessianCSV;
         std::vector<double> lhe_weights;
         float gen_weight;
+        string pdfset_;
         string pdfid_1;
         string pdfid_2;
+        bool flashgg_flag_;
+        bool pdfset_flag_;
+        bool alpha_s_flag_;
+        bool scale_flag_;
 	};
     
 	PDFWeightProducer::PDFWeightProducer( const edm::ParameterSet &iConfig ):
 		LHEEventToken_( consumes<LHEEventProduct>( iConfig.getUntrackedParameter<InputTag>( "LHEEventTag", InputTag( "LHEEventProduct" ) ) ) ),
         srcTokenGen_( consumes<GenEventInfoProduct>( iConfig.getUntrackedParameter<InputTag>("GenTag", InputTag("generator") ) ) )
 	{
-        
+        pdfset_flag_ = iConfig.getUntrackedParameter<bool>("pdfset_flag",false);
+        flashgg_flag_ = iConfig.getUntrackedParameter<bool>("flashgg_flag",true);       
+        alpha_s_flag_ = iConfig.getUntrackedParameter<bool>("alpha_s_flag","true");
+        scale_flag_ = iConfig.getUntrackedParameter<bool>("scale_flag","true"); 
 		tag_ = iConfig.getUntrackedParameter<string>( "tag", "initrwgt" );
-		pdfid_1 = iConfig.getUntrackedParameter<string>("pdfid_1","0");
-		pdfid_2 = iConfig.getUntrackedParameter<string>("pdfid_2","0");
+//		pdfid_1 = iConfig.getUntrackedParameter<string>("pdfid_1","0");
+//		pdfid_2 = iConfig.getUntrackedParameter<string>("pdfid_2","0");
+        pdfset_ = iConfig.getUntrackedParameter<string>("pdfset","NNPDF30_lo_as_0130.LHgrid");
 		delimiter_1_ = iConfig.getUntrackedParameter<string>( "delimiter_1", "id=\"" );
 		delimiter_2_ = iConfig.getUntrackedParameter<string>( "delimiter_2", "\">" );
+        delimiter_3_ = iConfig.getUntrackedParameter<string>( "delimiter_3", "</weightgroup>" );
         nPdfEigWeights_ = iConfig.getParameter<unsigned int>("nPdfEigWeights");
         mc2hessianCSV = iConfig.getParameter<edm::FileInPath>("mc2hessianCSV");
 
@@ -133,40 +144,85 @@ namespace flashgg {
 				weight_lines = iter->lines();
 			}
 
+            if(flashgg_flag_){
+            
             PDFWeightProducer::set_generator_type(lines);
-            std::cout << " After set_generator_type on " << iter->tag() << " we have pdfids: " << pdfid_1 << " " << pdfid_2 << std::endl;
+            //std::cout << " After set_generator_type on " << iter->tag() << " we have pdfids: " << pdfid_1 << " " << pdfid_2 << std::endl;
+
+            }
+
         }
 
+        if(scale_flag_){
+
+        string m_format;
+
+        if(flashgg_flag_){
+            m_format = "muR";
+        } 
+
+        if(pdfset_flag_){
+            m_format = "mur";
+        } 
+
         for( unsigned int iLine = 0; iLine < weight_lines.size(); iLine++ ) {
-            if ( weight_lines[iLine].find("muR") != std::string::npos ) {
+            if ( weight_lines[iLine].find(m_format) != std::string::npos ) {
                 //                std::cout << "Line for scale: " << weight_lines[iLine];
                 size_t pos1 = weight_lines[iLine].find("\"");
                 size_t pos2 = weight_lines[iLine].find("\"",pos1+1);
                 assert (pos1 != std::string::npos && pos2 != std::string::npos);
                 string tempstr = weight_lines[iLine].substr(pos1+1,pos2-pos1-1);
                 int scaleind = atoi(tempstr.c_str());
-                //                std::cout << "    " << pos1 << " " << pos2 << " " << tempstr << " " << scaleind << std::endl;
+                                //std::cout << "    " << pos1 << " " << pos2 << " " << tempstr << " " << scaleind << std::endl;
                 scale_indices.push_back( scaleind );
             } else {
                 //                std::cout << "Line NOT for scale: " << weight_lines[iLine];
             }
+          }
         }
         //        std::cout << std::endl;
         
         for( unsigned int iLine = 0; iLine < weight_lines.size(); iLine++ ) {
             
             string line = weight_lines.at( iLine );
-            size_t pos = line.find( pdfid_1 );
+            string main;
+
+            if(flashgg_flag_){
+        
+                main = pdfid_1;
+            }
+
+            if(pdfset_flag_){
+
+                main = pdfset_;
+
+            }
+
+            size_t pos = line.find( main );
             string token;
-            while( (pos = line.find(pdfid_1)) != std::string::npos ){
-                token = line.substr(pos, pdfid_1.length() );
-                if( token.compare( pdfid_1 ) == 0 ){
-                    upper_index = iLine;
+            while( (pos = line.find(main)) != std::string::npos ){
+                token = line.substr(pos, main.length() );
+                //cout << "token " << token << endl;
+                if( token.compare( main ) == 0 ){
+
+                    if (pdfset_flag_){
+
+                    upper_index = iLine + 1;
                     break;
+            
+                    }
+
+                    if (flashgg_flag_){
+
+                    upper_index = iLine;
+                    //cout << "iLine " << iLine << endl;
+                    break;
+            
+                    }
+
                 } else {				
                     upper_index = 0;
                 }
-                
                 
             }
             
@@ -177,19 +233,27 @@ namespace flashgg {
             
             string nline = weight_lines.at( nLine );
             
-            //cout << nline << endl;	
+            //cout << "nline " << nline << endl;	
             string jline = removeSpaces( nline );
-            //						cout << "jline " << jline << endl;
+            //cout << "jline " << jline << endl;
             string jtoken;																					
             size_t jpos;				
-			
+		
+            if(flashgg_flag_) {
+	
             while( ( jpos = jline.find( pdfid_2 ) ) != std::string::npos ) {
                 jtoken = jline.substr( jpos, pdfid_2.length() );
                 //std::cout << "jtoken " << jtoken << std::endl;
                 break;
+               }
+			}
+
+            if(pdfset_flag_){
+
+            if( jline.compare(delimiter_3_ ) == 0 ) {break;}
+
             }
-			
-			
+
             string ntoken;
             string mtoken;
             
@@ -203,10 +267,16 @@ namespace flashgg {
             int wgt = stoi( mtoken );
             
             PDFWeightProducer::weight_indices.push_back( wgt );
-            
+           
+            if(flashgg_flag_){
+ 
             if( jtoken.compare( pdfid_2 ) == 0 ) { break; }
             
+            }
+
         }
+
+        if(flashgg_flag_ && alpha_s_flag_ ){
 
         // See slide 13 here: https://indico.cern.ch/event/459797/contribution/2/attachments/1181555/1710844/mcaod-Nov4-2015.pdf
         int alphas_1 = PDFWeightProducer::weight_indices.back() + 1;
@@ -217,6 +287,7 @@ namespace flashgg {
         //        std::cout << " Alpha indices: " << alphas_1 << " " << alphas_2 << std::endl;
 
         //        std::cout << " PDF weight indices final size: " << weight_indices.size() << std::endl;
+        }
     }
 
 	void PDFWeightProducer::produce( Event &evt, const EventSetup & )
@@ -259,6 +330,7 @@ namespace flashgg {
 					lhe_weights.push_back( weight );
 				}
 			}
+            if(flashgg_flag_ && alpha_s_flag_){
 			for( int k = 0; k<size_alpha; k++ ){
 				int id_k = PDFWeightProducer::alpha_indices[k];
                 //                std::cout << " checking alpha_index " << id_k << " against id " << id_i << std::endl;
@@ -268,7 +340,9 @@ namespace flashgg {
                     uint16_t alpha_16 = MiniFloatConverter::float32to16( alpha );
                     pdfWeight.alpha_s_container.push_back(alpha_16);	
                 }
+             }
             }
+            if(scale_flag_ ){ 
             for( unsigned k = 0 ; k < PDFWeightProducer::scale_indices.size() ; k++ ) {
                 int id_k = PDFWeightProducer::scale_indices[k];
                 if ( id_i == id_k ) {
@@ -277,6 +351,7 @@ namespace flashgg {
                     pdfWeight.qcd_scale_container.push_back( scale_16 );
                 }
             }
+          }
 		}
 
 		//cout << "should be 100   " << lhe_weights.size() << endl;

--- a/MicroAOD/plugins/PDFWeightObjectProducer.cc
+++ b/MicroAOD/plugins/PDFWeightObjectProducer.cc
@@ -54,6 +54,7 @@ namespace flashgg {
         bool pdfset_flag_;
         bool alpha_s_flag_;
         bool scale_flag_;
+        bool skip;
 	};
     
 	PDFWeightProducer::PDFWeightProducer( const edm::ParameterSet &iConfig ):
@@ -180,7 +181,6 @@ namespace flashgg {
             }
           }
         }
-        //        std::cout << std::endl;
         
         for( unsigned int iLine = 0; iLine < weight_lines.size(); iLine++ ) {
             
@@ -226,15 +226,26 @@ namespace flashgg {
                 
             }
             
-            if( upper_index != 0 ){break;} 
+            if( upper_index != 0 ){break;}
         }
+
 
         for( unsigned int nLine = upper_index; nLine < weight_lines.size(); nLine++ ) {
             
             string nline = weight_lines.at( nLine );
-            
+           
+            skip = false;
+ 
             //cout << "nline " << nline << endl;	
             string jline = removeSpaces( nline );
+            if(jline.empty()){cout << "WARNING unknown text format, member vectors will be empty or filled with incorrect values" << endl;
+
+                skip = true;
+                break;
+            }
+
+            //cout << skip << endl;
+
             //cout << "jline " << jline << endl;
             string jtoken;																					
             size_t jpos;				
@@ -254,12 +265,14 @@ namespace flashgg {
 
             }
 
+            if (!skip){
+
             string ntoken;
             string mtoken;
-            
+           
             size_t mpos_1 = jline.find( delimiter_1_ );
             size_t mpos_3 = jline.find( delimiter_2_ );
-            
+           
             ntoken = jline.erase( mpos_3 );
             mtoken = jline.substr( mpos_1 + delimiter_1_.length() );
             //cout << "mtoken " << mtoken << endl;
@@ -273,10 +286,10 @@ namespace flashgg {
             if( jtoken.compare( pdfid_2 ) == 0 ) { break; }
             
             }
+          }
+        }         
 
-        }
-
-        if(flashgg_flag_ && alpha_s_flag_ ){
+        if((flashgg_flag_ && alpha_s_flag_)  && !skip ){
 
         // See slide 13 here: https://indico.cern.ch/event/459797/contribution/2/attachments/1181555/1710844/mcaod-Nov4-2015.pdf
         int alphas_1 = PDFWeightProducer::weight_indices.back() + 1;
@@ -288,6 +301,7 @@ namespace flashgg {
 
         //        std::cout << " PDF weight indices final size: " << weight_indices.size() << std::endl;
         }
+      //cout << "reaches this point " << endl;
     }
 
 	void PDFWeightProducer::produce( Event &evt, const EventSetup & )
@@ -317,7 +331,7 @@ namespace flashgg {
 		int upper_bound = LHEEventHandle->weights().size();
 		int size_weight = PDFWeightProducer::weight_indices.size();
 		int size_alpha = PDFWeightProducer::alpha_indices.size();
-		//cout << "lower_bound " << lower_bound << " upper_bound " << upper_bound << endl;
+		//cout << "upper_bound " << upper_bound << endl;
 		for( int i = 0; i < upper_bound; i++ ) {
 			int id_i = stoi( LHEEventHandle->weights()[i].id );
 			for( int j = 0; j<size_weight; j++ ){
@@ -354,7 +368,7 @@ namespace flashgg {
           }
 		}
 
-		//cout << "should be 100   " << lhe_weights.size() << endl;
+		//cout << "should be 100 or 101 " << lhe_weights.size() << endl;
 
 		pdfweightshelper_.Init(size_weight,nPdfEigWeights_,mc2hessianCSV);
         
@@ -387,9 +401,9 @@ namespace flashgg {
 
 		evt.put( PDFWeight );
 
-        //		cout << "FINAL pdf_weight_container size " <<pdfWeight.pdf_weight_container.size() << endl;
-        //        cout << "FINAL alpha_s_container size " <<pdfWeight.alpha_s_container.size() << endl;
-        //        cout << "FINAL qcd_scale_container size " <<pdfWeight.qcd_scale_container.size() << endl;
+        		//cout << "FINAL pdf_weight_container size " <<pdfWeight.pdf_weight_container.size() << endl;
+                //cout << "FINAL alpha_s_container size " <<pdfWeight.alpha_s_container.size() << endl;
+                //cout << "FINAL qcd_scale_container size " <<pdfWeight.qcd_scale_container.size() << endl;
 
 
 	}

--- a/MicroAOD/python/flashggPDFWeightObject_cfi.py
+++ b/MicroAOD/python/flashggPDFWeightObject_cfi.py
@@ -3,8 +3,14 @@ import FWCore.ParameterSet.Config as cms
 flashggPDFWeightObject = cms.EDProducer('FlashggPDFWeightProducer',
 		tag = cms.untracked.string("initrwgt"),
 		nPdfEigWeights = cms.uint32(60),
+		pdfset_flag = cms.untracked.bool(False),
+		flashgg_flag = cms.untracked.bool(True),
+		alpha_s_flag = cms.untracked.bool(True),
+		scale_flag = cms.untracked.bool(True),
+		pdfset = cms.untracked.string("NNPDF30_lo_as_0130_nf_4.LHgrid"),
 		delimiter_1 = cms.untracked.string("id=\""),
 		delimiter_2 = cms.untracked.string("\">"),
+		delimiter_3 = cms.untracked.string("</weightgroup>"),
 		LHEEventTag = cms.untracked.InputTag('externalLHEProducer'),
 		mc2hessianCSV = cms.FileInPath('PhysicsTools/HepMCCandAlgos/data/NNPDF30_lo_as_0130_hessian_60.csv')
 	)

--- a/Validation/plugins/PDFValidation.cc
+++ b/Validation/plugins/PDFValidation.cc
@@ -65,20 +65,34 @@ PDFWeight::analyze( const edm::Event &evt, const edm::EventSetup &iSetup )
 	//    Handle<LHEEventProduct> LHEHandle;
 	//    evt.getByToken( LHEEventToken_, LHEHandle );
 
-//	    Handle<vector<flashgg::PDFWeightObject> > WeightHandle;
-//	    evt.getByToken( WeightToken_, WeightHandle );
-//	    const PtrVector<flashgg::PDFWeightObject> mcWeightPointers = WeightHandle->ptrVector();
+	    Handle<vector<flashgg::PDFWeightObject> > WeightHandle;
+	    evt.getByToken( WeightToken_, WeightHandle );
+	//   const PtrVector<flashgg::PDFWeightObject> mcWeightPointers = WeightHandle->ptrVector();
 
 	//cout << "XS  " << LHEHandle->originalXWGTUP() << endl;
 
-//	        for( unsigned int weight_index = 0; weight_index < (*WeightHandle).size(); weight_index++ ){
-//	            vector<uint16_t> compressed_weights = (*WeightHandle)[weight_index].pdf_weight_container; 
- //               std::vector<float> uncompressed = (*WeightHandle)[weight_index].uncompress( compressed_weights );
-//	            for( unsigned int j=0; j<(*WeightHandle)[weight_index].pdf_weight_container.size();j++ ) {
-//	                    cout << "compresed weight " << (*WeightHandle)[weight_index].pdf_weight_container[j] << endl;
-//	                    cout << "uncompressed weight " << uncompressed[j] << endl;
-//	       }
-//	    }
+	        for( unsigned int weight_index = 0; weight_index < (*WeightHandle).size(); weight_index++ ){
+	            vector<uint16_t> compressed_weights = (*WeightHandle)[weight_index].pdf_weight_container; 
+                std::vector<float> uncompressed = (*WeightHandle)[weight_index].uncompress( compressed_weights );
+                vector<uint16_t> compressed_alpha = (*WeightHandle)[weight_index].alpha_s_container;
+                std::vector<float> uncompressed_alpha = (*WeightHandle)[weight_index].uncompress( compressed_alpha );
+                vector<uint16_t> compressed_scale = (*WeightHandle)[weight_index].qcd_scale_container;
+                std::vector<float> uncompressed_scale = (*WeightHandle)[weight_index].uncompress( compressed_scale );
+
+	            for( unsigned int j=0; j<(*WeightHandle)[weight_index].pdf_weight_container.size();j++ ) {
+	                    cout << "compresed weight " << (*WeightHandle)[weight_index].pdf_weight_container[j] << endl;
+	                    cout << "uncompressed weight " << uncompressed[j] << endl;
+	       }
+                for( unsigned int j=0; j<(*WeightHandle)[weight_index].alpha_s_container.size();j++ ) {
+                        cout << "compressed variation " << (*WeightHandle)[weight_index].alpha_s_container[j] << endl;
+                        cout << "uncompressed variation " << uncompressed_alpha[j] << endl;
+           }
+                for( unsigned int j=0; j<(*WeightHandle)[weight_index].qcd_scale_container.size();j++ ) {
+                        cout << "compressed scale " << (*WeightHandle)[weight_index].qcd_scale_container[j] << endl;
+                        cout << "uncompressed scale " << uncompressed_scale[j] << endl;
+           }
+	    
+    }
 }
 
 
@@ -96,20 +110,20 @@ PDFWeight::endJob()
 	void
 PDFWeight::beginRun( edm::Run const &iRun, edm::EventSetup const &iSetup )
 {
-	Handle<LHERunInfoProduct> run;
-	typedef vector<LHERunInfoProduct::Header>::const_iterator headers_const_iterator;
-
-	iRun.getByLabel( "externalLHEProducer", run );
-	LHERunInfoProduct myLHERunInfoProduct = *( run.product() );
-
-	for( headers_const_iterator iter = myLHERunInfoProduct.headers_begin(); iter != myLHERunInfoProduct.headers_end(); iter++ ) {
-		if( iter->tag() == "init" )
-		{ cout << iter->tag() << endl; }
-		vector<string> lines = iter->lines();
-		for( unsigned int iLine = 0; iLine < lines.size(); iLine++ ) {
-			cout << lines.at( iLine );
-		}
-	}
+//	Handle<LHERunInfoProduct> run;
+//	typedef vector<LHERunInfoProduct::Header>::const_iterator headers_const_iterator;
+//
+//	iRun.getByLabel( "externalLHEProducer", run );
+//	LHERunInfoProduct myLHERunInfoProduct = *( run.product() );
+//
+//	for( headers_const_iterator iter = myLHERunInfoProduct.headers_begin(); iter != myLHERunInfoProduct.headers_end(); iter++ ) {
+//		if( iter->tag() == "init" )
+//		{ cout << iter->tag() << endl; }
+//		vector<string> lines = iter->lines();
+//		for( unsigned int iLine = 0; iLine < lines.size(); iLine++ ) {
+//			cout << lines.at( iLine );
+//		}
+//	}
 }
 
 

--- a/Validation/plugins/PDFValidation.cc
+++ b/Validation/plugins/PDFValidation.cc
@@ -65,20 +65,20 @@ PDFWeight::analyze( const edm::Event &evt, const edm::EventSetup &iSetup )
 	//    Handle<LHEEventProduct> LHEHandle;
 	//    evt.getByToken( LHEEventToken_, LHEHandle );
 
-	    Handle<vector<flashgg::PDFWeightObject> > WeightHandle;
-	    evt.getByToken( WeightToken_, WeightHandle );
+//	    Handle<vector<flashgg::PDFWeightObject> > WeightHandle;
+//	    evt.getByToken( WeightToken_, WeightHandle );
 //	    const PtrVector<flashgg::PDFWeightObject> mcWeightPointers = WeightHandle->ptrVector();
 
 	//cout << "XS  " << LHEHandle->originalXWGTUP() << endl;
 
-	        for( unsigned int weight_index = 0; weight_index < (*WeightHandle).size(); weight_index++ ){
-	            vector<uint16_t> compressed_weights = (*WeightHandle)[weight_index].pdf_weight_container; 
-                std::vector<float> uncompressed = (*WeightHandle)[weight_index].uncompress( compressed_weights );
-	            for( unsigned int j=0; j<(*WeightHandle)[weight_index].pdf_weight_container.size();j++ ) {
-	                    cout << "compresed weight " << (*WeightHandle)[weight_index].pdf_weight_container[j] << endl;
-	                    cout << "uncompressed weight " << uncompressed[j] << endl;
-	       }
-	    }
+//	        for( unsigned int weight_index = 0; weight_index < (*WeightHandle).size(); weight_index++ ){
+//	            vector<uint16_t> compressed_weights = (*WeightHandle)[weight_index].pdf_weight_container; 
+ //               std::vector<float> uncompressed = (*WeightHandle)[weight_index].uncompress( compressed_weights );
+//	            for( unsigned int j=0; j<(*WeightHandle)[weight_index].pdf_weight_container.size();j++ ) {
+//	                    cout << "compresed weight " << (*WeightHandle)[weight_index].pdf_weight_container[j] << endl;
+//	                    cout << "uncompressed weight " << uncompressed[j] << endl;
+//	       }
+//	    }
 }
 
 
@@ -96,20 +96,20 @@ PDFWeight::endJob()
 	void
 PDFWeight::beginRun( edm::Run const &iRun, edm::EventSetup const &iSetup )
 {
-//	Handle<LHERunInfoProduct> run;
-//	typedef vector<LHERunInfoProduct::Header>::const_iterator headers_const_iterator;
-//
-//	iRun.getByLabel( "externalLHEProducer", run );
-//	LHERunInfoProduct myLHERunInfoProduct = *( run.product() );
-//
-//	for( headers_const_iterator iter = myLHERunInfoProduct.headers_begin(); iter != myLHERunInfoProduct.headers_end(); iter++ ) {
-//		if( iter->tag() == "init" )
-//		{ cout << iter->tag() << endl; }
-//		vector<string> lines = iter->lines();
-//		for( unsigned int iLine = 0; iLine < lines.size(); iLine++ ) {
-//			cout << lines.at( iLine );
-//		}
-//	}
+	Handle<LHERunInfoProduct> run;
+	typedef vector<LHERunInfoProduct::Header>::const_iterator headers_const_iterator;
+
+	iRun.getByLabel( "externalLHEProducer", run );
+	LHERunInfoProduct myLHERunInfoProduct = *( run.product() );
+
+	for( headers_const_iterator iter = myLHERunInfoProduct.headers_begin(); iter != myLHERunInfoProduct.headers_end(); iter++ ) {
+		if( iter->tag() == "init" )
+		{ cout << iter->tag() << endl; }
+		vector<string> lines = iter->lines();
+		for( unsigned int iLine = 0; iLine < lines.size(); iLine++ ) {
+			cout << lines.at( iLine );
+		}
+	}
 }
 
 


### PR DESCRIPTION
In this pull request some old functionality was restored to handle recent cases for samples outside flashgg. Four flags were added to control different parts of the code which are format specific. 

For flashgg samples the flags for the scale, alpha_s and "flashgg_flag" need to be turned on in the python file and the "pdfset_flag" off .

For different mc samples (depending on the lhe txt format) the "flashgg_flag" needs to be turned off, alpha_s (depending on the pdf set) needs to be turned off, scale turned on and "pdfset_flag" on .

