### PR TITLE
support for 80x pileup jet id mva, store in flashgg::Jet

### DIFF
--- a/DataFormats/interface/Jet.h
+++ b/DataFormats/interface/Jet.h
@@ -28,12 +28,14 @@ namespace flashgg {
         bool hasPuJetId( const edm::Ptr<reco::Vertex> vtx ) const;
         bool passesPuJetId( const edm::Ptr<reco::Vertex> vtx, PileupJetIdentifier::Id level = PileupJetIdentifier::kLoose ) const;
         void setSimpleRMS( float theRMS )  { simpleRMS_ = theRMS; }
+        void setSimpleMVA( float theMVA )  { simpleMVA_ = theMVA; }
         float rms() const { return simpleRMS_; }
         float rms( const edm::Ptr<reco::Vertex> vtx ) const;
         float betaStar( const edm::Ptr<reco::Vertex> vtx ) const;
         bool passesPuJetId( const edm::Ptr<DiPhotonCandidate> dipho, PileupJetIdentifier::Id level = PileupJetIdentifier::kLoose )const;
         float rms( const edm::Ptr<DiPhotonCandidate> dipho ) const;
         float betaStar( const edm::Ptr<DiPhotonCandidate> dipho ) const;
+        float puJetIdMVA() const { return simpleMVA_; }
         Jet *clone() const { return ( new Jet( *this ) ); }
         
         void  setQGL(const float qglikelihood=-99) {qglikelihood_ = qglikelihood;}
@@ -44,6 +46,7 @@ namespace flashgg {
         std::map<edm::Ptr<reco::Vertex>, MinimalPileupJetIdentifier> puJetId_;
         float qglikelihood_;
         float simpleRMS_; // simpler storage for PFCHS where this is not vertex-dependent
+        float simpleMVA_;
     };
 }
 

--- a/DataFormats/src/Jet.cc
+++ b/DataFormats/src/Jet.cc
@@ -6,6 +6,7 @@ Jet::Jet() : pat::Jet()
 {
     simpleRMS_ = -1.;
     qglikelihood_ = -999.;
+    simpleMVA_ = -999.;
     puJetId_.clear();
 }
 

--- a/DataFormats/src/classes_def.xml
+++ b/DataFormats/src/classes_def.xml
@@ -176,7 +176,8 @@
 </class>
 <class name="std::pair<edm::Ptr<reco::Vertex>,flashgg::MinimalPileupJetIdentifier>"/>
 <class name="std::map<edm::Ptr<reco::Vertex>,flashgg::MinimalPileupJetIdentifier>"/>
-<class name="flashgg::Jet" ClassVersion="12">
+<class name="flashgg::Jet" ClassVersion="13">
+ <version ClassVersion="13" checksum="2175929989"/>
   <version ClassVersion="12" checksum="1532368094"/>
   <version ClassVersion="11" checksum="3459570589"/>
   <version ClassVersion="10" checksum="2045570510"/>

--- a/MicroAOD/plugins/JetProducer.cc
+++ b/MicroAOD/plugins/JetProducer.cc
@@ -9,7 +9,7 @@
 #include "DataFormats/PatCandidates/interface/Jet.h"
 #include "flashgg/DataFormats/interface/Jet.h"
 #include "flashgg/DataFormats/interface/DiPhotonCandidate.h"
-//#include "RecoJets/JetProducers/interface/PileupJetIdAlgo.h"
+#include "RecoJets/JetProducers/interface/PileupJetIdAlgo.h"
 #include "DataFormats/PatCandidates/interface/PackedCandidate.h"
 #include "flashgg/DataFormats/interface/VertexCandidateMap.h"
 #include "FWCore/Utilities/interface/EDMException.h"
@@ -30,31 +30,39 @@ namespace flashgg {
         void produce( Event &, const EventSetup & ) override;
         EDGetTokenT<View<pat::Jet> > jetToken_;
         EDGetTokenT<View<DiPhotonCandidate> > diPhotonToken_;
-        EDGetTokenT<View<reco::Vertex> >  vertexToken_;
+        EDGetTokenT<reco::VertexCollection >  vertexToken_;
         EDGetTokenT< VertexCandidateMap > vertexCandidateMapToken_;
         //EDGetTokenT<edm::ValueMap<float> > qgToken_; 
         //edm::InputTag qgToken_;
         edm::InputTag qgVariablesInputTag;
         edm::EDGetTokenT<edm::ValueMap<float> > qgToken;
-        //        unique_ptr<PileupJetIdAlgo>  pileupJetIdAlgo_;
-        //        ParameterSet pileupJetIdParameters_;
+        unique_ptr<PileupJetIdAlgo>  pileupJetIdAlgo_;
+        ParameterSet pileupJetIdParameters_;
         bool usePuppi;
         bool computeSimpleRMS;
+        unsigned jetCollectionIndex_;
+        EDGetTokenT<double> rhoToken_;
+        EDGetTokenT<View<pat::Jet> > jetDebugToken_;
+        bool debug_;
     };
 
 
     JetProducer::JetProducer( const ParameterSet &iConfig ) :
         jetToken_( consumes<View<pat::Jet> >( iConfig.getParameter<InputTag> ( "JetTag" ) ) ),
         diPhotonToken_( consumes<View<DiPhotonCandidate> >( iConfig.getParameter<InputTag>( "DiPhotonTag" ) ) ),
-        vertexToken_  ( consumes<View<reco::Vertex> >( iConfig.getParameter<InputTag> ( "VertexTag" ) ) ),
+        vertexToken_  ( consumes<reco::VertexCollection>( iConfig.getParameter<InputTag> ( "VertexTag" ) ) ),
         vertexCandidateMapToken_( consumes<VertexCandidateMap>( iConfig.getParameter<InputTag>( "VertexCandidateMapTag" ) )),
         qgVariablesInputTag( iConfig.getParameter<edm::InputTag>( "qgVariablesInputTag" ) ),
-        computeSimpleRMS( iConfig.getParameter<bool>( "ComputeSimpleRMS" ) )
+        pileupJetIdParameters_( iConfig.getParameter<ParameterSet>( "PileupJetIdParameters" ) ),
+        computeSimpleRMS( iConfig.getParameter<bool>( "ComputeSimpleRMS" ) ),
+        jetCollectionIndex_( iConfig.getParameter<unsigned> ( "JetCollectionIndex" ) ),
         //GluonTagSrc_  (iConfig.getParameter<edm::InputTag>("GluonTagSrc") )
-        //        pileupJetIdParameters_( iConfig.getParameter<ParameterSet>( "PileupJetIdParameters" ) ),
+        rhoToken_( consumes<double>(iConfig.getParameter<edm::InputTag>("rho") ) ),
+        jetDebugToken_( consumes<View<pat::Jet> >( iConfig.getUntrackedParameter<InputTag> ( "JetDebugTag",edm::InputTag("slimmedJets") ) ) ),
+        debug_( iConfig.getUntrackedParameter<bool>( "Debug",false ) )
         //        usePuppi( iConfig.getUntrackedParameter<bool>( "UsePuppi", false ) )
     {
-        //        pileupJetIdAlgo_.reset( new PileupJetIdAlgo( pileupJetIdParameters_ ) );
+        pileupJetIdAlgo_.reset( new PileupJetIdAlgo( pileupJetIdParameters_, true ) );
         //qgToken_ = consumes<edm::ValueMap<float> >(edm::InputTag("GluonTagSrc", "qgLikelihood"));
         qgToken  = consumes<edm::ValueMap<float>>( edm::InputTag( qgVariablesInputTag.label(), "qgLikelihood" ) );
         
@@ -68,14 +76,20 @@ namespace flashgg {
         Handle<View<pat::Jet> > jets;
         evt.getByToken( jetToken_, jets );
         // const PtrVector<pat::Jet>& jetPointers = jets->ptrVector();
+
+        Handle<View<pat::Jet> > debugJets;
+        if (debug_) {
+            evt.getByToken( jetDebugToken_, debugJets );
+        }
         
         // input DiPhoton candidates
         Handle<View<DiPhotonCandidate> > diPhotons;
         evt.getByToken( diPhotonToken_, diPhotons );
         // const PtrVector<DiPhotonCandidate>& diPhotonPointers = diPhotons->ptrVector();
 
-        Handle<View<reco::Vertex> > primaryVertices;
+        Handle<reco::VertexCollection> primaryVertices;
         evt.getByToken( vertexToken_, primaryVertices );
+        const reco::VertexCollection & vertexes = *(primaryVertices.product());
         // const PtrVector<reco::Vertex>& pvPointers = primaryVertices->ptrVector();
         // std::cout << " jet test ==" << primaryVertices->size() <<  std::endl;
 
@@ -92,8 +106,20 @@ namespace flashgg {
         //evt.getByToken(GluonTagSrc_, qgHandle);
         edm::Handle<edm::ValueMap<float>> qgHandle;
         evt.getByToken( qgToken, qgHandle );
+
+        edm::Handle< double > rhoHandle;
+        evt.getByToken( rhoToken_, rhoHandle);
+        double rho = *rhoHandle;
         
         auto_ptr<vector<flashgg::Jet> > jetColl( new vector<flashgg::Jet> );
+
+        if (debug_) {
+            for( unsigned int i = 0 ; i < debugJets->size() ; i++ ) {
+                if (debugJets->ptrAt(i)->pt() > 20 ) {
+                    std::cout << " DEBUG JET pt eta mva " << debugJets->ptrAt(i)->pt() << " " << debugJets->ptrAt(i)->eta() << " " << debugJets->ptrAt(i)->userFloat("pileupJetId:fullDiscriminant") << std::endl;
+                }
+            }
+        }
         
         for( unsigned int i = 0 ; i < jets->size() ; i++ ) {
             Ptr<pat::Jet> pjet = jets->ptrAt( i );
@@ -123,6 +149,38 @@ namespace flashgg {
             if(qgHandle.isValid()) qgLikelihood = ( *qgHandle )[jets->refAt( i )];;
             fjet.setQGL(qgLikelihood);
             //std::cout << "QGL jet["<< i << "] == " << qgLikelihood << std::endl;
+
+            if ( jetCollectionIndex_ == 0 ) {
+                PileupJetIdentifier lPUJetId = pileupJetIdAlgo_->computeIdVariables( pjet.get(), 0., &vertexes[0], vertexes, rho );
+                //                fjet.setPuJetId( primaryVertices->ptrAt( 0 ), lPUJetId );
+                if (debug_ && fjet.pt() > 20) {
+                    std::cout << "[STANDARD] pt=" << fjet.pt() << " eta=" << fjet.eta() 
+                              << " lPUJetID RMS, betaStar, mva: " << lPUJetId.RMS() << " " << lPUJetId.betaStar() << " " << lPUJetId.mva() 
+                              << "; simpleRMS " << fjet.rms() << "; match=" << (bool)(fjet.genJet()) << std::endl;
+                }
+                fjet.setSimpleMVA( lPUJetId.mva() );
+            } else {
+                for( unsigned int j = 0 ; j < diPhotons->size() ; j++ ) {
+                    Ptr<DiPhotonCandidate> diPhoton = diPhotons->ptrAt( j );
+                    if ( diPhoton->jetCollectionIndex() == jetCollectionIndex_ ) {
+                        Ptr<reco::Vertex> vtx = diPhoton->vtx();
+                        PileupJetIdentifier lPUJetId = pileupJetIdAlgo_->computeIdVariables( pjet.get(), 0., vtx.get(), vertexes, rho );
+                        if (debug_ && fjet.pt() > 20) {
+                            std::cout << "[NON-STANDARD] pt=" << fjet.pt() << " eta=" << fjet.eta()
+                                      << " lPUJetID RMS, betaStar, mva: " << lPUJetId.RMS() << " " << lPUJetId.betaStar() << " " << lPUJetId.mva()
+                                      << "; simpleRMS " << fjet.rms() << "; match=" << (bool)(fjet.genJet()) << std::endl;
+                            PileupJetIdentifier lPUJetId0 = pileupJetIdAlgo_->computeIdVariables( pjet.get(), 0., &vertexes[0], vertexes, rho );
+                            std::cout << "[NON-S W VTX0] pt=" << fjet.pt() << " eta=" << fjet.eta()
+                                      << " lPUJetID RMS, betaStar, mva: " << lPUJetId0.RMS() << " " << lPUJetId0.betaStar() << " " << lPUJetId0.mva()
+                                      << "; simpleRMS " << fjet.rms() << "; match=" << (bool)(fjet.genJet()) << std::endl;
+                        }
+                        fjet.setSimpleMVA( lPUJetId.mva() );
+                        break;
+                    }
+                }
+            }
+
+
             /*
             for( unsigned int j = 0 ; j < diPhotons->size() ; j++ ) {
                 Ptr<DiPhotonCandidate> diPhoton = diPhotons->ptrAt( j );

--- a/MicroAOD/python/flashggJets_cfi.py
+++ b/MicroAOD/python/flashggJets_cfi.py
@@ -109,6 +109,8 @@ def addFlashggPFCHSJets(process,
   
   from RecoJets.JetProducers.QGTagger_cfi import QGTagger
   setattr( process, 'QGTaggerPFCHS' + label,  QGTagger.clone( srcJets   = 'patJetsAK4PFCHSLeg' + label ,jetsLabel = 'QGL_AK4PFchs'))
+
+  from RecoJets.JetProducers.PileupJetIDParams_cfi import full_80x_chs
   
   flashggJets = cms.EDProducer('FlashggJetProducer',
                                DiPhotonTag = cms.InputTag('flashggDiPhotons'),
@@ -116,7 +118,10 @@ def addFlashggPFCHSJets(process,
                                JetTag      = cms.InputTag('patJetsAK4PFCHSLeg' + label),
                                VertexCandidateMapTag = cms.InputTag("flashggVertexMapForCHS"),
                                qgVariablesInputTag   = cms.InputTag('QGTaggerPFCHS'+label, 'qgLikelihood'),
-                               ComputeSimpleRMS = cms.bool(True)
+                               ComputeSimpleRMS = cms.bool(True),
+                               PileupJetIdParameters = full_80x_chs,
+                               rho     = cms.InputTag("fixedGridRhoFastjetAll"),
+                               JetCollectionIndex = cms.uint32(vertexIndex)
                                )
   setattr( process, 'flashggPFCHSJets'+ label, flashggJets)
 

--- a/MicroAOD/test/microAODstd.py
+++ b/MicroAOD/test/microAODstd.py
@@ -7,7 +7,8 @@ process.load("FWCore.MessageService.MessageLogger_cfi")
 
 process.load("Configuration.StandardSequences.GeometryDB_cff")
 process.load("Configuration.StandardSequences.MagneticField_cff")
-process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_condDBv2_cff") # gives deprecated message in 80X but still runs
+#process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_condDBv2_cff") # gives deprecated message in 80X but still runs
+process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
 from Configuration.AlCa.GlobalTag import GlobalTag
 
 process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32( 100) )
@@ -17,7 +18,7 @@ import os
 if os.environ["CMSSW_VERSION"].count("CMSSW_7_6"):
     process.GlobalTag = GlobalTag(process.GlobalTag, '76X_mcRun2_asymptotic_v13')
 elif os.environ["CMSSW_VERSION"].count("CMSSW_8_0"):
-    process.GlobalTag = GlobalTag(process.GlobalTag,'80X_mcRun2_asymptotic_v11')
+    process.GlobalTag = GlobalTag(process.GlobalTag,'80X_mcRun2_asymptotic_2016_miniAODv2')
 else:
     raise Exception,"The default setup for microAODstd.py does not support releases other than 76X and 80X"
 
@@ -63,8 +64,10 @@ process.RandomNumberGeneratorService.flashggRandomizedPhotons = cms.PSet(
 #process.source = cms.Source("PoolSource",fileNames=cms.untracked.vstring("/store/mc/RunIISpring15MiniAODv2/VHToGG_M125_13TeV_amcatnloFXFX_madspin_pythia8/MINIAODSIM/74X_mcRun2_asymptotic_v2-v1/40000/6C4EEC22-C36D-E511-8CCF-002590AC4C74.root"))
 #process.source = cms.Source("PoolSource",fileNames=cms.untracked.vstring("/store/data/Run2015D/DoubleEG/MINIAOD/05Oct2015-v1/50000/DEDE4FB0-556F-E511-9F9F-0025905B85E8.root"))
 #process.source = cms.Source("PoolSource",fileNames=cms.untracked.vstring("/store/mc/RunIISpring15MiniAODv2/GluGluHToGG_M-125_13TeV_powheg_pythia8/MINIAODSIM/74X_mcRun2_asymptotic_v2-v1/50000/048F7B0F-0A6E-E511-B710-00259073E37A.root"))
-process.source = cms.Source("PoolSource",fileNames=cms.untracked.vstring("/store/mc/RunIIFall15DR76/GluGluHToGG_M-125_13TeV_powheg_pythia8/MINIAODSIM/25nsFlat10to25TSG_76X_mcRun2_asymptotic_v12-v1/00000/0C6C1B51-9198-E511-B305-002590747D94.root"))
+#process.source = cms.Source("PoolSource",fileNames=cms.untracked.vstring("/store/mc/RunIIFall15DR76/GluGluHToGG_M-125_13TeV_powheg_pythia8/MINIAODSIM/25nsFlat10to25TSG_76X_mcRun2_asymptotic_v12-v1/00000/0C6C1B51-9198-E511-B305-002590747D94.root"))
 
+#80x
+process.source = cms.Source("PoolSource",fileNames=cms.untracked.vstring("/store/mc/RunIISpring16MiniAODv2/GluGluHToGG_M-125_13TeV_powheg_pythia8/MINIAODSIM/PUSpring16RAWAODSIM_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/70000/083E0403-2825-E611-89C4-0CC47A6C1038.root"))
 
 process.MessageLogger.cerr.threshold = 'ERROR' # can't get suppressWarning to work: disable all warnings for now
 # process.MessageLogger.suppressWarning.extend(['SimpleMemoryCheck','MemoryCheck']) # this would have been better...

--- a/setup.sh
+++ b/setup.sh
@@ -128,6 +128,10 @@ cd $CMSSW_BASE/src
 #git cms-addpkg RecoEgamma/EgammaTools
 #git cms-merge-topic -u sethzenz:topic-conversion-tools-for-pat-ele-74X
 
+echo "Setting up pileup jet id..."
+git cms-addpkg RecoJets/JetProducers
+git cms-merge-topic -u sethzenz:topic-PileupJetId-NonStandardVtx
+
 echo "Setting up TnP tools..."
 #git cms-addpkg DataFormats/RecoCandidate
 #git cms-addpkg PhysiscsTools/TagAndProbe


### PR DESCRIPTION
Support the latest 80x pileup id mva, so that we can do further study as part of the VBF tag.  This is needed for MicroAOD processing. *Important note: setup.sh is changed*

This is not super-well validated but it's better than nothing (and certainly harmless).  Some details:

* MiniAODv2 had a buggy version of the id mva, so to validate I had to run the buggy code to confirm that the ID MVA value was the same one stored, for 0th vertices.  This was only true most of the time, but I assume the differences come down to running on Candidates in MiniAOD-production vs running on PackedCandidates later.  

* After this validation I include a version of the code to fix the bug.  Note that this is in a new cmssw branch that's included from setup.sh

* Next I edited the code so that it would respect our non-0th vertex choice.  The results seem sane-ish but I have no way to validate this but look at distributions.  That's why this first pass is needed in MicroAOD