### PR TITLE
added missing commas in MetaData/work/campaigns/RunIISpring16DR80X-2_2_0-25ns_ICHEP16_MiniAODv2.json 

### DIFF
--- a/MetaData/work/campaigns/RunIISpring16DR80X-2_2_0-25ns_ICHEP16_MiniAODv2.json
+++ b/MetaData/work/campaigns/RunIISpring16DR80X-2_2_0-25ns_ICHEP16_MiniAODv2.json
@@ -17,8 +17,8 @@
         "/DoubleMuon/Run2016E-PromptReco-v2/MINIAOD",
         "/SingleMuon/Run2016B-PromptReco-v1/MINIAOD",
         "/SingleMuon/Run2016B-PromptReco-v2/MINIAOD",
-        "/SingleMuon/Run2016C-PromptReco-v2/MINIAOD"
-        "/SingleMuon/Run2016D-PromptReco-v2/MINIAOD"
+        "/SingleMuon/Run2016C-PromptReco-v2/MINIAOD",
+        "/SingleMuon/Run2016D-PromptReco-v2/MINIAOD",
         "/SingleMuon/Run2016E-PromptReco-v2/MINIAOD"
                 ],
         "sig" : [


### PR DESCRIPTION
to make it parseable  .

(side note: if we used the python parser 
```
catalog = eval(open(catalogFname).read())
```
instead of a json parser we could have trailing commas and we would not run into this
'copy & paste of the last line' problem :-) )