### PR TITLE
saving z/w children for VHMEt tagTruth

### DIFF
--- a/MicroAOD/python/flashggPrunedGenParticles_cfi.py
+++ b/MicroAOD/python/flashggPrunedGenParticles_cfi.py
@@ -4,6 +4,8 @@ flashggPrunedGenParticles = cms.EDProducer("GenParticlePruner",
                                     src = cms.InputTag("prunedGenParticles"),
                                     select = cms.vstring("drop  *  ", # this is the default
                                                          "keep++ abs(pdgId) = 6",
+                                                         "keep++ pdgId = 23", #save Z descendants
+                                                         "keep++ abs(pdgId) = 24", #save W descendants
                                                          "drop abs(pdgId) > 25",
                                                          "keep status = 3",
                                                          "keep status = 23",


### PR DESCRIPTION
Adding some collections so that we can measure efficiency of VH tags vs V decay products.


Average event size goes from 15.637kb/event to 15.849kb/event on the VH signal samples.  

Affected collection:
Branch Name | Average Uncompressed Size (Bytes/Event) | Average Compressed Size (Bytes/Event) 
recoGenParticles_flashggPrunedGenParticles__FLASHggMicroAOD. 2258.41 479.572

recoGenParticles_flashggPrunedGenParticles__FLASHggMicroAOD. 1182.52 266.864