### PR TITLE
Update flashggMet_RunCorrectionAndUncertainties_cff.py

### DIFF
--- a/MicroAOD/python/flashggMet_RunCorrectionAndUncertainties_cff.py
+++ b/MicroAOD/python/flashggMet_RunCorrectionAndUncertainties_cff.py
@@ -64,24 +64,6 @@ def runMETs(process,isMC):
 
 def setMetCorr(process, metCorr):
     
-    process.pfMEtMultShiftCorr.paramaters                 = metCorr
-    process.patPFMetTxyCorr.paramaters                    = metCorr
-    process.multPhiCorrParams_T0rtTxy_25ns                = cms.VPSet( pset for pset in metCorr)
-    process.multPhiCorrParams_T0rtT1Txy_25ns              = cms.VPSet( pset for pset in metCorr)
-    process.multPhiCorrParams_T0rtT1T2Txy_25ns            = cms.VPSet( pset for pset in metCorr)
-    process.multPhiCorrParams_T0pcTxy_25ns                = cms.VPSet( pset for pset in metCorr)
-    process.multPhiCorrParams_T0pcT1Txy_25ns              = cms.VPSet( pset for pset in metCorr)
-    process.multPhiCorrParams_T0pcT1T2Txy_25ns            = cms.VPSet( pset for pset in metCorr)
-    process.multPhiCorrParams_T1Txy_25ns                  = cms.VPSet( pset for pset in metCorr)
-    process.multPhiCorrParams_T1T2Txy_25ns                = cms.VPSet( pset for pset in metCorr)
-    process.patMultPhiCorrParams_T0pcT1SmearTxy_25ns      = cms.VPSet( pset for pset in metCorr)
-    process.patMultPhiCorrParams_T0pcT1T2SmearTxy_25ns    = cms.VPSet( pset for pset in metCorr)
-    process.patMultPhiCorrParams_T0pcT1T2Txy_25ns         = cms.VPSet( pset for pset in metCorr)
-    process.patMultPhiCorrParams_T0pcT1Txy_25ns           = cms.VPSet( pset for pset in metCorr)
-    process.patMultPhiCorrParams_T0pcTxy_25ns             = cms.VPSet( pset for pset in metCorr)
-    process.patMultPhiCorrParams_T1SmearTxy_25ns          = cms.VPSet( pset for pset in metCorr)
-    process.patMultPhiCorrParams_T1T2SmearTxy_25ns        = cms.VPSet( pset for pset in metCorr)
-    process.patMultPhiCorrParams_T1T2Txy_25ns             = cms.VPSet( pset for pset in metCorr)
-    process.patMultPhiCorrParams_T1Txy_25ns               = cms.VPSet( pset for pset in metCorr)
-    process.patMultPhiCorrParams_Txy_25ns                 = cms.VPSet( pset for pset in metCorr)
-    
+    process.pfMEtMultShiftCorr.parameters                 = metCorr
+    process.patPFMetTxyCorr.parameters                    = metCorr
+   


### PR DESCRIPTION
Fixed a typo and removed definitions which we don't actually need.

There's an additional question still pending to MET, but the first pass of the MET phi corrections looked good on my end.  We can always correct at a later step (as we were already doing) if the official MET recipe doesn't look good once we analyze the full dataset.