### PR TITLE
fix job_utils.py outfile name directory

### DIFF
--- a/MetaData/python/jobs_utils.py
+++ b/MetaData/python/jobs_utils.py
@@ -311,6 +311,7 @@ class JobsManager(object):
                 jobargs.extend( ["dataset=%s" % dset, "outputFile=%s" % outfile ] )
                 # add (and replace) per-dataset job arguments
                 dargs = dopts.get("args",[])
+                print "SCZ Debug:",jobargs
                 if type(dargs) != list:
                     print "\nERROR : dataset-specific arguments should be list not %s" % (type(dargs))
                     print "          dataset %s" % dset
@@ -319,7 +320,12 @@ class JobsManager(object):
                     replace = {}
                     for arg in dargs:
                         aname,val = arg.split("=")
-                        replace[aname] = arg
+                        if aname == "outputFile":
+                            if val.count("/") != outfile.count("/"):
+                                print "SCZ The specified outputFile does not yield same the subdir as expected:",val
+                                val = "/".join(outfile.split("/")[:-1]+[val.split("/")[-1]])
+                                print "SCZ So we adjust the outputFile name to: ",val
+                        replace[aname] = "=".join((aname,val))
                     newargs = []
                     anames = []
                     for arg in jobargs:

--- a/MetaData/python/jobs_utils.py
+++ b/MetaData/python/jobs_utils.py
@@ -311,7 +311,6 @@ class JobsManager(object):
                 jobargs.extend( ["dataset=%s" % dset, "outputFile=%s" % outfile ] )
                 # add (and replace) per-dataset job arguments
                 dargs = dopts.get("args",[])
-                print "SCZ Debug:",jobargs
                 if type(dargs) != list:
                     print "\nERROR : dataset-specific arguments should be list not %s" % (type(dargs))
                     print "          dataset %s" % dset


### PR DESCRIPTION
I discovered that running on lxplus, where files are copied at the end of the jobs, if outputFile is specified as a per-job argument, the expected subdir is not applied to the given argument.  This PR fixes it at least for this use case.

I cc @vtavolar because we were discussing it this morning, and cc @musella in case he can see a way this change would break some other use case.

