### PR TITLE
Untagged categorisation 

### DIFF
--- a/Taggers/python/flashggTags_cff.py
+++ b/Taggers/python/flashggTags_cff.py
@@ -19,7 +19,7 @@ flashggUntagged = cms.EDProducer("FlashggUntaggedTagProducer",
                                  SystLabel      = cms.string(""),
                                  MVAResultTag   = cms.InputTag('flashggDiPhotonMVA'),
                                  GenParticleTag = cms.InputTag( "flashggPrunedGenParticles" ),
-                                 Boundaries     = cms.vdouble(-0.435,0.187,0.574,0.895), #,1.000),
+                                 Boundaries     = cms.vdouble(-0.398,0.308,0.624,0.907), #,1.000),
                                  RequireScaledPtCuts = cms.bool(True)
 )
 


### PR DESCRIPTION
This PR includes the optimised boundaries for 4 untagged categories, meant to be used for consistency with the latest diphoton MVA training commited by @yhaddad in #691 .