### PR TITLE
Make code compatible with 74X and 76X

### DIFF
--- a/MicroAOD/python/MicroAODCustomize.py
+++ b/MicroAOD/python/MicroAODCustomize.py
@@ -1,4 +1,4 @@
-
+import os
 import FWCore.ParameterSet.Config as cms
 import FWCore.ParameterSet.VarParsing as VarParsing
 class MicroAODCustomize(object):
@@ -121,6 +121,11 @@ class MicroAODCustomize(object):
             self.customizeFileNames(process)
         if self.timing == 1:
             self.customizeTiming(process)
+        if os.environ["CMSSW_VERSION"].count("CMSSW_7_6"):
+            self.customize76X(process)
+        elif len(self.globalTag) == 0:
+            self.globalTag = "74X_mcRun2_asymptotic_v4"
+            self.customizeGlobalTag(process)
         if self.bunchSpacing == 25:
             pass #default
         elif self.bunchSpacing == 50:
@@ -298,6 +303,8 @@ class MicroAODCustomize(object):
         process.flashggPhotons.photonIdMVAweightfile_EB = cms.FileInPath("flashgg/MicroAOD/data/MVAweights_Spring15_50ns_barrel.xml")
         process.flashggPhotons.photonIdMVAweightfile_EE = cms.FileInPath("flashgg/MicroAOD/data/MVAweights_Spring15_50ns_endcap.xml")
 
+    def customize76X(self,process):
+        delattr(process,"QGPoolDBESSource")
 
 # customization object
 customize = MicroAODCustomize()

--- a/MicroAOD/python/flashggJets_cfi.py
+++ b/MicroAOD/python/flashggJets_cfi.py
@@ -11,7 +11,7 @@ import os
 
 flashggBTag = 'pfCombinedInclusiveSecondaryVertexV2BJetTags'
 maxJetCollections = 8
-#qgDatabaseVersion = 'v1' # check https://twiki.cern.ch/twiki/bin/viewauth/CMS/QGDataBaseVersion
+qgDatabaseVersion = 'v1' # check https://twiki.cern.ch/twiki/bin/viewauth/CMS/QGDataBaseVersion
 
 def addFlashggPFCHSJets(process, 
                         vertexIndex = 0, 
@@ -88,18 +88,18 @@ def addFlashggPFCHSJets(process,
   #process.patJetCorrFactorsAK4PFCHSLeg.primaryVertices = "offlineSlimmedPrimaryVertices"
   getattr(process, 'patJetCorrFactorsAK4PFCHSLeg' + label).primaryVertices = "offlineSlimmedPrimaryVertices"
   
-  #== QGTagging
-#  process.QGPoolDBESSource = cms.ESSource("PoolDBESSource",
-#                                          CondDBSetup,
-#                                          toGet = cms.VPSet(),
-#                                          connect = cms.string('frontier://FrontierProd/CMS_COND_PAT_000'),)
+  #== QGTagging, will be removed in 76X via customization
+  process.QGPoolDBESSource = cms.ESSource("PoolDBESSource",
+                                          CondDBSetup,
+                                          toGet = cms.VPSet(),
+                                          connect = cms.string('frontier://FrontierProd/CMS_COND_PAT_000'),)
   
-#  for type in ['AK4PFchs','AK4PFchs_antib']:
-#    process.QGPoolDBESSource.toGet.extend(cms.VPSet(cms.PSet(
-#          record = cms.string('QGLikelihoodRcd'),
-#          tag    = cms.string('QGLikelihoodObject_'+qgDatabaseVersion+'_'+type),
-#          label  = cms.untracked.string('QGL_'+type)
-#          )))
+  for type in ['AK4PFchs','AK4PFchs_antib']:
+    process.QGPoolDBESSource.toGet.extend(cms.VPSet(cms.PSet(
+          record = cms.string('QGLikelihoodRcd'),
+          tag    = cms.string('QGLikelihoodObject_'+qgDatabaseVersion+'_'+type),
+          label  = cms.untracked.string('QGL_'+type)
+          )))
   
   from RecoJets.JetProducers.QGTagger_cfi import QGTagger
   setattr( process, 'QGTaggerPFCHS' + label,  QGTagger.clone( srcJets   = 'patJetsAK4PFCHSLeg' + label ,jetsLabel = 'QGL_AK4PFchs'))

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ Before you start, **please take note** of these warnings and comments:
 * **N.B.** This is to set up the latest area in a self-consistent way. If you want a particular flashgg version corresponding to other samples, please see https://twiki.cern.ch/twiki/bin/viewauth/CMS/FLASHggFramework#Instructions_for_users
 
 Get everything you need, starting from a clean area:
+
+Instructions for processing of 76X MiniAOD:
  ```
  cmsrel CMSSW_7_6_3
  cd CMSSW_7_6_3/src
@@ -17,7 +19,17 @@ Get everything you need, starting from a clean area:
  git clone https://github.com/cms-analysis/flashgg flashgg
  source flashgg/setup.sh
  ```
-Now if everything looks reasonable, you can build:
+To process 74X MiniAOD, instead do:
+ ```
+ cmsrel CMSSW_7_4_15
+ cd CMSSW_7_4_15/src
+ cmsenv
+ git cms-init
+ cd $CMSSW_BASE/src
+ git clone https://github.com/cms-analysis/flashgg flashgg
+ source flashgg/setup_74X.sh
+ ```
+In either case, if everything now looks reasonable, you can build:
  ```
  cd $CMSSW_BASE/src
  scram b -j 9

--- a/setup.sh
+++ b/setup.sh
@@ -108,7 +108,6 @@ git cms-merge-topic -u matteosan1:egm_tnp_76X
 
 echo "Setting up weight and pat electron conversion..."
 git cms-addpkg CommonTools/UtilAlgos
-git cms-addpkg DataFormats/RecoCandidate
 git cms-addpkg RecoEgamma/EgammaTools
 git remote add cmssw-sethzenz https://github.com/sethzenz/cmssw.git
 git fetch cmssw-sethzenz

--- a/setup_74X.sh
+++ b/setup_74X.sh
@@ -1,0 +1,125 @@
+#!/bin/bash
+
+SETUP_REMOTES=false
+
+echo
+echo "Welcome to the FLASHgg automagic setup script!"
+
+if [ ! -f $CMSSW_BASE/src/.git/HEAD ];
+then
+  echo "CMSSW area appears not to be set up correctly. Check README carefully."
+  echo
+  return 1
+fi
+
+NFILES=`ls -1 ${CMSSW_BASE}/src | wc -l`
+if [ ! ${NFILES} = "1" ]
+then
+  echo "CMSSW area appears to have extra files already. Start over and check README carefully."
+  echo "You can remove this condition from the setup script if you wish, but proceed with caution!"
+  echo
+  return 1
+fi
+
+echo
+echo "You should have checked out from cms-analysis/flashgg. Renaming this to upstream for convenience of existing developers..."
+cd $CMSSW_BASE/src/flashgg
+git remote rename origin upstream
+git remote set-url --push upstream DISALLOWED
+GITHUBUSERNAME=`git config user.github`
+echo "Setting up a new origin repo, assuming your fork name is ${GITHUBUSERNAME} - check this!"
+git remote add origin git@github.com:${GITHUBUSERNAME}/flashgg.git
+git config branch.master.remote origin
+
+if ${SETUP_REMOTES} ; then
+  echo "Setting up remotes listed in setup script..."
+  cd $CMSSW_BASE/src/flashgg
+  git remote add ArnabPurohit https://github.com/ArnabPurohit/flashgg
+  git remote add bcourbon https://github.com/bcourbon/flashgg
+  git remote add bmarzocc https://github.com/bmarzocc/flashgg
+  git remote add camilocarrillo https://github.com/camilocarrillo/flashgg
+  git remote add cms-flashgg https://github.com/cms-flashgg/flashgg
+  git remote add crovelli https://github.com/crovelli/flashgg
+  git remote add favaro https://github.com/favaro/flashgg
+  git remote add fcouderc https://github.com/fcouderc/flashgg
+  git remote add ferriff https://github.com/ferriff/flashgg
+  git remote add FMantegazzini FMantegazzini/flashgg
+  git remote add heppye https://github.com/heppye/flashgg
+  git remote add InnaKucher https://github.com/InnaKucher/flashgg
+  git remote add itopsisg https://github.com/itopsisg/flashgg
+  git remote add J-C-Wright https://github.com/J-C-Wright/flashgg
+  git remote add JunquanTao https://github.com/JunquanTao/flashgg
+  git remote add kmondal https://github.com/kmondal/flashgg
+  git remote add ldcorpe https://github.com/ldcorpe/flashgg
+  git remote add malcles https://github.com/malcles/flashgg
+  git remote add martinamalberti https://github.com/martinamalberti/flashgg
+  git remote add matteosan1 https://github.com/matteosan1/flashgg
+  git remote add mdonega https://github.com/mdonega/flashgg
+  git remote add mmachet https://github.com/mmachet/flashgg
+  git remote add molmedon https://github.com/molmedon/flashgg
+  git remote add mplaner https://github.com/mplaner/flashgg
+  git remote add musella https://github.com/musella/flashgg
+  git remote add nancymarinelli https://github.com/nancymarinelli/flashgg
+  git remote add OlivierBondu https://github.com/OlivierBondu/flashgg
+  git remote add pmeridian https://github.com/pmeridian/flashgg
+  git remote add quittnat https://github.com/quittnat/flashgg
+  git remote add rateixei https://github.com/rateixei/flashgg
+  git remote add ResonantHbbHgg https://github.com/ResonantHbbHgg/flashgg
+  git remote add sethzenz https://github.com/sethzenz/flashgg
+  git remote add simonepigazzini https://github.com/simonepigazzini/flashgg
+  git remote add swagata87 https://github.com/swagata87/flashgg
+  git remote add vtavolar https://github.com/vtavolar/flashgg
+  git remote add yhaddad https://github.com/yhaddad/flashgg
+  git remote add upstream-writable git@github.com:cms-analysis/flashgg.git
+else
+  echo "Not setting up additional remote names (default)"
+fi
+
+cd $CMSSW_BASE/src
+
+# Removed because it requires new merging and it is not needed for default PFCHS
+# Will be restored if/when required for future studies
+#echo
+#echo "Setting up pileupjetid..."
+#git cms-addpkg RecoJets/JetProducers
+#git cms-merge-topic sethzenz:topic-pujid-74X
+#echo
+
+echo "Setting up weight counter..."
+git cms-addpkg CommonTools/UtilAlgos 
+git cms-addpkg DataFormats/Common
+git cms-merge-topic sethzenz:topic-weights-count-74X
+
+# PUPPI is automagically in the release since 7_4_11 and 7_5_2, but we still need Multi-PUPPI
+echo "Setting up PUPPI..."
+git cms-addpkg CommonTools/PileupAlgos
+git cms-merge-topic sethzenz:topic-puppi-7_4_12 
+echo
+
+echo "Modifying FastjetJetProducer to avoid wasting time on empty collections..."
+git cms-addpkg RecoJets/JetProducers
+git cms-merge-topic sethzenz:topic-jetprod-skipempty
+echo
+
+echo "Setting up Conversion tools for pat electron..."
+git cms-addpkg RecoEgamma/EgammaTools
+git cms-merge-topic -u sethzenz:topic-conversion-tools-for-pat-ele-74X
+
+echo "Setting up TnP tools..."
+git cms-addpkg DataFormats/RecoCandidate
+git cms-addpkg PhysiscsTools/TagAndProbe
+git cms-merge-topic -u matteosan1:egm_tnp
+
+echo "Setting up PDF weight tool..."
+git-cms-merge-topic bendavid:pdfweights_74x
+
+echo "adding hook for indentation"
+ln -s $CMSSW_BASE/src/flashgg/Validation/scripts/flashgg_indent_check.sh $CMSSW_BASE/src/flashgg/.git/hooks/pre-commit
+
+echo "Unfortunately we have to delete some files to compile the 74X recipe with the 76X repository"
+echo "rm Validation/plugins/FlashggTriggerCandProducer.cc"
+rm $CMSSW_BASE/src/flashgg/Validation/plugins/FlashggTriggerCandProducer.cc
+
+echo
+echo "Done with setup script! You still need to build!"
+echo


### PR DESCRIPTION
This PR should make MicroAOD production possible with the same code base, using either 74X or 76X samples.  However note that separate areas with a compatible release will need to be built, and different setup.sh files are given for each case.  There is one change required in python in 76X which is autodetected in customize using $CMSSW_VERSION, and if no globaltag is specified the default globaltag is also changed in customize.