### PR TITLE
updated muon scale factors

### DIFF
--- a/Systematics/python/flashggMuonSystematics_cfi.py
+++ b/Systematics/python/flashggMuonSystematics_cfi.py
@@ -3,10 +3,17 @@ import FWCore.ParameterSet.Config as cms
 binInfo = cms.PSet(
 		variables = cms.vstring("pt"),
 		bins = cms.VPSet(
-			cms.PSet(lowBounds = cms.vdouble(1.0), upBounds = cms.vdouble(25.0), values = cms.vdouble(0.8), uncertainties = cms.vdouble(.05,0.3)),
-			cms.PSet(lowBounds = cms.vdouble(25.0), upBounds = cms.vdouble(100.0), values = cms.vdouble(0.9), uncertainties = cms.vdouble(.05,0.3)),
-			cms.PSet(lowBounds = cms.vdouble(100.0), upBounds = cms.vdouble(300.0), values = cms.vdouble(0.95), uncertainties = cms.vdouble(.05,0.3))
-			)
+	                # TightID+LoosePFRelative isolation scale factors : SF = SF(ID)*SF(iso|ID)
+                        # taken from : https://twiki.cern.ch/twiki/bin/view/CMS/MuonReferenceEffsRun2
+                        cms.PSet(lowBounds = cms.vdouble(20.000000), upBounds = cms.vdouble(25.000000), values = cms.vdouble(0.992659), uncertainties = cms.vdouble(0.014311,0.014311)),
+                        cms.PSet(lowBounds = cms.vdouble(25.000000), upBounds = cms.vdouble(30.000000), values = cms.vdouble(0.988595), uncertainties = cms.vdouble(0.014204,0.014204)),
+                        cms.PSet(lowBounds = cms.vdouble(30.000000), upBounds = cms.vdouble(40.000000), values = cms.vdouble(0.988147), uncertainties = cms.vdouble(0.014151,0.014151)),
+                        cms.PSet(lowBounds = cms.vdouble(40.000000), upBounds = cms.vdouble(50.000000), values = cms.vdouble(0.987304), uncertainties = cms.vdouble(0.014859,0.014859)),
+                        cms.PSet(lowBounds = cms.vdouble(50.000000), upBounds = cms.vdouble(60.000000), values = cms.vdouble(0.983446), uncertainties = cms.vdouble(0.014165,0.014165)),
+                        cms.PSet(lowBounds = cms.vdouble(60.000000), upBounds = cms.vdouble(80.000000), values = cms.vdouble(0.987193), uncertainties = cms.vdouble(0.014235,0.014235)),
+                        cms.PSet(lowBounds = cms.vdouble(80.000000), upBounds = cms.vdouble(120.000000), values = cms.vdouble(0.983453), uncertainties = cms.vdouble(0.014742,0.014742)),
+                        cms.PSet(lowBounds = cms.vdouble(120.000000), upBounds = cms.vdouble(9999.000000), values = cms.vdouble(1.003003), uncertainties = cms.vdouble(0.027881,0.027881))
+                        )
 		)	
 
 flashggMuonSystematics = cms.EDProducer('FlashggMuonEffSystematicProducer',
@@ -15,7 +22,7 @@ flashggMuonSystematics = cms.EDProducer('FlashggMuonEffSystematicProducer',
 					SystMethods = cms.VPSet(cms.PSet( MethodName = cms.string("FlashggMuonEffScale"),
 									  Label = cms.string("MuonWeight"),
 									  NSigmas = cms.vint32(-1,1),
-									  OverallRange = cms.string("abs(eta)<1.5"),
+									  OverallRange = cms.string("abs(eta)<2.4"),
 									  BinList = binInfo,
 									  Debug = cms.untracked.bool(False)
                                                                           )


### PR DESCRIPTION
Muon ID+isolation scale factors updated from: https://twiki.cern.ch/twiki/bin/view/CMS/MuonReferenceEffsRun2#Results_for_2015_data