### PR TITLE
re-added support for authentication when performing queries to DAS

### DIFF
--- a/MetaData/python/samples_utils.py
+++ b/MetaData/python/samples_utils.py
@@ -119,7 +119,7 @@ class SamplesManager(object):
             if "*" in dataset:
                 # response = das_query("https://cmsweb.cern.ch","dataset dataset=%s | grep dataset.name" % dataset, 0, 0, False, self.dbs_instance_, ckey=x509(), cert=x509())
                 # response = das_query("https://cmsweb.cern.ch","dataset dataset=%s instance=%s | grep dataset.name" % (dataset, self.dbs_instance_), 0, 0, False, ckey=x509(), cert=x509())
-                response = das_query("https://cmsweb.cern.ch","dataset dataset=%s instance=%s | grep dataset.name" % (dataset, self.dbs_instance_), 0, 0, False)
+                response = das_query("https://cmsweb.cern.ch","dataset dataset=%s instance=%s | grep dataset.name" % (dataset, self.dbs_instance_), 0, 0, False, ckey=x509(), cert=x509())
                 ## print response
                 for d in response["data"]:
                     ## print d
@@ -145,7 +145,7 @@ class SamplesManager(object):
         @dsetName: dataset name
         """
         ## response = das_query("https://cmsweb.cern.ch","file dataset=%s | grep file.name,file.nevents" % dsetName, 0, 0, False, self.dbs_instance_, ckey=x509(), cert=x509())
-        response = das_query("https://cmsweb.cern.ch","file dataset=%s instance=%s | grep file.name,file.nevents" % (dsetName,self.dbs_instance_), 0, 0, False, )
+        response = das_query("https://cmsweb.cern.ch","file dataset=%s instance=%s | grep file.name,file.nevents" % (dsetName,self.dbs_instance_), 0, 0, False, ckey=x509(), cert=x509())
         
         files=[]
         for d in response["data"]:


### PR DESCRIPTION
needed since some time, e.g. to do `fggManageSamples.py import <dataset>`.

Should fix #752 . 

Checked the modifications -- when running without a grid proxy, one now gets an error message when running `fggManageSamples.py import <dataset>` also showing the command how to obtain a grid proxy.