### PR TITLE
Fix products of systematic weights, details in code comments

### DIFF
--- a/DataFormats/interface/WeightedObject.h
+++ b/DataFormats/interface/WeightedObject.h
@@ -20,7 +20,7 @@ namespace flashgg {
         void setWeight( string key, float val );
         void setCentralWeight( float val ) { setWeight( central_key, val ); }
         bool hasWeight( string key ) const;
-        void includeWeights( const WeightedObject &other );
+        void includeWeights( const WeightedObject &other, bool usecentralifnotfound = true );
         vector<string>::const_iterator weightListBegin() const { return _labels.begin(); }
         vector<string>::const_iterator weightListEnd() const { return _labels.end(); }
 

--- a/DataFormats/src/WeightedObject.cc
+++ b/DataFormats/src/WeightedObject.cc
@@ -35,17 +35,39 @@ namespace flashgg {
         return _weights[std::distance( _labels.begin(), found_label )];
     }
 
-    void WeightedObject::includeWeights( const WeightedObject &other )
+    void WeightedObject::includeWeights( const WeightedObject &other, bool usecentralifnotfound /* old behavior: false */ )
     {
         // multiplies weights which are present in this and other, imports weights that are only in other
+
+        // The usecentralifnotfound is a subtle point:  supposer we have electron_down < electron_central < electron_up
+        // Now we are building a set of weights for a TTHLeptonic Tag with this method.
+        // We ask a jet for its electron weight, which of course it does  not have.
+        // With usecentralifnotfound = false we would effectively be putting a contribution of 1 in from the jet.
+        // But we will always put in the central value of the jet for the central value of the tag (as we should).
+        // So if the central weight of the jet is 2 we could now have electron_down_tag < electron_up_tag < central_tag
+        // Turning on usecentralifnotfound means that we use the jet weight of 2 as a multiplier for all weights
+        // not contained by the jet, so e.g. electron_down_tag/central_tag = electron_down/electron_central as expected.
+        // Please see Taggers/plugins/TTHLeptonicTagProducer.cc for an easier-to-read code example
+        // used to debug this and illustrate why we need this behavior.  
+
+        float initialcentralweight = centralWeight();
+
         for( auto keyIt = _labels.begin() ; keyIt != _labels.end() ; keyIt++ ) {
             if( other.hasWeight( *keyIt ) ) {
                 setWeight( *keyIt, weight( *keyIt ) * other.weight( *keyIt ) );
+            } else {
+                if ( usecentralifnotfound ) {
+                    setWeight( *keyIt, weight( *keyIt ) * other.centralWeight() );
+                }
             }
         }
         for( auto keyIt = other._labels.begin() ; keyIt != other._labels.end() ; keyIt++ ) {
             if( !hasWeight( *keyIt ) ) {
-                setWeight( *keyIt, other.weight( *keyIt ) );
+                if ( usecentralifnotfound ) {
+                    setWeight( *keyIt, initialcentralweight * other.weight( *keyIt ) );
+                } else {
+                    setWeight( *keyIt, other.weight( *keyIt ) );
+                }
             }
         }
     }

--- a/Taggers/plugins/TTHLeptonicTagProducer.cc
+++ b/Taggers/plugins/TTHLeptonicTagProducer.cc
@@ -404,6 +404,33 @@ namespace flashgg {
                 }
                 tthltags_obj.includeWeights( *dipho );
 
+                // This code illustrates why usecentralifnotfound had to be added to DataFormats/src/WeightedObject.cc
+                // See the comment there for what's going on, once read the lines below should help understand
+                if (false && systLabel_ == "") {
+                    std::cout << "DEBUGGING WEIGHTS   - FOR TTHLEPTONIC TAG:" << std::endl;
+                    for (auto it = tthltags_obj.weightListBegin() ; it != tthltags_obj.weightListEnd(); it++) {
+                        float checkold = dipho->weight(*it);
+                        float checknew = (dipho->hasWeight(*it) ? dipho->weight(*it) : dipho->centralWeight() );
+                        std::cout << "  DIPHO " << (*it) << " " << dipho->weight(*it) << std::endl;
+                        if( tagElectrons.size() > 0 && ElectronJets ) {
+                            checkold *= tagElectrons[0]->weight(*it);
+                            checknew *= (tagElectrons[0]->hasWeight(*it) ? tagElectrons[0]->weight(*it) : tagElectrons[0]->centralWeight() );
+                            std::cout << "  ELE " << (*it) << " " << tagElectrons[0]->weight(*it) << std::endl;
+                        }
+                        if( tagMuons.size() > 0 && muonJets ) {
+                            checkold *= tagMuons[0]->weight(*it);
+                            checknew *= (tagMuons[0]->hasWeight(*it) ? tagMuons[0]->weight(*it) : tagMuons[0]->centralWeight() );
+                            std::cout << "  MU " << (*it) << " " << tagMuons[0]->weight(*it) << std::endl;
+                        }
+                        for( unsigned num = 0; num < tagJets.size(); num++ ) {
+                            checkold *= tagJets[num]->weight(*it);
+                            checknew *= (tagJets[num]->hasWeight(*it) ? tagJets[num]->weight(*it) : tagJets[num]->centralWeight() );
+                            std::cout << " JET " << num << " " << (*it) << " " << tagJets[num]->weight(*it) << std::endl;
+                        }                            
+                        std::cout << "  TAG " << (*it) << " " << tthltags_obj.weight(*it) << " CHECKOLD: " << checkold << " CHECKNEW: " << checknew << std::endl;
+                    }
+                }
+
                 tthltags_obj.setJets( tagJets );
                 tthltags_obj.setBJets( tagBJets );
                 tthltags_obj.setMuons( tagMuons );


### PR DESCRIPTION
Found a bug associated with how we treat weights for different object systematics when multiple objects are imported.  It only affected the TTH tags because only they use weights for multiple types of objects.  

The logic has been checked very carefully on an event-by-event basis.  Please see the code changes themselves for a detailed explanation, and for those who want to understand further, please consult the debugging code, an illustrative snippet of the output of which is now: https://sethzenz.web.cern.ch/sethzenz/cms/illustration3.txt