### PR TITLE
new RMS uncertainty module for jets, +/- 0.002

### DIFF
--- a/Systematics/plugins/JetRMSShift.cc
+++ b/Systematics/plugins/JetRMSShift.cc
@@ -1,0 +1,80 @@
+#include "flashgg/Systematics/interface/ObjectSystMethodBinnedByFunctor.h"
+#include "DataFormats/Common/interface/Handle.h"
+#include "DataFormats/Common/interface/PtrVector.h"
+#include "flashgg/DataFormats/interface/Jet.h"
+#include "CommonTools/Utils/interface/StringCutObjectSelector.h"
+
+#include "JetMETCorrections/JetCorrector/interface/JetCorrector.h"
+#include "CondFormats/JetMETObjects/interface/JetCorrectionUncertainty.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "CondFormats/JetMETObjects/interface/JetCorrectorParameters.h"
+#include "JetMETCorrections/Objects/interface/JetCorrectionsRecord.h"
+
+
+namespace flashgg {
+
+    class JetRMSShift: public ObjectSystMethodBinnedByFunctor<flashgg::Jet, int>
+    {
+
+    public:
+        typedef StringCutObjectSelector<Jet, true> selector_type;
+
+        JetRMSShift( const edm::ParameterSet &conf, edm::ConsumesCollector && iC, const GlobalVariablesComputer * gv );
+        void applyCorrection( flashgg::Jet &y, int syst_shift ) override;
+        std::string shiftLabel( int ) const override;
+
+    private:
+        selector_type overall_range_;
+        bool debug_;
+    };
+
+
+    JetRMSShift::JetRMSShift( const edm::ParameterSet &conf, edm::ConsumesCollector && iC, const GlobalVariablesComputer * gv ) :
+        ObjectSystMethodBinnedByFunctor( conf, std::forward<edm::ConsumesCollector>(iC), gv  ),
+        overall_range_( conf.getParameter<std::string>( "OverallRange" ) )
+    {
+    }
+
+    std::string JetRMSShift::shiftLabel( int syst_value ) const
+    {
+        std::string result;
+        if( syst_value == 0 ) {
+            result = Form( "%sCentral", label().c_str() );
+        } else if( syst_value > 0 ) {
+            result = Form( "%sUp%.2dsigma", label().c_str(), syst_value );
+        } else {
+            result = Form( "%sDown%.2dsigma", label().c_str(), -1 * syst_value );
+        }
+        return result;
+    }
+
+    void JetRMSShift::applyCorrection( flashgg::Jet &y, int syst_shift )
+    {
+        if( overall_range_( y ) ) {
+            auto val_err = binContents( y );
+            if( val_err.first.size() == 1 && val_err.second.size() == 1 ) { // otherwise no-op because we don't have an entry
+                float shift_val = val_err.first[0];  // e.g. 0 if no central value change
+                if (!applyCentralValue()) shift_val = 0.;
+                float shift_err = val_err.second[0]; // e.g. 0.002
+                float shift = shift_val + syst_shift * shift_err;
+                float theRms = y.rms();
+                y.setSimpleRMS( theRms + shift );
+                if ( this->debug_ ) {
+                    std::cout << "JetRMSShift::applyCorrection syst_shift=" << syst_shift << " old rms=" << theRms << " new rms=" << y.rms() << std::endl;
+                }
+            }
+        }
+    }
+}
+
+DEFINE_EDM_PLUGIN( FlashggSystematicJetMethodsFactory,
+                   flashgg::JetRMSShift,
+                   "FlashggJetRMSShift" );
+// Local Variables:
+// mode:c++
+// indent-tabs-mode:nil
+// tab-width:4
+// c-basic-offset:4
+// End:
+// vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4
+

--- a/Systematics/python/flashggJetSystematics_cfi.py
+++ b/Systematics/python/flashggJetSystematics_cfi.py
@@ -63,6 +63,13 @@ bDiscriminator74X = cms.double(0.890)
 bDiscriminator76X = cms.double(0.800)
 from flashgg.MicroAOD.flashggJets_cfi import flashggBTag
 
+RMSShiftBins = cms.PSet(
+    variables = cms.vstring("abs(eta)"),
+    bins = cms.VPSet(
+                     cms.PSet( lowBounds = cms.vdouble(0.000), upBounds = cms.vdouble(999.), values = cms.vdouble( 0.0 ), uncertainties = cms.vdouble( 0.002 ))
+                     )
+    )
+
 def createJetSystematicsForTag(process,jetInputTag):
   num = jetInputTag.productInstanceLabel
   newName = 'flashggJetSystematics'+num
@@ -97,6 +104,13 @@ def createJetSystematicsForTag(process,jetInputTag):
 						 	   bDiscriminator = bDiscriminator76X, #Medium working point for CSV B tagger, for CMSSW74X use: bDiscriminator74X
 							   Debug = cms.untracked.bool(False),
                                                            ApplyCentralValue = cms.bool(True)
+                                                           ),
+                                                 cms.PSet( MethodName = cms.string("FlashggJetRMSShift"),
+                                                           Label = cms.string("RMSShift"),
+                                                           NSigmas = cms.vint32(-1,1),
+                                                           OverallRange = cms.string("abs(eta)<5.0"),
+                                                           BinList  = RMSShiftBins,
+                                                           ApplyCentralValue = cms.bool(False)
                                                            )
                                                  )
                          

--- a/Systematics/test/ZPlusJetDumper_cfg.py
+++ b/Systematics/test/ZPlusJetDumper_cfg.py
@@ -56,8 +56,8 @@ else:
         for direction in ["Up","Down"]:
             jetsystlabels.append("JEC%s01sigma" % direction)
             jetsystlabels.append("JER%s01sigma" % direction)
-            systlabels.append("JEC%s01sigma" % direction)
-            systlabels.append("JER%s01sigma" % direction)
+            jetsystlabels.append("RMSShift%s01sigma" % direction)
+        systlabels += jetsystlabels
     else:
         print "Background MC, so store mgg and central only"
         customizeSystematicsForBackground(process)

--- a/Systematics/test/workspaceStd.py
+++ b/Systematics/test/workspaceStd.py
@@ -48,6 +48,7 @@ if customize.processId.count("h_") or customize.processId.count("vbf_"): # conve
         phosystlabels.append("SigmaEOverEShift%s01sigma" % direction)
         jetsystlabels.append("JEC%s01sigma" % direction)
         jetsystlabels.append("JER%s01sigma" % direction)
+        jetsystlabels.append("RMSShift%s01sigma" % direction)
         variablesToUse.append("LooseMvaSF%s01sigma[1,-999999.,999999.] := weight(\"LooseMvaSF%s01sigma\")" % (direction,direction))
         variablesToUse.append("PreselSF%s01sigma[1,-999999.,999999.] := weight(\"PreselSF%s01sigma\")" % (direction,direction))
         variablesToUse.append("electronVetoSF%s01sigma[1,-999999.,999999.] := weight(\"electronVetoSF%s01sigma\")" % (direction,direction))


### PR DESCRIPTION
We plotted the RMS for our usual balance Z+1 jets sample.  We see consistently that data-MC agreement can be obtained by shifting left/right by 0.002, which is one bin in this plot:

https://escott.web.cern.ch/escott/ZPlots/Best76/histogram_stack_jet_rms_VBF_zjet_76x_log.pdf

Separated into eta ranges (0-1, 1-2.5, 2.5-3, 3-4, 4-4.7) we get:

https://escott.web.cern.ch/escott/ZPlots/Eta0/histogram_stack_jet_rms_VBF_zjet_76x_log.pdf
https://escott.web.cern.ch/escott/ZPlots/Eta1/histogram_stack_jet_rms_VBF_zjet_76x_log.pdf
https://escott.web.cern.ch/escott/ZPlots/Eta2/histogram_stack_jet_rms_VBF_zjet_76x_log.pdf
https://escott.web.cern.ch/escott/ZPlots/Eta3/histogram_stack_jet_rms_VBF_zjet_76x_log.pdf
https://escott.web.cern.ch/escott/ZPlots/Eta4/histogram_stack_jet_rms_VBF_zjet_76x_log.pdf

All seem consistent with the 0.002 shift.  We'll make nice systematic band plots with this producer and show them to the JME group, the ARC, et al.