### PR TITLE
Changes for pileup jet id studies

### DIFF
--- a/MetaData/README.md
+++ b/MetaData/README.md
@@ -95,6 +95,17 @@ https://twiki.cern.ch/twiki/bin/viewauth/CMS/FLASHggFramework#Instructions_for_u
 
 ### SRING16 (80x)
 
+#### 80X Pu Jet ID update 
+
+Tags for flashgg: `2_1_0` and `RunIISpring16DR80X-2_1_0-25ns_ICHEP16`
+
+```
+cd $CMSSW_BASE/src/flashgg/MetaData/work
+./prepareCrabJobs.py -C RunIISpring16DR80X-2_1_1-25ns_ICHEP16 -U 5 -L 25 -s campaigns/RunIISpring16DR80X-2_1_1-25ns_ICHEP16.json -V 2_1_1 -p ${CMSSW_BASE}/src/flashgg/MicroAOD/test/microAODstd.py --lumiMask ${PWD}/jsons/json_DCSONLY_1466185760.txt
+cd RunIISpring16DR80X-2_1_1-25ns_ICHEP16
+echo crabConfig_*.py | xargs -n 1 crab sub
+```
+
 #### 80X trainings on 80X
 
 Tags for flashgg: `2_1_0` and `RunIISpring16DR80X-2_1_0-25ns_ICHEP16`

--- a/MetaData/work/campaigns/RunIISpring16DR80X-2_1_1-25ns_ICHEP16.json
+++ b/MetaData/work/campaigns/RunIISpring16DR80X-2_1_1-25ns_ICHEP16.json
@@ -1,0 +1,13 @@
+{
+    "data" : [
+                "/DoubleEG/Run2016B-PromptReco-v1/MINIAOD",
+                "/DoubleEG/Run2016B-PromptReco-v2/MINIAOD",
+                "/SingleElectron/Run2016B-PromptReco-v1/MINIAOD",
+                "/SingleElectron/Run2016B-PromptReco-v2/MINIAOD"
+	      ],
+    "sig"  : [
+	      ],
+    "bkg"  : [
+    	         "/DYJetsToLL_M-50_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM"
+    	      ]
+}

--- a/MetaData/work/campaigns/globalTagsLookup.json
+++ b/MetaData/work/campaigns/globalTagsLookup.json
@@ -40,5 +40,6 @@
     "RunIISpring16MiniAODv2-PUSpring16RAWAODSIM_minus10percentMaterial_80X_mcRun2_asymptotic_2016_miniAODv2_v0" : ["80X_mcRun2_asymptotic_2016_v3"],
     "RunIISpring16MiniAODv2-PUSpring16RAWAODSIM_minus5percentMaterial_80X_mcRun2_asymptotic_2016_miniAODv2_v0"  : ["80X_mcRun2_asymptotic_2016_v3"],
     "RunIISpring16MiniAODv2-PUSpring16RAWAODSIM_plus10percentMaterial_80X_mcRun2_asymptotic_2016_miniAODv2_v0"  : ["80X_mcRun2_asymptotic_2016_v3"],
-    "RunIISpring16MiniAODv2-PUSpring16RAWAODSIM_plus5percentMaterial_80X_mcRun2_asymptotic_2016_miniAODv2_v0"   : ["80X_mcRun2_asymptotic_2016_v3"]
+    "RunIISpring16MiniAODv2-PUSpring16RAWAODSIM_plus5percentMaterial_80X_mcRun2_asymptotic_2016_miniAODv2_v0"   : ["80X_mcRun2_asymptotic_2016_v3"],
+    "RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0" : ["80X_mcRun2_asymptotic_2016_v3"]
 }

--- a/MicroAOD/python/flashggJets_cfi.py
+++ b/MicroAOD/python/flashggJets_cfi.py
@@ -121,7 +121,8 @@ def addFlashggPFCHSJets(process,
                                ComputeSimpleRMS = cms.bool(True),
                                PileupJetIdParameters = full_80x_chs,
                                rho     = cms.InputTag("fixedGridRhoFastjetAll"),
-                               JetCollectionIndex = cms.uint32(vertexIndex)
+                               JetCollectionIndex = cms.uint32(vertexIndex),
+                               Debug = cms.untracked.bool(False)
                                )
   setattr( process, 'flashggPFCHSJets'+ label, flashggJets)
 

--- a/setup.sh
+++ b/setup.sh
@@ -130,7 +130,8 @@ cd $CMSSW_BASE/src
 
 echo "Setting up pileup jet id..."
 git cms-addpkg RecoJets/JetProducers
-git cms-merge-topic -u sethzenz:topic-PileupJetId-NonStandardVtx
+#git cms-merge-topic -u sethzenz:topic-PileupJetId-NonStandardVtx
+git cms-merge-topic -u sethzenz:topic-PileupJetId-NonStandardVtx-bugfixSync
 
 echo "Setting up TnP tools..."
 #git cms-addpkg DataFormats/RecoCandidate


### PR DESCRIPTION
The current Pu Jet ID training was done with some buggy variable definitions.  I've had to play with the behavior of the PU Jet ID module (new tag in setup.sh) to get the outputs close to those on AOD.  Some (but not all) of the recent improvements from Jet MET had to be switched back.  The new debugging tools I used to figure this out are included in this PR.

I have not yet implemented saving the variables, to allow MVA re-evaluation, because the buggy internal variable definitions go into the JetMET pileup jet id object itself.  But I will implemented some sort of workaround before we do a full-scale production with pu jet id.

A small production (DY+Jets, DoubleEG, SingleElectron) was submitted to study distributions, especially for standard vs. non-standard vertices.  Details of the production included in the PR.