### PR TITLE
Fix consumes dumpers

### DIFF
--- a/MicroAOD/interface/GlobalVariablesComputer.h
+++ b/MicroAOD/interface/GlobalVariablesComputer.h
@@ -2,8 +2,12 @@
 #define flashgg_GlobalVariablesComputer_h
 
 #include "FWCore/Common/interface/EventBase.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "DataFormats/VertexReco/interface/VertexFwd.h"
+#include "SimDataFormats/PileupSummaryInfo/interface/PileupSummaryInfo.h"
 
 namespace flashgg {
 
@@ -22,6 +26,7 @@ namespace flashgg {
         };
 
         GlobalVariablesComputer( const edm::ParameterSet &cfg );
+        GlobalVariablesComputer( const edm::ParameterSet &cfg, edm::ConsumesCollector &&cc );
 
         void update( const edm::EventBase &event );
 
@@ -35,11 +40,16 @@ namespace flashgg {
         bool puReWeight() const { return puReWeight_; }
         
     protected:
-        edm::InputTag rhoTag_, vtxTag_;
+
+        void _init( const edm::ParameterSet & cfg );
+
+        edm::InputTag rhoTag_, vtxTag_, puInfo_;
+        edm::EDGetTokenT<double> rhoToken_;
+        edm::EDGetTokenT<reco::VertexCollection> vtxToken_;
+        edm::EDGetTokenT<std::vector<PileupSummaryInfo> > puInfoToken_;
         bool getPu_, puReWeight_, useTruePu_;
         std::vector<double> puBins_;
         std::vector<double> puWeight_;
-        edm::InputTag puInfo_;
 
         cache_t cache_;
     };

--- a/Taggers/interface/GlobalVariablesDumper.h
+++ b/Taggers/interface/GlobalVariablesDumper.h
@@ -2,6 +2,7 @@
 #define flashgg_GlobalVariablesDumper_h
 
 #include "FWCore/Common/interface/EventBase.h"
+#include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
@@ -15,6 +16,7 @@ namespace flashgg {
     {
     public:
         GlobalVariablesDumper( const edm::ParameterSet &cfg );
+        GlobalVariablesDumper( const edm::ParameterSet &cfg, edm::ConsumesCollector && cc );
         ~GlobalVariablesDumper();
 
         void bookTreeVariables( TTree *target, const std::map<std::string, std::string> &replacements );
@@ -24,8 +26,13 @@ namespace flashgg {
         void dumpLumiFactor(double lumiFactor);
 
         void setProcessIndex(int processIndex) {processIndex_= processIndex;}
+
     private:
+
+        void _init( const edm::ParameterSet &cfg );
+
         edm::InputTag triggerTag_;
+        edm::EDGetTokenT<edm::TriggerResults> triggerToken_;
         std::vector<std::pair<std::string, bool>> bits_;
         
         bool dumpLumiFactor_;


### PR DESCRIPTION
Should maintain FWLite compatibility everywhere.
Adjust dumpers and the GlobalVariables stuff.

This PR should supersed #497 , @simonepigazzini please check.

It needs PR #504 for testing.
Tested with the standard `MicroAOD/test/microAODstd.py` and `Taggers/test/diphotonsDumper_cfg.py`. I don't have examples for FWLite, but  maybe @andreypz does and could make a quick test.