### PR TITLE
turn on new central JEC for Data and require explicit label to be given

### DIFF
--- a/Systematics/plugins/JetSystematicProducer.cc
+++ b/Systematics/plugins/JetSystematicProducer.cc
@@ -31,16 +31,19 @@ namespace flashgg {
         void produce( edm::Event &, const edm::EventSetup & ) override;
         bool correctionsSet_;
         bool doCentralJEC_;
+        string JECLabel_;
     };
 
     JetSystematicProducer::JetSystematicProducer ( const edm::ParameterSet &iConfig ) : ObjectSystematicProducer<flashgg::Jet,int,std::vector>( iConfig ) {
         correctionsSet_ = false;
         doCentralJEC_ = iConfig.getParameter<bool>("DoCentralJEC");
+        JECLabel_ = iConfig.getParameter<string>("JECLabel");
     }
     
     void JetSystematicProducer::produce( edm::Event &iEvent, const edm::EventSetup & iSetup ) {
         if (doCentralJEC_) {
-            const JetCorrector* corrector = JetCorrector::getJetCorrector ("ak4PFCHSL1FastL2L3",iSetup); 
+            // Sal: IIRC, you want "ak4PFCHSL1FastL2L3Residual" for data, "ak4PFCHSL1FastL2L3" for MC
+            const JetCorrector* corrector = JetCorrector::getJetCorrector (JECLabel_,iSetup); 
             for( unsigned int ncorr = 0; ncorr < this->Corrections_.size(); ncorr++ ) {
                 this->Corrections_.at( ncorr )->setJEC(corrector,iEvent,iSetup);
             }

--- a/Systematics/python/flashggJetSystematics_cfi.py
+++ b/Systematics/python/flashggJetSystematics_cfi.py
@@ -28,6 +28,7 @@ def createJetSystematicsForTag(process,jetInputTag):
           cms.EDProducer('FlashggJetSystematicProducer',
                          src = jetInputTag,
                          DoCentralJEC = cms.bool(False),
+                         JECLabel = cms.string("UNDEFINED"),
                          SystMethods2D = cms.VPSet(),
                          SystMethods = cms.VPSet(cms.PSet( MethodName = cms.string("FlashggJetEnergyCorrector"),
                                                            Label = cms.string("JEC"),

--- a/Systematics/test/MicroAODtoWorkspace.py
+++ b/Systematics/test/MicroAODtoWorkspace.py
@@ -95,9 +95,22 @@ elif customize.processId == "Data":
             newvpset += [pset]
     process.flashggDiPhotonSystematics.SystMethods = newvpset
     systprodlist = [] #[process.flashggMuonSystematics,process.flashggElectronSystematics]
-    systprodlist += [getattr(process,"flashggJetSystematics%i"%i) for i in range(len(UnpackedJetCollectionVInputTag))]
     for systprod in systprodlist:
-        systprod.SystMethods = cms.VPSet() # empty everything
+        systprod.SystMethods = cms.VPSet() # empty everything                                                                                                                                                                                                      
+    jetsystprodlist = [getattr(process,"flashggJetSystematics%i"%i) for i in range(len(UnpackedJetCollectionVInputTag))]
+    for systprod in jetsystprodlist:
+        # For any MicroAOD up to 1_3_0 the JEC in Data MicroAOD were bugged and this line makes sure they are fixed
+        # It should be a noop in cases where they are already correct
+        newvpset = cms.VPSet()
+        for pset in systprod.SystMethods:
+            if pset.Label.value().count("JEC"):
+                pset.NSigmas = cms.vint32() # Do not perform shifts, central value only                                                                                                                                                                        
+#                pset.Debug = True
+                newvpset += [pset]
+            systprod.SystMethods = newvpset
+        systprod.DoCentralJEC = True
+        systprod.JECLabel = "ak4PFCHSL1FastL2L3Residual"
+        process.load("JetMETCorrections/Configuration/JetCorrectionServices_cff")
 else:
     print "Background MC, so store mgg and central only"
     variablesToUse = minimalNonSignalVariables


### PR DESCRIPTION
Companion at systematics/dumper level to #507; output synchronization confirmed with the other checks.    This turns on JEC central shift in MicroAODtoWorkspace.py and the VBF dumper for data only so that older MicroAOD can be used with the right JEC.  Values automatically obtained from GlobalTag + user-specified string, which is given in the python config.