### PR TITLE
use proper diphoton scale for data in VBF dumper

### DIFF
--- a/Taggers/python/flashggTags_cff.py
+++ b/Taggers/python/flashggTags_cff.py
@@ -16,7 +16,7 @@ flashggUntagged = cms.EDProducer("FlashggUntaggedTagProducer",
                                  SystLabel=cms.string(""),
                                  MVAResultTag=cms.InputTag('flashggDiPhotonMVA'),
                                  GenParticleTag=cms.InputTag( "flashggPrunedGenParticles" ),
-                                 Boundaries=cms.untracked.vdouble(-0.089,0.563,0.798,0.945,1.000)
+                                 Boundaries=cms.vdouble(-0.089,0.563,0.798,0.945,1.000)
 )
 
 flashggTTHHadronicTag = cms.EDProducer("FlashggTTHHadronicTagProducer",


### PR DESCRIPTION
Add the diphoton systematics to VBF dumper, but do central values only; correctly apply the central scale shift for data.

Incidentally switch an UntaggedTagProducer boundary variable to tracked.