### PR TITLE
10 jet collections, because there exists an event which needs over 8

### DIFF
--- a/MicroAOD/python/flashggJets_cfi.py
+++ b/MicroAOD/python/flashggJets_cfi.py
@@ -10,7 +10,7 @@ from CondCore.DBCommon.CondDBSetup_cfi import *
 import os
 
 flashggBTag = 'pfCombinedInclusiveSecondaryVertexV2BJetTags'
-maxJetCollections = 8
+maxJetCollections = 10
 #qgDatabaseVersion = 'v1' # check https://twiki.cern.ch/twiki/bin/viewauth/CMS/QGDataBaseVersion
 qgDatabaseVersion = '80X'
 


### PR DESCRIPTION
This is a change for MicroAOD, required to process one ReMiniAOD event that would otherwise crash, which is in this file: /store/data/Run2016E/DoubleEG/MINIAOD/03Feb2017-v1/80000/CA5635A7-ACEA-E611-B569-002590D9D8D4.root	   The exact event number and the details of the crash are here:
```
----- Begin Fatal Exception 16-Feb-2017 13:22:57 CET-----------------------
An exception of category 'Configuration' occurred while
   [0] Processing run: 277127 lumi: 809 event: 1511130886
   [1] Running path 'p'
   [2] Calling event method for module FlashggDiPhotonProducer/'flashggDiPhotons'
Exception Message:
 We need to setJetCollectionIndex to a value more than MaxJetCollections=8 -- you must reconfigure and rerun
----- End Fatal Exception -------------------------------------------------
```

This fix is related to the fact that we run a separate round of PFCHS clustering for each vertex that has an attached diphoton, as well as the 0th vertex, so that whichever diphoton we pick later we have a different jet collection.  Usually this is only 1 or 2 jet collections, but it can rarely be more.  (If there are 4 EM objects in the event, there are 4*3*2/2 = 12 candidate diphotons, each of which in principle can be matched to a different vertex, although in practice this would be a very strange event.)   For technical reasons, we have to specify a fixed maximum number of jet collections in the configuration.  Formerly, this was 8 and there was no problem, but in the ReMiniAOD it seems that more is required.  I changed it to 10.

I've confirmed the event above can be processed with the current fix, and I am now resubmitting the 1 job to complete the DoubleEG catalog.  For the benefit of any other people submitting their own uAOD, I will send a detailed email on this procedure to the flashgg list.