### PR TITLE
Fix `[Errno 36] File name too long` error when checking files

### DIFF
--- a/MetaData/python/samples_utils.py
+++ b/MetaData/python/samples_utils.py
@@ -4,6 +4,8 @@ from das_client import get_data as das_query
 
 from pprint import pprint
 
+from hashlib import sha256
+
 import os,json,fcntl,sys
 from parallel  import *
 from threading import Semaphore
@@ -477,7 +479,7 @@ class SamplesManager(object):
         @fileName: file name
         """
         fName = fileName
-        tmp = ".tmp%s_%d.json"%(dsetName.replace("/","_"),ifile)
+        tmp = ".tmp%s_%d.json"%(sha256(dsetName).hexdigest(),ifile)
         if self.continue_:
             if os.path.exists(tmp):
                 print "%s already exists" % tmp


### PR DESCRIPTION
The error is raised by `fggCheckFile.py` when called from within `sample_utils.py`if the dataset name is too (sic).

This fix/improvement introduces a `sha256()` of the dataset name in the temporary file creation in `sample_utils.py` so to have a unique filename with constant length.

Tested by checking few datasets both interactively and via lsf.