### PR TITLE
fix TnP version and cherry pick hash for pdf weight tools

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -104,7 +104,8 @@ cd $CMSSW_BASE/src
 echo "Setting up TnP tools..."
 #git cms-addpkg DataFormats/RecoCandidate
 #git cms-addpkg PhysiscsTools/TagAndProbe
-git cms-merge-topic -u matteosan1:egm_tnp_76X
+#git cms-merge-topic -u matteosan1:egm_tnp_76X
+git cms-merge-topic -u matteosan1:egm_tnp_76X_v1
 
 echo "Setting up weight and pat electron conversion..."
 git cms-addpkg CommonTools/UtilAlgos
@@ -118,8 +119,8 @@ git remote rm cmssw-sethzenz
 echo "Setting up PDF weight tool..."
 #git-cms-merge-topic bendavid:pdfweights_76x
 git cms-addpkg PhysicsTools/HepMCCandAlgos
-git cherry-pick 9e4300582f284fa1fed6dcdbee88b3f75da39165
-
+#git cherry-pick 9e4300582f284fa1fed6dcdbee88b3f75da39165
+git cherry-pick ca5f8100a28c597ad118e3a4b3dcadda7f6e45ca
 
 echo "adding hook for indentation"
 ln -s $CMSSW_BASE/src/flashgg/Validation/scripts/flashgg_indent_check.sh $CMSSW_BASE/src/flashgg/.git/hooks/pre-commit


### PR DESCRIPTION
No promises but the changes here may make the code set itself up smoother.  Please watch for tags and hashes in setup.sh that don't work, and report them!

This may also help:
export CMSSW_GIT_REFERENCE=/cvmfs/cms.cern.ch/cmssw.git.daily