### PR TITLE
e-veto SFs from Zmmg with 12.9/fb data and shower shape correction file v3

### DIFF
--- a/Systematics/python/flashggDiPhotonSystematics_cfi.py
+++ b/Systematics/python/flashggDiPhotonSystematics_cfi.py
@@ -22,14 +22,14 @@ preselBins = cms.PSet(
         )
     )
 
-# slide 13 of https://indico.cern.ch/event/535800/contributions/2213640/attachments/1295950/1956455/201607ZmmgWith2016data_Update6p26perfb.pdf from the update with 6.26/fb
+# slide 7 of https://indico.cern.ch/event/535800/contributions/2213640/attachments/1295950/1968761/201607ZmmgWith2016data_Update12p9perfb.pdf from the update with 12.9/fb
 electronVetoBins = cms.PSet(
     variables = cms.vstring("abs(superCluster.eta)","r9"),
     bins = cms.VPSet(
-        cms.PSet( lowBounds = cms.vdouble( 0.0, 0.00 ) , upBounds = cms.vdouble( 1.5, 0.85 ) , values = cms.vdouble( 0.9910 ) , uncertainties = cms.vdouble( 0.0049 )  ) ,
-        cms.PSet( lowBounds = cms.vdouble( 0.0, 0.85 ) , upBounds = cms.vdouble( 1.5, 999. ) , values = cms.vdouble( 0.9961 ) , uncertainties = cms.vdouble( 0.0012 )  ) ,
-        cms.PSet( lowBounds = cms.vdouble( 1.5, 0.00 ) , upBounds = cms.vdouble( 6.0, 0.90 ) , values = cms.vdouble( 0.9939 ) , uncertainties = cms.vdouble( 0.0171 )  ) ,
-        cms.PSet( lowBounds = cms.vdouble( 1.5, 0.90 ) , upBounds = cms.vdouble( 6.0, 999. ) , values = cms.vdouble( 0.9994 ) , uncertainties = cms.vdouble( 0.0033 )  ) 
+        cms.PSet( lowBounds = cms.vdouble( 0.0, 0.00 ) , upBounds = cms.vdouble( 1.5, 0.85 ) , values = cms.vdouble( 0.9925 ) , uncertainties = cms.vdouble( 0.0045 )  ) ,
+        cms.PSet( lowBounds = cms.vdouble( 0.0, 0.85 ) , upBounds = cms.vdouble( 1.5, 999. ) , values = cms.vdouble( 0.9960 ) , uncertainties = cms.vdouble( 0.0010 )  ) ,
+        cms.PSet( lowBounds = cms.vdouble( 1.5, 0.00 ) , upBounds = cms.vdouble( 6.0, 0.90 ) , values = cms.vdouble( 0.9880 ) , uncertainties = cms.vdouble( 0.0142 )  ) ,
+        cms.PSet( lowBounds = cms.vdouble( 1.5, 0.90 ) , upBounds = cms.vdouble( 6.0, 999. ) , values = cms.vdouble( 0.9999 ) , uncertainties = cms.vdouble( 0.0029 )  ) 
         )
     )
 

--- a/Systematics/python/flashggDiPhotonSystematics_cfi.py
+++ b/Systematics/python/flashggDiPhotonSystematics_cfi.py
@@ -22,14 +22,14 @@ preselBins = cms.PSet(
         )
     )
 
-# slide 7 of https://indico.cern.ch/event/535800/contributions/2213640/attachments/1295950/1968761/201607ZmmgWith2016data_Update12p9perfb.pdf from the update with 12.9/fb
+# slide 7 of https://indico.cern.ch/event/535800/contributions/2213640/attachments/1295950/1968770/201607ZmmgWith2016data_Update12p9perfb.pdf from the update with 12.9/fb
 electronVetoBins = cms.PSet(
     variables = cms.vstring("abs(superCluster.eta)","r9"),
     bins = cms.VPSet(
-        cms.PSet( lowBounds = cms.vdouble( 0.0, 0.00 ) , upBounds = cms.vdouble( 1.5, 0.85 ) , values = cms.vdouble( 0.9925 ) , uncertainties = cms.vdouble( 0.0045 )  ) ,
+        cms.PSet( lowBounds = cms.vdouble( 0.0, 0.00 ) , upBounds = cms.vdouble( 1.5, 0.85 ) , values = cms.vdouble( 0.9924 ) , uncertainties = cms.vdouble( 0.0045 )  ) ,
         cms.PSet( lowBounds = cms.vdouble( 0.0, 0.85 ) , upBounds = cms.vdouble( 1.5, 999. ) , values = cms.vdouble( 0.9960 ) , uncertainties = cms.vdouble( 0.0010 )  ) ,
-        cms.PSet( lowBounds = cms.vdouble( 1.5, 0.00 ) , upBounds = cms.vdouble( 6.0, 0.90 ) , values = cms.vdouble( 0.9880 ) , uncertainties = cms.vdouble( 0.0142 )  ) ,
-        cms.PSet( lowBounds = cms.vdouble( 1.5, 0.90 ) , upBounds = cms.vdouble( 6.0, 999. ) , values = cms.vdouble( 0.9999 ) , uncertainties = cms.vdouble( 0.0029 )  ) 
+        cms.PSet( lowBounds = cms.vdouble( 1.5, 0.00 ) , upBounds = cms.vdouble( 6.0, 0.90 ) , values = cms.vdouble( 0.9863 ) , uncertainties = cms.vdouble( 0.0138 )  ) ,
+        cms.PSet( lowBounds = cms.vdouble( 1.5, 0.90 ) , upBounds = cms.vdouble( 6.0, 999. ) , values = cms.vdouble( 1.0000 ) , uncertainties = cms.vdouble( 0.0029 )  ) 
         )
     )
 


### PR DESCRIPTION
Update of e-veto SFs from Zmmg with 12.9/fb data and shower shape correction file v3 in Systematics/python/flashggDiPhotonSystematics_cfi.py