### PR TITLE
recognize new miniAODv2 for pu distribution import

### DIFF
--- a/MetaData/python/JobConfig.py
+++ b/MetaData/python/JobConfig.py
@@ -129,6 +129,7 @@ class JobConfig(object):
         try:
             from SimGeneral.MixingModule.mix_2016_25ns_SpringMC_PUScenarioV1_PoissonOOTPU_cfi import mix as mix_2016_80_25ns
             self.pu_distribs["80X_mcRun2_asymptotic_2016"] = mix_2016_80_25ns.input.nbPileupEvents
+            self.pu_distribs["PUSpring16"] = mix_2016_80_25ns.input.nbPileupEvents
         except Exception:
             print "Failed to load 80X mixing, this is expected in 7X!"
             

--- a/MetaData/python/JobConfig.py
+++ b/MetaData/python/JobConfig.py
@@ -256,7 +256,17 @@ class JobConfig(object):
                                 matches = filter(lambda x: x in dsetname, self.pu_distribs.keys() )
                                 print matches
                                 if len(matches) > 1:
-                                    matches = filter(lambda x: x == dsetname, matches)
+                                    print "Multiple matches, check if they're all the same"
+                                    allsame = True
+                                    for i in range(1,len(matches)):
+                                        if self.pu_distribs[matches[0]] != self.pu_distribs[matches[i]]:
+                                            allsame = False
+                                    if allsame:
+                                        print "They're all the same so we just take the 0th one:",matches[0]
+                                        matches = [matches[0]]
+                                    else:
+                                        print "Not all the same... so we return to the old behavior and take an exact match, otherwise leave empty..."
+                                        matches = filter(lambda x: x == dsetname, matches)
                                 if len(matches) != 1:
                                     raise Exception("Could not determine sample pu distribution for reweighting. Possible matches are [%s]. Selected [%s]\n dataset: %s" % 
                                                 ( ",".join(self.pu_distribs.keys()), ",".join(matches), dsetname ) )


### PR DESCRIPTION
The new uAOD sometimes don't have the expected string to identify which PU distribution to import.  This seems to fix the situation at least for the ntuples I've been looking at.  I checked in CMSSW and it doesn't appear any new PU distributions have been added that I should use instead:

https://github.com/cms-sw/cmssw/tree/0397259dd747cee94b68928f17976224c037057a/SimGeneral/MixingModule/python

However I would be grateful if someone can check and confirm.