### PR TITLE
creating the puweight output branch in GlobalVariablesDumper also for data

### DIFF
--- a/MicroAOD/src/GlobalVariablesComputer.cc
+++ b/MicroAOD/src/GlobalVariablesComputer.cc
@@ -149,9 +149,7 @@ namespace flashgg {
             cache_.nvtx = vertices->size();
         }
 
-        if (evt.isRealData()) {
-            cache_.puweight = 1.;
-        }
+        cache_.puweight = 1.;
 
         if( ! evt.isRealData() && getPu_ ) {
             double truePu=0., obsPu=0.;

--- a/MicroAOD/src/GlobalVariablesComputer.cc
+++ b/MicroAOD/src/GlobalVariablesComputer.cc
@@ -148,7 +148,11 @@ namespace flashgg {
         if( doVtx_ ) {
             cache_.nvtx = vertices->size();
         }
-        
+
+        if (evt.isRealData()) {
+            cache_.puweight = 1.;
+        }
+
         if( ! evt.isRealData() && getPu_ ) {
             double truePu=0., obsPu=0.;
             for( auto & frame : *puInfo ) {
@@ -167,7 +171,7 @@ namespace flashgg {
                     int ibin = (std::lower_bound(puBins_.begin(), puBins_.end(), cache_.npu) - puBins_.begin()) -1;
                     cache_.puweight = puWeight_[ibin];
                 }
-            }
+            } 
         }
 
     }

--- a/Taggers/src/GlobalVariablesDumper.cc
+++ b/Taggers/src/GlobalVariablesDumper.cc
@@ -91,8 +91,12 @@ namespace flashgg {
         tree->Branch( "nvtx", &cache_.nvtx );
         if( getPu_ ) {
             tree->Branch( "npu", &cache_.npu );
-            if( puReWeight_ ) { tree->Branch( "puweight", &cache_.puweight ); }
         }
+        // create the output branch puweight even for data
+        // so we can more easily merge different types
+        // of processes into one tree
+        tree->Branch( "puweight", &cache_.puweight );
+
         for( auto &bit : bits_ ) {
             tree->Branch( bit.first.c_str(), &bit.second, ( bit.first + "/O" ).c_str() );
         }


### PR DESCRIPTION
This allows merging of dumped trees from MC and data with hadd (otherwise, data trees which do not have the puweight branch are ignored by hadd). Setting puweight to one for data in GlobalVariablesComputer.