### PR TITLE
classdef for 76x by default, tweak customization

### DIFF
--- a/DataFormats/src/classes_def.xml
+++ b/DataFormats/src/classes_def.xml
@@ -188,7 +188,7 @@
 <class name="edm::Ptr<flashgg::Electron>"/>
 <class name="std::vector<flashgg::Electron>"/>
 <class name="edm::Wrapper<std::vector<flashgg::Electron> >"/>
-<class name="flashgg::Muon" ClassVersion="11">
+<class name="flashgg::Muon" ClassVersion="10">
  <version ClassVersion="11" checksum="3269337733"/>
   <version ClassVersion="10" checksum="1803852641"/>
 </class>

--- a/MicroAOD/python/MicroAODCustomize.py
+++ b/MicroAOD/python/MicroAODCustomize.py
@@ -123,7 +123,7 @@ class MicroAODCustomize(object):
             self.customizeTiming(process)
         if os.environ["CMSSW_VERSION"].count("CMSSW_7_6"):
             self.customize76X(process)
-        if os.environ["CMSSW_VERSION"].count("CMSSW_8_0"):
+        elif os.environ["CMSSW_VERSION"].count("CMSSW_8_0"):
             self.customize80X(process)
         elif len(self.globalTag) == 0:
             self.globalTag = "74X_mcRun2_asymptotic_v4"


### PR DESCRIPTION
Two addenda to #615 

* flashgg::Muon classdef has to change (manually) between 76X and 80X; make 76X the default
* Fix logic mistake in customization that missets the 76X globaltag

I have also verified that the simple_Tag_test output is identical between 76X and 80X.