### PR TITLE
keep debug variables, do not keep old rechits

### DIFF
--- a/MicroAOD/python/MicroAODCustomize.py
+++ b/MicroAOD/python/MicroAODCustomize.py
@@ -234,7 +234,7 @@ class MicroAODCustomize(object):
                 path.remove( getattr(process,mod))
             print getattr(process,pathName)
         process.out.outputCommands.append("drop *_*Gen*_*_*")
-        process.out.outputCommands.append("keep *_*_*RecHit*_*") # for bad events
+        process.out.outputCommands.append("keep *_reducedEgamma_*RecHit*_*") # for bad events
         delattr(process,"flashggPrunedGenParticles") # will be run due to unscheduled mode unless deleted
         self.customizeHighMassIsolations(process)
         process.load("flashgg/MicroAOD/flashggDiPhotonFilter_cfi")

--- a/MicroAOD/python/flashggMicroAODOutputCommands_cff.py
+++ b/MicroAOD/python/flashggMicroAODOutputCommands_cff.py
@@ -18,13 +18,13 @@ microAODDefaultOutputCommand = cms.untracked.vstring("drop *",
                                                      "keep *_offlineBeamSpot_*_*",
                                                      "keep *_TriggerResults_*_*",
                                                      "keep *_eventCount_*_*",
-                                                     "keep *CaloClusters_*_*_*",
+                                                     "keep *CaloClusters_reducedEgamma_*_*",
                                                      "keep *_weightsCount_*_*",
                                                      "keep *_generator_*_*",
                                                      "keep *_slimmedGenJets_*_*",
                                                      "keep *_flashggDiPhotons_*_*", # STILL NEEDED
                                                      "keep *_slimmedAddPileupInfo_*_*", # Was huge in old MiniAod - hopefully better now
-                                                     "keep *GsfElectronCore*_*_*_*", # needed by at least one Tag
+                                                     "keep *GsfElectronCore*_reducedEgamma_*_*", # needed by at least one Tag
 
                                                      "keep *_flashggSelected*_*_*",
                                                      # Drop intermediate collections in favor of selected/final collections
@@ -38,6 +38,8 @@ microAODDefaultOutputCommand = cms.untracked.vstring("drop *",
 						     "drop intedmValueMap_electronMVAValueMapProducer_*_*",
 						     "drop floatedmValueMap_photonMVAValueMapProducer_*_*",
                                                      "keep *_selectedPatTrigger_*_*",
+                                                     "keep *_particleFlowEGammaGSFixed_dupECALClusters_*",
+                                                     "keep *_ecalMultiAndGSGlobalRecHitEB_hitsNotReplaced_*"
                                                      )
 
 # Should be included for now for ongoing studies, but to be removed some day


### PR DESCRIPTION
For ReMiniAOD they now list some collections that might be useful for debugging [1], which have been added.  Some extra debug collections were accidentally kept so far [2], and they are removed.  I don't anticipate that the existing ReMiniAOD "test" jobs will need to be rerun.

[1] https://twiki.cern.ch/twiki/bin/view/CMSPublic/ReMiniAOD03Feb2017Notes

> bool                                  "particleFlowEGammaGSFixed"   "dupECALClusters"   "PAT"             
> edm::EDCollection<DetId>              "ecalMultiAndGSGlobalRecHitEB"   "hitsNotReplaced"   "PAT"             

[2] And also I found some debugging collections that we were keeping by accident in the ReMiniAOD test jobs.  These will be removed and should make the next jobs smaller:

< edm::SortedCollection<EcalRecHit,edm::StrictWeakOrdering<EcalRecHit> >    "reducedEgammaBeforeGSFix"   "reducedEBRecHits"   "PAT"             
16d16
< edm::SortedCollection<EcalRecHit,edm::StrictWeakOrdering<EcalRecHit> >    "reducedEgammaBeforeGSFix"   "reducedEERecHits"   "PAT"             
18d17
< edm::SortedCollection<EcalRecHit,edm::StrictWeakOrdering<EcalRecHit> >    "reducedEgammaBeforeGSFix"   "reducedESRecHits"   "PAT"             
22d20
< vector<reco::CaloCluster>             "reducedEgammaBeforeGSFix"   "reducedEBEEClusters"   "PAT"             
24d21
< vector<reco::CaloCluster>             "reducedEgammaBeforeGSFix"   "reducedESClusters"   "PAT"             
26d22
< vector<reco::GsfElectronCore>         "reducedEgammaBeforeGSFix"   "reducedGedGsfElectronCores"   "PAT"             
