### PR TITLE
Updated catalog for ICHEP (MiniAODv2/reHLT based for MC)

### DIFF
--- a/MetaData/work/campaigns/RunIISpring16DR80X-2_2_0-25ns_ICHEP16_MiniAODv2.json
+++ b/MetaData/work/campaigns/RunIISpring16DR80X-2_2_0-25ns_ICHEP16_MiniAODv2.json
@@ -76,6 +76,7 @@
         "/DYJetsToLL_M-50_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/RunIISpring16MiniAODv2-PUSpring16_minus5percentMaterial_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v2/MINIAODSIM",
         "/DYJetsToLL_M-50_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/RunIISpring16MiniAODv2-PUSpring16_plus10percentMaterial_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM",
         "/DYJetsToLL_M-50_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/RunIISpring16MiniAODv2-PUSpring16_plus5percentMaterial_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM",
+        "/DYJetsToLL_M-50_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/RunIISpring16MiniAODv2-BS2016_BSandPUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM",
 
         "/DYToEE_NNPDF30_13TeV-powheg-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM",
 


### PR DESCRIPTION
   * final bunch of `SingleElectron`, `SingleMuon`, `DoubleMuon` data