### PR TITLE
Fix clone method to keep genPV for VHTagTruth

### DIFF
--- a/DataFormats/src/VHTagTruth.cc
+++ b/DataFormats/src/VHTagTruth.cc
@@ -34,6 +34,7 @@ VHTagTruth *VHTagTruth::clone() const
     result->setVhasHadrons( VhasHadrons() );
     result->setVhasMissingLeptons( VhasMissingLeptons() );
     result->setVpt( Vpt() );
+    result->setGenPV( genPV() );
     return result;
 
 }


### PR DESCRIPTION
This should fix the VH bug that Louie/Ed/Seth were analyzing.

It was dropping the genPV during the clone step because of the missing line.