### PR TITLE
Move some systematics manipulation into common python

### DIFF
--- a/Systematics/interface/BaseSystMethod.h
+++ b/Systematics/interface/BaseSystMethod.h
@@ -22,7 +22,8 @@ namespace flashgg {
             _Name( conf.getParameter<std::string>( "MethodName" ) ),
             _Label( conf.getParameter<std::string>( "Label" ) ),
             _MakesWeight( false ),
-            _RandomEngine( nullptr )
+            _RandomEngine( nullptr ),
+            _ApplyCentralValue( conf.getParameter<bool>( "ApplyCentralValue" ) )
         { }
         BaseSystMethod() {};
         virtual ~BaseSystMethod() {};
@@ -43,6 +44,7 @@ namespace flashgg {
         const std::string &name() const { return _Name; };
         const std::string &label() const { return _Label; };
         bool makesWeight() const { return _MakesWeight; }
+        bool applyCentralValue() const { return _ApplyCentralValue; }
 
         virtual std::string shiftLabel( param_var syst_val ) const = 0;
         virtual void setJECUncertainty ( const JetCorrectorParameters & ) {
@@ -65,7 +67,7 @@ namespace flashgg {
                 throw cms::Exception( "Configuration" ) << "Tried to access BaseSystMethod::RandomEngine() when it is not set";
             }
             return _RandomEngine;
-        }
+        }        
 
     protected:
         void setMakesWeight( bool makes_weight ) { _MakesWeight = makes_weight; }
@@ -75,7 +77,7 @@ namespace flashgg {
         const std::string _Label;
         bool _MakesWeight;
         CLHEP::HepRandomEngine *_RandomEngine;
-
+        bool _ApplyCentralValue;
     };
 }
 

--- a/Systematics/interface/DiPhotonFromPhotonBase.h
+++ b/Systematics/interface/DiPhotonFromPhotonBase.h
@@ -54,6 +54,7 @@ namespace flashgg {
                 conf2.copyFrom(conf,"NSigmas");
                 conf2.copyFrom(conf,"OverallRange");
                 conf2.copyFrom(conf,"Debug");
+                conf2.copyFrom(conf,"ApplyCentralValue");
                 const auto &pset = conf.getParameterSet( "BinList2" );
                 conf2.addParameter<edm::ParameterSet>("BinList", pset);
                 std::string binListName = "BinList";

--- a/Systematics/interface/ObjectEffScale.h
+++ b/Systematics/interface/ObjectEffScale.h
@@ -105,10 +105,13 @@ namespace flashgg {
 
             }
         }
+        if (!this->applyCentralValue()) theWeight = 1.;
         double Weight = theWeight + ( theError * syst_shift );
         //        lep.setWeight( shiftLabel(syst_shift), Weight );
         //std::cout << "Weight " << lep.weight() << std::endl;
         if( this->debug_ ) { std::cout << "  end of ObjectEffScale<flashgg_object, param_var>::makeWeight - returning " << Weight << std::endl; }
+
+        
 
         return Weight;
     }

--- a/Systematics/interface/ObjectWeight.h
+++ b/Systematics/interface/ObjectWeight.h
@@ -61,7 +61,11 @@ namespace flashgg {
             } else {
                 throw cms::Exception("BadConfig") << " We do not recognize the bin format or this object is not in any bin";
             }
-            theWeight = central;
+            if (this->applyCentralValue()) {
+                theWeight = central;
+            } else {
+                theWeight = 1;
+            }
             if ( syst_shift < 0 ) theWeight += syst_shift * errdown;
             if ( syst_shift > 0 ) theWeight += syst_shift * errup;
             if( this->debug_ ) {

--- a/Systematics/plugins/DiPhotonWeightFromFracRV.cc
+++ b/Systematics/plugins/DiPhotonWeightFromFracRV.cc
@@ -59,6 +59,7 @@ namespace flashgg {
 	      }
 	      
 	      float weight = val_err.first[index];
+          if (!applyCentralValue()) weight = 1.;
 	      float eUp, eDown;
 	      if(val_err.second.size() == 4){
 		eUp= val_err.second[index*2];

--- a/Systematics/plugins/JetEnergyCorrector.cc
+++ b/Systematics/plugins/JetEnergyCorrector.cc
@@ -65,7 +65,7 @@ namespace flashgg {
     {
         if( overall_range_( y ) ) {
             double jec_adjust = 1.;
-            if (jec_set_) {
+            if (jec_set_ && applyCentralValue()) {
                 double jec = jec_cor_->correction( y.correctedJet("Uncorrected") , *evt_, *evt_setup_ );
                 double oldjec = (y.energy()/y.correctedJet("Uncorrected").energy());
                 if ( debug_ ) {

--- a/Systematics/plugins/JetSmearConstant.cc
+++ b/Systematics/plugins/JetSmearConstant.cc
@@ -51,6 +51,7 @@ namespace flashgg {
             auto val_err = binContents( y );
             if( val_err.first.size() == 1 && val_err.second.size() == 1 ) { // otherwise no-op because we don't have an entry
                 float scale_factor_central = val_err.first[0];
+                if(!applyCentralValue()) scale_factor_central = 1.;
                 float scale_factor_err = val_err.second[0];
                 float scale_factor = scale_factor_central + syst_shift * scale_factor_err;
                 float recpt = y.pt();

--- a/Systematics/plugins/PhotonMvaShift.cc
+++ b/Systematics/plugins/PhotonMvaShift.cc
@@ -45,6 +45,7 @@ namespace flashgg {
             auto val_err = binContents( y );
             if( val_err.first.size() == 1 && val_err.second.size() == 1 ) { // otherwise no-op because we don't have an entry
                 float shift_val = val_err.first[0];  // e.g. 0 if no central value change
+                if (!applyCentralValue()) shift_val = 0.;
                 float shift_err = val_err.second[0]; // e.g. 0.1
                 float shift = shift_val + syst_shift * shift_err;
                 std::vector<edm::Ptr<reco::Vertex> > keys;

--- a/Systematics/plugins/PhotonScale.cc
+++ b/Systematics/plugins/PhotonScale.cc
@@ -18,13 +18,11 @@ namespace flashgg {
 
     private:
         selector_type overall_range_;
-        bool no_central_shift_;
     };
 
     PhotonScale::PhotonScale( const edm::ParameterSet &conf ) :
         ObjectSystMethodBinnedByFunctor( conf ),
-        overall_range_( conf.getParameter<std::string>( "OverallRange" ) ),
-        no_central_shift_( conf.getParameter<bool>( "NoCentralShift" ) )
+        overall_range_( conf.getParameter<std::string>( "OverallRange" ) )
     {
     }
 
@@ -47,7 +45,7 @@ namespace flashgg {
             auto val_err = binContents( y );
             if( val_err.first.size() == 1 && val_err.second.size() == 1 ) { // otherwise no-op because we don't have an entry
                 float shift_val = val_err.first[0];
-                if (no_central_shift_) shift_val = 0.;
+                if (!applyCentralValue()) shift_val = 0.;
                 float shift_err = val_err.second[0];
                 float scale = 1 + shift_val + syst_shift * shift_err;
                 if( debug_ ) {

--- a/Systematics/plugins/PhotonSigEoverEShift.cc
+++ b/Systematics/plugins/PhotonSigEoverEShift.cc
@@ -45,6 +45,7 @@ namespace flashgg {
             auto val_err = binContents( y );
             if( val_err.first.size() == 1 && val_err.second.size() == 1 ) { // otherwise no-op because we don't have an entry
                 float shift_val = val_err.first[0];  // e.g. 0 if no central value change
+                if (!applyCentralValue()) shift_val = 0.;
                 float shift_err = val_err.second[0]; // e.g. 0.1
                 float shift = shift_val + syst_shift * shift_err;
                 //              std::vector<edm::Ptr<reco::Vertex> > keys;

--- a/Systematics/plugins/PhotonSigEoverESmearing.cc
+++ b/Systematics/plugins/PhotonSigEoverESmearing.cc
@@ -24,6 +24,7 @@ namespace flashgg {
         ObjectSystMethodBinnedByFunctor( conf ),
         overall_range_( conf.getParameter<std::string>( "OverallRange" ) )
     {
+        if (!applyCentralValue()) throw cms::Exception("SmearingLogic") << "If we do not apply central smearing we cannot scale down the smearing";
     }
 
     std::string PhotonSigEoverESmearing::shiftLabel( int syst_value ) const

--- a/Systematics/plugins/PhotonSmearConstant.cc
+++ b/Systematics/plugins/PhotonSmearConstant.cc
@@ -32,6 +32,7 @@ namespace flashgg {
         exaggerateShiftUp_( conf.getParameter<bool>( "ExaggerateShiftUp" ) )
 
     {
+        if (!applyCentralValue()) throw cms::Exception("SmearingLogic") << "If we do not apply central smearing we cannot scale down the smearing";
     }
 
     std::string PhotonSmearConstant::shiftLabel( int syst_value ) const

--- a/Systematics/plugins/PhotonSmearStochastic.cc
+++ b/Systematics/plugins/PhotonSmearStochastic.cc
@@ -38,6 +38,7 @@ namespace flashgg {
         random_label_(conf.getParameter<std::string>("RandomLabel")),
         exaggerateShiftUp_( conf.getParameter<bool>( "ExaggerateShiftUp" ) ) // default: false
     {
+        if (!applyCentralValue()) throw cms::Exception("SmearingLogic") << "If we do not apply central smearing we cannot scale down the smearing";
     }
 
     std::string PhotonSmearStochastic::shiftLabel( std::pair<int, int> syst_value ) const

--- a/Systematics/python/SystematicsCustomize.py
+++ b/Systematics/python/SystematicsCustomize.py
@@ -78,7 +78,7 @@ def customizeLeptonSystematicsForData(process):
         systprod.SystMethods = cms.VPSet() # empty everything
 
 def customizeJetSystematicsForData(process):
-    # By default remote the systematic entirely
+    # By default remove the systematic entirely
     # For JEC, re-do central value in case the global tag has been updated
 
     from flashgg.Taggers.flashggTags_cff import UnpackedJetCollectionVInputTag
@@ -91,7 +91,7 @@ def customizeJetSystematicsForData(process):
             if pset.Label.value().count("JEC"):
                 pset.NSigmas = cms.vint32() # Do not perform shifts, central value only                                                                                            
                 newvpset += [pset]
-            systprod.SystMethods = newvpset
+        systprod.SystMethods = newvpset
         systprod.DoCentralJEC = True
         systprod.JECLabel = "ak4PFCHSL1FastL2L3Residual"
         process.load("JetMETCorrections/Configuration/JetCorrectionServices_cff")

--- a/Systematics/python/SystematicsCustomize.py
+++ b/Systematics/python/SystematicsCustomize.py
@@ -1,5 +1,36 @@
 import FWCore.ParameterSet.Config as cms
 
+def printSystematicInfo(process):
+    vpsetlist = [process.flashggDiPhotonSystematics.SystMethods, process.flashggMuonSystematics.SystMethods, process.flashggElectronSystematics.SystMethods]
+#    from flashgg.Taggers.flashggTags_cff import UnpackedJetCollectionVInputTag
+#    vpsetlist += [getattr(process,"flashggJetSystematics%i"%i).SystMethods for i in range(len(UnpackedJetCollectionVInputTag))]
+    vpsetlist += [process.flashggJetSystematics0.SystMethods]
+    print (14*"-"+" DUMPING SYSTEMATIC OVERVIEW "+14*"-")
+    print "%20s %15s %20s" % ("Systematic","Central value?","Systematic shifts?")
+    print 57*"-"
+    for vpset in vpsetlist:
+        for pset in vpset:
+#            if detailed:
+#               if hasattr(pset,"PhotonMethodName"):
+#                    print pset.PhotonMethodName.value(),pset.Label.value(),pset.OverallRange.value(),
+#                else:    
+#                    print pset.MethodName.value(),pset.Label.value(),pset.OverallRange.value(),
+            syst = pset.Label.value()
+            if pset.ApplyCentralValue.value():
+                cv = "YES"
+            else:
+                cv = "NO"
+            sigmalist = pset.NSigmas.value()    
+            sig = ""
+            if len(sigmalist) > 0:
+                for val in sigmalist:
+                    sig += "%i " % val
+            else:    
+                sig += "NO"
+            print "%20s %15s %20s" % (syst,cv,sig)
+        print 57*"-"
+
+
 def createStandardSystematicsProducers(process):
     process.load("flashgg/Taggers/flashggTagSequence_cfi")
     process.load("flashgg.Systematics.flashggDiPhotonSystematics_cfi")
@@ -65,7 +96,7 @@ def customizePhotonSystematicsForData(process):
     newvpset = cms.VPSet()
     for pset in process.flashggDiPhotonSystematics.SystMethods:
         if pset.Label.value().count("Scale"):
-            pset.NoCentralShift = cms.bool(False) # Turn on central shift for data (it is off for MC)
+            pset.ApplyCentralValue = cms.bool(True) # Turn on central shift for data (it is off for MC)
             pset.NSigmas = cms.vint32() # Do not perform shift
             newvpset += [pset]
     process.flashggDiPhotonSystematics.SystMethods = newvpset

--- a/Systematics/python/SystematicsCustomize.py
+++ b/Systematics/python/SystematicsCustomize.py
@@ -1,0 +1,99 @@
+import FWCore.ParameterSet.Config as cms
+
+def createStandardSystematicsProducers(process):
+    process.load("flashgg/Taggers/flashggTagSequence_cfi")
+    process.load("flashgg.Systematics.flashggDiPhotonSystematics_cfi")
+    process.load("flashgg.Systematics.flashggMuonSystematics_cfi")
+    process.load("flashgg.Systematics.flashggElectronSystematics_cfi")
+
+    from flashgg.Taggers.flashggTags_cff import UnpackedJetCollectionVInputTag
+    from flashgg.Systematics.flashggJetSystematics_cfi import createJetSystematics
+    jetSystematicsInputTags = createJetSystematics(process,UnpackedJetCollectionVInputTag)
+    return jetSystematicsInputTags
+
+def modifyTagSequenceForSystematics(process,jetSystematicsInputTags):
+    process.flashggTagSequence.remove(process.flashggUnpackedJets) # to avoid unnecessary cloning
+    from PhysicsTools.PatAlgos.tools.helpers import cloneProcessingSnippet,massSearchReplaceAnyInputTag
+    massSearchReplaceAnyInputTag(process.flashggTagSequence,cms.InputTag("flashggDiPhotons"),cms.InputTag("flashggDiPhotonSystematics"))
+    massSearchReplaceAnyInputTag(process.flashggTagSequence,cms.InputTag("flashggSelectedElectrons"),cms.InputTag("flashggElectronSystematics"))
+    massSearchReplaceAnyInputTag(process.flashggTagSequence,cms.InputTag("flashggSelectedMuons"),cms.InputTag("flashggMuonSystematics"))
+    from flashgg.Taggers.flashggTags_cff import UnpackedJetCollectionVInputTag
+    for i in range(len(jetSystematicsInputTags)):
+        massSearchReplaceAnyInputTag(process.flashggTagSequence,UnpackedJetCollectionVInputTag[i],jetSystematicsInputTags[i])
+
+    process.flashggSystTagMerger = cms.EDProducer("TagMerger",src=cms.VInputTag("flashggTagSorter"))
+    process.systematicsTagSequences = cms.Sequence()
+
+def cloneTagSequenceForEachSystematic(process,systlabels,phosystlabels,jetsystlabels,jetSystematicsInputTags):
+    for systlabel in systlabels:
+        if systlabel == "":
+            continue
+        from PhysicsTools.PatAlgos.tools.helpers import cloneProcessingSnippet,massSearchReplaceAnyInputTag
+        newseq = cloneProcessingSnippet(process,process.flashggTagSequence,systlabel)
+        if systlabel in phosystlabels:
+            massSearchReplaceAnyInputTag(newseq,cms.InputTag("flashggDiPhotonSystematics"),cms.InputTag("flashggDiPhotonSystematics",systlabel))
+        if systlabel in jetsystlabels:
+            for i in range(len(jetSystematicsInputTags)):
+                massSearchReplaceAnyInputTag(newseq,jetSystematicsInputTags[i],cms.InputTag(jetSystematicsInputTags[i].moduleLabel,systlabel))
+        for name in newseq.moduleNames():
+            module = getattr(process,name)
+            if hasattr(module,"SystLabel"):
+                module.SystLabel = systlabel
+        process.systematicsTagSequences += newseq
+        process.flashggSystTagMerger.src.append(cms.InputTag("flashggTagSorter" + systlabel))
+
+def customizeSystematicsForBackground(process):
+    # Keep default MC central value behavior, remove all up/down shifts
+
+    from flashgg.Taggers.flashggTags_cff import UnpackedJetCollectionVInputTag
+    vpsetlist = [process.flashggDiPhotonSystematics.SystMethods, process.flashggMuonSystematics.SystMethods, process.flashggElectronSystematics.SystMethods]
+    vpsetlist += [getattr(process,"flashggJetSystematics%i"%i).SystMethods for i in range(len(UnpackedJetCollectionVInputTag))]
+    for vpset in vpsetlist:
+        for pset in vpset:
+            pset.NSigmas = cms.vint32()
+
+def customizeSystematicsForData(process):
+    customizePhotonSystematicsForData(process)
+    customizeLeptonSystematicsForData(process)
+    customizeJetSystematicsForData(process)
+
+def customizePhotonSystematicsForData(process):
+    # By default remove the systematic entirely (central value and shifts)
+    # For scale: put in central value, but omit shifts
+    # TODO: this is wrong for sigE/E and possibly others - check!
+
+    newvpset = cms.VPSet()
+    for pset in process.flashggDiPhotonSystematics.SystMethods:
+        if pset.Label.value().count("Scale"):
+            pset.NoCentralShift = cms.bool(False) # Turn on central shift for data (it is off for MC)
+            pset.NSigmas = cms.vint32() # Do not perform shift
+            newvpset += [pset]
+    process.flashggDiPhotonSystematics.SystMethods = newvpset
+
+def customizeLeptonSystematicsForData(process):
+    # Remove systematics entirely
+
+    systprodlist = [process.flashggMuonSystematics,process.flashggElectronSystematics]
+    for systprod in systprodlist:
+        systprod.SystMethods = cms.VPSet() # empty everything
+
+def customizeJetSystematicsForData(process):
+    # By default remote the systematic entirely
+    # For JEC, re-do central value in case the global tag has been updated
+
+    from flashgg.Taggers.flashggTags_cff import UnpackedJetCollectionVInputTag
+    jetsystprodlist = [getattr(process,"flashggJetSystematics%i"%i) for i in range(len(UnpackedJetCollectionVInputTag))]
+    for systprod in jetsystprodlist:
+        # For updating bugged or unavailable JEC
+        # It should be a noop in cases where they are already correct
+        newvpset = cms.VPSet()
+        for pset in systprod.SystMethods:
+            if pset.Label.value().count("JEC"):
+                pset.NSigmas = cms.vint32() # Do not perform shifts, central value only                                                                                            
+                newvpset += [pset]
+            systprod.SystMethods = newvpset
+        systprod.DoCentralJEC = True
+        systprod.JECLabel = "ak4PFCHSL1FastL2L3Residual"
+        process.load("JetMETCorrections/Configuration/JetCorrectionServices_cff")
+
+

--- a/Systematics/python/flashggDiPhotonSystematics_cfi.py
+++ b/Systematics/python/flashggDiPhotonSystematics_cfi.py
@@ -263,14 +263,14 @@ flashggDiPhotonSystematics = cms.EDProducer('FlashggDiPhotonSystematicProducer',
                 # the number of syst methods matches the number of nuisance parameters
                 # assumed for a given systematic uncertainty and is NOT required
                 # to match 1-to-1 the number of bins above.
-		SystMethods = cms.VPSet(
+                SystMethods = cms.VPSet(
                                         cms.PSet( PhotonMethodName = cms.string("FlashggPhotonScale"),
                                                   MethodName = cms.string("FlashggDiPhotonFromPhoton"),
                                                   Label = cms.string("MCScaleHighR9EB"),
                                                   NSigmas = cms.vint32(-1,1),
                                                   OverallRange = cms.string("r9>0.94&&abs(superCluster.eta)<1.5"),
                                                   BinList = scaleBinsRereco,
-                                                  NoCentralShift = cms.bool(True),
+                                                  ApplyCentralValue = cms.bool(False),
                                                   Debug = cms.untracked.bool(False)
                                                   ),
                                         cms.PSet( PhotonMethodName = cms.string("FlashggPhotonScale"),
@@ -279,7 +279,7 @@ flashggDiPhotonSystematics = cms.EDProducer('FlashggDiPhotonSystematicProducer',
                                                   NSigmas = cms.vint32(-1,1),
                                                   OverallRange = cms.string("r9<0.94&&abs(superCluster.eta)<1.5"),
                                                   BinList = scaleBinsRereco,
-                                                  NoCentralShift = cms.bool(True),
+                                                  ApplyCentralValue = cms.bool(False),
                                                   Debug = cms.untracked.bool(False)
                                                   ),
                                         cms.PSet( PhotonMethodName = cms.string("FlashggPhotonScale"),
@@ -288,7 +288,7 @@ flashggDiPhotonSystematics = cms.EDProducer('FlashggDiPhotonSystematicProducer',
                                                   NSigmas = cms.vint32(-1,1),
                                                   OverallRange = cms.string("r9>0.94&&abs(superCluster.eta)>=1.5"),
                                                   BinList = scaleBinsRereco,
-                                                  NoCentralShift = cms.bool(True),
+                                                  ApplyCentralValue = cms.bool(False),
                                                   Debug = cms.untracked.bool(False)
                                                   ),
                                         cms.PSet( PhotonMethodName = cms.string("FlashggPhotonScale"),
@@ -297,7 +297,7 @@ flashggDiPhotonSystematics = cms.EDProducer('FlashggDiPhotonSystematicProducer',
                                                   NSigmas = cms.vint32(-1,1),
                                                   OverallRange = cms.string("r9<0.94&&abs(superCluster.eta)>=1.5"),
                                                   BinList = scaleBinsRereco,
-                                                  NoCentralShift = cms.bool(True),
+                                                  ApplyCentralValue = cms.bool(False),
                                                   Debug = cms.untracked.bool(False)
                                                   ),
                                         cms.PSet( PhotonMethodName = cms.string("FlashggPhotonSmearConstant"),
@@ -312,6 +312,7 @@ flashggDiPhotonSystematics = cms.EDProducer('FlashggDiPhotonSystematicProducer',
                                                   RandomLabel = cms.string("rnd_g_E"),
                                                   Debug = cms.untracked.bool(False),
                                                   ExaggerateShiftUp = cms.bool(False),
+                                                  ApplyCentralValue = cms.bool(True)
                                                   ),
                                         cms.PSet( PhotonMethodName = cms.string("FlashggPhotonSmearConstant"),
                                                   MethodName = cms.string("FlashggDiPhotonFromPhoton"),
@@ -325,6 +326,7 @@ flashggDiPhotonSystematics = cms.EDProducer('FlashggDiPhotonSystematicProducer',
                                                   RandomLabel = cms.string("rnd_g_E"),
                                                   Debug = cms.untracked.bool(False),
                                                   ExaggerateShiftUp = cms.bool(False),
+                                                  ApplyCentralValue = cms.bool(True)
                                                   ),
                                         cms.PSet( PhotonMethodName = cms.string("FlashggPhotonSmearConstant"),
                                                   MethodName = cms.string("FlashggDiPhotonFromPhoton"),
@@ -338,6 +340,7 @@ flashggDiPhotonSystematics = cms.EDProducer('FlashggDiPhotonSystematicProducer',
                                                   RandomLabel = cms.string("rnd_g_E"),
                                                   Debug = cms.untracked.bool(False),
                                                   ExaggerateShiftUp = cms.bool(False),
+                                                  ApplyCentralValue = cms.bool(True)
                                                   ),
                                         cms.PSet( PhotonMethodName = cms.string("FlashggPhotonSmearConstant"),
                                                   MethodName = cms.string("FlashggDiPhotonFromPhoton"),
@@ -351,6 +354,7 @@ flashggDiPhotonSystematics = cms.EDProducer('FlashggDiPhotonSystematicProducer',
                                                   RandomLabel = cms.string("rnd_g_E"),
                                                   Debug = cms.untracked.bool(False),
                                                   ExaggerateShiftUp = cms.bool(False),
+                                                  ApplyCentralValue = cms.bool(True)
                                                   ),
                                         cms.PSet( PhotonMethodName = cms.string("FlashggPhotonMvaShift"),
                                                   MethodName = cms.string("FlashggDiPhotonFromPhoton"),
@@ -358,7 +362,8 @@ flashggDiPhotonSystematics = cms.EDProducer('FlashggDiPhotonSystematicProducer',
                                                   NSigmas = cms.vint32(-1,1),
                                                   OverallRange = cms.string("1"),
                                                   BinList = mvaShiftBins,
-                                                  Debug = cms.untracked.bool(False)
+                                                  Debug = cms.untracked.bool(False),
+                                                  ApplyCentralValue = cms.bool(True)
                                                   ),
                                         cms.PSet( PhotonMethodName = cms.string("FlashggPhotonWeight"),
                                                   MethodName = cms.string("FlashggDiPhotonFromPhoton"),
@@ -366,7 +371,8 @@ flashggDiPhotonSystematics = cms.EDProducer('FlashggDiPhotonSystematicProducer',
                                                   NSigmas = cms.vint32(-1,1),
                                                   OverallRange = cms.string("1"),
                                                   BinList = preselBins,
-                                                  Debug = cms.untracked.bool(False)
+                                                  Debug = cms.untracked.bool(False),
+                                                  ApplyCentralValue = cms.bool(True)
                                                   ),
                                         cms.PSet( PhotonMethodName = cms.string("FlashggPhotonWeight"),
                                                   MethodName = cms.string("FlashggDiPhotonFromPhoton"),
@@ -375,7 +381,8 @@ flashggDiPhotonSystematics = cms.EDProducer('FlashggDiPhotonSystematicProducer',
                                                   OverallRange = cms.string("1"),
                                                   BinList = leadTriggerScaleBins,
                                                   BinList2 = subleadTriggerScaleBins,
-                                                  Debug = cms.untracked.bool(False)
+                                                  Debug = cms.untracked.bool(False),
+                                                  ApplyCentralValue = cms.bool(True)
                                                   ),
                                         cms.PSet( PhotonMethodName = cms.string("FlashggPhotonWeight"),
                                                   MethodName = cms.string("FlashggDiPhotonFromPhoton"),
@@ -383,7 +390,8 @@ flashggDiPhotonSystematics = cms.EDProducer('FlashggDiPhotonSystematicProducer',
                                                   NSigmas = cms.vint32(-1,1),
                                                   OverallRange = cms.string("1"),
                                                   BinList = looseMvaBins,
-                                                  Debug = cms.untracked.bool(False)
+                                                  Debug = cms.untracked.bool(False),
+                                                  ApplyCentralValue = cms.bool(True)
                                                   ),
                                         cms.PSet( PhotonMethodName = cms.string("FlashggPhotonSigEOverEShift"),
                                                   MethodName = cms.string("FlashggDiPhotonFromPhoton"),
@@ -391,7 +399,8 @@ flashggDiPhotonSystematics = cms.EDProducer('FlashggDiPhotonSystematicProducer',
                                                   NSigmas = cms.vint32(-1,1),
                                                   OverallRange = cms.string("1"),
                                                   BinList = sigmaEOverEShiftBins,
-                                                  Debug = cms.untracked.bool(False)
+                                                  Debug = cms.untracked.bool(False),
+                                                  ApplyCentralValue = cms.bool(True)
                                                   ),
                                         cms.PSet( PhotonMethodName = cms.string("FlashggPhotonSigEoverESmearing"),
                                                   MethodName = cms.string("FlashggDiPhotonFromPhoton"),
@@ -399,14 +408,16 @@ flashggDiPhotonSystematics = cms.EDProducer('FlashggDiPhotonSystematicProducer',
                                                   NSigmas = cms.vint32(0,0),
                                                   OverallRange = cms.string("1"),
                                                   BinList = smearBinsRereco,
-                                                  Debug = cms.untracked.bool(False)
+                                                  Debug = cms.untracked.bool(False),
+                                                  ApplyCentralValue = cms.bool(True)
                                                   ),
                                         cms.PSet( MethodName = cms.string("FlashggDiPhotonWeightFromFracRV"),
                                                   Label = cms.string("FracRVWeight"),
                                                   NSigmas = cms.vint32(-1,1),
                                                   OverallRange = cms.string("1"),
                                                   BinList = RVBins,
-                                                  Debug = cms.untracked.bool(False)
+                                                  Debug = cms.untracked.bool(False),
+                                                  ApplyCentralValue = cms.bool(True)
                                                   )
                                         )
                                             )

--- a/Systematics/python/flashggElectronSystematics_cfi.py
+++ b/Systematics/python/flashggElectronSystematics_cfi.py
@@ -65,7 +65,8 @@ flashggElectronSystematics = cms.EDProducer('FlashggElectronEffSystematicProduce
                                                                               NSigmas = cms.vint32(-1,1),
                                                                               OverallRange = cms.string("abs(eta)<2.5"),
                                                                               BinList = binInfo,
-                                                                              Debug = cms.untracked.bool(False)
+                                                                              Debug = cms.untracked.bool(False),
+                                                                              ApplyCentralValue = cms.bool(True)
                                                                               )	
                                                                     )
                                             )

--- a/Systematics/python/flashggJetSystematics_cfi.py
+++ b/Systematics/python/flashggJetSystematics_cfi.py
@@ -34,7 +34,8 @@ def createJetSystematicsForTag(process,jetInputTag):
                                                            Label = cms.string("JEC"),
                                                            NSigmas = cms.vint32(-1,1),
                                                            OverallRange = cms.string("abs(eta)<5.0"),
-                                                           Debug = cms.untracked.bool(False)
+                                                           Debug = cms.untracked.bool(False),
+                                                           ApplyCentralValue = cms.bool(True)
                                                            ),
                                                  cms.PSet( MethodName = cms.string("FlashggJetSmearConstant"),
                                                            Label = cms.string("JER"),
@@ -43,6 +44,7 @@ def createJetSystematicsForTag(process,jetInputTag):
                                                            RandomLabel = cms.string("rnd_g_JER"), # for no-match case
                                                            BinList = smearBins,
                                                            Debug = cms.untracked.bool(False),
+                                                           ApplyCentralValue = cms.bool(True)
                                                            )
                                                  )
                          

--- a/Systematics/python/flashggMuonSystematics_cfi.py
+++ b/Systematics/python/flashggMuonSystematics_cfi.py
@@ -25,7 +25,8 @@ flashggMuonSystematics = cms.EDProducer('FlashggMuonEffSystematicProducer',
 									  NSigmas = cms.vint32(-1,1),
 									  OverallRange = cms.string("abs(eta)<2.4"),
 									  BinList = binInfo,
-									  Debug = cms.untracked.bool(False)
+									  Debug = cms.untracked.bool(False),
+                                                                          ApplyCentralValue = cms.bool(True)
                                                                           )
 								)
                                         )

--- a/Systematics/test/workspaceStd.py
+++ b/Systematics/test/workspaceStd.py
@@ -1,0 +1,232 @@
+#!/usr/bin/env cmsRun
+
+import FWCore.ParameterSet.Config as cms
+import FWCore.Utilities.FileUtils as FileUtils
+from flashgg.Systematics.SystematicDumperDefaultVariables import minimalVariables,minimalHistograms,minimalNonSignalVariables,systematicVariables
+
+# SYSTEMATICS SECTION
+
+process = cms.Process("FLASHggSyst")
+
+process.load("FWCore.MessageService.MessageLogger_cfi")
+
+process.load("Configuration.StandardSequences.GeometryDB_cff")
+process.load("Configuration.StandardSequences.MagneticField_cff")
+process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_condDBv2_cff")
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag.globaltag = '74X_mcRun2_asymptotic_v4' # keep updated for JEC
+process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(100) )
+process.MessageLogger.cerr.FwkReport.reportEvery = cms.untracked.int32( 1000 )
+
+from flashgg.Systematics.SystematicsCustomize import *
+jetSystematicsInputTags = createStandardSystematicsProducers(process)
+modifyTagSequenceForSystematics(process,jetSystematicsInputTags)
+
+systlabels = [""]
+phosystlabels = []
+jetsystlabels = []
+elesystlabels = []
+musystlabels = []
+
+# import flashgg customization to check if we have signal or background
+from flashgg.MetaData.JobConfig import customize
+customize.parse()
+print "customize.processId:",customize.processId
+# Only run systematics for signal events
+if customize.processId.count("h_") or customize.processId.count("vbf_"): # convention: ggh vbf wzh (wh zh) tth
+    print "Signal MC, so adding systematics and dZ"
+    variablesToUse = minimalVariables
+    for direction in ["Up","Down"]:
+        phosystlabels.append("MvaShift%s01sigma" % direction)
+        phosystlabels.append("SigmaEOverEShift%s01sigma" % direction)
+        jetsystlabels.append("JEC%s01sigma" % direction)
+        jetsystlabels.append("JER%s01sigma" % direction)
+        variablesToUse.append("LooseMvaSF%s01sigma[1,-999999.,999999.] := weight(\"LooseMvaSF%s01sigma\")" % (direction,direction))
+        variablesToUse.append("PreselSF%s01sigma[1,-999999.,999999.] := weight(\"PreselSF%s01sigma\")" % (direction,direction))
+        variablesToUse.append("TriggerWeight%s01sigma[1,-999999.,999999.] := weight(\"TriggerWeight%s01sigma\")" % (direction,direction))
+        variablesToUse.append("FracRVWeight%s01sigma[1,-999999.,999999.] := weight(\"FracRVWeight%s01sigma\")" % (direction,direction))
+        variablesToUse.append("ElectronWeight%s01sigma[1,-999999.,999999.] := weight(\"ElectronWeight%s01sigma\")" % (direction,direction))
+        variablesToUse.append("MuonWeight%s01sigma[1,-999999.,999999.] := weight(\"MuonWeight%s01sigma\")" % (direction,direction))
+        for r9 in ["HighR9","LowR9"]:
+            for region in ["EB","EE"]:
+                phosystlabels.append("MCSmear%s%s%s01sigma" % (r9,region,direction))
+                phosystlabels.append("MCScale%s%s%s01sigma" % (r9,region,direction))
+    systlabels += phosystlabels
+    systlabels += jetsystlabels
+elif customize.processId == "Data":
+    print "Data, so turn of all shifts and systematics, with some exceptions"
+    variablesToUse = minimalNonSignalVariables
+    customizeSystematicsForData(process)
+else:
+    print "Background MC, so store mgg and central only"
+    variablesToUse = minimalNonSignalVariables
+    customizeSystematicsForBackground(process)
+
+print "--- Systematics  with independent collections ---"
+print systlabels
+print "-------------------------------------------------"
+print "--- Variables to be dumped, including systematic weights ---"
+print variablesToUse
+print "------------------------------------------------------------"
+
+cloneTagSequenceForEachSystematic(process,systlabels,phosystlabels,jetsystlabels,jetSystematicsInputTags)
+
+###### Dumper section
+
+from FWCore.ParameterSet.VarParsing import VarParsing
+from flashgg.MetaData.samples_utils import SamplesManager
+
+process.source = cms.Source ("PoolSource",
+                             fileNames = cms.untracked.vstring(
+        #                             "file:myMicroAODOutputFile.root"
+        #        "root://eoscms.cern.ch//eos/cms/store/group/phys_higgs/cmshgg/sethzenz/flashgg/RunIISpring15-ReMiniAOD-1_1_0-25ns/1_1_0/VBFHToGG_M-125_13TeV_powheg_pythia8/RunIISpring15-ReMiniAOD-1_1_0-25ns-1_1_0-v0-RunIISpring15MiniAODv2-74X_mcRun2_asymptotic_v2-v1/160105_224017/0000/myMicroAODOutputFile_1.root"
+        "/store/group/phys_higgs/cmshgg/szenz/flashgg/RunIISpring15-ReReco74X-Rerun-1_1_0-25ns/1_2_0/DoubleEG/RunIISpring15-ReReco74X-Rerun-1_1_0-25ns-1_2_0-v0-Run2015D-04Dec2015-v2/160117_214114/0000/myMicroAODOutputFile_10.root"
+#        "root://eoscms.cern.ch//eos/cms/store/group/phys_higgs/cmshgg/sethzenz/flashgg/RunIISpring15-ReMiniAOD-1_1_0-25ns/1_1_0/ttHJetToGG_M125_13TeV_amcatnloFXFX_madspin_pythia8/RunIISpring15-ReMiniAOD-1_1_0-25ns-1_1_0-v0-RunIISpring15MiniAODv2-74X_mcRun2_asymptotic_v2-v1/160105_224456/0000/myMicroAODOutputFile_2.root"
+        #"root://eoscms.cern.ch//eos/cms//store/group/phys_higgs/cmshgg/sethzenz/flashgg/RunIISpring15-ReMiniAOD-1_1_0-25ns/1_1_0/VHToGG_M120_13TeV_amcatnloFXFX_madspin_pythia8/RunIISpring15-ReMiniAOD-1_1_0-25ns-1_1_0-v0-RunIISpring15MiniAODv2-74X_mcRun2_asymptotic_v2-v1/160105_224138/0000/myMicroAODOutputFile_1.root"
+        ))
+
+process.TFileService = cms.Service("TFileService",
+                                   fileName = cms.string("test.root"))
+
+process.extraDumpers = cms.Sequence()
+process.load("flashgg.Taggers.diphotonTagDumper_cfi") ##  import diphotonTagDumper 
+import flashgg.Taggers.dumperConfigTools as cfgTools
+
+process.tagsDumper.className = "DiPhotonTagDumper"
+process.tagsDumper.src = "flashggSystTagMerger"
+#process.tagsDumper.src = "flashggTagSystematics"
+process.tagsDumper.processId = "test"
+process.tagsDumper.dumpTrees = False
+process.tagsDumper.dumpWorkspace = True
+process.tagsDumper.dumpHistos = False
+process.tagsDumper.quietRooFit = True
+process.tagsDumper.nameTemplate = cms.untracked.string("$PROCESS_$SQRTS_$CLASSNAME_$SUBCAT_$LABEL")
+
+tagList=[
+["UntaggedTag",4],
+["VBFTag",2],
+#["VHTightTag",0],
+#["VHLooseTag",0],
+#["VHEtTag",0],
+#["VHHadronicTag",0],
+["TTHHadronicTag",0],
+["TTHLeptonicTag",0]
+]
+
+definedSysts=set()
+process.tagsDumper.classifierCfg.remap=cms.untracked.VPSet()
+for tag in tagList: 
+  tagName=tag[0]
+  tagCats=tag[1]
+  # remap return value of class-based classifier
+  process.tagsDumper.classifierCfg.remap.append( cms.untracked.PSet( src=cms.untracked.string("flashgg%s"%tagName), dst=cms.untracked.string(tagName) ) )
+  for systlabel in systlabels:
+      if not systlabel in definedSysts:
+          # the cut corresponding to the systematics can be defined just once
+          cutstring = "hasSyst(\"%s\") "%(systlabel)
+          definedSysts.add(systlabel)
+      else:
+          cutstring = None
+      if systlabel == "":
+          currentVariables = variablesToUse
+      else:
+          currentVariables = systematicVariables
+      
+      isBinnedOnly = (systlabel !=  "")
+      if customize.processId.count("h_") or customize.processId.count("vbf_") and (systlabel ==  ""):
+          print "Signal MC central value, so dumping PDF weights"
+          dumpPdfWeights = True
+          nPdfWeights = 60
+          nAlphaSWeights = 2
+          nScaleWeights = 9
+      else:
+          print "Data, background MC, or non-central value: no PDF weights"
+          dumpPdfWeights = False
+          nPdfWeights = -1
+          nAlphaSWeights = -1
+          nScaleWeights = -1
+      
+      cfgTools.addCategory(process.tagsDumper,
+                           systlabel,
+                           classname=tagName,
+                           cutbased=cutstring,
+                           subcats=tagCats, 
+                           variables=currentVariables,
+                           histograms=minimalHistograms,
+                           binnedOnly=isBinnedOnly,
+                           dumpPdfWeights=dumpPdfWeights,
+                           nPdfWeights=nPdfWeights,
+                           nAlphaSWeights=nAlphaSWeights,
+                           nScaleWeights=nScaleWeights
+                           )
+
+# Require standard diphoton trigger
+from HLTrigger.HLTfilters.hltHighLevel_cfi import hltHighLevel
+process.hltHighLevel= hltHighLevel.clone(HLTPaths = cms.vstring("HLT_Diphoton30_18_R9Id_OR_IsoCaloId_AND_HE_R9Id_Mass95_v1") )
+process.options = cms.untracked.PSet( wantSummary = cms.untracked.bool(True) )
+
+# ee bad supercluster filter on data
+process.load('RecoMET.METFilters.eeBadScFilter_cfi')
+process.eeBadScFilter.EERecHitSource = cms.InputTag("reducedEgamma","reducedEERecHits") # Saved MicroAOD Collection (data only)
+process.dataRequirements = cms.Sequence()
+if customize.processId == "Data":
+        process.dataRequirements += process.hltHighLevel
+        process.dataRequirements += process.eeBadScFilter
+
+# Split WH and ZH
+process.genFilter = cms.Sequence()
+if (customize.processId.count("wh") or customize.processId.count("zh")) and not customize.processId.count("wzh"):
+    process.load("flashgg/Systematics/VHFilter_cfi")
+    process.genFilter += process.VHFilter
+    process.VHFilter.chooseW = bool(customize.processId.count("wh"))
+    process.VHFilter.chooseZ = bool(customize.processId.count("zh"))
+
+process.p = cms.Path(process.dataRequirements*
+                     process.genFilter*
+                     process.flashggDiPhotonSystematics*
+                     process.flashggMuonSystematics*process.flashggElectronSystematics*
+                     (process.flashggUnpackedJets*process.jetSystematicsSequence)*
+                     (process.flashggTagSequence*process.systematicsTagSequences)*
+                     process.flashggSystTagMerger*
+                     process.tagsDumper)
+
+print "--- Dumping modules that take diphotons as input: ---"
+mns = process.p.moduleNames()
+for mn in mns:
+    module = getattr(process,mn)
+    if hasattr(module,"src") and type(module.src) == type(cms.InputTag("")) and module.src.value().count("DiPhoton"):
+        print str(module),module.src
+    elif hasattr(module,"DiPhotonTag"):
+        print str(module),module.DiPhotonTag
+
+################################
+## Dump merged tags to screen ##
+################################
+
+#process.load("flashgg/Taggers/flashggTagTester_cfi")
+#process.flashggTagTester.TagSorter = cms.InputTag("flashggTagSystematics")
+#process.flashggTagTester.TagSorter = cms.InputTag("flashggSystTagMerger")
+#process.flashggTagTester.ExpectMultiples = cms.untracked.bool(True)
+#process.p += process.flashggTagTester
+
+##############
+## Dump EDM ##
+##############
+
+#process.out = cms.OutputModule("PoolOutputModule", fileName = cms.untracked.string('CustomizeWillChangeThisAnyway.root'),
+#                               outputCommands = cms.untracked.vstring('keep *') # dump everything! small tests only!
+#                               )
+#process.e = cms.EndPath(process.out)
+
+############################
+## Dump the output Python ##
+############################
+print process.dumpPython()
+#processDumpFile = open('processDump.py', 'w')
+#print >> processDumpFile, process.dumpPython()
+
+# set default options if needed
+customize.setDefault("maxEvents",100)
+customize.setDefault("targetLumi",2.61e+3)
+# call the customization
+customize(process)

--- a/Systematics/test/workspaceStd.py
+++ b/Systematics/test/workspaceStd.py
@@ -198,6 +198,10 @@ for mn in mns:
         print str(module),module.src
     elif hasattr(module,"DiPhotonTag"):
         print str(module),module.DiPhotonTag
+print
+printSystematicInfo(process)
+
+
 
 ################################
 ## Dump merged tags to screen ##
@@ -221,7 +225,7 @@ for mn in mns:
 ############################
 ## Dump the output Python ##
 ############################
-print process.dumpPython()
+#print process.dumpPython()
 #processDumpFile = open('processDump.py', 'w')
 #print >> processDumpFile, process.dumpPython()
 


### PR DESCRIPTION
I have verified that the new workspaceStd.py perfectly mimics MicroAODToWorkspace.py, but a lot of its tricky manipulation is moved into separated python functions in Systematics/python/SystematicsCustomize.py

This will make it easier to see what is being done and find bugs.  N.B. I know of at least one bug (sigE/E smearing central value must be applied to data as well as MC) that will be fixed in a separate PR.

In the future MicroAODToWorkspace.py will be depreciated.  New/updated dumpers that need the final versions of objects can hopefully use the common functions.