### PR TITLE
76X scales and smearings via EGM tool

### DIFF
--- a/Systematics/interface/BaseSystMethod.h
+++ b/Systematics/interface/BaseSystMethod.h
@@ -51,7 +51,6 @@ namespace flashgg {
         virtual std::string shiftLabel( param_var syst_val ) const = 0;
 
         virtual void eventInitialize( const edm::Event &, const edm::EventSetup & ) {
-
         }
 
         virtual void setRandomEngine( CLHEP::HepRandomEngine &eng )

--- a/Systematics/interface/DiPhotonFromPhotonBase.h
+++ b/Systematics/interface/DiPhotonFromPhotonBase.h
@@ -21,6 +21,7 @@ namespace flashgg {
         void applyCorrection( DiPhotonCandidate &y, param_var syst_shift ) override;
         float makeWeight( const DiPhotonCandidate &y, param_var syst_shift ) override;
         std::string shiftLabel( param_var ) const override;
+        void eventInitialize( const edm::Event &iEvent, const edm::EventSetup & iSetup ) override;
 
         void setRandomEngine( CLHEP::HepRandomEngine &eng ) override
         {
@@ -109,6 +110,16 @@ namespace flashgg {
                       << y.mass() << " " << y.pt() << " " << y.leadingPhoton()->energy() << " " << y.subLeadingPhoton()->energy() << " "
                       << y.leadingPhoton()->eta() << " " << y.subLeadingPhoton()->eta() << std::endl;
         }
+    }
+
+    template<class param_var>
+    void DiPhotonFromPhotonBase<param_var>::eventInitialize( const edm::Event &ev, const edm::EventSetup & es )
+    {
+        if( debug_ ) {
+            std::cout << "calling event initialize for both photons " << std::endl;
+        }
+        photon_corr_->eventInitialize( ev, es );
+        photon_corr2_->eventInitialize( ev, es );
     }
 }
 

--- a/Systematics/plugins/PhotonScaleEGMTool.cc
+++ b/Systematics/plugins/PhotonScaleEGMTool.cc
@@ -47,8 +47,6 @@ namespace flashgg {
 
     void PhotonScaleEGMTool::eventInitialize( const edm::Event &iEvent, const edm::EventSetup & iSetup ) {
         run_number_ = iEvent.run();
-        printf("--> run number: %u\n", run_number_);
-        assert(0);
     }
     
     std::string PhotonScaleEGMTool::shiftLabel( int syst_value ) const
@@ -67,7 +65,6 @@ namespace flashgg {
     void PhotonScaleEGMTool::applyCorrection( flashgg::Photon &y, int syst_shift )
     {
         if( overall_range_( y ) ) {
-        printf("--> passo: %u\n", run_number_);
             auto shift_val = scaler_.ScaleCorrection(run_number_, y.isEB(), y.full5x5_r9(), y.superCluster()->eta(), y.et());
             auto shift_err = scaler_.ScaleCorrectionUncertainty(run_number_, y.isEB(), y.full5x5_r9(), y.superCluster()->eta(), y.et());
             if (!applyCentralValue()) shift_val = 1.;

--- a/Systematics/plugins/PhotonScaleEGMTool.cc
+++ b/Systematics/plugins/PhotonScaleEGMTool.cc
@@ -1,0 +1,93 @@
+#include "flashgg/DataFormats/interface/Photon.h"
+//#include "flashgg/Systematics/interface/ObjectSystMethodBinnedByFunctor.h"
+#include "flashgg/Systematics/interface/BaseSystMethod.h"
+#include "DataFormats/Common/interface/Handle.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "DataFormats/Common/interface/PtrVector.h"
+#include "EgammaAnalysis/ElectronTools/interface/EnergyScaleCorrection_class.hh"
+#include "CommonTools/Utils/interface/StringCutObjectSelector.h"
+
+namespace edm {
+    class Event;
+}
+
+namespace flashgg {
+
+    //class PhotonScaleEGMTool: public ObjectSystMethodBinnedByFunctor<flashgg::Photon, int>
+    class PhotonScaleEGMTool: public BaseSystMethod<flashgg::Photon, int>
+    {
+
+    public:
+        typedef StringCutObjectSelector<Photon, true> selector_type;
+
+        PhotonScaleEGMTool( const edm::ParameterSet &conf, edm::ConsumesCollector && iC, const GlobalVariablesComputer *gv );
+        void applyCorrection( flashgg::Photon &y, int syst_shift ) override;
+        std::string shiftLabel( int ) const override;
+        void eventInitialize( const edm::Event &iEvent, const edm::EventSetup & iSetup ) override;
+
+    private:
+        selector_type overall_range_;
+        std::string correctionFile_;
+        EnergyScaleCorrection_class scaler_;
+        bool exaggerateShiftUp_; // debugging
+        bool debug_;
+        unsigned run_number_;
+    };
+
+    PhotonScaleEGMTool::PhotonScaleEGMTool( const edm::ParameterSet &conf, edm::ConsumesCollector && iC, const GlobalVariablesComputer *gv ) :
+        BaseSystMethod( conf, std::forward<edm::ConsumesCollector>(iC)  ),
+        overall_range_( conf.getParameter<std::string>( "OverallRange" ) ),
+        correctionFile_( conf.getParameter<std::string>( "CorrectionFile" )),
+        scaler_(correctionFile_),
+        exaggerateShiftUp_( conf.getParameter<bool>( "ExaggerateShiftUp" ) ),
+        debug_( conf.getUntrackedParameter<bool>( "Debug", false ) )
+    {
+        if (applyCentralValue()) scaler_.doScale = true;
+    }
+
+    void PhotonScaleEGMTool::eventInitialize( const edm::Event &iEvent, const edm::EventSetup & iSetup ) {
+        run_number_ = iEvent.run();
+        printf("--> run number: %u\n", run_number_);
+        assert(0);
+    }
+    
+    std::string PhotonScaleEGMTool::shiftLabel( int syst_value ) const
+    {
+        std::string result;
+        if( syst_value == 0 ) {
+            result = Form( "%sCentral", label().c_str() );
+        } else if( syst_value > 0 ) {
+            result = Form( "%sUp%.2dsigma", label().c_str(), syst_value );
+        } else {
+            result = Form( "%sDown%.2dsigma", label().c_str(), -1 * syst_value );
+        }
+        return result;
+    }
+
+    void PhotonScaleEGMTool::applyCorrection( flashgg::Photon &y, int syst_shift )
+    {
+        if( overall_range_( y ) ) {
+        printf("--> passo: %u\n", run_number_);
+            auto shift_val = scaler_.ScaleCorrection(run_number_, y.isEB(), y.full5x5_r9(), y.superCluster()->eta(), y.et());
+            auto shift_err = scaler_.ScaleCorrectionUncertainty(run_number_, y.isEB(), y.full5x5_r9(), y.superCluster()->eta(), y.et());
+            if (!applyCentralValue()) shift_val = 1.;
+            float scale = shift_val + syst_shift * shift_err;
+            if( debug_ ) {
+                std::cout << "  " << shiftLabel( syst_shift ) << ": Photon has pt= " << y.pt() << " eta=" << y.eta()
+                    << " and we apply a multiplicative correction of " << scale << std::endl;
+            }
+            y.updateEnergy( shiftLabel( syst_shift ), scale * y.energy() );
+        }
+    }
+}
+
+DEFINE_EDM_PLUGIN( FlashggSystematicPhotonMethodsFactory,
+                   flashgg::PhotonScaleEGMTool,
+                   "FlashggPhotonScaleEGMTool" );
+// Local Variables:
+// mode:c++
+// indent-tabs-mode:nil
+// tab-width:4
+// c-basic-offset:4
+// End:
+// vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4

--- a/Systematics/plugins/PhotonSigEoverESmearing.cc
+++ b/Systematics/plugins/PhotonSigEoverESmearing.cc
@@ -59,7 +59,7 @@ namespace flashgg {
                     std::cout << beforeSigEoE << " ";
                     std::cout << std::endl;
                 }
-                y.addUserFloat("unsmaeraedSigmaEoE", y.sigEOverE() );
+                y.addUserFloat("unsmearedSigmaEoE", y.sigEOverE() );
                 y.smearSigmaEOverEValueBy( shift ); 
                 // the others are no longer used at this stage anyway, so it cannot hurt
                 if ( debug_) {

--- a/Systematics/plugins/PhotonSigEoverESmearingEGMTool.cc
+++ b/Systematics/plugins/PhotonSigEoverESmearingEGMTool.cc
@@ -1,0 +1,112 @@
+// written by F Ferri, adapted by S Zenz  
+
+#include "flashgg/Systematics/interface/BaseSystMethod.h"
+#include "DataFormats/Common/interface/Handle.h"
+#include "DataFormats/Common/interface/PtrVector.h"
+#include "flashgg/DataFormats/interface/Photon.h"
+#include "CommonTools/Utils/interface/StringCutObjectSelector.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "EgammaAnalysis/ElectronTools/interface/EnergyScaleCorrection_class.hh"
+
+namespace flashgg {
+    
+    class PhotonSigEoverESmearingEGMTool: public BaseSystMethod<flashgg::Photon, std::pair<int, int> >
+    {
+        
+    public:
+        typedef StringCutObjectSelector<Photon, true> selector_type;
+        
+        PhotonSigEoverESmearingEGMTool( const edm::ParameterSet &conf, edm::ConsumesCollector && iC, const GlobalVariablesComputer *gv );
+        void applyCorrection( flashgg::Photon &y, std::pair<int, int> syst_shift ) override;
+        std::string shiftLabel( std::pair<int, int> ) const override;
+        void eventInitialize( const edm::Event &iEvent, const edm::EventSetup & iSetup ) override;
+        
+        const std::string &firstParameterName() const { return label1_; }
+        const std::string &secondParameterName() const { return label2_; }
+        
+    private:
+        selector_type overall_range_;
+        const std::string label1_;
+        const std::string label2_;
+        EnergyScaleCorrection_class scaler_;
+        bool exaggerateShiftUp_; // debugging
+        unsigned run_number_;
+        bool debug_;
+    };
+
+    void PhotonSigEoverESmearingEGMTool::eventInitialize( const edm::Event &iEvent, const edm::EventSetup & iSetup ) {
+        run_number_ = iEvent.run();
+    }
+    
+    PhotonSigEoverESmearingEGMTool::PhotonSigEoverESmearingEGMTool( const edm::ParameterSet &conf, edm::ConsumesCollector && iC, const GlobalVariablesComputer *gv ) :
+        BaseSystMethod( conf, std::forward<edm::ConsumesCollector>(iC) ),
+        overall_range_( conf.getParameter<std::string>( "OverallRange" ) ),
+        label1_( conf.getParameter<std::string>( "FirstParameterName" ) ), // default: "Rho"
+        label2_( conf.getParameter<std::string>( "SecondParameterName" ) ), // default; "Phi"
+        scaler_(conf.getParameter<std::string>( "CorrectionFile" )),
+        exaggerateShiftUp_( conf.getParameter<bool>( "ExaggerateShiftUp" ) ), // default: false
+        debug_( conf.getUntrackedParameter<bool>("Debug", false) )
+    {
+        if (!applyCentralValue()) throw cms::Exception("SmearingLogic") << "If we do not apply central smearing we cannot scale down the smearing";
+        else scaler_.doSmearings = true;
+    }
+    
+    std::string PhotonSigEoverESmearingEGMTool::shiftLabel( std::pair<int, int> syst_value ) const
+    {
+        std::string result = label();
+        if( syst_value.first == 0 && syst_value.second == 0 ) {
+            result += "Central";
+        } else {
+            if( syst_value.first > 0 ) { result += Form( "%sUp%.2dsigma", firstParameterName().c_str(), syst_value.first ); }
+            if( syst_value.first < 0 ) { result += Form( "%sDown%.2dsigma", firstParameterName().c_str(), -1 * syst_value.first ); }
+            if( syst_value.second > 0 ) { result += Form( "%sUp%.2dsigma", secondParameterName().c_str(), syst_value.second ); }
+            if( syst_value.second < 0 ) { result += Form( "%sDown%.2dsigma", secondParameterName().c_str(), -1 * syst_value.second ); }
+        }
+        return result;
+    }
+    
+    void PhotonSigEoverESmearingEGMTool::applyCorrection( flashgg::Photon &y, std::pair<int, int> syst_shift )
+    {
+        if( overall_range_( y ) ) {
+            // Nothing will happen, with no warning, if the bin count doesn't match expected options
+            // TODO for production: make this behavior more robust
+            
+            // the combination of central value + NSigma * sigma is already
+            // computed by getSmearingSigma(...)
+            auto sigma = scaler_.getSmearingSigma(run_number_, y.isEB(), y.full5x5_r9(), y.superCluster()->eta(), y.et(), syst_shift.first, syst_shift.second);
+
+            if( debug_ ) { 
+                std::cout << "  " << shiftLabel( syst_shift ) << ": Photon has pt= " << y.pt() << " eta=" << y.superCluster()->eta() << " full5x5_r9=" << y.full5x5_r9()
+                    << " and we apply a sigmaEoverE smearing of " << sigma << std::endl;
+                std::cout << " syst_shift.first: " << syst_shift.first << " syst_shift.second: " << syst_shift.second <<std::endl;
+                std::cout << "     sigE/E VALUE BEFORE: ";
+                auto beforeSigEoE = y.sigEOverE();
+                std::cout << beforeSigEoE << " ";
+                std::cout << std::endl;
+            }
+
+            y.addUserFloat("unsmearedSigmaEoE", y.sigEOverE() );
+            y.smearSigmaEOverEValueBy( sigma );
+
+            if ( debug_) {
+                auto afterSigEoE = y.sigEOverE();
+                std::cout << "     sigE/E VALUE AFTER: ";
+                std::cout << afterSigEoE << " ";
+                std::cout << std::endl;
+            }
+
+        }
+    }
+}
+
+DEFINE_EDM_PLUGIN( FlashggSystematicPhotonMethodsFactory2D,
+                   flashgg::PhotonSigEoverESmearingEGMTool,
+                   "FlashggPhotonSigEoverESmearingEGMTool" );
+
+// Local Variables:
+// mode:c++
+// indent-tabs-mode:nil
+// tab-width:4
+// c-basic-offset:4
+// End:
+// vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4

--- a/Systematics/plugins/PhotonSmearStochasticEGMTool.cc
+++ b/Systematics/plugins/PhotonSmearStochasticEGMTool.cc
@@ -50,6 +50,7 @@ namespace flashgg {
         debug_( conf.getUntrackedParameter<bool>("Debug", false) )
     {
         if (!applyCentralValue()) throw cms::Exception("SmearingLogic") << "If we do not apply central smearing we cannot scale down the smearing";
+        else scaler_.doSmearings = true;
     }
     
     std::string PhotonSmearStochasticEGMTool::shiftLabel( std::pair<int, int> syst_value ) const

--- a/Systematics/python/SystematicsCustomize.py
+++ b/Systematics/python/SystematicsCustomize.py
@@ -31,17 +31,22 @@ def printSystematicVPSet(vpsetlist):
                 cv = "NO"
             sigmalist = pset.NSigmas.value()    
             sig = ""
-            if type(sigmalist) == 'list' and len(sigmalist) > 0:
+            sig2 = ""
+            if type(sigmalist) == type([]) and len(sigmalist) > 0:
                 for val in sigmalist:
                     sig += "%i " % val
-            if type(sigmalist) == 'FWCore.ParameterSet.Types.PSet':
-                    for p in sigmalist:
-                            for val in p:
-                                    sig += "%i" % val
-                            sig += "-;-"
+            elif type(sigmalist) == type(cms.PSet()) and (len(sigmalist.firstVar) > 0 or len(sigmalist.secondVar) > 0):
+                sig += "1st: "
+                for val in sigmalist.firstVar:
+                    sig += "%i " % val
+                sig2 += "2nd: "
+                for val in sigmalist.secondVar:
+                        sig2 += "%i " % val
             else:    
                 sig += "NO"
             print "%20s %15s %20s" % (syst,cv,sig)
+            if (sig2 != ""):
+                print "%20s %15s %20s" % ("","",sig2)
         if len(vpset):
             print 57*"-"
 
@@ -123,7 +128,10 @@ def customizeSystematicsForBackground(process):
     vpsetlist += [getattr(process,"flashggJetSystematics%i"%i).SystMethods for i in range(len(UnpackedJetCollectionVInputTag))]
     for vpset in vpsetlist:
         for pset in vpset:
-            pset.NSigmas = cms.vint32()
+            if type(pset.NSigmas) == type(cms.vint32()):
+                pset.NSigmas = cms.vint32() # Do not perform shift
+            else:
+                pset.NSigmas = cms.PSet( firstVar = cms.vint32(), secondVar = cms.vint32() ) # Do not perform shift - 2D case
             if hasattr(pset,"SetupUncertainties"):
                 pset.SetupUncertainties = False
 
@@ -140,7 +148,7 @@ def customizeVPSetForData(systs, phScaleBins):
             if type(pset.NSigmas) == type(cms.vint32()):
                 pset.NSigmas = cms.vint32() # Do not perform shift
             else:
-                pset.NSigmas = cms.PSet( firstVar = cms.vint32(), secondVar = cms.vint32() )
+                pset.NSigmas = cms.PSet( firstVar = cms.vint32(), secondVar = cms.vint32() ) # Do not perform shift - 2D case
             if pset.Label.value().count("Scale") and phScaleBins != None: 
                 pset.BinList = phScaleBins
             newvpset += [pset]

--- a/Systematics/python/SystematicsCustomize.py
+++ b/Systematics/python/SystematicsCustomize.py
@@ -137,7 +137,10 @@ def customizeVPSetForData(systs, phScaleBins):
     for pset in systs:
         if pset.Label.value().count("Scale") or pset.Label.value().count("SigmaEOverESmearing"):
             pset.ApplyCentralValue = cms.bool(True) # Turn on central shift for data (it is off for MC)
-            pset.NSigmas = cms.vint32() # Do not perform shift
+            if type(pset.NSigmas) == type(cms.vint32()):
+                pset.NSigmas = cms.vint32() # Do not perform shift
+            else:
+                pset.NSigmas = cms.PSet( firstVar = cms.vint32(), secondVar = cms.vint32() )
             if pset.Label.value().count("Scale") and phScaleBins != None: 
                 pset.BinList = phScaleBins
             newvpset += [pset]

--- a/Systematics/python/flashggDiPhotonSystematics_cfi.py
+++ b/Systematics/python/flashggDiPhotonSystematics_cfi.py
@@ -376,6 +376,11 @@ emptyBins = cms.PSet(
     bins = cms.VPSet()
     )
 
+emptySigma = cms.PSet(
+    firstVar = cms.vint32(),
+    secondVar = cms.vint32()
+)
+
 scalesAndSmearingsPrefix = cms.string("EgammaAnalysis/ElectronTools/data/76X_16DecRereco_2015_photons")
 
 

--- a/Systematics/python/flashggDiPhotonSystematics_cfi.py
+++ b/Systematics/python/flashggDiPhotonSystematics_cfi.py
@@ -371,6 +371,338 @@ materialBinsRun1 = cms.PSet(
         )
     )
 
+emptyBins = cms.PSet(
+    variables = cms.vstring("1"),
+    bins = cms.VPSet()
+    )
+
+scalesAndSmearingsPrefix = cms.string("EgammaAnalysis/ElectronTools/data/76X_16DecRereco_2015_photons")
+
+
+MCScaleHighR9EB = cms.PSet( PhotonMethodName = cms.string("FlashggPhotonScale"),
+          MethodName = cms.string("FlashggDiPhotonFromPhoton"),
+          Label = cms.string("MCScaleHighR9EB"),
+          NSigmas = cms.vint32(-1,1),
+          OverallRange = cms.string("r9>0.94&&abs(superCluster.eta)<1.5"),
+          BinList = photonScaleUncertBins,
+          ApplyCentralValue = cms.bool(False),
+          Debug = cms.untracked.bool(False)
+          )
+
+MCScaleLowR9EB = cms.PSet( PhotonMethodName = cms.string("FlashggPhotonScale"),
+          MethodName = cms.string("FlashggDiPhotonFromPhoton"),
+          Label = cms.string("MCScaleLowR9EB"),
+          NSigmas = cms.vint32(-1,1),
+          OverallRange = cms.string("r9<0.94&&abs(superCluster.eta)<1.5"),
+          BinList = photonScaleUncertBins,
+          ApplyCentralValue = cms.bool(False),
+          Debug = cms.untracked.bool(False)
+          )
+
+MCScaleHighR9EE = cms.PSet( PhotonMethodName = cms.string("FlashggPhotonScale"),
+          MethodName = cms.string("FlashggDiPhotonFromPhoton"),
+          Label = cms.string("MCScaleHighR9EE"),
+          NSigmas = cms.vint32(-1,1),
+          OverallRange = cms.string("r9>0.94&&abs(superCluster.eta)>=1.5"),
+          BinList = photonScaleUncertBins,
+          ApplyCentralValue = cms.bool(False),
+          Debug = cms.untracked.bool(False)
+          )
+
+MCScaleLowR9EE = cms.PSet( PhotonMethodName = cms.string("FlashggPhotonScale"),
+          MethodName = cms.string("FlashggDiPhotonFromPhoton"),
+          Label = cms.string("MCScaleLowR9EE"),
+          NSigmas = cms.vint32(-1,1),
+          OverallRange = cms.string("r9<0.94&&abs(superCluster.eta)>=1.5"),
+          BinList = photonScaleUncertBins,
+          ApplyCentralValue = cms.bool(False),
+          Debug = cms.untracked.bool(False)
+          )
+
+MaterialCentral = cms.PSet( PhotonMethodName = cms.string("FlashggPhotonScale"),
+          MethodName = cms.string("FlashggDiPhotonFromPhoton"),
+          Label = cms.string("MaterialCentral"),
+          NSigmas = cms.vint32(-1,1),
+          OverallRange = cms.string("abs(superCluster.eta)<1.0"),
+          BinList = materialBinsRun1,
+          ApplyCentralValue = cms.bool(False),
+          Debug = cms.untracked.bool(False)
+          )
+
+MaterialForward = cms.PSet( PhotonMethodName = cms.string("FlashggPhotonScale"),
+          MethodName = cms.string("FlashggDiPhotonFromPhoton"),
+          Label = cms.string("MaterialForward"),
+          NSigmas = cms.vint32(-1,1),
+          OverallRange = cms.string("abs(superCluster.eta)>=1.0"),
+          BinList = materialBinsRun1,
+          ApplyCentralValue = cms.bool(False),
+          Debug = cms.untracked.bool(False)
+          )
+
+MCSmearHighR9EE = cms.PSet( PhotonMethodName = cms.string("FlashggPhotonSmearConstant"),
+          MethodName = cms.string("FlashggDiPhotonFromPhoton"),
+          Label = cms.string("MCSmearHighR9EE"),
+          NSigmas = cms.vint32(-1,1),
+          OverallRange = cms.string("r9>0.94&&abs(superCluster.eta)>=1.5"),
+          BinList = photonSmearBins,
+          # has to match the labels embedded in the photon object as
+          # defined e.g. in flashgg/MicroAOD/python/flashggRandomizedPerPhotonDiPhotonProducer_cff.py
+          #           or in flashgg/MicroAOD/python/flashggRandomizedPhotonProducer_cff.py (if at MicroAOD prod.)
+          RandomLabel = cms.string("rnd_g_E"),
+          Debug = cms.untracked.bool(False),
+          ExaggerateShiftUp = cms.bool(False),
+          ApplyCentralValue = cms.bool(True)
+          )
+
+MCSmearLowR9EE = cms.PSet( PhotonMethodName = cms.string("FlashggPhotonSmearConstant"),
+          MethodName = cms.string("FlashggDiPhotonFromPhoton"),
+          Label = cms.string("MCSmearLowR9EE"),
+          NSigmas = cms.vint32(-1,1),
+          OverallRange = cms.string("r9<0.94&&abs(superCluster.eta)>=1.5"),
+          BinList = photonSmearBins,
+          # has to match the labels embedded in the photon object as
+          # defined e.g. in flashgg/MicroAOD/python/flashggRandomizedPerPhotonDiPhotonProducer_cff.py
+          #           or in flashgg/MicroAOD/python/flashggRandomizedPhotonProducer_cff.py (if at MicroAOD prod.)
+          RandomLabel = cms.string("rnd_g_E"),
+          Debug = cms.untracked.bool(False),
+          ExaggerateShiftUp = cms.bool(False),
+          ApplyCentralValue = cms.bool(True)
+          )
+
+MCSmearHighR9EB = cms.PSet( PhotonMethodName = cms.string("FlashggPhotonSmearConstant"),
+          MethodName = cms.string("FlashggDiPhotonFromPhoton"),
+          Label = cms.string("MCSmearHighR9EB"),
+          NSigmas = cms.vint32(-1,1),
+          OverallRange = cms.string("r9>0.94&&abs(superCluster.eta)<1.5"),
+          BinList = photonSmearBins,
+          # has to match the labels embedded in the photon object as
+          # defined e.g. in flashgg/MicroAOD/python/flashggRandomizedPerPhotonDiPhotonProducer_cff.py
+          #           or in flashgg/MicroAOD/python/flashggRandomizedPhotonProducer_cff.py (if at MicroAOD prod.)
+          RandomLabel = cms.string("rnd_g_E"),
+          Debug = cms.untracked.bool(False),
+          ExaggerateShiftUp = cms.bool(False),
+          ApplyCentralValue = cms.bool(True)
+          )
+
+MCSmearLowR9EB = cms.PSet( PhotonMethodName = cms.string("FlashggPhotonSmearConstant"),
+          MethodName = cms.string("FlashggDiPhotonFromPhoton"),
+          Label = cms.string("MCSmearLowR9EB"),
+          NSigmas = cms.vint32(-1,1),
+          OverallRange = cms.string("r9<=0.94&&abs(superCluster.eta)<1.5"),
+          BinList = photonSmearBins,
+          # has to match the labels embedded in the photon object as
+          # defined e.g. in flashgg/MicroAOD/python/flashggRandomizedPerPhotonDiPhotonProducer_cff.py
+          #           or in flashgg/MicroAOD/python/flashggRandomizedPhotonProducer_cff.py (if at MicroAOD prod.)
+          RandomLabel = cms.string("rnd_g_E"),
+          Debug = cms.untracked.bool(False),
+          ExaggerateShiftUp = cms.bool(False),
+          ApplyCentralValue = cms.bool(True)
+          )
+
+MvaShift = cms.PSet( PhotonMethodName = cms.string("FlashggPhotonMvaShift"),
+          MethodName = cms.string("FlashggDiPhotonFromPhoton"),
+          Label = cms.string("MvaShift"),
+          NSigmas = cms.vint32(-1,1),
+          OverallRange = cms.string("1"),
+          BinList = mvaShiftBins,
+          Debug = cms.untracked.bool(False),
+          ApplyCentralValue = cms.bool(True)
+          )
+
+PreselSF = cms.PSet( PhotonMethodName = cms.string("FlashggPhotonWeight"),
+          MethodName = cms.string("FlashggDiPhotonFromPhoton"),
+          Label = cms.string("PreselSF"),
+          NSigmas = cms.vint32(-1,1),
+          OverallRange = cms.string("1"),
+          BinList = preselBins,
+          Debug = cms.untracked.bool(False),
+          ApplyCentralValue = cms.bool(True)
+          )
+
+electronVetoSF = cms.PSet( PhotonMethodName = cms.string("FlashggPhotonWeight"),
+          MethodName = cms.string("FlashggDiPhotonFromPhoton"),
+          Label = cms.string("electronVetoSF"),
+          NSigmas = cms.vint32(-1,1),
+          OverallRange = cms.string("1"),
+          BinList = electronVetoBins,
+          Debug = cms.untracked.bool(False),
+          ApplyCentralValue = cms.bool(True)
+          )
+
+TriggerWeight = cms.PSet( PhotonMethodName = cms.string("FlashggPhotonWeight"),
+          MethodName = cms.string("FlashggDiPhotonFromPhoton"),
+          Label = cms.string("TriggerWeight"),
+          NSigmas = cms.vint32(-1,1),
+          OverallRange = cms.string("1"),
+          BinList = leadTriggerScaleBins,
+          BinList2 = subleadTriggerScaleBins,
+          Debug = cms.untracked.bool(False),
+          ApplyCentralValue = cms.bool(True)
+          )
+
+LooseMvaSF = cms.PSet( PhotonMethodName = cms.string("FlashggPhotonWeight"),
+          MethodName = cms.string("FlashggDiPhotonFromPhoton"),
+          Label = cms.string("LooseMvaSF"),
+          NSigmas = cms.vint32(-1,1),
+          OverallRange = cms.string("1"),
+          BinList = looseMvaBins,
+          Debug = cms.untracked.bool(False),
+          ApplyCentralValue = cms.bool(True)
+          )
+
+SigmaEOverEShift = cms.PSet( PhotonMethodName = cms.string("FlashggPhotonSigEOverEShift"),
+          MethodName = cms.string("FlashggDiPhotonFromPhoton"),
+          Label = cms.string("SigmaEOverEShift"),
+          NSigmas = cms.vint32(-1,1),
+          OverallRange = cms.string("1"),
+          BinList = sigmaEOverEShiftBins,
+          Debug = cms.untracked.bool(False),
+          ApplyCentralValue = cms.bool(True)
+          )
+
+SigmaEOverESmearing = cms.PSet( PhotonMethodName = cms.string("FlashggPhotonSigEoverESmearing"),
+          MethodName = cms.string("FlashggDiPhotonFromPhoton"),
+          Label = cms.string("SigmaEOverESmearing"),
+          NSigmas = cms.vint32(),
+          OverallRange = cms.string("1"),
+          BinList = photonSmearBins,
+          Debug = cms.untracked.bool(False),
+          ApplyCentralValue = cms.bool(True)
+          )
+
+FracRVWeight = cms.PSet( MethodName = cms.string("FlashggDiPhotonWeightFromFracRV"),
+          Label = cms.string("FracRVWeight"),
+          NSigmas = cms.vint32(-1,1),
+          OverallRange = cms.string("1"),
+          BinList = RVBins,
+          Debug = cms.untracked.bool(False),
+          ApplyCentralValue = cms.bool(True)
+          )
+
+MCSmearHighR9EE_EGM = cms.PSet( PhotonMethodName = cms.string("FlashggPhotonSmearStochasticEGMTool"),
+         MethodName = cms.string("FlashggDiPhotonFromPhoton2D"),
+         Label = cms.string("MCSmearHighR9EE"),
+         FirstParameterName = cms.string("Rho"),
+         SecondParameterName = cms.string("Phi"),
+         CorrectionFile = scalesAndSmearingsPrefix,
+         NSigmas = cms.PSet( firstVar = cms.vint32(1,-1,0,0),
+                                                                                                  secondVar = cms.vint32(0,0,1,-1)),
+         OverallRange = cms.string("r9>0.94&&abs(superCluster.eta)>=1.5"),
+         BinList = emptyBins,
+         # has to match the labels embedded in the photon object as
+         # defined e.g. in flashgg/MicroAOD/python/flashggRandomizedPerPhotonDiPhotonProducer_cff.py
+         #           or in flashgg/MicroAOD/python/flashggRandomizedPhotonProducer_cff.py (if at MicroAOD prod.)
+         RandomLabel = cms.string("rnd_g_E"),
+         Debug = cms.untracked.bool(False),
+         ExaggerateShiftUp = cms.bool(False),
+         ApplyCentralValue = cms.bool(True)
+         )
+
+MCSmearLowR9EE_EGM = cms.PSet( PhotonMethodName = cms.string("FlashggPhotonSmearStochasticEGMTool"),
+         MethodName = cms.string("FlashggDiPhotonFromPhoton2D"),
+         Label = cms.string("MCSmearLowR9EE"),
+         FirstParameterName = cms.string("Rho"),
+         SecondParameterName = cms.string("Phi"),
+         CorrectionFile = scalesAndSmearingsPrefix,
+         NSigmas = cms.PSet( firstVar = cms.vint32(1,-1,0,0),
+                            secondVar = cms.vint32(0,0,1,-1)),
+         OverallRange = cms.string("r9<=0.94&&abs(superCluster.eta)>=1.5"),
+         BinList = emptyBins,
+         # has to match the labels embedded in the photon object as
+         # defined e.g. in flashgg/MicroAOD/python/flashggRandomizedPerPhotonDiPhotonProducer_cff.py
+         #           or in flashgg/MicroAOD/python/flashggRandomizedPhotonProducer_cff.py (if at MicroAOD prod.)
+         RandomLabel = cms.string("rnd_g_E"),
+         Debug = cms.untracked.bool(False),
+         ExaggerateShiftUp = cms.bool(False),
+         ApplyCentralValue = cms.bool(True)
+         )
+
+MCSmearHighR9EB_EGM = cms.PSet( PhotonMethodName = cms.string("FlashggPhotonSmearStochasticEGMTool"),
+         MethodName = cms.string("FlashggDiPhotonFromPhoton2D"),
+         Label = cms.string("MCSmearHighR9EB"),
+         FirstParameterName = cms.string("Rho"),
+         SecondParameterName = cms.string("Phi"),
+         CorrectionFile = scalesAndSmearingsPrefix,
+         NSigmas = cms.PSet( firstVar = cms.vint32(1,-1,0,0),
+                                                                                                  secondVar = cms.vint32(0,0,1,-1)),
+         OverallRange = cms.string("r9>0.94&&abs(superCluster.eta)<1.5"),
+         BinList = emptyBins,
+         # has to match the labels embedded in the photon object as
+         # defined e.g. in flashgg/MicroAOD/python/flashggRandomizedPerPhotonDiPhotonProducer_cff.py
+         #           or in flashgg/MicroAOD/python/flashggRandomizedPhotonProducer_cff.py (if at MicroAOD prod.)
+         RandomLabel = cms.string("rnd_g_E"),
+         Debug = cms.untracked.bool(False),
+         ExaggerateShiftUp = cms.bool(False),
+         ApplyCentralValue = cms.bool(True)
+         )
+
+MCSmearLowR9EB_EGM = cms.PSet( PhotonMethodName = cms.string("FlashggPhotonSmearStochasticEGMTool"),
+         MethodName = cms.string("FlashggDiPhotonFromPhoton2D"),
+         Label = cms.string("MCSmearLowR9EB"),
+         FirstParameterName = cms.string("Rho"),
+         SecondParameterName = cms.string("Phi"),
+         CorrectionFile = scalesAndSmearingsPrefix,
+         NSigmas = cms.PSet( firstVar = cms.vint32(1,-1,0,0),
+                            secondVar = cms.vint32(0,0,1,-1)),
+         OverallRange = cms.string("r9<=0.94&&abs(superCluster.eta)<1.5"),
+         BinList = emptyBins,
+         # has to match the labels embedded in the photon object as
+         # defined e.g. in flashgg/MicroAOD/python/flashggRandomizedPerPhotonDiPhotonProducer_cff.py
+         #           or in flashgg/MicroAOD/python/flashggRandomizedPhotonProducer_cff.py (if at MicroAOD prod.)
+         RandomLabel = cms.string("rnd_g_E"),
+         Debug = cms.untracked.bool(False),
+         ExaggerateShiftUp = cms.bool(False),
+         ApplyCentralValue = cms.bool(True)
+         )
+
+MCScaleHighR9EB_EGM = cms.PSet( PhotonMethodName = cms.string("FlashggPhotonScaleEGMTool"),
+         MethodName = cms.string("FlashggDiPhotonFromPhoton"),
+         Label = cms.string("MCScaleHighR9EB"),
+         NSigmas = cms.vint32(-1,1),
+         OverallRange = cms.string("r9>0.94&&abs(superCluster.eta)<1.5"),
+         BinList = emptyBins,
+         CorrectionFile = scalesAndSmearingsPrefix,
+         ApplyCentralValue = cms.bool(False),
+         ExaggerateShiftUp = cms.bool(False),
+         Debug = cms.untracked.bool(False)
+         )
+
+MCScaleLowR9EB_EGM = cms.PSet( PhotonMethodName = cms.string("FlashggPhotonScaleEGMTool"),
+         MethodName = cms.string("FlashggDiPhotonFromPhoton"),
+         Label = cms.string("MCScaleLowR9EB"),
+         NSigmas = cms.vint32(-1,1),
+         OverallRange = cms.string("r9<0.94&&abs(superCluster.eta)<1.5"),
+         BinList = emptyBins,
+         CorrectionFile = scalesAndSmearingsPrefix,
+         ApplyCentralValue = cms.bool(False),
+         ExaggerateShiftUp = cms.bool(False),
+         Debug = cms.untracked.bool(False)
+         )
+
+MCScaleHighR9EE_EGM = cms.PSet( PhotonMethodName = cms.string("FlashggPhotonScaleEGMTool"),
+         MethodName = cms.string("FlashggDiPhotonFromPhoton"),
+         Label = cms.string("MCScaleHighR9EE"),
+         NSigmas = cms.vint32(-1,1),
+         OverallRange = cms.string("r9>0.94&&abs(superCluster.eta)>=1.5"),
+         BinList = emptyBins,
+         CorrectionFile = scalesAndSmearingsPrefix,
+         ApplyCentralValue = cms.bool(False),
+         ExaggerateShiftUp = cms.bool(False),
+         Debug = cms.untracked.bool(False)
+         )
+
+MCScaleLowR9EE_EGM = cms.PSet( PhotonMethodName = cms.string("FlashggPhotonScaleEGMTool"),
+         MethodName = cms.string("FlashggDiPhotonFromPhoton"),
+         Label = cms.string("MCScaleLowR9EE"),
+         NSigmas = cms.vint32(-1,1),
+         OverallRange = cms.string("r9<0.94&&abs(superCluster.eta)>=1.5"),
+         BinList = emptyBins,
+         CorrectionFile = scalesAndSmearingsPrefix,
+         ApplyCentralValue = cms.bool(False),
+         ExaggerateShiftUp = cms.bool(False),
+         Debug = cms.untracked.bool(False)
+         )
+
 
 flashggDiPhotonSystematics = cms.EDProducer('FlashggDiPhotonSystematicProducer',
 		src = cms.InputTag("flashggUpdatedIdMVADiPhotons"),
@@ -379,198 +711,23 @@ flashggDiPhotonSystematics = cms.EDProducer('FlashggDiPhotonSystematicProducer',
                 # assumed for a given systematic uncertainty and is NOT required
                 # to match 1-to-1 the number of bins above.
                 SystMethods = cms.VPSet(
-                                        cms.PSet( PhotonMethodName = cms.string("FlashggPhotonScale"),
-                                                  MethodName = cms.string("FlashggDiPhotonFromPhoton"),
-                                                  Label = cms.string("MCScaleHighR9EB"),
-                                                  NSigmas = cms.vint32(-1,1),
-                                                  OverallRange = cms.string("r9>0.94&&abs(superCluster.eta)<1.5"),
-                                                  BinList = photonScaleUncertBins,
-                                                  ApplyCentralValue = cms.bool(False),
-                                                  Debug = cms.untracked.bool(False)
-                                                  ),
-                                        cms.PSet( PhotonMethodName = cms.string("FlashggPhotonScale"),
-                                                  MethodName = cms.string("FlashggDiPhotonFromPhoton"),
-                                                  Label = cms.string("MCScaleLowR9EB"),
-                                                  NSigmas = cms.vint32(-1,1),
-                                                  OverallRange = cms.string("r9<0.94&&abs(superCluster.eta)<1.5"),
-                                                  BinList = photonScaleUncertBins,
-                                                  ApplyCentralValue = cms.bool(False),
-                                                  Debug = cms.untracked.bool(False)
-                                                  ),
-                                        cms.PSet( PhotonMethodName = cms.string("FlashggPhotonScale"),
-                                                  MethodName = cms.string("FlashggDiPhotonFromPhoton"),
-                                                  Label = cms.string("MCScaleHighR9EE"),
-                                                  NSigmas = cms.vint32(-1,1),
-                                                  OverallRange = cms.string("r9>0.94&&abs(superCluster.eta)>=1.5"),
-                                                  BinList = photonScaleUncertBins,
-                                                  ApplyCentralValue = cms.bool(False),
-                                                  Debug = cms.untracked.bool(False)
-                                                  ),
-                                        cms.PSet( PhotonMethodName = cms.string("FlashggPhotonScale"),
-                                                  MethodName = cms.string("FlashggDiPhotonFromPhoton"),
-                                                  Label = cms.string("MCScaleLowR9EE"),
-                                                  NSigmas = cms.vint32(-1,1),
-                                                  OverallRange = cms.string("r9<0.94&&abs(superCluster.eta)>=1.5"),
-                                                  BinList = photonScaleUncertBins,
-                                                  ApplyCentralValue = cms.bool(False),
-                                                  Debug = cms.untracked.bool(False)
-                                                  ),
-                                        cms.PSet( PhotonMethodName = cms.string("FlashggPhotonScale"),
-                                                  MethodName = cms.string("FlashggDiPhotonFromPhoton"),
-                                                  Label = cms.string("MaterialCentral"),
-                                                  NSigmas = cms.vint32(-1,1),
-                                                  OverallRange = cms.string("abs(superCluster.eta)<1.0"),
-                                                  BinList = materialBinsRun1,
-                                                  ApplyCentralValue = cms.bool(False),
-                                                  Debug = cms.untracked.bool(False)
-                                                  ),
-                                        cms.PSet( PhotonMethodName = cms.string("FlashggPhotonScale"),
-                                                  MethodName = cms.string("FlashggDiPhotonFromPhoton"),
-                                                  Label = cms.string("MaterialForward"),
-                                                  NSigmas = cms.vint32(-1,1),
-                                                  OverallRange = cms.string("abs(superCluster.eta)>=1.0"),
-                                                  BinList = materialBinsRun1,
-                                                  ApplyCentralValue = cms.bool(False),
-                                                  Debug = cms.untracked.bool(False)
-                                                  ),
-                                        cms.PSet( PhotonMethodName = cms.string("FlashggPhotonSmearConstant"),
-                                                  MethodName = cms.string("FlashggDiPhotonFromPhoton"),
-                                                  Label = cms.string("MCSmearHighR9EE"),
-                                                  NSigmas = cms.vint32(-1,1),
-                                                  OverallRange = cms.string("r9>0.94&&abs(superCluster.eta)>=1.5"),
-                                                  BinList = photonSmearBins,
-                                                  # has to match the labels embedded in the photon object as
-                                                  # defined e.g. in flashgg/MicroAOD/python/flashggRandomizedPerPhotonDiPhotonProducer_cff.py
-                                                  #           or in flashgg/MicroAOD/python/flashggRandomizedPhotonProducer_cff.py (if at MicroAOD prod.)
-                                                  RandomLabel = cms.string("rnd_g_E"),
-                                                  Debug = cms.untracked.bool(False),
-                                                  ExaggerateShiftUp = cms.bool(False),
-                                                  ApplyCentralValue = cms.bool(True)
-                                                  ),
-                                        cms.PSet( PhotonMethodName = cms.string("FlashggPhotonSmearConstant"),
-                                                  MethodName = cms.string("FlashggDiPhotonFromPhoton"),
-                                                  Label = cms.string("MCSmearLowR9EE"),
-                                                  NSigmas = cms.vint32(-1,1),
-                                                  OverallRange = cms.string("r9<0.94&&abs(superCluster.eta)>=1.5"),
-                                                  BinList = photonSmearBins,
-                                                  # has to match the labels embedded in the photon object as
-                                                  # defined e.g. in flashgg/MicroAOD/python/flashggRandomizedPerPhotonDiPhotonProducer_cff.py
-                                                  #           or in flashgg/MicroAOD/python/flashggRandomizedPhotonProducer_cff.py (if at MicroAOD prod.)
-                                                  RandomLabel = cms.string("rnd_g_E"),
-                                                  Debug = cms.untracked.bool(False),
-                                                  ExaggerateShiftUp = cms.bool(False),
-                                                  ApplyCentralValue = cms.bool(True)
-                                                  ),
-                                        cms.PSet( PhotonMethodName = cms.string("FlashggPhotonSmearConstant"),
-                                                  MethodName = cms.string("FlashggDiPhotonFromPhoton"),
-                                                  Label = cms.string("MCSmearHighR9EB"),
-                                                  NSigmas = cms.vint32(-1,1),
-                                                  OverallRange = cms.string("r9>0.94&&abs(superCluster.eta)<1.5"),
-                                                  BinList = photonSmearBins,
-                                                  # has to match the labels embedded in the photon object as
-                                                  # defined e.g. in flashgg/MicroAOD/python/flashggRandomizedPerPhotonDiPhotonProducer_cff.py
-                                                  #           or in flashgg/MicroAOD/python/flashggRandomizedPhotonProducer_cff.py (if at MicroAOD prod.)
-                                                  RandomLabel = cms.string("rnd_g_E"),
-                                                  Debug = cms.untracked.bool(False),
-                                                  ExaggerateShiftUp = cms.bool(False),
-                                                  ApplyCentralValue = cms.bool(True)
-                                                  ),
-                                        cms.PSet( PhotonMethodName = cms.string("FlashggPhotonSmearConstant"),
-                                                  MethodName = cms.string("FlashggDiPhotonFromPhoton"),
-                                                  Label = cms.string("MCSmearLowR9EB"),
-                                                  NSigmas = cms.vint32(-1,1),
-                                                  OverallRange = cms.string("r9<=0.94&&abs(superCluster.eta)<1.5"),
-                                                  BinList = photonSmearBins,
-                                                  # has to match the labels embedded in the photon object as
-                                                  # defined e.g. in flashgg/MicroAOD/python/flashggRandomizedPerPhotonDiPhotonProducer_cff.py
-                                                  #           or in flashgg/MicroAOD/python/flashggRandomizedPhotonProducer_cff.py (if at MicroAOD prod.)
-                                                  RandomLabel = cms.string("rnd_g_E"),
-                                                  Debug = cms.untracked.bool(False),
-                                                  ExaggerateShiftUp = cms.bool(False),
-                                                  ApplyCentralValue = cms.bool(True)
-                                                  ),
-                                        cms.PSet( PhotonMethodName = cms.string("FlashggPhotonMvaShift"),
-                                                  MethodName = cms.string("FlashggDiPhotonFromPhoton"),
-                                                  Label = cms.string("MvaShift"),
-                                                  NSigmas = cms.vint32(-1,1),
-                                                  OverallRange = cms.string("1"),
-                                                  BinList = mvaShiftBins,
-                                                  Debug = cms.untracked.bool(False),
-                                                  ApplyCentralValue = cms.bool(True)
-                                                  ),
-                                        cms.PSet( PhotonMethodName = cms.string("FlashggSinglePhotonViewWeight"),
-                                                  MethodName = cms.string("FlashggDiPhotonFromSinglePhotonView"),
-                                                  Label = cms.string("MvaLinearSyst"),
-                                                  NSigmas = cms.vint32(-1,1),
-                                                  OverallRange = cms.string("phoIdMvaWrtChosenVtx<0.2"),
-                                                  BinList = mvaLinearSystBins,
-                                                  Debug = cms.untracked.bool(False),
-                                                  ApplyCentralValue = cms.bool(False)
-                                                  ),
-                                        cms.PSet( PhotonMethodName = cms.string("FlashggPhotonWeight"),
-                                                  MethodName = cms.string("FlashggDiPhotonFromPhoton"),
-                                                  Label = cms.string("PreselSF"),
-                                                  NSigmas = cms.vint32(-1,1),
-                                                  OverallRange = cms.string("1"),
-                                                  BinList = preselBins,
-                                                  Debug = cms.untracked.bool(False),
-                                                  ApplyCentralValue = cms.bool(True)
-                                                  ),
-                                        cms.PSet( PhotonMethodName = cms.string("FlashggPhotonWeight"),
-                                                  MethodName = cms.string("FlashggDiPhotonFromPhoton"),
-                                                  Label = cms.string("electronVetoSF"),
-                                                  NSigmas = cms.vint32(-1,1),
-                                                  OverallRange = cms.string("1"),
-                                                  BinList = electronVetoBins,
-                                                  Debug = cms.untracked.bool(False),
-                                                  ApplyCentralValue = cms.bool(True)
-                                                  ),
-                                        cms.PSet( PhotonMethodName = cms.string("FlashggPhotonWeight"),
-                                                  MethodName = cms.string("FlashggDiPhotonFromPhoton"),
-                                                  Label = cms.string("TriggerWeight"),
-                                                  NSigmas = cms.vint32(-1,1),
-                                                  OverallRange = cms.string("1"),
-                                                  BinList = leadTriggerScaleBins,
-                                                  BinList2 = subleadTriggerScaleBins,
-                                                  Debug = cms.untracked.bool(False),
-                                                  ApplyCentralValue = cms.bool(True)
-                                                  ),
-                                        cms.PSet( PhotonMethodName = cms.string("FlashggPhotonWeight"),
-                                                  MethodName = cms.string("FlashggDiPhotonFromPhoton"),
-                                                  Label = cms.string("LooseMvaSF"),
-                                                  NSigmas = cms.vint32(-1,1),
-                                                  OverallRange = cms.string("1"),
-                                                  BinList = looseMvaBins,
-                                                  Debug = cms.untracked.bool(False),
-                                                  ApplyCentralValue = cms.bool(True)
-                                                  ),
-                                        cms.PSet( PhotonMethodName = cms.string("FlashggPhotonSigEOverEShift"),
-                                                  MethodName = cms.string("FlashggDiPhotonFromPhoton"),
-                                                  Label = cms.string("SigmaEOverEShift"),
-                                                  NSigmas = cms.vint32(-1,1),
-                                                  OverallRange = cms.string("1"),
-                                                  BinList = sigmaEOverEShiftBins,
-                                                  Debug = cms.untracked.bool(False),
-                                                  ApplyCentralValue = cms.bool(True)
-                                                  ),
-                                        cms.PSet( PhotonMethodName = cms.string("FlashggPhotonSigEoverESmearing"),
-                                                  MethodName = cms.string("FlashggDiPhotonFromPhoton"),
-                                                  Label = cms.string("SigmaEOverESmearing"),
-                                                  NSigmas = cms.vint32(),
-                                                  OverallRange = cms.string("1"),
-                                                  BinList = photonSmearBins,
-                                                  Debug = cms.untracked.bool(False),
-                                                  ApplyCentralValue = cms.bool(True)
-                                                  ),
-                                        cms.PSet( MethodName = cms.string("FlashggDiPhotonWeightFromFracRV"),
-                                                  Label = cms.string("FracRVWeight"),
-                                                  NSigmas = cms.vint32(-1,1),
-                                                  OverallRange = cms.string("1"),
-                                                  BinList = RVBins,
-                                                  Debug = cms.untracked.bool(False),
-                                                  ApplyCentralValue = cms.bool(True)
-                                                  )
-                                        )
-                                            )
-
-
+                    MCScaleHighR9EB,
+                    MCScaleLowR9EB,
+                    MCScaleHighR9EE,
+                    MCScaleLowR9EE,
+                    MaterialCentral,
+                    MaterialForward,
+                    MCSmearHighR9EE,
+                    MCSmearLowR9EE,
+                    MCSmearHighR9EB,
+                    MCSmearLowR9EB,
+                    MvaShift,
+                    PreselSF,
+                    electronVetoSF,
+                    TriggerWeight,
+                    LooseMvaSF,
+                    SigmaEOverEShift,
+                    SigmaEOverESmearing,
+                    FracRVWeight
+                )
+                )

--- a/Systematics/python/flashggDiPhotonSystematics_cfi.py
+++ b/Systematics/python/flashggDiPhotonSystematics_cfi.py
@@ -381,7 +381,11 @@ emptySigma = cms.PSet(
     secondVar = cms.vint32()
 )
 
-scalesAndSmearingsPrefix = cms.string("EgammaAnalysis/ElectronTools/data/76X_16DecRereco_2015_photons")
+# latest greatest
+# scalesAndSmearingsPrefix = cms.string("EgammaAnalysis/ElectronTools/data/76X_16DecRereco_2015_photons")
+
+# unblinding version + Et-dependent scale uncertainties
+scalesAndSmearingsPrefix = cms.string("EgammaAnalysis/ElectronTools/data/76X_16DecRereco_2015_Etunc")
 
 
 MCScaleHighR9EB = cms.PSet( PhotonMethodName = cms.string("FlashggPhotonScale"),

--- a/Systematics/python/flashggDiPhotonSystematics_cfi.py
+++ b/Systematics/python/flashggDiPhotonSystematics_cfi.py
@@ -570,6 +570,19 @@ SigmaEOverESmearing = cms.PSet( PhotonMethodName = cms.string("FlashggPhotonSigE
           ApplyCentralValue = cms.bool(True)
           )
 
+SigmaEOverESmearingEGMTool = cms.PSet( PhotonMethodName = cms.string("FlashggPhotonSigEoverESmearingEGMTool"),
+          MethodName = cms.string("FlashggDiPhotonFromPhoton"),
+          Label = cms.string("SigmaEOverESmearing"),
+          FirstParameterName = cms.string("Rho"),
+          SecondParameterName = cms.string("Phi"),
+          CorrectionFile = scalesAndSmearingsPrefix,
+          NSigmas = cms.vint32(),
+          OverallRange = cms.string("1"),
+          BinList = emptyBins,
+          Debug = cms.untracked.bool(False),
+          ApplyCentralValue = cms.bool(True)
+          )
+
 FracRVWeight = cms.PSet( MethodName = cms.string("FlashggDiPhotonWeightFromFracRV"),
           Label = cms.string("FracRVWeight"),
           NSigmas = cms.vint32(-1,1),

--- a/Systematics/python/flashggDiPhotonSystematics_cfi.py
+++ b/Systematics/python/flashggDiPhotonSystematics_cfi.py
@@ -586,10 +586,12 @@ SigmaEOverESmearing_EGM = cms.PSet( PhotonMethodName = cms.string("FlashggPhoton
           FirstParameterName = cms.string("Rho"),
           SecondParameterName = cms.string("Phi"),
           CorrectionFile = scalesAndSmearingsPrefix,
-          NSigmas = cms.vint32(),
+          NSigmas = cms.PSet( firstVar = cms.vint32(),
+                            secondVar = cms.vint32()),
           OverallRange = cms.string("1"),
           BinList = emptyBins,
           Debug = cms.untracked.bool(False),
+          ExaggerateShiftUp = cms.bool(False),
           ApplyCentralValue = cms.bool(True)
           )
 

--- a/Systematics/python/flashggDiPhotonSystematics_cfi.py
+++ b/Systematics/python/flashggDiPhotonSystematics_cfi.py
@@ -509,6 +509,16 @@ MvaShift = cms.PSet( PhotonMethodName = cms.string("FlashggPhotonMvaShift"),
           ApplyCentralValue = cms.bool(True)
           )
 
+MvaLinearSyst = cms.PSet( PhotonMethodName = cms.string("FlashggSinglePhotonViewWeight"),
+          MethodName = cms.string("FlashggDiPhotonFromSinglePhotonView"),
+          Label = cms.string("MvaLinearSyst"),
+          NSigmas = cms.vint32(-1,1),
+          OverallRange = cms.string("phoIdMvaWrtChosenVtx<0.2"),
+          BinList = mvaLinearSystBins,
+          Debug = cms.untracked.bool(False),
+          ApplyCentralValue = cms.bool(False)
+          )
+
 PreselSF = cms.PSet( PhotonMethodName = cms.string("FlashggPhotonWeight"),
           MethodName = cms.string("FlashggDiPhotonFromPhoton"),
           Label = cms.string("PreselSF"),
@@ -570,8 +580,8 @@ SigmaEOverESmearing = cms.PSet( PhotonMethodName = cms.string("FlashggPhotonSigE
           ApplyCentralValue = cms.bool(True)
           )
 
-SigmaEOverESmearingEGMTool = cms.PSet( PhotonMethodName = cms.string("FlashggPhotonSigEoverESmearingEGMTool"),
-          MethodName = cms.string("FlashggDiPhotonFromPhoton"),
+SigmaEOverESmearing_EGM = cms.PSet( PhotonMethodName = cms.string("FlashggPhotonSigEoverESmearingEGMTool"),
+          MethodName = cms.string("FlashggDiPhotonFromPhoton2D"),
           Label = cms.string("SigmaEOverESmearing"),
           FirstParameterName = cms.string("Rho"),
           SecondParameterName = cms.string("Phi"),
@@ -599,7 +609,7 @@ MCSmearHighR9EE_EGM = cms.PSet( PhotonMethodName = cms.string("FlashggPhotonSmea
          SecondParameterName = cms.string("Phi"),
          CorrectionFile = scalesAndSmearingsPrefix,
          NSigmas = cms.PSet( firstVar = cms.vint32(1,-1,0,0),
-                                                                                                  secondVar = cms.vint32(0,0,1,-1)),
+                            secondVar = cms.vint32(0,0,1,-1)),
          OverallRange = cms.string("r9>0.94&&abs(superCluster.eta)>=1.5"),
          BinList = emptyBins,
          # has to match the labels embedded in the photon object as


### PR DESCRIPTION
Validated on Zee:
   - https://cern.ch/fe/p/hgg/scale_smearings_76X/

With the following tweak:
   - https://github.com/cms-analysis/flashgg/commit/2d6c4c094da755e6788a9f20e5c1eb630137450f#diff-3b45c37da2ee09f2df947eae8f310e97

validated also for the WS production (thanks Seth and Louie!):
   - new scales and smearings (with slightly larger smearings):
     https://lcorpe.web.cern.ch/lcorpe/outdir_HggAnalysis_040316/sigplots/
   - old scales and smearings (unblinding version):
     https://lcorpe.web.cern.ch/lcorpe/outdir_HggAnalysis_290216/sigplots/

Latest scales and smearings files available from:
   - https://github.com/cms-sw/cmssw/compare/CMSSW_7_6_X...ferriff:scale_smearings_76X_photons
by cherry-picking
   - https://github.com/cms-sw/cmssw/commit/17869e7ed59c85fc8a4f8407809ce184be6d1c74

The files will be included shortly in @matteosan1 branch.