### PR TITLE
ICHEP catalog update

### DIFF
--- a/MetaData/work/campaigns/RunIISpring16DR80X-2_2_0-25ns_ICHEP16_MiniAODv2.json
+++ b/MetaData/work/campaigns/RunIISpring16DR80X-2_2_0-25ns_ICHEP16_MiniAODv2.json
@@ -71,7 +71,6 @@
         "/ttHJetToGG_M130_13TeV_amcatnloFXFX_madspin_pythia8_v2/RunIISpring16MiniAODv2-PUSpring16RAWAODSIM_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v3/MINIAODSIM"
                 ],
         "bkg" : [
-        "/DYJetsToLL_M-50_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/RunIISpring16MiniAODv1-PUSpring16_80X_mcRun2_asymptotic_2016_v3-v1/MINIAODSIM",
         "/DYJetsToLL_M-50_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM",
         "/DYJetsToLL_M-50_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/RunIISpring16MiniAODv2-PUSpring16_minus10percentMaterial_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM",
         "/DYJetsToLL_M-50_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/RunIISpring16MiniAODv2-PUSpring16_minus5percentMaterial_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v2/MINIAODSIM",


### PR DESCRIPTION
   * updated `SingleElectron` with the missing files recovered
   * add `DYJetsToLL_M-50` with -10% material variations

*Please ignore /DYJetsToLL_M-50_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/ferrif-RunIISpring16DR80X-2_2_0-25ns_ICHEP16_MiniAODv2-2_2_0-v0-RunIISpring16MiniAODv1-PUSpring16_80X_mcRun2_asymptotic_2016_v3-v1-94d03017ce60e1991044b8807b85a209/USER* that needs to be invalidated in DAS to avoid getting back in at each catalog regeneration (I will take care of this later on).