### PR TITLE
Store other tag inf

### DIFF
--- a/DataFormats/interface/DiPhotonTagBase.h
+++ b/DataFormats/interface/DiPhotonTagBase.h
@@ -10,6 +10,8 @@ namespace flashgg {
     class DiPhotonTagBase : public WeightedObject
     {
     public:
+        enum tag_t { kUndefined = 0, kUntagged, kVBF, kTTHHadronic, kTTHLeptonic, kVHTight, kVHLoose, kVHHadronic, kVHEt };
+
         DiPhotonTagBase();
         virtual ~DiPhotonTagBase(); 
         DiPhotonTagBase( edm::Ptr<DiPhotonCandidate>, DiPhotonMVAResult );
@@ -32,6 +34,27 @@ namespace flashgg {
         void setIsGold ( int runNumber );
         void setIsGoldMC( bool isGold ) { isGold_ = isGold; }
         bool isGold() const { return isGold_; }
+        virtual DiPhotonTagBase::tag_t tagEnum() const { return DiPhotonTagBase::kUndefined; }
+        unsigned nOtherTags() const { 
+            assert(otherTagTypes_.size() == otherTagCategories_.size());
+            assert(otherTagTypes_.size() == otherTagIndices_.size());
+            return otherTagTypes_.size(); 
+        }
+        void addOtherTag( const DiPhotonTagBase& other ) { 
+            otherTagTypes_.push_back(other.tagEnum());
+            otherTagCategories_.push_back(other.categoryNumber());
+            otherTagIndices_.push_back(other.diPhotonIndex());
+        }
+        void addOtherTags( std::vector<std::tuple<DiPhotonTagBase::tag_t,int,int> > others ) { 
+            for (unsigned i = 0 ; i < others.size() ; i++) {
+                otherTagTypes_.push_back(std::get<0>(others[i]));
+                otherTagCategories_.push_back(std::get<1>(others[i]));
+                otherTagIndices_.push_back(std::get<2>(others[i]));
+            }
+        }
+        DiPhotonTagBase::tag_t otherTagType( unsigned i ) const { return otherTagTypes_[i]; }
+        int otherTagCategory( unsigned i ) const { return otherTagCategories_[i]; }
+        int otherTagDiPhotonIndex ( unsigned i ) const { return otherTagIndices_[i]; }
     private:
         DiPhotonMVAResult mva_result_;
         int category_number_;
@@ -40,6 +63,10 @@ namespace flashgg {
         edm::Ptr<TagTruthBase> truth_;
         string systLabel_;
         bool isGold_;
+        //        std::vector<std::tuple<DiPhotonTagBase::tag_t,int,int> > otherTags_; // (type,category,diphoton index) 
+        std::vector<DiPhotonTagBase::tag_t> otherTagTypes_;
+        std::vector<int> otherTagCategories_;
+        std::vector<int> otherTagIndices_;
     };
 
 }

--- a/DataFormats/interface/TTHHadronicTag.h
+++ b/DataFormats/interface/TTHHadronicTag.h
@@ -24,6 +24,8 @@ namespace flashgg {
         void setNBLoose( int nb ) { Nbtagloose_ = nb; }
         void setNBMedium( int nb ) { Nbtagmedium_ = nb; }
 
+        DiPhotonTagBase::tag_t tagEnum() const override {return DiPhotonTagBase::kTTHHadronic; }
+
     private:
         int Nbtagloose_;
         int Nbtagmedium_;

--- a/DataFormats/interface/TTHLeptonicTag.h
+++ b/DataFormats/interface/TTHLeptonicTag.h
@@ -29,6 +29,8 @@ namespace flashgg {
         void setMuons( std::vector<edm::Ptr<Muon> > Muons ) {Muons_ = Muons;}
         void setElectrons( std::vector<edm::Ptr<Electron> > Electrons ) {Electrons_ = Electrons;}
 
+        DiPhotonTagBase::tag_t tagEnum() const override {return DiPhotonTagBase::kTTHLeptonic; }
+
     private:
         std::vector<edm::Ptr<Muon> > Muons_;
         std::vector<edm::Ptr<Electron> > Electrons_;

--- a/DataFormats/interface/UntaggedTag.h
+++ b/DataFormats/interface/UntaggedTag.h
@@ -14,6 +14,7 @@ namespace flashgg {
         UntaggedTag( edm::Ptr<DiPhotonCandidate>, DiPhotonMVAResult );
         UntaggedTag( edm::Ptr<DiPhotonCandidate>, edm::Ptr<DiPhotonMVAResult> );
         virtual UntaggedTag *clone() const;
+        DiPhotonTagBase::tag_t tagEnum() const override {return DiPhotonTagBase::kUntagged; }
 
     private:
 

--- a/DataFormats/interface/VBFTag.h
+++ b/DataFormats/interface/VBFTag.h
@@ -53,6 +53,8 @@ namespace flashgg {
             return (vbfDiPhoDiJet_mva_result_.vbfMvaResult.leadJet_ptr.isNonnull() && vbfDiPhoDiJet_mva_result_.vbfMvaResult.subleadJet_ptr.isNonnull()); 
         };
         const bool hasValidVBFTriJet() const; 
+
+        DiPhotonTagBase::tag_t tagEnum() const override {return DiPhotonTagBase::kVBF; }
     private:
         VBFDiPhoDiJetMVAResult vbfDiPhoDiJet_mva_result_;
     };

--- a/DataFormats/interface/VHEtTag.h
+++ b/DataFormats/interface/VHEtTag.h
@@ -21,6 +21,8 @@ namespace flashgg {
         const edm::Ptr<DiPhotonCandidate> diPhotonCandidate() const { return theDiPhotonCandidate_;}
         void setMet( edm::Ptr<pat::MET> );
 
+        DiPhotonTagBase::tag_t tagEnum() const override {return DiPhotonTagBase::kVHEt; }
+
     private:
         edm::Ptr<DiPhotonCandidate> theDiPhotonCandidate_;
         edm::Ptr<pat::MET> theMet_;

--- a/DataFormats/interface/VHHadronicTag.h
+++ b/DataFormats/interface/VHHadronicTag.h
@@ -25,6 +25,8 @@ namespace flashgg {
 
         void setJets( edm::Ptr<flashgg::Jet>, edm::Ptr<flashgg::Jet> );
 
+        DiPhotonTagBase::tag_t tagEnum() const override {return DiPhotonTagBase::kVHHadronic; }
+
     private:
         edm::Ptr<DiPhotonCandidate> theDiPhotonCandidate_;
         //edm::Ptr<DiPhotonMVAResult> theDiPhotonMVAResult_;

--- a/DataFormats/interface/VHLooseTag.h
+++ b/DataFormats/interface/VHLooseTag.h
@@ -30,6 +30,8 @@ namespace flashgg {
         void setMET( std::vector<edm::Ptr<pat::MET> > MET ) {MET_ = MET;}
         void setElectrons( std::vector<edm::Ptr<Electron> > Electrons ) {Electrons_ = Electrons;}
 
+        DiPhotonTagBase::tag_t tagEnum() const override {return DiPhotonTagBase::kVHLoose; }
+
     private:
         std::vector<edm::Ptr<Muon> > Muons_;
         std::vector<edm::Ptr<Electron> > Electrons_;

--- a/DataFormats/interface/VHTightTag.h
+++ b/DataFormats/interface/VHTightTag.h
@@ -30,6 +30,8 @@ namespace flashgg {
         void setMET( std::vector<edm::Ptr<pat::MET> > MET ) {MET_ = MET;}
         void setElectrons( std::vector<edm::Ptr<Electron> > Electrons ) {Electrons_ = Electrons;}
 
+        DiPhotonTagBase::tag_t tagEnum() const override {return DiPhotonTagBase::kVHTight; }
+
     private:
         std::vector<edm::Ptr<Muon> > Muons_;
         std::vector<edm::Ptr<Electron> > Electrons_;

--- a/DataFormats/src/classes_def.xml
+++ b/DataFormats/src/classes_def.xml
@@ -29,25 +29,29 @@
 </class>
 <class name="std::vector<flashgg::VBFDiPhoDiJetMVAResult>"/>
 <class name="edm::Wrapper<std::vector<flashgg::VBFDiPhoDiJetMVAResult> >"/>
-<class name="flashgg::DiPhotonTagBase" ClassVersion="11">
+<class name="flashgg::DiPhotonTagBase" ClassVersion="12">
+ <version ClassVersion="12" checksum="2747850133"/>
  <version ClassVersion="11" checksum="232592888"/>
   <version ClassVersion="10" checksum="2111686847"/>
 </class>
 <class name="std::vector<flashgg::DiPhotonTagBase>"/>
 <class name="edm::Wrapper<std::vector<flashgg::DiPhotonTagBase> >"/>
-<class name="flashgg::UntaggedTag" ClassVersion="11">
+<class name="flashgg::UntaggedTag" ClassVersion="12">
+ <version ClassVersion="12" checksum="3256565386"/>
  <version ClassVersion="11" checksum="741308141"/>
   <version ClassVersion="10" checksum="2620402100"/>
 </class>
 <class name="std::vector<flashgg::UntaggedTag>"/>
 <class name="edm::Wrapper<std::vector<flashgg::UntaggedTag> >"/>
-<class name="flashgg::VBFTag" ClassVersion="11">
+<class name="flashgg::VBFTag" ClassVersion="12">
+ <version ClassVersion="12" checksum="3071493064"/>
  <version ClassVersion="11" checksum="1094465099"/>
   <version ClassVersion="10" checksum="19580082"/>
 </class>
 <class name="std::vector<flashgg::VBFTag>"/>
 <class name="edm::Wrapper<std::vector<flashgg::VBFTag> >"/>
-<class name="flashgg::TTHLeptonicTag" ClassVersion="11">
+<class name="flashgg::TTHLeptonicTag" ClassVersion="12">
+ <version ClassVersion="12" checksum="1015665249"/>
  <version ClassVersion="11" checksum="2848650298"/>
   <version ClassVersion="10" checksum="727624063"/>
 </class>
@@ -55,13 +59,15 @@
 <class name="edm::Wrapper<std::vector<flashgg::TTHLeptonicTag> >"/>
 <class name="std::vector<pat::Muon>"/>
 <class name="edm::Ptr<reco::GenParticle>"/>
-<class name="flashgg::TTHHadronicTag" ClassVersion="11">
+<class name="flashgg::TTHHadronicTag" ClassVersion="12">
+ <version ClassVersion="12" checksum="3228179576"/>
  <version ClassVersion="11" checksum="1031304475"/>
   <version ClassVersion="10" checksum="3253508898"/>
 </class>
 <class name="std::vector<flashgg::TTHHadronicTag>"/>
 <class name="edm::Wrapper<std::vector<flashgg::TTHHadronicTag> >"/>
-<class name="flashgg::VHEtTag" ClassVersion="11">
+<class name="flashgg::VHEtTag" ClassVersion="12">
+ <version ClassVersion="12" checksum="1192814105"/>
  <version ClassVersion="11" checksum="884120660"/>
   <version ClassVersion="10" checksum="1061507347"/>
 </class>
@@ -75,19 +81,22 @@
 </class>
 <class name="std::vector<flashgg::VBFTagTruth>"/>
 <class name="edm::Wrapper<std::vector<flashgg::VBFTagTruth> >"/>
-<class name="flashgg::VHLooseTag" ClassVersion="11">
+<class name="flashgg::VHLooseTag" ClassVersion="12">
+ <version ClassVersion="12" checksum="2427728431"/>
  <version ClassVersion="11" checksum="3802982704"/>
   <version ClassVersion="10" checksum="1025135485"/>
 </class>
 <class name="std::vector<flashgg::VHLooseTag>"/>
 <class name="edm::Wrapper<std::vector<flashgg::VHLooseTag> >"/>
-<class name="flashgg::VHTightTag" ClassVersion="11">
+<class name="flashgg::VHTightTag" ClassVersion="12">
+ <version ClassVersion="12" checksum="1711188723"/>
  <version ClassVersion="11" checksum="3086442996"/>
   <version ClassVersion="10" checksum="308595777"/>
 </class>
 <class name="std::vector<flashgg::VHTightTag>"/>
 <class name="edm::Wrapper<std::vector<flashgg::VHTightTag> >"/>
-<class name="flashgg::VHHadronicTag" ClassVersion="11">
+<class name="flashgg::VHHadronicTag" ClassVersion="12">
+ <version ClassVersion="12" checksum="1541512627"/>
  <version ClassVersion="11" checksum="1986614206"/>
   <version ClassVersion="10" checksum="2760911373"/>
 </class>

--- a/Taggers/plugins/TagSorter.cc
+++ b/Taggers/plugins/TagSorter.cc
@@ -61,16 +61,24 @@ namespace flashgg {
 
         double minAcceptableObjectWeight;
         double maxAcceptableObjectWeight;
+
+        bool debug_;
+        bool storeOtherTagInfo_;
+
+        std::vector<std::tuple<DiPhotonTagBase::tag_t,int,int> > otherTags_; // (type,category,diphoton index)
     };
 
     TagSorter::TagSorter( const ParameterSet &iConfig ) :
         diPhotonToken_( consumes<View<flashgg::DiPhotonCandidate> >( iConfig.getParameter<InputTag> ( "DiPhotonTag" ) ) )
     {
 
-        massCutUpper = iConfig.getParameter<double>( "massCutUpper" );
-        massCutLower = iConfig.getParameter<double>( "massCutLower" );
-        minAcceptableObjectWeight = iConfig.getParameter<double>( "minAcceptableObjectWeight" );
-        maxAcceptableObjectWeight = iConfig.getParameter<double>( "maxAcceptableObjectWeight" );
+        massCutUpper = iConfig.getParameter<double>( "MassCutUpper" );
+        massCutLower = iConfig.getParameter<double>( "MassCutLower" );
+        minAcceptableObjectWeight = iConfig.getParameter<double>( "MinAcceptableObjectWeight" );
+        maxAcceptableObjectWeight = iConfig.getParameter<double>( "MaxAcceptableObjectWeight" );
+
+        debug_ = iConfig.getUntrackedParameter<bool>( "Debug", false );
+        storeOtherTagInfo_ = iConfig.getParameter<bool>( "StoreOtherTagInfo" );
 
         const auto &vpset = iConfig.getParameterSetVector( "TagPriorityRanges" );
 
@@ -82,7 +90,6 @@ namespace flashgg {
             int c2 = pset.getUntrackedParameter<int>( "MaxCategory", 999 );
             unsigned int i = 0;
             for( ; i < labels.size() ; i++ ) {
-                //                std::cout << labels[i] << " " << tag.label() << std::endl;
                 if( labels[i] == tag.label() ) { break; }
             }
             if( i == TagList_.size() ) {
@@ -98,38 +105,37 @@ namespace flashgg {
 
     void TagSorter::produce( Event &evt, const EventSetup & )
     {
-
         auto_ptr<edm::OwnVector<flashgg::DiPhotonTagBase> > SelectedTag( new edm::OwnVector<flashgg::DiPhotonTagBase> );
         auto_ptr<edm::OwnVector<flashgg::TagTruthBase> > SelectedTagTruth( new edm::OwnVector<flashgg::TagTruthBase> );
 
-        //		int priority = -1; // for debug
+        // Cache other tags for each event; but do not use the old ones next time
+        otherTags_.clear(); 
+
+        int priority = -1; // for debug
+
+        bool alreadyChosen = false;
+
         for( auto tpr = TagPriorityRanges.begin() ; tpr != TagPriorityRanges.end() ; tpr++ ) {
-            //    	priority += 1; // for debug
+            priority += 1; // for debug
 
             Handle<View<flashgg::DiPhotonTagBase> > TagVectorEntry;
             evt.getByToken( TagList_[tpr->collIndex], TagVectorEntry );
 
-            //            Handle<View<flashgg::TagTruthBase> > TruthVectorEntry;
-            //            evt.getByToken( TagList_[tpr->collIndex], TruthVectorEntry );
-
-            //            std::cout << std::cout << " TruthVectorEntry->size() = " << TruthVectorEntry->size() << std::endl;
-            //            assert ( TruthVectorEntry->size() == TagVectorEntry->size() );
-
             edm::RefProd<edm::OwnVector<TagTruthBase> > rTagTruth = evt.getRefBeforePut<edm::OwnVector<TagTruthBase> >();
 
-            //		const PtrVector<flashgg::DiPhotonTagBase>& TagPointers =  TagVectorEntry->ptrVector();
-            // get Tags by requesting them as a DiPhotonTagBase, from which they inherit.
-
-            int chosenIndex = -1 ; //this will become the index of the highest priority candidate (operator<)
+            int chosen_i = -1 ; //this will become the index of the highest priority candidate 
 
             // Looking from highest priority to lowest, check if the tag has any entries.
-            for( unsigned int  TagPointerLoop = 0; TagPointerLoop < TagVectorEntry->size() ; TagPointerLoop++ )        {
+            for( unsigned int  tag_i = 0; tag_i < TagVectorEntry->size() ; tag_i++ )        {
 
-                float mass = TagVectorEntry->ptrAt( TagPointerLoop )->diPhoton()->mass();
-                int category = TagVectorEntry->ptrAt( TagPointerLoop )->categoryNumber();
+                float mass = TagVectorEntry->ptrAt( tag_i )->diPhoton()->mass();
+                float sumPt = TagVectorEntry->ptrAt( tag_i )->diPhoton()->sumPt();
+                int category = TagVectorEntry->ptrAt( tag_i )->categoryNumber();
 
-                // std::cout << "[DEBUG]" << tpr->name << " " << tpr->minCat << " " << tpr->maxCat << " "
-                //           << mass << " " << category << " " << TagPointerLoop << std::endl;
+                if (debug_) {
+                    std::cout << "[TagSorter DEBUG]" << tpr->name << " " << tpr->minCat << " " << tpr->maxCat << " "
+                              << mass << " " << category << " " << tag_i << std::endl;
+                }
 
                 // ignore candidate tags with category number outside the present range we're looking at
                 if( category < tpr->minCat || category > tpr->maxCat ) { continue ; }
@@ -137,32 +143,91 @@ namespace flashgg {
                 // ignore candidate tags with diphoton outside of the allowed mass range.
                 if( ( mass < massCutLower ) || ( mass > massCutUpper ) ) {continue ;}
 
-                // All the real work for prioritizing inside a tag type is done inside DiPhotonTagBase::operator<
-                if( chosenIndex == -1 || ( TagVectorEntry->ptrAt( chosenIndex ).get() < TagVectorEntry->ptrAt( TagPointerLoop ).get() ) );
-                chosenIndex = TagPointerLoop;
-
-                float centralObjectWeight = TagVectorEntry->ptrAt( TagPointerLoop )->centralWeight();
-                if (centralObjectWeight < minAcceptableObjectWeight || centralObjectWeight > maxAcceptableObjectWeight) {
-                    throw cms::Exception( "TagObjectWeight" ) << " Tag centralWeight=" << centralObjectWeight << " outside of bound [" 
-                                                              << minAcceptableObjectWeight << "," << maxAcceptableObjectWeight 
-                                                              << "] - " << tpr->name << " chosenIndex=" << chosenIndex << " - change bounds or debug tag";
+                if ( alreadyChosen ) {
+                    // This tag would have worked but the selection has already been done for a higher tag
+                    // The fact that we are still running means we are storing additional information
+                    assert( storeOtherTagInfo_ );
+                    SelectedTag->back().addOtherTag( *(TagVectorEntry->ptrAt( tag_i )) );
+                } else {
+                    // We can still pick a tag in the current priority range
+                    // We pick this one if:
+                    // i. this is the first, or 
+                    // ii. if this is a higher category than existing one, or 
+                    // iii. if it is an equal category and has higher sumPt
+                    // In the case of (ii) or (iii) we also save the old tag info if storeOtherTagInfo_ is true
+                    if ( (chosen_i == -1) ||
+                         (TagVectorEntry->ptrAt( chosen_i )->categoryNumber() > category) ||
+                         (TagVectorEntry->ptrAt( chosen_i )->categoryNumber() == category && TagVectorEntry->ptrAt( chosen_i )->diPhoton()->sumPt() < sumPt) ) {
+                        if ( chosen_i >= 0 && storeOtherTagInfo_ ) {
+                            otherTags_.emplace_back( TagVectorEntry->ptrAt( chosen_i )->tagEnum(), 
+                                                     TagVectorEntry->ptrAt( chosen_i )->categoryNumber(),
+                                                     TagVectorEntry->ptrAt( chosen_i )->diPhotonIndex() 
+                                                     );
+                        }
+                        if ( debug_  ) {
+                            std::cout << "[TagSorter DEBUG] Updating chosen_i " << chosen_i << " --> " << tag_i  << std::endl;
+                            if ( chosen_i >= 0 ) {
+                                std::cout << "    [TagSorter DEBUG] So: updating mass " << TagVectorEntry->ptrAt( chosen_i )->diPhoton()->mass() << " --> " << mass
+                                          << " sumPt " << TagVectorEntry->ptrAt( chosen_i )->diPhoton()->sumPt() << " --> "
+                                          << TagVectorEntry->ptrAt( tag_i )->diPhoton()->sumPt()
+                                          << " cat " << TagVectorEntry->ptrAt( chosen_i )->categoryNumber() << " --> " << category
+                                          << std::endl;
+                            }
+                        }
+                        chosen_i = tag_i;
+                    }
                 }
             }
 
-            if( chosenIndex != -1 ) {
-                SelectedTag->push_back( *TagVectorEntry->ptrAt( chosenIndex ) );
-                edm::Ptr<TagTruthBase> truth = TagVectorEntry->ptrAt( chosenIndex )->tagTruth();
+            if( chosen_i != -1 ) {
+
+                float centralObjectWeight = TagVectorEntry->ptrAt( chosen_i )->centralWeight();
+                if (centralObjectWeight < minAcceptableObjectWeight || centralObjectWeight > maxAcceptableObjectWeight) {
+                    throw cms::Exception( "TagObjectWeight" ) << " Tag centralWeight=" << centralObjectWeight << " outside of bound ["
+                                                              << minAcceptableObjectWeight << "," << maxAcceptableObjectWeight
+                                                              << "] - " << tpr->name << " chosen_i=" << chosen_i << " - change bounds or debug tag";
+                }
+
+                SelectedTag->push_back( *TagVectorEntry->ptrAt( chosen_i ) );
+                edm::Ptr<TagTruthBase> truth = TagVectorEntry->ptrAt( chosen_i )->tagTruth();
                 if( truth.isNonnull() ) {
                     SelectedTagTruth->push_back( *truth );
                     SelectedTag->back().setTagTruth( edm::refToPtr( edm::Ref<edm::OwnVector<TagTruthBase> >( rTagTruth, 0 ) ) ); // Normally this 0 would be the index number
                 }
-                //debug message:
-                //  std::cout << "[DEBUG] Priority " << priority << " Tag Found! Tag entry "<< chosenIndex  << " with sumPt "
-                //    	     << TagVectorEntry->ptrAt(chosenIndex)->sumPt() << ", systLabel " << TagVectorEntry->ptrAt(chosenIndex)->systLabel() << ", systLabelHash " << TagVectorEntry->ptrAt(chosenIndex)->systLabelHash() <<   std::endl;
-                break;
+                if ( debug_ ) {
+                    std::cout << "[TagSorter DEBUG] Priority " << priority << " Tag Found! Tag entry "<< chosen_i  << " with sumPt "
+                              << TagVectorEntry->ptrAt(chosen_i)->sumPt() << ", systLabel " << TagVectorEntry->ptrAt(chosen_i)->systLabel() << std::endl;
+                }
+                if ( storeOtherTagInfo_ ) {
+                    if ( debug_ ) {
+                        std::cout << "[TagSorter DEBUG] Saving other interpretations, so we save the ones so far (if any) and then continue looping for new ones" << std::endl;
+                    }
+                    alreadyChosen = true;
+                    SelectedTag->back().addOtherTags( otherTags_ );
+                    
+                } else {
+                    if ( debug_ ) {
+                        std::cout << "[TagSorter DEBUG] Not saving other interpretations so we break out of the tag priority loop" << std::endl;
+                    }
+                    break; 
+                }
             } else {
-                //debug message
-                // std::cout << "[DEBUG] No Priority " << priority << " Tag ..., looking for Priority " << (priority+1) << " Tag.. " << std::endl;
+                if ( debug_ ) {
+                    std::cout << "[TagSorter DEBUG] No Priority " << priority << " Tag ..., looking for Priority " << (priority+1) << " Tag.. " << std::endl;
+                }
+            }
+        } 
+
+        if ( SelectedTag->size() == 1  && storeOtherTagInfo_ && debug_ ) {
+            if ( SelectedTag->back().nOtherTags() > 0 ) {
+                std::cout << "[TagSorter DEBUG] List of other tags: (" << SelectedTag->back().nOtherTags() << " total):" << std::endl;
+                for ( unsigned i = 0 ; i < SelectedTag->back().nOtherTags() ; i++) {
+                    std::cout << "[TagSorter DEBUG]  (tag_t,cat,dipho_i)=(" << SelectedTag->back().otherTagType(i) << "," 
+                              << SelectedTag->back().otherTagCategory(i) << ","
+                              << SelectedTag->back().otherTagDiPhotonIndex(i) << ")" << std::endl;
+                }
+            } else {
+                std::cout << "[TagSorter DEBUG] No other tag interpretations for this event" << std::endl;
             }
         }
 

--- a/Taggers/python/flashggTagSorter_cfi.py
+++ b/Taggers/python/flashggTagSorter_cfi.py
@@ -12,22 +12,14 @@ flashggTagSorter = cms.EDProducer('FlashggTagSorter',
 #                                                                cms.PSet(TagName = cms.InputTag('flashggVHEtTag')),
                                                                  cms.PSet(TagName = cms.InputTag('flashggTTHHadronicTag')),   
                                                                  cms.PSet(TagName = cms.InputTag('flashggVBFTag')),     
-#                                                                
 #                                                                cms.PSet(TagName = cms.InputTag('flashggVHHadronicTag')),
                                                                  cms.PSet(TagName = cms.InputTag('flashggUntagged'))
                                                                 ),
-                                  massCutUpper=cms.double(180.),
-                                  massCutLower=cms.double(100),
-                                  minAcceptableObjectWeight = cms.double(0.1),
-                                  maxAcceptableObjectWeight = cms.double(10.)
+                                  MassCutUpper=cms.double(180.),
+                                  MassCutLower=cms.double(100),
+                                  MinAcceptableObjectWeight = cms.double(0.5),
+                                  MaxAcceptableObjectWeight = cms.double(2.0),
+                                  StoreOtherTagInfo = cms.bool(False),
+                                  Debug = cms.untracked.bool(False)
                                   )
-
-#                                  TagVectorTag = cms.untracked.VInputTag(
-#                                                                        cms.untracked.InputTag('flashggVHLooseTag'),
-#                                                                        cms.untracked.InputTag('flashggVHTightTag'),
-#                                                                        cms.untracked.InputTag('flashggTTHLeptonicTag'),
-#                                                                        cms.untracked.InputTag('flashggTTHHadronicTag'),
-#                                                                        cms.untracked.InputTag('flashggVBFTag'),
-#                                                                        cms.untracked.InputTag('flashggVHHadronicTag'),
-#                                                                        cms.untracked.InputTag('flashggUntagged'),
 


### PR DESCRIPTION
Replaces #611 after rebase.  Output confirmed identical.

* Store info on other tags interpretations: tag type (enum), category, and diphoton index
* Rewrite of TagSorter for clarity of selection steps, storage of info, and full debug info

Example of output run on TTH events, including readback test: https://sethzenz.web.cern.ch/sethzenz/cms/tagtest003.txt