### PR TITLE
update photon ID MVA with copied diphotons as part of tag sequence

### DIFF
--- a/DataFormats/interface/Photon.h
+++ b/DataFormats/interface/Photon.h
@@ -60,6 +60,7 @@ namespace flashgg {
         void setpfChgIsoWrtChosenVtx03( float val ) {pfChgIsoWrtChosenVtx03_ = val;};
         void setESEffSigmaRR( float val ) {ESEffSigmaRR_ = val;};
         void setPhoIdMvaD( std::map<edm::Ptr<reco::Vertex>, float> valmap ) {  phoIdMvaD_ = valmap; };  // concept: pass the pre-computed map when calling this in the producer
+        void setPhoIdMvaWrtVtx( edm::Ptr<reco::Vertex> key, float val ) { phoIdMvaD_[key] = val; } // For later updates, e.g. recomputation when vertex is already selected
         void updateEnergy( std::string key, float val );
         void shiftAllMvaValuesBy( float val );
         void shiftSigmaEOverEValueBy( float val );

--- a/Systematics/python/SystematicsCustomize.py
+++ b/Systematics/python/SystematicsCustomize.py
@@ -44,8 +44,9 @@ def createStandardSystematicsProducers(process):
 
 def modifyTagSequenceForSystematics(process,jetSystematicsInputTags):
     process.flashggTagSequence.remove(process.flashggUnpackedJets) # to avoid unnecessary cloning
+    process.flashggTagSequence.remove(process.flashggUpdatedIdMVADiPhotons) # Needs to be run before systematics
     from PhysicsTools.PatAlgos.tools.helpers import cloneProcessingSnippet,massSearchReplaceAnyInputTag
-    massSearchReplaceAnyInputTag(process.flashggTagSequence,cms.InputTag("flashggDiPhotons"),cms.InputTag("flashggDiPhotonSystematics"))
+    massSearchReplaceAnyInputTag(process.flashggTagSequence,cms.InputTag("flashggUpdatedIdMVADiPhotons"),cms.InputTag("flashggDiPhotonSystematics"))
     massSearchReplaceAnyInputTag(process.flashggTagSequence,cms.InputTag("flashggSelectedElectrons"),cms.InputTag("flashggElectronSystematics"))
     massSearchReplaceAnyInputTag(process.flashggTagSequence,cms.InputTag("flashggSelectedMuons"),cms.InputTag("flashggMuonSystematics"))
     from flashgg.Taggers.flashggTags_cff import UnpackedJetCollectionVInputTag

--- a/Systematics/python/flashggDiPhotonSystematics_cfi.py
+++ b/Systematics/python/flashggDiPhotonSystematics_cfi.py
@@ -258,7 +258,7 @@ RVBins = cms.PSet(
                 )
 
 flashggDiPhotonSystematics = cms.EDProducer('FlashggDiPhotonSystematicProducer',
-		src = cms.InputTag("flashggDiPhotons"),
+		src = cms.InputTag("flashggUpdatedIdMVADiPhotons"),
                 SystMethods2D = cms.VPSet(),
                 # the number of syst methods matches the number of nuisance parameters
                 # assumed for a given systematic uncertainty and is NOT required

--- a/Systematics/test/MicroAODtoWorkspace.py
+++ b/Systematics/test/MicroAODtoWorkspace.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env cmsRun
 
+raise Exception,"please use workspaceStd.py instead, this file is here for reference but no longer maintained"
+
 import FWCore.ParameterSet.Config as cms
 import FWCore.Utilities.FileUtils as FileUtils
 from flashgg.Systematics.SystematicDumperDefaultVariables import minimalVariables,minimalHistograms,minimalNonSignalVariables,systematicVariables

--- a/Systematics/test/workspaceStd.py
+++ b/Systematics/test/workspaceStd.py
@@ -187,6 +187,7 @@ if (customize.processId.count("wh") or customize.processId.count("zh")) and not 
 
 process.p = cms.Path(process.dataRequirements*
                      process.genFilter*
+                     process.flashggUpdatedIdMVADiPhotons*
                      process.flashggDiPhotonSystematics*
                      process.flashggMuonSystematics*process.flashggElectronSystematics*
                      (process.flashggUnpackedJets*process.jetSystematicsSequence)*

--- a/Taggers/plugins/DiPhotonWithUpdatedPhoIdMVAProducer.cc
+++ b/Taggers/plugins/DiPhotonWithUpdatedPhoIdMVAProducer.cc
@@ -1,0 +1,79 @@
+#include "DataFormats/Common/interface/Handle.h"
+#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "flashgg/MicroAOD/interface/PhotonIdUtils.h"
+#include "flashgg/DataFormats/interface/DiPhotonCandidate.h"
+
+namespace flashgg {
+
+    class DiPhotonWithUpdatedPhoIdMVAProducer : public edm::EDProducer
+    {
+    public:
+        DiPhotonWithUpdatedPhoIdMVAProducer( const edm::ParameterSet & );
+        void produce( edm::Event &, const edm::EventSetup & ) override;
+
+    private:
+        edm::EDGetTokenT<edm::View<flashgg::DiPhotonCandidate> > token_;
+        edm::EDGetTokenT<double> rhoToken_;
+        PhotonIdUtils phoTools_;
+        edm::FileInPath phoIdMVAweightfileEB_, phoIdMVAweightfileEE_;
+        bool debug_;
+    };
+
+    DiPhotonWithUpdatedPhoIdMVAProducer::DiPhotonWithUpdatedPhoIdMVAProducer( const edm::ParameterSet &ps ) :
+        token_(consumes<edm::View<flashgg::DiPhotonCandidate> >(ps.getParameter<edm::InputTag>("src"))),
+        rhoToken_( consumes<double>( ps.getParameter<edm::InputTag>( "rhoFixedGridCollection" ) ) ),
+        debug_( ps.getParameter<bool>( "Debug" ) )
+    {
+        phoIdMVAweightfileEB_ = ps.getParameter<edm::FileInPath>( "photonIdMVAweightfile_EB" );
+        phoIdMVAweightfileEE_ = ps.getParameter<edm::FileInPath>( "photonIdMVAweightfile_EE" );
+        phoTools_.setupMVA( phoIdMVAweightfileEB_.fullPath(), phoIdMVAweightfileEE_.fullPath() );
+
+        produces<std::vector<flashgg::DiPhotonCandidate> >();
+    }
+
+    void DiPhotonWithUpdatedPhoIdMVAProducer::produce( edm::Event &evt, const edm::EventSetup & )
+    {
+        edm::Handle<edm::View<flashgg::DiPhotonCandidate> > objects;
+        evt.getByToken( token_, objects );
+
+        edm::Handle<double> rhoHandle;
+        evt.getByToken( rhoToken_, rhoHandle );
+        const double rhoFixedGrd = *( rhoHandle.product() );
+
+        auto_ptr<std::vector<flashgg::DiPhotonCandidate> > out_obj( new std::vector<flashgg::DiPhotonCandidate>() );
+
+        for (const auto & obj : *objects) {
+            if (this->debug_) {
+                std::cout << " Input DiPhoton lead (sublead) MVA: " << obj.leadPhotonId() << " " << obj.subLeadPhotonId() << std::endl;
+            }
+            flashgg::DiPhotonCandidate *new_obj = obj.clone();
+            new_obj->makePhotonsPersistent();
+            float newleadmva = phoTools_.computeMVAWrtVtx( new_obj->getLeadingPhoton(), new_obj->vtx(), rhoFixedGrd );
+            new_obj->getLeadingPhoton().setPhoIdMvaWrtVtx( new_obj->vtx(), newleadmva);
+            float newsubleadmva = phoTools_.computeMVAWrtVtx( new_obj->getSubLeadingPhoton(), new_obj->vtx(), rhoFixedGrd );
+            new_obj->getSubLeadingPhoton().setPhoIdMvaWrtVtx( new_obj->vtx(), newsubleadmva);
+            if (this->debug_) {
+                std::cout << " Output DiPhoton lead (sublead) MVA: " << new_obj->leadPhotonId() << " " << new_obj->subLeadPhotonId() << std::endl;
+            }
+            out_obj->push_back(*new_obj);
+        }
+        evt.put(out_obj);
+    }
+}
+
+typedef flashgg::DiPhotonWithUpdatedPhoIdMVAProducer FlashggDiPhotonWithUpdatedPhoIdMVAProducer;
+DEFINE_FWK_MODULE( FlashggDiPhotonWithUpdatedPhoIdMVAProducer );
+
+// Local Variables:
+// mode:c++
+// indent-tabs-mode:nil
+// tab-width:4
+// c-basic-offset:4
+// End:
+// vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4

--- a/Taggers/python/flashggPreselectedDiPhotons_cfi.py
+++ b/Taggers/python/flashggPreselectedDiPhotons_cfi.py
@@ -63,7 +63,7 @@ rediscoveryHLTcutsV1 = cms.VPSet(
 #Also included: the super-loose ID MVA cuts
 flashggPreselectedDiPhotons = cms.EDFilter(
     "GenericDiPhotonCandidateSelector",
-    src = cms.InputTag("flashggDiPhotons"),
+    src = cms.InputTag("flashggUpdatedIdMVADiPhotons"),
     rho = cms.InputTag("fixedGridRhoAll"),
     cut = cms.string(
         "    (leadingPhoton.full5x5_r9>0.8||leadingPhoton.egChargedHadronIso<20||leadingPhoton.egChargedHadronIso/leadingPhoton.pt<0.3)"

--- a/Taggers/python/flashggTagSequence_cfi.py
+++ b/Taggers/python/flashggTagSequence_cfi.py
@@ -4,8 +4,10 @@ from flashgg.Taggers.flashggVBFMVA_cff import flashggVBFMVA,flashggVBFDiPhoDiJet
 from flashgg.Taggers.flashggTags_cff import *
 from flashgg.Taggers.flashggPreselectedDiPhotons_cfi import flashggPreselectedDiPhotons
 from flashgg.Taggers.flashggTagSorter_cfi import flashggTagSorter
+from flashgg.Taggers.flashggUpdatedIdMVADiPhotons_cfi import flashggUpdatedIdMVADiPhotons
 
-flashggTagSequence = cms.Sequence(flashggPreselectedDiPhotons
+flashggTagSequence = cms.Sequence(flashggUpdatedIdMVADiPhotons
+                                  * flashggPreselectedDiPhotons
 				  * flashggDiPhotonMVA
                                   * flashggUnpackedJets
                                   * flashggVBFMVA

--- a/Taggers/python/flashggUpdatedIdMVADiPhotons_cfi.py
+++ b/Taggers/python/flashggUpdatedIdMVADiPhotons_cfi.py
@@ -1,0 +1,9 @@
+import FWCore.ParameterSet.Config as cms
+
+flashggUpdatedIdMVADiPhotons = cms.EDProducer("FlashggDiPhotonWithUpdatedPhoIdMVAProducer",
+                                              src=cms.InputTag("flashggDiPhotons"),
+                                              rhoFixedGridCollection = cms.InputTag('fixedGridRhoAll'),
+                                              photonIdMVAweightfile_EB = cms.FileInPath("flashgg/MicroAOD/data/MVAweights_76X_25ns_barrel.xml"),
+                                              photonIdMVAweightfile_EE = cms.FileInPath("flashgg/MicroAOD/data/MVAweights_76X_25ns_endcap.xml"),
+                                              Debug=cms.bool(False)
+                                              )


### PR DESCRIPTION
This was the quickest and conceptually cleanest way for me to update the photon ID MVA so that @vtavolar can get started.

In principle it is less efficient than @musella's proposal, to do the same change with a SystMethod, because it makes a new DiPhoton collection.   But for me it is clearer because it replaces the ID MVA before preselection.

I have made the PR fully self-consistent, in that the TagSequence and Systematics Customizers are updated appropriately for its presence.  But I am happy to discuss changes before accepting.