### PR TITLE
added a parameter applyCorrections to DiPhotonWithUpdatedPhoIdMVAProducer

### DIFF
--- a/Taggers/plugins/DiPhotonWithUpdatedPhoIdMVAProducer.cc
+++ b/Taggers/plugins/DiPhotonWithUpdatedPhoIdMVAProducer.cc
@@ -25,6 +25,13 @@ namespace flashgg {
         edm::EDGetTokenT<double> rhoToken_;
         PhotonIdUtils phoTools_;
         edm::FileInPath phoIdMVAweightfileEB_, phoIdMVAweightfileEE_, correctionFile_;
+
+        /** whether to actually apply corrections (true) or not (false). 
+
+            This is explcitly configurable (ParameterSet.existsAs(..) fails with an error 
+            in recent releases if the given correction file does not exist). 
+
+            Disabling corrections is useful for testing corrections etc. */
         bool correctInputs_;
         bool debug_;
         //        std::vector<TGraph*> corrections_;
@@ -34,13 +41,13 @@ namespace flashgg {
     DiPhotonWithUpdatedPhoIdMVAProducer::DiPhotonWithUpdatedPhoIdMVAProducer( const edm::ParameterSet &ps ) :
         token_(consumes<edm::View<flashgg::DiPhotonCandidate> >(ps.getParameter<edm::InputTag>("src"))),
         rhoToken_( consumes<double>( ps.getParameter<edm::InputTag>( "rhoFixedGridCollection" ) ) ),
+        correctInputs_( ps.getParameter<bool> ("applyCorrections") ),
         debug_( ps.getParameter<bool>( "Debug" ) )
     {
         phoIdMVAweightfileEB_ = ps.getParameter<edm::FileInPath>( "photonIdMVAweightfile_EB" );
         phoIdMVAweightfileEE_ = ps.getParameter<edm::FileInPath>( "photonIdMVAweightfile_EE" );
         phoTools_.setupMVA( phoIdMVAweightfileEB_.fullPath(), phoIdMVAweightfileEE_.fullPath() );
 
-        correctInputs_ = ps.existsAs<edm::FileInPath>("correctionFile") ? true: false;
         if (correctInputs_) {
             correctionFile_ = ps.getParameter<edm::FileInPath>( "correctionFile" );
             TFile* f = TFile::Open(correctionFile_.fullPath().c_str());

--- a/Taggers/python/flashggUpdatedIdMVADiPhotons_cfi.py
+++ b/Taggers/python/flashggUpdatedIdMVADiPhotons_cfi.py
@@ -10,5 +10,6 @@ flashggUpdatedIdMVADiPhotons = cms.EDProducer("FlashggDiPhotonWithUpdatedPhoIdMV
                                               photonIdMVAweightfile_EB = cms.FileInPath("flashgg/MicroAOD/data/MVAweights_80X_25ns_barrel_MoriondVtx.xml"),
                                               photonIdMVAweightfile_EE = cms.FileInPath("flashgg/MicroAOD/data/MVAweights_80X_25ns_endcap_MoriondVtx.xml"),
                                               correctionFile           = cms.FileInPath("flashgg/MicroAOD/data/transformation_76X_v2.root"),
-                                              Debug                    = cms.bool(False)
+                                              Debug                    = cms.bool(False),
+                                              applyCorrections         = cms.bool(True),
                                               )


### PR DESCRIPTION
To be able to disable the corrections of the photon id MVA input variables for testing purposes.

The official version of the code tries to disable corrections when the file given with the 'correctionFile' parameter does not exist. However, this generates an exception:
```
python encountered the error: <type 'exceptions.RuntimeError'>
edm::FileInPath unable to find file
```

This patch allows to disable the corrections explicitly (the default setting of the new parameter is true in the corresponding _cfi.py file).