### PR TITLE
more code for dumping optimization trees ('opttrees')

### DIFF
--- a/DataFormats/interface/TagCandidate.h
+++ b/DataFormats/interface/TagCandidate.h
@@ -1,0 +1,71 @@
+#ifndef FLASHgg_TagCandidate_h
+#define FLASHgg_TagCandidate_h
+
+#include "DataFormats/Candidate/interface/CompositeCandidate.h"
+#include "flashgg/DataFormats/interface/DiPhotonTagBase.h"
+
+namespace flashgg {
+    class TagCandidate : public reco::CompositeCandidate
+    {
+    public:
+        TagCandidate();
+        TagCandidate( const flashgg::DiPhotonTagBase* tag, int triggerBits[3] );
+        ~TagCandidate();
+
+        const edm::Ptr<DiPhotonCandidate> diPhoton() const { return tag_->diPhoton(); }
+        const flashgg::DiPhotonMVAResult diPhotonMVA() const { return tag_->diPhotonMVA(); }
+        float diPhoMVAValue() const      { return tag_->diPhotonMVA().mvaValue(); }
+        int categoryNumber () const      { return tag_->categoryNumber() + cat_; } 
+        float vbfMVA() const             { return vbfMVA_;            }
+        float combindedMVA() const       { return combindedMVA_;      }
+        float dijet_leadEta () const     { return dijet_leadEta_;     }
+        float dijet_subleadEta() const   { return dijet_subleadEta_;  }
+        float dijet_abs_dEta() const     { return dijet_abs_dEta_;    }
+        float dijet_LeadJPt () const     { return dijet_LeadJPt_;     }
+        float dijet_SubJPt() const       { return dijet_SubJPt_;      }
+        float dijet_Zep() const          { return dijet_Zep_;         }
+        float dijet_dphi_trunc() const   { return dijet_dphi_trunc_;  }
+        float dijet_dipho_dphi() const   { return dijet_dipho_dphi_;  }
+        float dijet_Mjj() const          { return dijet_Mjj_;         }
+        float dijet_dy() const           { return dijet_dy_;          }
+        float dijet_leady () const       { return dijet_leady_;       }
+        float dijet_subleady() const     { return dijet_subleady_;    }
+        float dijet_dipho_pt() const     { return dijet_dipho_pt_;    }
+        float dijet_minDRJetPho() const  { return dijet_minDRJetPho_; }
+        int triggerBit(int i) const      { return triggerBits_[i];    }
+        int genMatchLead() const         { return int (tag_->diPhoton()->leadingPhoton()->hasGenMatchType() && 
+                                                      (tag_->diPhoton()->leadingPhoton()->genMatchType() == 1)); }
+        int genMatchSubLead() const      { return int (tag_->diPhoton()->subLeadingPhoton()->hasGenMatchType() && 
+                                                      (tag_->diPhoton()->subLeadingPhoton()->genMatchType() == 1)); }
+        
+    private:        
+        const flashgg::DiPhotonTagBase* tag_;
+        int triggerBits_[3];
+        int cat_;
+        float vbfMVA_;           
+        float combindedMVA_;     
+        float dijet_leadEta_;   
+        float dijet_subleadEta_; 
+        float dijet_abs_dEta_;   
+        float dijet_LeadJPt_;   
+        float dijet_SubJPt_;     
+        float dijet_Zep_;        
+        float dijet_dphi_trunc_; 
+        float dijet_dipho_dphi_; 
+        float dijet_Mjj_;        
+        float dijet_dy_;         
+        float dijet_leady_;     
+        float dijet_subleady_;   
+        float dijet_dipho_pt_;   
+        float dijet_minDRJetPho_;
+    };
+}
+#endif
+// Local Variables:
+// mode:c++
+// indent-tabs-mode:nil
+// tab-width:4
+// c-basic-offset:4
+// End:
+// vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4
+

--- a/DataFormats/interface/UntaggedTag.h
+++ b/DataFormats/interface/UntaggedTag.h
@@ -1,3 +1,6 @@
+#ifndef flashgg_UntaggedTag
+#define flashgg_UntaggedTag
+
 #include "flashgg/DataFormats/interface/DiPhotonTagBase.h"
 
 namespace flashgg {
@@ -18,6 +21,8 @@ namespace flashgg {
 
     };
 }
+
+#endif
 // Local Variables:
 // mode:c++
 // indent-tabs-mode:nil

--- a/DataFormats/src/TagCandidate.cc
+++ b/DataFormats/src/TagCandidate.cc
@@ -1,0 +1,84 @@
+#include "flashgg/DataFormats/interface/TagCandidate.h"
+#include "flashgg/DataFormats/interface/VBFTag.h"
+
+using namespace flashgg;
+
+TagCandidate::TagCandidate(): tag_(0) {
+    vbfMVA_            = -9999.;
+    combindedMVA_      = -9999.;
+    dijet_leadEta_     = -9999.;
+    dijet_subleadEta_  = -9999.;
+    dijet_abs_dEta_    = -9999.;
+    dijet_LeadJPt_     = -9999.;
+    dijet_SubJPt_      = -9999.;
+    dijet_Zep_         = -9999.;
+    dijet_dphi_trunc_  = -9999.;
+    dijet_dipho_dphi_  = -9999.;
+    dijet_Mjj_         = -9999.;
+    dijet_dy_          = -9999.;
+    dijet_leady_       = -9999.;
+    dijet_subleady_    = -9999.;
+    dijet_dipho_pt_    = -9999.;
+    dijet_minDRJetPho_ = -9999.;
+    cat_ = 2;
+    for (int i=0; i<3; i++)
+        triggerBits_[i] = 0;
+}
+
+TagCandidate::~TagCandidate() 
+{}
+
+TagCandidate::TagCandidate( const flashgg::DiPhotonTagBase* tag, int triggerBits[3] ): tag_(tag) {
+    cat_ = 2; 
+        
+    for (int i=0; i<3; i++)
+        triggerBits_[i] = triggerBits[i];
+
+    //const UntaggedTag *untagged = dynamic_cast<const UntaggedTag *>( tag_ );
+    const VBFTag *vbf = dynamic_cast<const VBFTag *>( tag_ );
+    if( vbf != NULL ) {
+        cat_ = 0;
+        vbfMVA_            = vbf->VBFMVA().VBFMVAValue();
+        combindedMVA_      = vbf->VBFDiPhoDiJetMVA().VBFDiPhoDiJetMVAValue();
+        dijet_leadEta_     = vbf->VBFMVA().dijet_leadEta;
+        dijet_subleadEta_  = vbf->VBFMVA().dijet_subleadEta;
+        dijet_abs_dEta_    = vbf->VBFMVA().dijet_abs_dEta;
+        dijet_LeadJPt_     = vbf->VBFMVA().dijet_LeadJPt;
+        dijet_SubJPt_      = vbf->VBFMVA().dijet_SubJPt;
+        dijet_Zep_         = vbf->VBFMVA().dijet_Zep;
+        dijet_dphi_trunc_  = vbf->VBFMVA().dijet_dphi_trunc;
+        dijet_dipho_dphi_  = vbf->VBFMVA().dijet_dipho_dphi;
+        dijet_Mjj_         = vbf->VBFMVA().dijet_Mjj;
+        dijet_dy_          = vbf->VBFMVA().dijet_dy;
+        dijet_leady_       = vbf->VBFMVA().dijet_leady;
+        dijet_subleady_    = vbf->VBFMVA().dijet_subleady;
+        dijet_dipho_pt_    = vbf->VBFMVA().dijet_dipho_pt;
+        dijet_minDRJetPho_ = vbf->VBFMVA().dijet_minDRJetPho;
+    } else {
+        vbfMVA_            = -9999.;
+        combindedMVA_      = -9999.;
+        dijet_leadEta_     = -9999.;
+        dijet_subleadEta_  = -9999.;
+        dijet_abs_dEta_    = -9999.;
+        dijet_LeadJPt_     = -9999.;
+        dijet_SubJPt_      = -9999.;
+        dijet_Zep_         = -9999.;
+        dijet_dphi_trunc_  = -9999.;
+        dijet_dipho_dphi_  = -9999.;
+        dijet_Mjj_         = -9999.;
+        dijet_dy_          = -9999.;
+        dijet_leady_       = -9999.;
+        dijet_subleady_    = -9999.;
+        dijet_dipho_pt_    = -9999.;
+        dijet_minDRJetPho_ = -9999.;
+    }     
+}
+
+// Local Variables:
+// mode:c++
+// indent-tabs-mode:nil
+// tab-width:4
+// c-basic-offset:4
+// End:
+// vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4
+

--- a/DataFormats/src/classes.h
+++ b/DataFormats/src/classes.h
@@ -32,6 +32,7 @@
 #include "flashgg/DataFormats/interface/WeightedObject.h"
 #include "flashgg/DataFormats/interface/PDFWeightObject.h"
 #include "flashgg/DataFormats/interface/ZPlusJetTag.h"
+#include "flashgg/DataFormats/interface/TagCandidate.h"
 
 #include <vector>
 #include <map>
@@ -259,7 +260,10 @@ namespace  {
         std::vector<edm::Ptr<flashgg::PhotonJetCandidate> >        vec_ptr_fgj_dip;
         edm::Wrapper<std::vector<edm::Ptr<flashgg::PhotonJetCandidate> > >   wrp_vec_ptr_fgj_dip;
 
-
+        flashgg::TagCandidate                                        tags;
+        edm::Wrapper<flashgg::TagCandidate>                      wrp_tags;
+        std::vector<flashgg::TagCandidate>                       vec_tags;
+        edm::Wrapper<std::vector<flashgg::TagCandidate> >    wrp_vec_tags;
     };
 }
 // Local Variables:

--- a/DataFormats/src/classes_def.xml
+++ b/DataFormats/src/classes_def.xml
@@ -253,4 +253,8 @@
 <class name="std::vector<edm::Ptr<flashgg::PhotonJetCandidate> >"/>
 <class name="edm::Wrapper<std::vector<edm::Ptr<flashgg::PhotonJetCandidate> > >"/>
 
+<class name="flashgg::TagCandidate" ClassVersion="0">
+</class>
+<class name="std::vector<flashgg::TagCandidate>"/>
+<class name="edm::Wrapper<std::vector<flashgg::TagCandidate> >"/>
 </lcgdict>

--- a/MicroAOD/plugins/TagCandidateProducer.cc
+++ b/MicroAOD/plugins/TagCandidateProducer.cc
@@ -1,0 +1,96 @@
+#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/EDMException.h"
+#include "FWCore/Common/interface/TriggerNames.h"
+#include "CommonTools/UtilAlgos/interface/TFileService.h"
+#include "DataFormats/Common/interface/Handle.h"
+
+#include "flashgg/DataFormats/interface/TagCandidate.h"
+
+#include <vector>
+#include <string>
+
+using namespace edm;
+using namespace std;
+
+namespace flashgg {
+
+    class TagCandidateProducer : public EDProducer
+    {
+
+    public:
+        TagCandidateProducer( const ParameterSet & );
+    private:
+        void produce( Event &, const EventSetup & ) override;
+        edm::EDGetTokenT<edm::OwnVector<flashgg::DiPhotonTagBase> > tagSorterToken_;
+        edm::EDGetTokenT<edm::TriggerResults> triggerResultsToken_;
+        edm::Handle<edm::TriggerResults> triggerResultsHandle_;
+        std::vector<std::string> pathNames_;        
+    };
+
+    TagCandidateProducer::TagCandidateProducer( const ParameterSet &iConfig ) :
+        tagSorterToken_( consumes<edm::OwnVector<flashgg::DiPhotonTagBase> >( iConfig.getUntrackedParameter<InputTag> ( "TagSorter"))),
+        triggerResultsToken_( consumes<edm::TriggerResults>(iConfig.getUntrackedParameter<edm::InputTag>("triggerResults"))), 
+        pathNames_(iConfig.getUntrackedParameter<std::vector<std::string> >("pathNames"))
+    {
+        produces<std::vector<flashgg::TagCandidate> >();
+        if (pathNames_.size() > 3) {
+            std::cerr << "Too many trigger bits..." << std::endl;
+            abort();
+        }
+    }
+
+    void TagCandidateProducer::produce( Event &evt, const EventSetup & )
+    {
+        
+        auto_ptr<std::vector<flashgg::TagCandidate> > tagsColl( new std::vector<flashgg::TagCandidate> );
+        
+        Handle<edm::OwnVector<flashgg::DiPhotonTagBase> > tagSorter;
+        evt.getByToken( tagSorterToken_, tagSorter );
+        
+        if( tagSorter.product()->size() > 0 ) {
+            int passSel[3];           
+            for (int i=0; i<3; i++) 
+                passSel[i] = 0;
+
+            bool isData = (evt.eventAuxiliary().isRealData());
+            evt.getByToken(triggerResultsToken_, triggerResultsHandle_);
+            
+            if (isData) {
+                const edm::TriggerResults& trigResults = *triggerResultsHandle_;
+                const edm::TriggerNames& trigNames = evt.triggerNames(trigResults);  
+                
+                for(size_t pathNr=0; pathNr<3; pathNr++){
+                    passSel[pathNr] = 0;
+                    
+                    if (pathNr < pathNames_.size()) {
+                        size_t pathIndex = trigNames.triggerIndex(pathNames_[pathNr]);
+                        if(pathIndex<trigResults.size() &&  trigResults.accept(pathIndex)) 
+                            passSel[pathNr] = 1;
+                    }
+                }
+            }
+
+            const flashgg::DiPhotonTagBase *chosenTag = &*( tagSorter.product()->begin() );
+            TagCandidate tags( chosenTag, passSel );
+            tagsColl->push_back( tags );
+        }
+ 
+        evt.put( tagsColl );                               
+    }
+}
+
+typedef flashgg::TagCandidateProducer FlashggTagCandidateProducer;
+DEFINE_FWK_MODULE( FlashggTagCandidateProducer );
+
+// Local Variables:
+// mode:c++
+// indent-tabs-mode:nil
+// tab-width:4
+// c-basic-offset:4
+// End:
+// vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4

--- a/MicroAOD/python/flashggTagCandidateProducer_cfi.py
+++ b/MicroAOD/python/flashggTagCandidateProducer_cfi.py
@@ -1,0 +1,9 @@
+import FWCore.ParameterSet.Config as cms
+
+flashggTagCandidateProducer = cms.EDProducer('FlashggTagCandidateProducer',
+                                             TagSorter = cms.untracked.InputTag('flashggTagSorter'),
+                                             triggerResults = cms.untracked.InputTag("TriggerResults"),
+                                             pathNames = cms.untracked.vstring("HLT_Diphoton30_18_R9Id_OR_IsoCaloId_AND_HE_R9Id_Mass95_v1",
+                                                                               "HLT_Diphoton30PV_18PV_R9Id_AND_IsoCaloId_AND_HE_R9Id_DoublePixelVeto_Mass55_v1",
+                                                                               "HLT_Diphoton30EB_18EB_R9Id_OR_IsoCaloId_AND_HE_R9Id_DoublePixelVeto_Mass55_v1")
+                             )

--- a/Taggers/interface/TagCandidateDumper.h
+++ b/Taggers/interface/TagCandidateDumper.h
@@ -1,0 +1,20 @@
+#ifndef flashgg_TagCandidateDumper_h
+#define flashgg_TagCandidateDumper_h
+
+#include "flashgg/DataFormats/interface/TagCandidate.h"
+#include "flashgg/Taggers/interface/CollectionDumper.h"
+
+namespace flashgg {
+    typedef CollectionDumper<std::vector<TagCandidate>, TagCandidate,
+                             CutBasedClassifier<TagCandidate> > CutBasedTagCandidateDumper;
+}
+
+#endif
+
+// Local Variables:
+// mode:c++
+// indent-tabs-mode:nil
+// tab-width:4
+// c-basic-offset:4
+// End:
+// vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4

--- a/Taggers/plugins/EDTagCandidateDumper.cc
+++ b/Taggers/plugins/EDTagCandidateDumper.cc
@@ -1,0 +1,16 @@
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "PhysicsTools/UtilAlgos/interface/EDAnalyzerWrapper.h"
+
+#include "flashgg/Taggers/interface/TagCandidateDumper.h"
+
+typedef edm::AnalyzerWrapper<flashgg::CutBasedTagCandidateDumper> CutBasedTagCandidateDumper;
+
+DEFINE_FWK_MODULE( CutBasedTagCandidateDumper );
+
+// Local Variables:
+// mode:c++
+// indent-tabs-mode:nil
+// tab-width:4
+// c-basic-offset:4
+// End:
+// vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4

--- a/Taggers/python/tagCandidateDumpConfig_cff.py
+++ b/Taggers/python/tagCandidateDumpConfig_cff.py
@@ -1,0 +1,27 @@
+import FWCore.ParameterSet.Config as cms
+
+from globalVariables_cff import globalVariables
+
+tagCandidateDumpConfig = cms.PSet(
+    className  = cms.untracked.string(""),
+    src = cms.InputTag(""),    
+    generatorInfo = cms.InputTag("generator"),
+    processId = cms.string(""),
+    processIndex = cms.int32(50),
+    maxCandPerEvent = cms.int32(-1),
+    lumiWeight = cms.double(1.0),# Over-written by metaData if using fggRunJobs
+    intLumi = cms.untracked.double(1000.), # in /pb. to be over-written by metaData if using fggRunJobs
+    classifierCfg = cms.PSet(categories = cms.VPSet()),
+    categories = cms.VPSet(),
+    
+    workspaceName = cms.untracked.string("cms_hgg_$SQRTS"),
+    nameTemplate = cms.untracked.string("$PROCESS_$SQRTS_$CLASSNAME_$SUBCAT_$LABEL"),
+    
+    dumpHistos = cms.untracked.bool(False),
+    dumpWorkspace = cms.untracked.bool(False),
+    dumpTrees = cms.untracked.bool(True),
+    
+    quietRooFit = cms.untracked.bool(False),
+    dumpGlobalVariables = cms.untracked.bool(True),
+    globalVariables = globalVariables
+)

--- a/Taggers/python/tagCandidateDumper_cfi.py
+++ b/Taggers/python/tagCandidateDumper_cfi.py
@@ -1,0 +1,7 @@
+import FWCore.ParameterSet.Config as cms
+
+from flashgg.Taggers.tagCandidateDumpConfig_cff import tagCandidateDumpConfig
+
+tagCandidateDumper = cms.EDAnalyzer('CutBasedTagCandidateDumper',
+                                    **tagCandidateDumpConfig.parameters_()
+                                    )

--- a/Validation/python/opttreeDumper.py
+++ b/Validation/python/opttreeDumper.py
@@ -4,7 +4,7 @@ import FWCore.ParameterSet.VarParsing as VarParsing
 
 from flashgg.MetaData.samples_utils import SamplesManager
 
-process = cms.Process("opttreeDumper")
+process = cms.Process("mytest")
 
 process.load("HLTrigger.HLTfilters.hltHighLevel_cfi")
 process.hltFilter = process.hltHighLevel.clone()
@@ -12,7 +12,7 @@ process.hltFilter.throw = cms.bool(True)
 
 from flashgg.MetaData.JobConfig import  JobConfig
 customize = JobConfig(crossSections=["$CMSSW_BASE/src/flashgg/MetaData/data/cross_sections.json"])
-customize.setDefault("maxEvents",10000)
+customize.setDefault("maxEvents",15000)
 customize.setDefault("targetLumi",2.6e+4)
 customize.parse()
 
@@ -20,7 +20,7 @@ if ("data" in customize.processId):
     process.hltFilter.HLTPaths = cms.vstring("HLT_Diphoton30_18_R9Id_OR_IsoCaloId_AND_HE_R9Id_Mass95_v*",
                                              "HLT_Diphoton30PV_18PV_R9Id_AND_IsoCaloId_AND_HE_R9Id_DoublePixelVeto_Mass55_v*",
                                              "HLT_Diphoton30EB_18EB_R9Id_OR_IsoCaloId_AND_HE_R9Id_DoublePixelVeto_Mass55_v*")
-else:
+else :
     process.hltFilter.HLTPaths = cms.vstring("*")
 
 process.load('RecoMET.METFilters.eeBadScFilter_cfi')
@@ -43,162 +43,248 @@ else:
 
 process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(-1) )
 
-process.source = cms.Source ("PoolSource",fileNames = cms.untracked.vstring("file:/afs/cern.ch/user/s/sani/mounteos/cms/store/group/phys_higgs/cmshgg/sethzenz/flashgg/RunIIFall15DR76-1_3_0-25ns/1_3_0/GluGluHToGG_M-125_13TeV_powheg_pythia8/RunIIFall15DR76-1_3_0-25ns-1_3_0-v0-RunIIFall15DR76-25nsFlat10to25TSG_76X_mcRun2_asymptotic_v12-v1/160116_110115/0000/myMicroAODOutputFile_1.root",
+process.source = cms.Source ("PoolSource",fileNames = cms.untracked.vstring("file:/afs/cern.ch/user/s/sani/mounteos/cms/store/group/phys_higgs/cmshgg/ferriff/flashgg/RunIIFall15DR76-1_3_0-25ns_ext1/1_3_1/GluGluHToGG_M125_13TeV_amcatnloFXFX_pythia8/RunIIFall15DR76-1_3_0-25ns_ext1-1_3_1-v0-RunIIFall15MiniAODv2-PU25nsData2015v1_76X_mcRun2_asymptotic_v12-v1/160127_023250/0000/myMicroAODOutputFile_1.root",
 ))
 
-import flashgg.Taggers.dumperConfigTools as cfgTools
-process.load("flashgg.Taggers.globalVariables_cff")
-process.globalVariables.puReWeight = cms.bool(True)
-if ("data" in customize.processId):
-    process.globalVariables.puReWeight = cms.bool(False)
-    process.dataRequirements += process.eeBadScFilter
+############################
+#       Systematics        #
+############################
+#process.load("flashgg.Systematics.flashggDiPhotonSystematics_cfi")
+#from PhysicsTools.PatAlgos.tools.helpers import cloneProcessingSnippet,massSearchReplaceAnyInputTag
+#massSearchReplaceAnyInputTag(process.diphotonDumper, cms.InputTag("flashggDiPhotons"),cms.InputTag("flashggDiPhotonSystematics"))
+#massSearchReplaceAnyInputTag(process.diphotonDumper, cms.InputTag("flashggPreselectedDiPhotons"),cms.InputTag("flashggDiPhotonSystematics"))
 
-process.load("flashgg.Taggers.diphotonDumper_cfi") 
-process.diphotonDumper.src = cms.InputTag("flashggDiPhotonSystematics")
-#process.diphotonDumper.src = cms.InputTag("flashggUpdatedIdMVADiPhotons")
-#process.diphotonDumper.src = cms.InputTag("flashggDiPhotons")
-process.diphotonDumper.dumpHistos = False
-process.diphotonDumper.dumpTrees  =  True
-process.diphotonDumper.dumpGlobalVariables = cms.untracked.bool(True)
-process.diphotonDumper.globalVariables = process.globalVariables
+process.load("flashgg/Taggers/flashggTagSequence_cfi")
+#process.flashggTagSequence.remove(process.flashggPreselectedDiPhotons)
+process.flashggTagSorter.massCutUpper=cms.double(100000.)
+process.flashggTagSorter.massCutLower=cms.double(90.)
+process.flashggUntagged.Boundaries=cms.vdouble(-99999.,0.31,0.62,0.86,0.98)
+
+process.flashggSystTagMerger = cms.EDProducer("TagMerger", src = cms.VInputTag("flashggTagSorter"))
+
+process.load("flashgg/MicroAOD/flashggTagCandidateProducer_cfi")
+process.load("flashgg/Taggers/tagCandidateDumper_cfi")
+process.tagCandidateDumper.src = cms.InputTag("flashggTagCandidateProducer")
 
 process.TFileService = cms.Service("TFileService",
                                    fileName = cms.string("histo.root"),
                                    closeFileFast = cms.untracked.bool(True)
                                    )
 
-# split tree, histogram and datasets by process
-cfgTools.addCategories(process.diphotonDumper,
+import flashgg.Taggers.dumperConfigTools as cfgTools
+cfgTools.addCategories(process.tagCandidateDumper,
                        ## categories definition
                        ## cuts are applied in cascade. Events getting to these categories have already failed the "Reject" selection
-                       [("All", "1", 0)
-                        #("EB", "abs(superCluster.eta)<1.479", 0),
-                        #("EE", "abs(superCluster.eta)>1.566",0)
-                        ],
-                       variables=["leadPhIso := leadingPhoton.pfPhoIso03()",
-                                  "leadNeuIso := leadingPhoton.pfNeutIso03()",
-                                  "subLeadNeuIso := subLeadingPhoton.pfNeutIso03()",
-                                  "subleadPhIso := subLeadingPhoton.pfPhoIso03()",
-                                  "leadsieie := leadingPhoton.full5x5_sigmaIetaIeta",
-                                  "leadcovieip := leadingPhoton.sieip",
-                                  "leadetawidth := leadingPhoton.superCluster.etaWidth",
-                                  "leadphiwidth := leadingPhoton.superCluster.phiWidth",
-                                  "leads4ratio := leadingPhoton.s4",
-                                  "leadr9 := leadingPhoton.r9",
-                                  "leadfull5x5r9 := leadingPhoton.full5x5_r9",
-                                  "subleadsieie := subLeadingPhoton.full5x5_sigmaIetaIeta",
-                                  "subleadcovieip := subLeadingPhoton.sieip",
-                                  "subleadetawidth := subLeadingPhoton.superCluster.etaWidth",
-                                  "subleadphiwidth := subLeadingPhoton.superCluster.phiWidth",
-                                  "subleads4ratio := subLeadingPhoton.s4",
-                                  "subleadr9 := subLeadingPhoton.r9",
-                                  "subleadfull5x5r9 := subLeadingPhoton.full5x5_r9",
-                                  "leadPt      := leadingPhoton.et",
-                                  "subleadPt   := subLeadingPhoton.et",
-                                  "leadEta     := leadingPhoton.eta",
-                                  "subleadEta  := subLeadingPhoton.eta",
-                                  "subIDMVA    := leadingView.phoIdMvaWrtChosenVtx()",
-                                  "leadIDMVA   := subLeadingView.phoIdMvaWrtChosenVtx()",
-                                  "sigmaEoE1   := leadingPhoton.sigEOverE",
-                                  "sigmaEoE2   := subLeadingPhoton.sigEOverE",
-                                  "leadChIsoRv := leadingView.pfChIso03WrtChosenVtx()",
-                                  "subleadChIsoRv := subLeadingView.pfChIso03WrtChosenVtx()",
-                                  "leadChIsoWv := leadingPhoton.pfChgIsoWrtWorstVtx03",
-                                  "subleadChIsoWv := subLeadingPhoton.pfChgIsoWrtWorstVtx03",
-                                  "leadESSigma := leadingPhoton.esEffSigmaRR",
-                                  "subleadESSigma := subLeadingPhoton.esEffSigmaRR",
-                                  "dipho_pt := pt",
-                                  "mass"
+                       [("All", "1", 0)],
+                       variables=["bdt_combined := combindedMVA", 
+                                  "dijet_MVA := vbfMVA",
+                                  "dipho_mva := diPhoMVAValue",
+                                  "mass := diPhoton.mass",
+                                  "cat := categoryNumber",
+                                  "dipho_pt := diPhoton.pt",
+                                  "dipho_phi := diPhoton.phi",
+                                  "dipho_eta := diPhoton.eta",
+                                  "dipho_PtoM := diPhoton.pt/diPhoton.mass",
+                                  "cosphi := diPhotonMVA.CosPhi",
+                                  "sigmaMrvoM := diPhotonMVA.sigmarv",
+                                  "sigmaMwvoM := diPhotonMVA.sigmawv",
+                                  # VTX 
+                                  "vtxprob := diPhotonMVA.vtxprob",
+                                  "ptbal := diPhoton.ptBal",
+                                  "ptasym := diPhoton.ptAsym",
+                                  "logspt2 := diPhoton.logSumPt2",
+                                  "p2conv := diPhoton.pullConv",
+                                  "nconv := diPhoton.nConv",
+                                  "vtxmva := diPhoton.vtxProbMVA",
+                                  "vtxdz := diPhoton.dZ1",
+                                  "vtx_x := diPhoton.vtx.x", 
+                                  "vtx_y := diPhoton.vtx.y", 
+                                  "vtx_z := diPhoton.vtx.z", 
+                                  "gv_x := diPhoton.genPV.x", 
+                                  "gv_y := diPhoton.genPV.y", 
+                                  "gv_z := diPhoton.genPV.z", 
+                                  # Trigger
+                                  "hlt1 := triggerBit(0)",
+                                  "hlt2 := triggerBit(1)",
+                                  "hlt3 := triggerBit(2)",
+                                  ##MET ????
+                                  # PHOTON 1 
+                                  "genmatch1 := genMatchLead",
+                                  "et1 := diPhoton.leadingPhoton.et",
+                                  "eta1 := diPhoton.leadingPhoton.superCluster.eta",
+                                  "phi1 := diPhoton.leadingPhoton.superCluster.phi",
+                                  "r91 := diPhoton.leadingPhoton.full5x5_r9",
+                                  "e1x31 :=  diPhoton.leadingPhoton.e1x3",
+                                  "e2x51 :=  diPhoton.leadingPhoton.e2x5",
+                                  "e3x31 :=  diPhoton.leadingPhoton.e3x3",
+                                  "e5x51 :=  diPhoton.leadingPhoton.e5x5",                                  
+                                  "sieie1 := diPhoton.leadingPhoton.full5x5_sigmaIetaIeta",
+                                  "hoe1 := diPhoton.leadingPhoton.hadronicOverEm",
+                                  "sigmaEoE1 := diPhoton.leadingPhoton.sigEOverE",
+                                  "ptoM1 := diPhoton.leadingPhoton.pt / diPhoton.mass",
+                                  "chiso1 := diPhoton.leadingView.pfChIso03WrtChosenVtx",
+                                  "chisow1 := diPhoton.leadingPhoton.pfChgIsoWrtWorstVtx04",
+                                  "phoiso1 := diPhoton.leadingPhoton.pfPhoIso03",
+                                  "phoiso041 := diPhoton.leadingPhoton.pfPhoIso04",
+                                  "ecaliso03_1 := diPhoton.leadingPhoton.ecalRecHitSumEtConeDR03",
+                                  "hcaliso03_1 := diPhoton.leadingPhoton.hcalTowerSumEtConeDR03",
+                                  "pfcluecal03_1 := diPhoton.leadingPhoton.ecalPFClusterIso",
+                                  "pfcluhcal03_1 := diPhoton.leadingPhoton.hcalPFClusterIso",
+                                  "trkiso03_1 := diPhoton.leadingPhoton.trkSumPtHollowConeDR03",
+                                  "pfchiso2_1 := diPhoton.leadingView.pfChIso02WrtChosenVtx",
+                                  "isEB1 := diPhoton.leadingPhoton.isEB",
+                                  "csev1 := diPhoton.leadingPhoton.passElectronVeto",
+                                  "haspixelseed1 := diPhoton.leadingPhoton.hasPixelSeed",
+                                  "sieip1 := diPhoton.leadingPhoton.sieip",
+                                  "etawidth1 := diPhoton.leadingPhoton.superCluster.etaWidth",
+                                  "phiwidth1 := diPhoton.leadingPhoton.superCluster.phiWidth",
+                                  "regrerr1 := diPhoton.leadingPhoton.sigEOverE * diPhoton.leadingPhoton.energy",
+                                  "idmva1 := diPhoton.leadingView.phoIdMvaWrtChosenVtx",
+                                  "s4ratio1 :=  diPhoton.leadingPhoton.s4",
+                                  "effSigma1 :=  diPhoton.leadingPhoton.esEffSigmaRR",
+                                  "scraw1 :=  diPhoton.leadingPhoton.superCluster.rawEnergy",
+                                  "ese1 :=  diPhoton.leadingPhoton.superCluster.preshowerEnergy",                                  
+                                  # PHOTON 2
+                                  "genmatch2 := genMatchSubLead",
+                                  "et2 := diPhoton.subLeadingPhoton.et",
+                                  "eta2 := diPhoton.subLeadingPhoton.superCluster.eta",
+                                  "phi2 := diPhoton.subLeadingPhoton.superCluster.phi",
+                                  "r92 := diPhoton.subLeadingPhoton.full5x5_r9",
+                                  "e1x32 :=  diPhoton.subLeadingPhoton.e1x3",
+                                  "e2x52 :=  diPhoton.subLeadingPhoton.e2x5",
+                                  "e3x32 :=  diPhoton.subLeadingPhoton.e3x3",
+                                  "e5x52 :=  diPhoton.subLeadingPhoton.e5x5",                                  
+                                  "sieie2 := diPhoton.subLeadingPhoton.full5x5_sigmaIetaIeta",
+                                  "hoe2 := diPhoton.subLeadingPhoton.hadronicOverEm",
+                                  "sigmaEoE2 := diPhoton.subLeadingPhoton.sigEOverE",
+                                  "ptoM2 := diPhoton.subLeadingPhoton.pt / diPhoton.mass",
+                                  "isEB2 := diPhoton.subLeadingPhoton.isEB",
+                                  "chiso2 := diPhoton.subLeadingView.pfChIso03WrtChosenVtx",
+                                  "chisow2 := diPhoton.subLeadingPhoton.pfChgIsoWrtWorstVtx04",
+                                  "phoiso2 := diPhoton.subLeadingPhoton.pfPhoIso03",                                  
+                                  "phoiso042 := diPhoton.subLeadingPhoton.pfPhoIso04",
+                                  "ecaliso03_2 := diPhoton.subLeadingPhoton.ecalRecHitSumEtConeDR03",
+                                  "hcaliso03_2 := diPhoton.subLeadingPhoton.hcalTowerSumEtConeDR03",
+                                  "pfcluecal03_2 := diPhoton.leadingPhoton.ecalPFClusterIso",
+                                  "pfcluhcal03_2 := diPhoton.leadingPhoton.hcalPFClusterIso",
+                                  "trkiso03_2 := diPhoton.subLeadingPhoton.trkSumPtHollowConeDR03",
+                                  "pfchiso2_2 := diPhoton.subLeadingView.pfChIso02WrtChosenVtx",
+                                  "csev2 := diPhoton.subLeadingPhoton.passElectronVeto",
+                                  "haspixelseed2 := diPhoton.subLeadingPhoton.hasPixelSeed",  
+                                  "sieip2 := diPhoton.subLeadingPhoton.sieip",
+                                  "etawidth2 := diPhoton.subLeadingPhoton.superCluster.etaWidth",
+                                  "phiwidth2 := diPhoton.subLeadingPhoton.superCluster.phiWidth",
+                                  "regrerr2 := diPhoton.subLeadingPhoton.sigEOverE* diPhoton.subLeadingPhoton.energy",
+                                  "idmva2 := diPhoton.subLeadingView.phoIdMvaWrtChosenVtx",
+                                  "s4ratio2 :=  diPhoton.subLeadingPhoton.s4",
+                                  "effSigma2 :=  diPhoton.subLeadingPhoton.esEffSigmaRR",
+                                  "scraw2 :=  diPhoton.subLeadingPhoton.superCluster.rawEnergy",
+                                  "ese2 :=  diPhoton.subLeadingPhoton.superCluster.preshowerEnergy",
+                                  # dijet
+                                  "dijet_leadEta",
+                                  "dijet_subleadEta",
+                                  "dijet_dEta := dijet_abs_dEta",
+                                  "dijet_LeadJPt",
+                                  "dijet_SubJPt",
+                                  "dijet_Zep",
+                                  "dijet_dPhi := dijet_dipho_dphi",
+                                  "dijet_Mjj",
+                                  "dijet_minDRJetPho",
                                   ],
                        histograms=[]                                   
                        )
-process.diphotonDumper.nameTemplate ="opttree_$SQRTS_$LABEL_$SUBCAT"
+process.tagCandidateDumper.nameTemplate ="opttree_$SQRTS_$LABEL_$SUBCAT"
 
-process.load("flashgg/Taggers/flashggDiPhotonMVA_cfi")
-##process.flashggDiPhotonMVA.DiPhotonTag = cms.InputTag("flashggDiPhotons")
-process.flashggDiPhotonMVA.DiPhotonTag = cms.InputTag("flashggDiPhotonSystematics")
-#process.flashggDiPhotonMVA.dumpHistos = False
-#process.flashggDiPhotonMVA.dumpTrees  =  True
 
-############################
-#       Systematics        #
-############################
-process.load("flashgg.Systematics.flashggDiPhotonSystematics_cfi")
-#from PhysicsTools.PatAlgos.tools.helpers import cloneProcessingSnippet,massSearchReplaceAnyInputTag
-#massSearchReplaceAnyInputTag(process.diphotonDumper, cms.InputTag("flashggDiPhotons"),cms.InputTag("flashggDiPhotonSystematics"))
-#massSearchReplaceAnyInputTag(process.diphotonDumper, cms.InputTag("flashggPreselectedDiPhotons"),cms.InputTag("flashggDiPhotonSystematics"))
+#process.systematicsTagSequences = cms.Sequence
+#systlabels = [""]
+#phosystlabels = []
+#
+##if customize.processId.count("h_") or customize.processId.count("vbf_"): # convention: ggh vbf wzh tth    
+#if ("mc" in customize.processId):
+#    print "Signal MC, so adding systematics and dZ"
+#    #variablesToUse = minimalVariables
+#    for direction in ["Up","Down"]:
+#        #phosystlabels.append("MvaShift%s01sigma" % direction)
+#        #phosystlabels.append("SigmaEOverEShift%s01sigma" % direction)
+#        #jetsystlabels.append("JEC%s01sigma" % direction)
+#        #jetsystlabels.append("JER%s01sigma" % direction)
+#        #variablesToUse.append("LooseMvaSF%s01sigma[1,-999999.,999999.] := weight(\"LooseMvaSF%s01sigma\")" % (direction,direction))
+#        #variablesToUse.append("PreselSF%s01sigma[1,-999999.,999999.] := weight(\"PreselSF%s01sigma\")" % (direction,direction))
+#        #variablesToUse.append("FracRVWeight%s01sigma[1,-999999.,999999.] := weight(\"FracRVWeight%s01sigma\")" % (direction,direction))
+#        for r9 in ["HighR9","LowR9"]:
+##            phosystlabels.append("MCSmear%sEE%s01sigma" % (r9,direction))
+##            for var in ["Rho","Phi"]:
+##                phosystlabels.append("MCSmear%sEB%s%s01sigma" % (r9,var,direction))
+#            for region in ["EB","EE"]:
+#                phosystlabels.append("MCSmear%s%s%s01sigma" % (r9,region,direction))
+#                phosystlabels.append("MCScale%s%s%s01sigma" % (r9,region,direction))
+##                variablesToUse.append("LooseMvaSF%s%s%s01sigma[1,-999999.,999999.] := weight(\"LooseMvaSF%s%s%s01sigma\")" % (r9,region,direction,r9,region,direction))
+##                variablesToUse.append("PreselSF%s%s%s01sigma[1,-999999.,999999.] := weight(\"PreselSF%s%s%s01sigma\")" % (r9,region,direction,r9,region,direction))
+#    systlabels += phosystlabels
+#elif ("data" in customize.processId):
+#    print "Data, so turn of all shifts and systematics, except for Photon Scale central value"
+#    #variablesToUse = minimalNonSignalVariables
+#    newvpset = cms.VPSet()
+#    for pset in process.flashggDiPhotonSystematics.SystMethods:
+#        if pset.Label.value().count("Scale"):
+#            pset.NoCentralShift = cms.bool(False) # Turn on central shift for data (it is off for MC)                        
+#            pset.NSigmas = cms.vint32() # Do not perform shift
+#            newvpset += [pset]
+#    process.flashggDiPhotonSystematics.SystMethods = newvpset
+#    #systprodlist = [] #[process.flashggMuonSystematics,process.flashggElectronSystematics]
+#    #systprodlist += [getattr(process,"flashggJetSystematics%i"%i) for i in range(len(UnpackedJetCollectionVInputTag))]
+#    #for systprod in systprodlist:
+#    #    systprod.SystMethods = cms.VPSet() # empty everything
+#else:
+#    print "Background MC, so store mgg and central only"
+#    #variablesToUse = minimalNonSignalVariables
+#    vpsetlist = [process.flashggDiPhotonSystematics.SystMethods] #, process.flashggMuonSystematics.SystMethods, process.flashggElectronSystematics.SystMethods]
+#    #vpsetlist += [getattr(process,"flashggJetSystematics%i"%i).SystMethods for i in range(len(UnpackedJetCollectionVInputTag))] 
+#    # i.e. process.flashggJetSystematics0.SystMethods, ...
+#    for vpset in vpsetlist:
+#        for pset in vpset:
+#            pset.NSigmas = cms.vint32() # Do not perform shifts if they will not be read, but still do all central values
+#
+##print "--- Systematics  with independent collections ---"
+##print systlabels
+##print "-------------------------------------------------"
+##print "--- Variables to be dumped, including systematic weights ---"
+##print variablesToUse
+##print "------------------------------------------------------------"
+#
+##for systlabel in systlabels:
+##    if systlabel == "":
+##        continue
+##    newseq = cloneProcessingSnippet(process,process.flashggTagSequence,systlabel)
+##    if systlabel in phosystlabels:
+##        massSearchReplaceAnyInputTag(newseq,cms.InputTag("flashggDiPhotonSystematics"),cms.InputTag("flashggDiPhotonSystematics",systlabel))
+###    #if systlabel in jetsystlabels:    
+###    #    for i in range(len(jetSystematicsInputTags)):
+###    #        massSearchReplaceAnyInputTag(newseq,jetSystematicsInputTags[i],cms.InputTag(jetSystematicsInputTags[i].moduleLabel,systlabel))
+##    for name in newseq.moduleNames():
+##        module = getattr(process,name)
+##        if hasattr(module,"SystLabel"):
+##            module.SystLabel = systlabel
+###    process.systematicsTagSequences += newseq
+###    process.flashggSystTagMerger.src.append(cms.InputTag("flashggTagSorter" + systlabel))
+#
+#############################
+##    Systematics end       #
+#############################
+#
+#process.load("flashgg.Taggers.flashggUpdatedIdMVADiPhotons_cfi")
+##process.p = cms.Path(process.dataRequirements*process.flashggDiPhotonMVA*process.DiPhotonWithZeeMVADumper*process.diphotonDumper)*process.flashggDiPhotonSystematics
+#process.p = cms.Path(process.flashggUpdatedIdMVADiPhotons*process.dataRequirements*process.diphotonDumper)
 
-process.flashggSystTagMerger = cms.EDProducer("TagMerger",src=cms.VInputTag("flashggTagSorter"))
-process.systematicsTagSequences = cms.Sequence()
-systlabels = [""]
-phosystlabels = []
+#process.out = cms.OutputModule("PoolOutputModule", 
+#                               fileName = cms.untracked.string("pippo.root"),
+#                               #SelectEvents = cms.untracked.PSet(SelectEvents = cms.vstring("p"))
+#                               )
+#process.outpath = cms.EndPath(process.out)
 
-#if customize.processId.count("h_") or customize.processId.count("vbf_"): # convention: ggh vbf wzh tth    
-if ("mc" in customize.processId):
-    print "Signal MC, so adding systematics and dZ"
-    #variablesToUse = minimalVariables
-    for direction in ["Up","Down"]:
-        #phosystlabels.append("MvaShift%s01sigma" % direction)
-        #phosystlabels.append("SigmaEOverEShift%s01sigma" % direction)
-        #variablesToUse.append("LooseMvaSF%s01sigma[1,-999999.,999999.] := weight(\"LooseMvaSF%s01sigma\")" % (direction,direction))
-        #variablesToUse.append("PreselSF%s01sigma[1,-999999.,999999.] := weight(\"PreselSF%s01sigma\")" % (direction,direction))
-        #variablesToUse.append("FracRVWeight%s01sigma[1,-999999.,999999.] := weight(\"FracRVWeight%s01sigma\")" % (direction,direction))
-        for r9 in ["HighR9","LowR9"]:
-#            phosystlabels.append("MCSmear%sEE%s01sigma" % (r9,direction))
-#            for var in ["Rho","Phi"]:
-#                phosystlabels.append("MCSmear%sEB%s%s01sigma" % (r9,var,direction))
-            for region in ["EB","EE"]:
-                phosystlabels.append("MCSmear%s%s%s01sigma" % (r9,region,direction))
-                phosystlabels.append("MCScale%s%s%s01sigma" % (r9,region,direction))
-#                variablesToUse.append("LooseMvaSF%s%s%s01sigma[1,-999999.,999999.] := weight(\"LooseMvaSF%s%s%s01sigma\")" % (r9,region,direction,r9,region,direction))
-#                variablesToUse.append("PreselSF%s%s%s01sigma[1,-999999.,999999.] := weight(\"PreselSF%s%s%s01sigma\")" % (r9,region,direction,r9,region,direction))
-    systlabels += phosystlabels
-elif ("data" in customize.processId):
-    print "Data, so turn of all shifts and systematics, except for Photon Scale central value"
-    #variablesToUse = minimalNonSignalVariables
-    newvpset = cms.VPSet()
-    for pset in process.flashggDiPhotonSystematics.SystMethods:
-        if pset.Label.value().count("Scale"):
-            pset.NoCentralShift = cms.bool(False) # Turn on central shift for data (it is off for MC)                        
-            pset.NSigmas = cms.vint32() # Do not perform shift
-            newvpset += [pset]
-    process.flashggDiPhotonSystematics.SystMethods = newvpset
-    #systprodlist = [] #[process.flashggMuonSystematics,process.flashggElectronSystematics]
-    #systprodlist += [getattr(process,"flashggJetSystematics%i"%i) for i in range(len(UnpackedJetCollectionVInputTag))]
-    #for systprod in systprodlist:
-    #    systprod.SystMethods = cms.VPSet() # empty everything
-else:
-    print "Background MC, so store mgg and central only"
-    #variablesToUse = minimalNonSignalVariables
-    vpsetlist = [process.flashggDiPhotonSystematics.SystMethods] #, process.flashggMuonSystematics.SystMethods, process.flashggElectronSystematics.SystMethods]
-    #vpsetlist += [getattr(process,"flashggJetSystematics%i"%i).SystMethods for i in range(len(UnpackedJetCollectionVInputTag))] 
-    # i.e. process.flashggJetSystematics0.SystMethods, ...
-    for vpset in vpsetlist:
-        for pset in vpset:
-            pset.NSigmas = cms.vint32() # Do not perform shifts if they will not be read, but still do all central values
 
-#for systlabel in systlabels:
-#    if systlabel == "":
-#        continue
-#    newseq = cloneProcessingSnippet(process,process.flashggTagSequence,systlabel)
-#    if systlabel in phosystlabels:
-#        massSearchReplaceAnyInputTag(newseq,cms.InputTag("flashggDiPhotonSystematics"),cms.InputTag("flashggDiPhotonSystematics",systlabel))
-##    #if systlabel in jetsystlabels:    
-##    #    for i in range(len(jetSystematicsInputTags)):
-##    #        massSearchReplaceAnyInputTag(newseq,jetSystematicsInputTags[i],cms.InputTag(jetSystematicsInputTags[i].moduleLabel,systlabel))
-#    for name in newseq.moduleNames():
-#        module = getattr(process,name)
-#        if hasattr(module,"SystLabel"):
-#            module.SystLabel = systlabel
-##    process.systematicsTagSequences += newseq
-##    process.flashggSystTagMerger.src.append(cms.InputTag("flashggTagSorter" + systlabel))
-
-############################
-#    Systematics end       #
-############################
-
-process.load("flashgg.Taggers.flashggUpdatedIdMVADiPhotons_cfi")
-process.p = cms.Path(process.flashggUpdatedIdMVADiPhotons*process.dataRequirements*process.diphotonDumper*process.flashggDiPhotonMVA)
+process.p = cms.Path(process.flashggTagSequence*process.flashggSystTagMerger*process.flashggTagCandidateProducer*process.tagCandidateDumper)
 
 customize(process)
 


### PR DESCRIPTION
pull request on behalf of @matteosan1 who wrote the code

added files:
- added class DataFormats/TagCandidate : contains event wide variables for VBF tagged events
- added an class MicroAOD/plugins/TagCandidateProducer.cc (including associated cfi file MicroAOD/python/flashggTagCandidateProducer_cfi.py): EDProducer for TagCandidate
- template instantiation and typedef to use the above in Taggers/interface/TagCandidateDumper.h and Taggers/plugins/EDTagCandidateDumper.cc
- associated python configuration fragments in Taggers/python/tagCandidateDumpConfig_cff.py and Taggers/python/tagCandidateDumper_cfi.py

modified files:
- added include guards in DataFormats/interface/UntaggedTag.h
- added new classes to dictionary definitions in DataFormats/src/classes.h and DataFormats/src/classes_def.xml
- Validation/python/opttreeDumper.py : added more variables to be dumped and other changes