### PR TITLE
switching the tool for lepton efficiency weights so that we no longer…

### DIFF
--- a/Systematics/plugins/ElectronWeight.cc
+++ b/Systematics/plugins/ElectronWeight.cc
@@ -1,0 +1,18 @@
+#include "flashgg/Systematics/interface/ObjectWeight.h"
+
+namespace flashgg {
+
+    typedef ObjectWeight<flashgg::Electron, int> ElectronWeight;
+}
+
+DEFINE_EDM_PLUGIN( FlashggSystematicElectronMethodsFactory,
+                   flashgg::ElectronWeight,
+                   "FlashggElectronWeight" );
+
+// Local Variables:
+// mode:c++
+// indent-tabs-mode:nil
+// tab-width:4
+// c-basic-offset:4
+// End:
+// vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4

--- a/Systematics/plugins/MuonWeight.cc
+++ b/Systematics/plugins/MuonWeight.cc
@@ -1,0 +1,18 @@
+#include "flashgg/Systematics/interface/ObjectWeight.h"
+
+namespace flashgg {
+
+    typedef ObjectWeight<flashgg::Muon, int> MuonWeight;
+}
+
+DEFINE_EDM_PLUGIN( FlashggSystematicMuonMethodsFactory,
+                   flashgg::MuonWeight,
+                   "FlashggMuonWeight" );
+
+// Local Variables:
+// mode:c++
+// indent-tabs-mode:nil
+// tab-width:4
+// c-basic-offset:4
+// End:
+// vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4

--- a/Systematics/python/flashggElectronSystematics_cfi.py
+++ b/Systematics/python/flashggElectronSystematics_cfi.py
@@ -60,7 +60,7 @@ binInfo = cms.PSet(
 flashggElectronSystematics = cms.EDProducer('FlashggElectronEffSystematicProducer',
                                             src = cms.InputTag("flashggSelectedElectrons"),
                                             SystMethods2D = cms.VPSet(),
-                                            SystMethods = cms.VPSet(cms.PSet( MethodName = cms.string("FlashggElectronEffScale"),
+                                            SystMethods = cms.VPSet(cms.PSet( MethodName = cms.string("FlashggElectronWeight"),
                                                                               Label = cms.string("ElectronWeight"),
                                                                               NSigmas = cms.vint32(-1,1),
                                                                               OverallRange = cms.string("abs(eta)<2.5"),

--- a/Systematics/python/flashggMuonSystematics_cfi.py
+++ b/Systematics/python/flashggMuonSystematics_cfi.py
@@ -5,6 +5,7 @@ binInfo = cms.PSet(
 		bins = cms.VPSet(
 	                # TightID+LoosePFRelative isolation scale factors : SF = SF(ID)*SF(iso|ID)
                         # taken from : https://twiki.cern.ch/twiki/bin/view/CMS/MuonReferenceEffsRun2
+                        cms.PSet(lowBounds = cms.vdouble(0.), upBounds = cms.vdouble(20.), values = cms.vdouble(1.), uncertainties = cms.vdouble(0.,0.)), # This bin should never be selected, just here to avoid crashes
                         cms.PSet(lowBounds = cms.vdouble(20.000000), upBounds = cms.vdouble(25.000000), values = cms.vdouble(0.992659), uncertainties = cms.vdouble(0.014311,0.014311)),
                         cms.PSet(lowBounds = cms.vdouble(25.000000), upBounds = cms.vdouble(30.000000), values = cms.vdouble(0.988595), uncertainties = cms.vdouble(0.014204,0.014204)),
                         cms.PSet(lowBounds = cms.vdouble(30.000000), upBounds = cms.vdouble(40.000000), values = cms.vdouble(0.988147), uncertainties = cms.vdouble(0.014151,0.014151)),
@@ -19,7 +20,7 @@ binInfo = cms.PSet(
 flashggMuonSystematics = cms.EDProducer('FlashggMuonEffSystematicProducer',
 					src = cms.InputTag("flashggSelectedMuons"),
 					SystMethods2D = cms.VPSet(),
-					SystMethods = cms.VPSet(cms.PSet( MethodName = cms.string("FlashggMuonEffScale"),
+					SystMethods = cms.VPSet(cms.PSet( MethodName = cms.string("FlashggMuonWeight"),
 									  Label = cms.string("MuonWeight"),
 									  NSigmas = cms.vint32(-1,1),
 									  OverallRange = cms.string("abs(eta)<2.4"),


### PR DESCRIPTION
… have any interpolation

Per discussion in #522.  Created typedefs for weight-scaling modules for Electrons and Muons with simple bin-by-bin lookup and no interpolation. 

Also had to add a meaningless pt < 20 bin to muons to avoid crashes prior to the tag pt cuts.