### PR TITLE
fix for using AAA on lxplus

### DIFF
--- a/MetaData/python/parallel.py
+++ b/MetaData/python/parallel.py
@@ -122,7 +122,9 @@ class LsfJob(object):
         self.jobid = jobid
     #----------------------------------------
     def preamble(self):
-        return ""
+        # fix to ensure AAA redirecting works properly on lxplus/lxbatch
+        # see https://hypernews.cern.ch/HyperNews/CMS/get/wanaccess/448/1/1.html
+        return "export XRD_NETWORKSTACK=IPv4"
 
     #----------------------------------------
     def epilogue(self,cmd,dest):


### PR DESCRIPTION
I've experienced problems using AAA on lxplus/lxbatch with CMSSW_8_0_8, redirection did not 
work properly. 

A solution which solves this problem was given here: https://hypernews.cern.ch/HyperNews/CMS/get/wanaccess/448/1/1/1.html

This patch implements this solution (setting an environment variable at the beginning of a
job script submitted to LSF).
