### PR TITLE
Correctly parse dataset name also when additional args are specified in the json

### DIFF
--- a/MetaData/python/jobs_utils.py
+++ b/MetaData/python/jobs_utils.py
@@ -578,10 +578,15 @@ class JobsManager(object):
 
         # loop over all types of processes (data, signal, background)
         for dsList in self.options.processes.values():
-            for dsName in dsList:
+            for idsName in dsList:
+                #if args were provided for this dataset, then it is a list...
+                if isinstance(idsName, list):
+                    dsName=idsName[0]
+                #... or just a string
+                else:
+                    dsName=idsName
 
                 # check if this datasets was selected
-                
                 if not self.isSelectedDataset(dsName):
                     # skip this dataset
                     continue


### PR DESCRIPTION
This commit extends the compatibility of the crossSection check for ntuple production to the usecase when additional arguments are specified together with the dataset name. The feature now works with json files like 

{"processes" : {
        "ggH" : [
            "/GluGluHToGG_M-125_13TeV_powheg_pythia8"
        ]
      }
}

and both with 

{"processes" : {
        "ggH" : [
            ["/GluGluHToGG_M-125_13TeV_powheg_pythia8", {"njobs":250, "args": ["processIndex=1"]}]
        ]
     }
}

Let me know if there are comments,
Vittorio