### PR TITLE
DY cross section is updated

### DIFF
--- a/MetaData/data/cross_sections.json
+++ b/MetaData/data/cross_sections.json
@@ -1,8 +1,8 @@
 {
         "DYJetsToLL_M-50_13TeV-madgraph-pythia8"                        : { "xs" : 4746.0                                },
-	"DYToEE_NNPDF30_13TeV-powheg-pythia8"                           : { "xs" : 2008.333333 },
-        "DYJetsToLL_M-50_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8"       : { "xs" : 6025.0, "itype":20                    },
-	"DYJetsToLL_M-50_TuneCUETP8M1_13TeV-madgraphMLM-pythia8"        : { "xs" : 6025.0, "itype":20                    },
+	"DYToEE_NNPDF30_13TeV-powheg-pythia8"                           : { "xs" : 1921.8 },
+        "DYJetsToLL_M-50_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8"       : { "xs" : 5765.4, "itype":20                    },
+	"DYJetsToLL_M-50_TuneCUETP8M1_13TeV-madgraphMLM-pythia8"        : { "xs" : 5765.4, "itype":20                    },
         "GJet_Pt40_doubleEMEnriched_TuneZ2star_13TeV-pythia6"           : { "xs" : 17180.0,  "br" : 0.0379,   "kf" : 1.0 },
         "GJet_Pt20to40_doubleEMEnriched_TuneZ2star_13TeV-pythia6"       : { "xs" : 145400.0, "br" : 0.001776, "kf" : 1.0 },
 	"DoubleEG"                                                      : { "xs" : 0.0, "itype" :0                       },


### PR DESCRIPTION
DY Cross section was updated at https://twiki.cern.ch/twiki/bin/viewauth/CMS/StandardModelCrossSectionsat13TeV with details in https://indico.cern.ch/event/538790/contributions/2188323/attachments/1284706/1910115/hengne_xzz2l2nu_20160603.pdf 