### PR TITLE
tweak matching and truncation per latest JetResolution twiki Smearing…

### DIFF
--- a/Systematics/plugins/JetSmear.cc
+++ b/Systematics/plugins/JetSmear.cc
@@ -5,6 +5,7 @@
 #include "CommonTools/Utils/interface/StringCutObjectSelector.h"
 #include "CLHEP/Random/RandGauss.h"
 #include "JetMETCorrections/Modules/interface/JetResolution.h"
+#include "DataFormats/Math/interface/deltaR.h"
 
 namespace flashgg {
 
@@ -111,7 +112,7 @@ namespace flashgg {
             if (debug_) std::cout << " GOT SCALE FACTOR " << std::endl;
             float recpt = y.pt();
             auto genjet = y.genJet();
-            if (genjet != nullptr) {
+            if (genjet != nullptr && deltaR(y,*(y.genJet())) < 0.2 && fabs(y.pt()-y.genJet()->pt()) < 3*r*y.pt()) {
                 float genpt = y.genJet()->pt();
                 float newpt = max<float>(0.,genpt + scale_factor*(recpt-genpt));
                 if ( debug_ ) {
@@ -124,10 +125,7 @@ namespace flashgg {
                     throw cms::Exception("Missing embedded random number") << "Could not find key " << random_label_ << " for random numbers embedded in the jet object, please make sure to read the appropriate version of MicroAOD and/or access the correct label and/or run the randomizer on-the-fly";
                 }
                 float rnd = y.userFloat(random_label_);       
-                float extra_smear_width = std::sqrt(scale_factor*scale_factor - 1) * r;
-                if (extra_smear_width < 0) {
-                    throw cms::Exception("NegativeSmearing") << " Calculated an extra_smear_width=" << extra_smear_width;
-                }
+                float extra_smear_width = std::sqrt(max<float>(scale_factor*scale_factor - 1,0.)) * r;
                 float escale = (1. + rnd * extra_smear_width);
                 if (debug_) {
                     std::cout << "  " << shiftLabel( syst_shift ) << ": Jet has pt=" << y.pt() << " eta=" << y.eta() << " NO GEN MATCH "


### PR DESCRIPTION
See https://twiki.cern.ch/twiki/bin/viewauth/CMS/JetResolution#Smearing_procedures for the math that is being changed (slightly).  This only became an issue because there is now a bin with SF < 1 with the latest data and MC.

Thanks to @gkrintir for pointing out this issue