### PR TITLE
Pattern matching when reviewing catalogues and update to RunIISpring16DR80X-2_1_0-25ns_ICHEP16

### DIFF
--- a/MetaData/python/samples_utils.py
+++ b/MetaData/python/samples_utils.py
@@ -403,13 +403,15 @@ class SamplesManager(object):
         if writeCatalog:
             self.writeCatalog(catalog)
 
-    def reviewCatalog(self):
+    def reviewCatalog(self, pattern=None):
         datasets,catalog = self.getAllDatasets()
 
         primaries = {}
         keepAll = False
         dataregex = re.compile("Run[0-9]+[A-Z]")
         for d in datasets:
+            if pattern and not fnmatch(d, pattern):
+                continue
             if not keepAll:
                 reply = ask_user("keep this dataset (yes/no/all)?\n %s\n" % d, ["y","n","a"])
                 if reply == "n":
@@ -931,5 +933,5 @@ Commands:
     def run_clear(self):
         self.mn.clearCatalog()
     
-    def run_review(self):
-        self.mn.reviewCatalog()
+    def run_review(self, pattern=None):
+        self.mn.reviewCatalog(pattern)


### PR DESCRIPTION
Hello,

with this PR is possible to match a pattern in the dataset name when reviewing a catalog using fggManageSamples.py

I used the new tool to merge the GluGluHToGG_M125_13TeV_amcatnloFXFX_pythia8 with its extension. This comes useful to avoid inadvertently picking also the same dataset with material variation in the catalog when running on muAODs. The merged catalogue is included in this PR.

Bests,
Vittorio

