### PR TITLE
fix mistake in recipe for JEC in MicroAOD production on data

### DIFF
--- a/MicroAOD/python/MicroAODCustomize.py
+++ b/MicroAOD/python/MicroAODCustomize.py
@@ -268,6 +268,7 @@ class MicroAODCustomize(object):
         from flashgg.MicroAOD.flashggJets_cfi import maxJetCollections
         for vtx in range(0,maxJetCollections):
             addFlashggPFCHSJets (process = process,
+                                 isData=(self.processType == "data"),
                                  vertexIndex =vtx,
                                  #doQGTagging = True,
                                  label = '' + str(vtx))

--- a/MicroAOD/python/flashggJets_cfi.py
+++ b/MicroAOD/python/flashggJets_cfi.py
@@ -14,6 +14,7 @@ maxJetCollections = 8
 qgDatabaseVersion = 'v1' # check https://twiki.cern.ch/twiki/bin/viewauth/CMS/QGDataBaseVersion
 
 def addFlashggPFCHSJets(process, 
+                        isData,
                         vertexIndex = 0, 
                         #doQGTagging = True, 
                         label ='', 
@@ -66,6 +67,11 @@ def addFlashggPFCHSJets(process,
   #Import RECO jet producer for ak4 PF and GEN jet
   from RecoJets.JetProducers.ak4PFJets_cfi  import ak4PFJets
   setattr(process, 'ak4PFJetsCHSLeg' + label, ak4PFJets.clone ( src = 'pfNoElectronsCHSLeg' + label, doAreaFastjet = True))
+
+  if isData:
+    JECs = ['L1FastJet', 'L2Relative', 'L3Absolute','L2L3Residual']
+  else:
+    JECs = ['L1FastJet', 'L2Relative', 'L3Absolute']
     
   # NOTE: this is the 74X recipe for the jet clustering
   addJetCollection(
@@ -77,7 +83,7 @@ def addFlashggPFCHSJets(process,
     pfCandidates   = cms.InputTag('packedPFCandidates'),
     svSource       = cms.InputTag('slimmedSecondaryVertices'),
     btagDiscriminators = [ flashggBTag ],
-    jetCorrections = ('AK4PFchs', ['L1FastJet', 'L2Relative', 'L3Absolute'], 'None'),
+    jetCorrections = ('AK4PFchs', JECs, 'None'),
     genJetCollection = cms.InputTag('slimmedGenJets'),
     genParticles     = cms.InputTag('prunedGenParticles'),
     # jet param


### PR DESCRIPTION
I've done careful checks that MiniAOD and PFCHS0 jets in MicroAOD are consistent, to make sure the JEC recipes are applied correctly. As suggested in a helpful discussion with @martinamalberti the data recipe was missing the L2L3Residuals.  This fixes it at the MicroAOD level.  Next I will provide an on-the-fly fix (for which the code already exists) to restore the JECs when running on existing MicroAOD; we can then see if this bugfix improves agreement in the VBF jet eta distribution.