### PR TITLE
set default values for private GlobalVariablesDumper variables

### DIFF
--- a/Taggers/interface/GlobalVariablesDumper.h
+++ b/Taggers/interface/GlobalVariablesDumper.h
@@ -21,7 +21,7 @@ namespace flashgg {
 
         void fill( const edm::EventBase &event );
         
-        void dumpLumiFactor(double lumiFactor) { dumpLumiFactor_ = true; lumiFactor_ = lumiFactor;  }
+        void dumpLumiFactor(double lumiFactor);
 
         void setProcessIndex(int processIndex) {processIndex_= processIndex;}
     private:

--- a/Taggers/src/GlobalVariablesDumper.cc
+++ b/Taggers/src/GlobalVariablesDumper.cc
@@ -13,6 +13,10 @@ using namespace reco;
 
 namespace flashgg {
 
+    void GlobalVariablesDumper::dumpLumiFactor(double lumiFactor) { 
+        dumpLumiFactor_ = true; 
+        lumiFactor_ = lumiFactor; 
+    }
 
     GlobalVariablesDumper::GlobalVariablesDumper( const ParameterSet &cfg ) :
         GlobalVariablesComputer( cfg )
@@ -26,6 +30,9 @@ namespace flashgg {
                 bits_.push_back( std::make_pair( bit, false ) );
             }
         }
+        dumpLumiFactor_ = false;
+        lumiFactor_ = -999.;
+        processIndex_ = -999;
     }
 
 


### PR DESCRIPTION
@yhaddad and I found when making VBF trees that some jobs produced files with a lumiFactor branch and some did not.  It turns out that lumiFactor_ is uninitialized in the GlobalVariablesDumper class, so that the branch might be initialized (and filled with garbage) even if dumpLumiFactor() is never called.  This PR fixes the issue by initializing dumpLumiFactor_ to false; I also initalized other member variables that were otherwise not set in the constructor to -999.

@musella, @vtavolar, can you have a look to make sure I have understood the code correctly?  Thanks!