### PR TITLE
remove getByLabel, plus c++11 magic for IsolationAlgo consumes

### DIFF
--- a/MicroAOD/interface/IsolationAlgoBase.h
+++ b/MicroAOD/interface/IsolationAlgoBase.h
@@ -9,6 +9,7 @@
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "DataFormats/ParticleFlowCandidate/interface/PFCandidate.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 
 // Shamelessly patterned on https://github.com/cms-sw/cmssw/blob/CMSSW_7_2_X/RecoParticleFlow/PFProducer/interface/BlockElementLinkerBase.h
 
@@ -18,7 +19,7 @@ namespace flashgg {
     {
 
     public:
-        IsolationAlgoBase( const edm::ParameterSet &conf )  : name_( conf.getParameter<std::string>( "name" ) ) {}
+        IsolationAlgoBase( const edm::ParameterSet &conf, edm::ConsumesCollector && iC )  : name_( conf.getParameter<std::string>( "name" ) ) {}
         virtual ~IsolationAlgoBase();
 
         virtual void begin( const pat::Photon &, const edm::Event &, const edm::EventSetup & ) {};
@@ -38,7 +39,7 @@ namespace flashgg {
 }
 
 #include "FWCore/PluginManager/interface/PluginFactory.h"
-typedef edmplugin::PluginFactory< flashgg::IsolationAlgoBase* ( const edm::ParameterSet & ) > FlashggIsolationAlgoFactory;
+typedef edmplugin::PluginFactory< flashgg::IsolationAlgoBase* ( const edm::ParameterSet &, edm::ConsumesCollector && ) > FlashggIsolationAlgoFactory;
 
 #endif
 // Local Variables:

--- a/MicroAOD/plugins/ElectronProducer.cc
+++ b/MicroAOD/plugins/ElectronProducer.cc
@@ -39,9 +39,10 @@ namespace flashgg {
         edm::EDGetTokenT<reco::ConversionCollection> convToken_;
         edm::EDGetTokenT<reco::BeamSpot> beamSpotToken_;
         edm::EDGetTokenT<edm::ValueMap<float> > mvaValuesMapToken_;
+        edm::EDGetTokenT<double> rhoToken_;
 
         float _Rho;
-        edm::InputTag rhoFixedGrid_;
+        //        edm::InputTag rhoFixedGrid_;
     };
 
     ElectronProducer::ElectronProducer( const ParameterSet &iConfig ):
@@ -49,15 +50,13 @@ namespace flashgg {
         vertexToken_( consumes<View<reco::Vertex> >( iConfig.getParameter<InputTag>( "vertexTag" ) ) ),
         convToken_( consumes<reco::ConversionCollection>( iConfig.getParameter<InputTag>( "convTag" ) ) ),
         beamSpotToken_( consumes<reco::BeamSpot >( iConfig.getParameter<InputTag>( "beamSpotTag" ) ) ),
-        mvaValuesMapToken_(consumes<edm::ValueMap<float> >(iConfig.getParameter<edm::InputTag>("mvaValuesMap" ) ) )
+        mvaValuesMapToken_(consumes<edm::ValueMap<float> >(iConfig.getParameter<edm::InputTag>("mvaValuesMap" ) ) ),
+        rhoToken_(consumes<double>(iConfig.getParameter<edm::InputTag>( "rhoFixedGridCollection" )))
     {
         applyCuts_ = iConfig.getUntrackedParameter<bool>( "ApplyCuts", false );
         verbose_ = iConfig.getUntrackedParameter<bool>( "verbose", false );
-        //	eventrhoToken_ = consumes<float>(iConfig.getParameter<edm::InputTag>("Rho"));
-        rhoFixedGrid_  = iConfig.getParameter<edm::InputTag>( "rhoFixedGridCollection" );
-
-        produces<vector<flashgg::Electron> >();
         // nontrigmva_ = 0;
+        produces<vector<flashgg::Electron> >();
     }
 
     void ElectronProducer::produce( Event &evt, const EventSetup & )
@@ -69,8 +68,10 @@ namespace flashgg {
         //	const PtrVector<pat::Electron> pelectronPointers = pelectrons->ptrVector();
 
         _Rho = 0;
+        //        Handle<double> rhoHandle;
+        //        evt.getByLabel( rhoFixedGrid_, rhoHandle );
         Handle<double> rhoHandle;
-        evt.getByLabel( rhoFixedGrid_, rhoHandle );
+        evt.getByToken( rhoToken_, rhoHandle );
 
         Handle<View<reco::Vertex> >  vtxs;
         evt.getByToken( vertexToken_, vtxs );

--- a/MicroAOD/plugins/PDFWeightObjectProducer.cc
+++ b/MicroAOD/plugins/PDFWeightObjectProducer.cc
@@ -54,7 +54,7 @@ namespace flashgg {
 		LHEEventToken_( consumes<LHEEventProduct>( iConfig.getParameter<InputTag>( "LHEEventTag" ) ) ),
         srcTokenGen_( consumes<GenEventInfoProduct>( iConfig.getParameter<InputTag>("GenTag") ) )
 	{
-        
+        consumes<LHERunInfoProduct,edm::InRun> (edm::InputTag("externalLHEProducer"));
 		tag_ = iConfig.getUntrackedParameter<string>( "tag", "initrwgt" );
 		pdfid_1 = iConfig.getUntrackedParameter<string>("pdfid_1","0");
 		pdfid_2 = iConfig.getUntrackedParameter<string>("pdfid_2","0");
@@ -117,7 +117,7 @@ namespace flashgg {
 		Handle<LHERunInfoProduct> run;
 		typedef vector<LHERunInfoProduct::Header>::const_iterator headers_const_iterator;
         
-		iRun.getByLabel( "externalLHEProducer", run );
+        iRun.getByLabel( "externalLHEProducer", run );
 		LHERunInfoProduct myLHERunInfoProduct = *( run.product() );
 
 		int upper_index = 0;

--- a/MicroAOD/plugins/PhotonProducer.cc
+++ b/MicroAOD/plugins/PhotonProducer.cc
@@ -55,12 +55,14 @@ namespace flashgg {
         edm::EDGetTokenT<EcalRecHitCollection> ecalHitEBToken_;
         edm::EDGetTokenT<EcalRecHitCollection> ecalHitEEToken_;
         edm::EDGetTokenT<EcalRecHitCollection> ecalHitESToken_;
-        edm::InputTag rhoFixedGrid_;
+        edm::EDGetTokenT<double> rhoToken_;
+        //        edm::InputTag rhoFixedGrid_;
 
         float lxyMin_ = 2.0;
         float probMin_ = 1e-6;
         int nHitsBeforeVtxMax_ = 0;
-        string electronLabel_;
+        //        string electronLabel_;
+        edm::EDGetTokenT<std::vector<pat::Electron> > electronToken_;
 
         edm::EDGetTokenT<reco::ConversionCollection> convToken_;
 
@@ -87,12 +89,14 @@ namespace flashgg {
         ecalHitEBToken_( consumes<EcalRecHitCollection>( iConfig.getParameter<edm::InputTag>( "reducedBarrelRecHitCollection" ) ) ),
         ecalHitEEToken_( consumes<EcalRecHitCollection>( iConfig.getParameter<edm::InputTag>( "reducedEndcapRecHitCollection" ) ) ),
         ecalHitESToken_( consumes<EcalRecHitCollection>( iConfig.getParameter<edm::InputTag>( "reducedPreshowerRecHitCollection" ) ) ),
+        rhoToken_( consumes<double>( iConfig.getParameter<edm::InputTag>( "rhoFixedGridCollection" ) ) ),
+        electronToken_( consumes<std::vector<pat::Electron> >( iConfig.getParameter<edm::InputTag>( "elecTag") ) ),
         convToken_( consumes<reco::ConversionCollection>( iConfig.getParameter<edm::InputTag>( "convTag" ) ) ),
         beamSpotToken_( consumes<reco::BeamSpot >( iConfig.getParameter<edm::InputTag>( "beamSpotTag" ) ) )
     {
 
-        electronLabel_ = iConfig.getParameter<string>( "elecLabel" );
-        rhoFixedGrid_  = iConfig.getParameter<edm::InputTag>( "rhoFixedGridCollection" );
+        //        electronLabel_ = iConfig.getParameter<string>( "elecLabel" );
+        //        rhoFixedGrid_  = iConfig.getParameter<edm::InputTag>( "rhoFixedGridCollection" );
 
         phoIdMVAweightfileEB_ = iConfig.getParameter<edm::FileInPath>( "photonIdMVAweightfile_EB" );
         phoIdMVAweightfileEE_ = iConfig.getParameter<edm::FileInPath>( "photonIdMVAweightfile_EE" );
@@ -120,7 +124,7 @@ namespace flashgg {
             for(size_t ip=0; ip<extraIsolationPlugins.size(); ++ip) {
                 auto & plugin = extraIsolationPlugins[ip];
                 auto className = plugin.getParameter<std::string>("algo");
-                extraIsoAlgos_[ip].reset( FlashggIsolationAlgoFactory::get()->create(className,plugin) );
+                extraIsoAlgos_[ip].reset( FlashggIsolationAlgoFactory::get()->create(className,plugin,consumesCollector()) );
             }
         }
 
@@ -146,14 +150,16 @@ namespace flashgg {
         evt.getByToken( vertexToken_, vertices );
         Handle<VertexCandidateMap> vertexCandidateMap;
         evt.getByToken( vertexCandidateMapToken_, vertexCandidateMap );
-        Handle<double> rhoHandle;        // the old way for now...move to getbytoken?
-        evt.getByLabel( rhoFixedGrid_, rhoHandle );
+        Handle<double> rhoHandle; 
+        evt.getByToken( rhoToken_, rhoHandle );
+        //        evt.getByLabel( rhoFixedGrid_, rhoHandle );
         Handle<vector<flashgg::GenPhotonExtra> > genPhotonsHandle;
         if( ! evt.isRealData() ) {
             evt.getByToken( genPhotonToken_, genPhotonsHandle );
         }
         Handle<std::vector<pat::Electron> > electronHandle;
-        evt.getByLabel( electronLabel_, electronHandle );
+        evt.getByToken( electronToken_, electronHandle );
+        //        evt.getByLabel( electronLabel_, electronHandle );
 
         Handle<reco::ConversionCollection> convs;
         evt.getByToken( convToken_, convs );

--- a/MicroAOD/plugins/StdIsolationAlgo.cc
+++ b/MicroAOD/plugins/StdIsolationAlgo.cc
@@ -6,7 +6,7 @@ namespace flashgg {
     class StdIsolationAlgo : public IsolationAlgoBase
     {
     public:
-        StdIsolationAlgo( const edm::ParameterSet &conf )  : IsolationAlgoBase( conf ),
+        StdIsolationAlgo( const edm::ParameterSet &conf, edm::ConsumesCollector && iC )  : IsolationAlgoBase( conf, std::forward<edm::ConsumesCollector>(iC) ),
             conesize_( conf.getParameter<double>( "coneSize" ) )
         {
             if( conf.exists( "charged" ) ) {

--- a/MicroAOD/plugins/VectorVectorJetCollector.cc
+++ b/MicroAOD/plugins/VectorVectorJetCollector.cc
@@ -28,11 +28,16 @@ namespace flashgg {
         typedef std::vector<edm::Handle<edm::View<flashgg::Jet> > > JetViewVector;
 
         std::vector<edm::InputTag> inputTagJets_;
+        std::vector<edm::EDGetTokenT<View<flashgg::Jet> > > tokenJets_;
     };
 
     VectorVectorJetCollector::VectorVectorJetCollector( const ParameterSet &iConfig ) :
         inputTagJets_( iConfig.getParameter<std::vector<edm::InputTag> >( "inputTagJets" ) )
     {
+        for (unsigned i = 0 ; i < inputTagJets_.size() ; i++) {
+            auto token = consumes<View<flashgg::Jet> >(inputTagJets_[i]);
+            tokenJets_.push_back(token);
+        }
         produces<vector<vector<Jet> > >();
     }
 
@@ -43,7 +48,8 @@ namespace flashgg {
         size_t output_size = 0;
         JetViewVector Jets( inputTagJets_.size() );
         for( size_t j = 0; j < inputTagJets_.size(); ++j ) {
-            evt.getByLabel( inputTagJets_[j], Jets[j] );
+            //            evt.getByLabel( inputTagJets_[j], Jets[j] );
+            evt.getByToken( tokenJets_[j], Jets[j] );
             if( Jets[j]->size() > 0 ) { output_size = j + 1; }
         }
 

--- a/MicroAOD/python/flashggPhotons_cfi.py
+++ b/MicroAOD/python/flashggPhotons_cfi.py
@@ -28,5 +28,5 @@ flashggPhotons = cms.EDProducer('FlashggPhotonProducer',
 
 				convTag = cms.InputTag('reducedEgamma','reducedConversions'),
 				beamSpotTag = cms.InputTag('offlineBeamSpot'),
-				elecLabel = cms.string("slimmedElectrons")
+				elecTag = cms.InputTag("slimmedElectrons")
                               )


### PR DESCRIPTION
Removed getByLabel in favor of getByToken in the few places we used it.  There are some interesting consequences to this for the isolation algorithm factory, which the interested can learn about here:

https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuideEDMGetDataFromEvent#Consumes_and_Helpers

And then here:

http://stackoverflow.com/questions/5481539/what-does-t-double-ampersand-mean-in-c11 (see "Perfect forwarding")