### PR TITLE
update JobConfig to get right gen pu for Moriond17 samples

### DIFF
--- a/MetaData/python/JobConfig.py
+++ b/MetaData/python/JobConfig.py
@@ -123,10 +123,16 @@ class JobConfig(object):
             
         try:
             from SimGeneral.MixingModule.mix_2016_25ns_SpringMC_PUScenarioV1_PoissonOOTPU_cfi import mix as mix_2016_80_25ns
-            self.pu_distribs["80X_mcRun2_asymptotic_2016"] = mix_2016_80_25ns.input.nbPileupEvents
             self.pu_distribs["PUSpring16"] = mix_2016_80_25ns.input.nbPileupEvents
         except Exception:
             print "Failed to load 80X mixing, this is expected in 7X!"
+
+        try:
+            from SimGeneral.MixingModule.mix_2016_25ns_Moriond17MC_PoissonOOTPU_cfi import mix as mix_Moriond17
+            self.pu_distribs["Summer16"] = mix_Moriond17.input.nbPileupEvents
+            self.pu_distribs["PUMoriond17"] = mix_Moriond17.input.nbPileupEvents
+        except Exception:
+            print "Failed to load Moriond17 mixing, this is expected in earlier releases"
             
     def __getattr__(self,name):
         ## did not manage to inherit from VarParsing, because of some issues in __init__


### PR DESCRIPTION
Without this change, running on JobConfig will silently use the wrong gen pu distribution.  cc @gkrintir @musella @martinamalberti because of ongoing email thread