### PR TITLE
include egamma id for electrons

### DIFF
--- a/DataFormats/interface/Electron.h
+++ b/DataFormats/interface/Electron.h
@@ -24,12 +24,37 @@ namespace flashgg {
         bool hasMatchedConversion() const { return hasMatchedConversion_; }
         void setHasMatchedConversion( bool val ) { hasMatchedConversion_ = val;}
 
+        bool passMVATightId( ) const {return passMVATightId_ ;}
+        void setPassMVATightId( bool val ) { passMVATightId_ = val;}
+        
+        bool passMVAMediumId( ) const {return passMVAMediumId_ ;}
+        void setPassMVAMediumId( bool val ) { passMVAMediumId_ = val;}
+
+        bool passTightId( ) const {return passTightId_ ;}
+        void setPassTightId( bool val ) { passTightId_ = val;}
+        
+        bool passMediumId( ) const {return passMediumId_ ;}
+        void setPassMediumId( bool val ) { passMediumId_ = val;}
+
+        bool passLooseId( ) const {return passLooseId_ ;}
+        void setPassLooseId( bool val ) { passLooseId_ = val;}
+
+        bool passVetoId( ) const {return passVetoId_ ;}
+        void setPassVetoId( bool val ) { passVetoId_ = val;}
+
+
         Electron *clone() const { return ( new Electron( *this ) ); }
 
     private:
         float nontrigmva_;
         float PfRhoAreaCorrectedIso_;
         bool hasMatchedConversion_;
+        bool passMVATightId_;
+        bool passMVAMediumId_;
+        bool passTightId_;
+        bool passMediumId_;
+        bool passLooseId_;
+        bool passVetoId_;
     };
 }
 

--- a/DataFormats/src/classes_def.xml
+++ b/DataFormats/src/classes_def.xml
@@ -191,7 +191,8 @@
 <class name="edm::Wrapper<std::vector<flashgg::Jet> >"/>
 <class name="std::vector<std::vector<flashgg::Jet> >"/>
 <class name="edm::Wrapper<std::vector<std::vector<flashgg::Jet> > >"/>
-<class name="flashgg::Electron" ClassVersion="10">
+<class name="flashgg::Electron" ClassVersion="11">
+  <version ClassVersion="11" checksum="2620301447"/>
   <version ClassVersion="10" checksum="3162935784"/>
 </class>
 <class name="edm::Ptr<flashgg::Electron>"/>

--- a/MicroAOD/python/flashggElectrons_cfi.py
+++ b/MicroAOD/python/flashggElectrons_cfi.py
@@ -7,12 +7,15 @@ process = cms.Process("FLASHggMicroAOD")
 # turn on VID producer, indicate data format  to be
 # DataFormat.AOD or DataFormat.MiniAOD, as appropriate 
 
+
 dataFormat = DataFormat.MiniAOD
 
 switchOnVIDElectronIdProducer(process, dataFormat)
 
 # define which IDs we want to produce
-my_id_modules = ['RecoEgamma.ElectronIdentification.Identification.mvaElectronID_Spring15_25ns_nonTrig_V1_cff']
+my_id_modules = ['RecoEgamma.ElectronIdentification.Identification.mvaElectronID_Spring15_25ns_nonTrig_V1_cff',
+                 'RecoEgamma.ElectronIdentification.Identification.cutBasedElectronID_Spring15_25ns_V1_cff',
+                 'RecoEgamma.ElectronIdentification.Identification.heepElectronID_HEEPV60_cff']
 
 #add them to the VID producer
 for idmod in my_id_modules:
@@ -30,6 +33,11 @@ flashggElectrons = cms.EDProducer('FlashggElectronProducer',
                 mvaValuesMap = cms.InputTag("electronMVAValueMapProducer:ElectronMVAEstimatorRun2Spring15NonTrig25nsV1Values"),
                 effAreasConfigFile = cms.FileInPath("RecoEgamma/ElectronIdentification/data/Spring15/effAreaElectrons_cone03_pfNeuHadronsAndPhotons_25ns.txt"),
   		eleMVAMediumIdMap = cms.InputTag("egmGsfElectronIDs:mvaEleID-Spring15-25ns-nonTrig-V1-wp90"),
-                eleMVATightIdMap = cms.InputTag("egmGsfElectronIDs:mvaEleID-Spring15-25ns-nonTrig-V1-wp80")
+                eleMVATightIdMap = cms.InputTag("egmGsfElectronIDs:mvaEleID-Spring15-25ns-nonTrig-V1-wp80"),
+                eleVetoIdMap = cms.InputTag("egmGsfElectronIDs:cutBasedElectronID-Spring15-25ns-V1-standalone-veto"),   
+                eleLooseIdMap = cms.InputTag("egmGsfElectronIDs:cutBasedElectronID-Spring15-25ns-V1-standalone-loose"),
+                eleMediumIdMap = cms.InputTag("egmGsfElectronIDs:cutBasedElectronID-Spring15-25ns-V1-standalone-medium"),
+                eleTightIdMap = cms.InputTag("egmGsfElectronIDs:cutBasedElectronID-Spring15-25ns-V1-standalone-tight"),
+                eleHEEPIdMap = cms.InputTag("egmGsfElectronIDs:heepElectronID-HEEPV60")
 
 		)

--- a/MicroAOD/python/flashggMicroAODSequence_cff.py
+++ b/MicroAOD/python/flashggMicroAODSequence_cff.py
@@ -14,8 +14,10 @@ from flashgg.MicroAOD.flashggMicroAODGenSequence_cff import *
 
 from PhysicsTools.SelectorUtils.centralIDRegistry import central_id_registry
 from RecoEgamma.ElectronIdentification.ElectronMVAValueMapProducer_cfi import *
+from PhysicsTools.SelectorUtils.tools.vid_id_tools import *
 
 
+from RecoEgamma.ElectronIdentification.egmGsfElectronIDs_cfi import *
 
 eventCount = cms.EDProducer("EventCountProducer")
 weightsCount = cms.EDProducer("WeightsCountProducer",
@@ -33,7 +35,7 @@ weightsCount = cms.EDProducer("WeightsCountProducer",
 
 flashggMicroAODSequence = cms.Sequence(eventCount+weightsCount
                                        +flashggVertexMapUnique+flashggVertexMapNonUnique
-                                       +electronMVAValueMapProducer*flashggElectrons*flashggSelectedElectrons
+                                       +electronMVAValueMapProducer*egmGsfElectronIDs*flashggElectrons*flashggSelectedElectrons
                                        +flashggMuons*flashggSelectedMuons
                                        +flashggMicroAODGenSequence
                                        +flashggPhotons * flashggRandomizedPhotons * flashggDiPhotons

--- a/Taggers/src/LeptonSelection.cc
+++ b/Taggers/src/LeptonSelection.cc
@@ -109,19 +109,19 @@ namespace flashgg {
         float eldEtaIn = elec->deltaEtaSuperClusterTrackAtVtx();
         float eldPhiIn = elec->deltaPhiSuperClusterTrackAtVtx();
         float elhOverE = elec->hcalOverEcal();
-        float elRelIsoEA = elec->standardHggIso()/elec->pt();
+        float elRelIsoEA = elec->standardHggIso();
         
         float elooEmooP =-999 ; 
         
         float elNonTrigMVA = elec->nonTrigMVA();
-        
+        bool passConversionVeto= elec->passConversionVeto();
         
         if( elec->ecalEnergy() == 0 ){
             elooEmooP = 1e30;
         }else if( !std::isfinite(elec->ecalEnergy())){	    
             elooEmooP = 1e30;
         }else{
-            elooEmooP = fabs(1.0/elec->ecalEnergy() - elec->eSuperClusterOverP()/elec->ecalEnergy() );
+            elooEmooP = fabs(1.0/elec->ecalEnergy() - elec->eSuperClusterOverP()/elec->ecalEnergy() );                       
         }
 
         float elDxy = fabs( elec->gsfTrack()->dxy( best_vtx_elec->position()) ) ;
@@ -146,6 +146,7 @@ namespace flashgg {
                && fabs(elDxy) < 0.0261
                && fabs(elDz) < 0.41
                && elMissedHits <=	2 
+               && passConversionVeto
                ) doPassLoose = true;
             
             if( 
@@ -158,6 +159,7 @@ namespace flashgg {
                && fabs(elDxy) < 0.0118
                && fabs(elDz) < 0.373
                && elMissedHits <=	2 
+               && passConversionVeto
                 ) doPassMedium = true;
             
         }else{
@@ -175,6 +177,7 @@ namespace flashgg {
                && fabs(elDxy) < 0.118
                && fabs(elDz) < 0.822
                && elMissedHits <=	1 
+               && passConversionVeto
                 ) doPassLoose = true;
             
             if( 
@@ -187,8 +190,9 @@ namespace flashgg {
                && fabs(elDxy) < 0.0739
                && fabs(elDz) < 0.602
                && elMissedHits <=	1 
+               && passConversionVeto
                 ) doPassMedium = true;
-            }
+        }
 
         IDs.push_back(doPassLoose);
         IDs.push_back(doPassMedium);
@@ -273,7 +277,7 @@ namespace flashgg {
 
             // Put 3 different thresholds as recommended by egamma POG
             
-            if( Electron->standardHggIso() / Electron->pt() > IsoThreshold ) continue; 
+            if( Electron->standardHggIso() > IsoThreshold ) continue; 
 
             if( Electron->gsfTrack()->hitPattern().numberOfHits( reco::HitPattern::MISSING_INNER_HITS ) > NumOfMissingHitsThreshold ) { continue; }
             //std::cout << "[DEBUG] passed  missing hits cut." << std::endl;


### PR DESCRIPTION
Hello Seth,

here you can find the modifications for adding the egamma recipes inside electrons in the proper way using egamma POG maps, as discussed by email. Since i did not touch the taggers yet and strictly added information, it should be backward compatible as you said. Once the new microAOD will be done with those electrons, we can move forward and change the way we select electrons in the taggers.

Best,

Julie
