### PR TITLE
Jet ID Updates

### DIFF
--- a/DataFormats/src/Jet.cc
+++ b/DataFormats/src/Jet.cc
@@ -81,21 +81,24 @@ bool Jet::passesJetID( JetIDLevel level) const
     
     //std::cout  << "DEBUG:: eta= " << eta << " NHF=" << NHF << std::endl;
     
-    bool jetID_barel_loose  =  (NHF<0.99 && NEMF<0.99 && NumConst>1) && ((abs(eta)<=2.4 && CHF>0 && CHM>0 && CEMF<0.99) || abs(eta)>2.4) && abs(eta)<=3.0;
-    bool jetID_barel_tight  =  (NHF<0.90 && NEMF<0.90 && NumConst>1) && ((abs(eta)<=2.4 && CHF>0 && CHM>0 && CEMF<0.99) || abs(eta)>2.4) && abs(eta)<=3.0;
-    bool jetID_foaward      =  (NEMF<0.90 && NumNeutralParticles >10 && abs(eta)>3.0 );
+    bool jetID_barrel_loose  =  (NHF<0.99 && NEMF<0.99 && NumConst>1) && ((fabs(eta)<=2.4 && CHF>0 && CHM>0 && CEMF<0.99) || fabs(eta)>2.4) && fabs(eta)<=2.7;
+    bool jetID_barrel_tight  =  (NHF<0.90 && NEMF<0.90 && NumConst>1) && ((fabs(eta)<=2.4 && CHF>0 && CHM>0 && CEMF<0.99) || fabs(eta)>2.4) && fabs(eta)<=2.7;
+    bool jetID_transition      =  (NEMF>0.01 && NHF<0.98 && NumNeutralParticles>2 && fabs(eta)>2.7 && fabs(eta)<3.0);
+    bool jetID_forward      =  (NEMF<0.90 && NumNeutralParticles >10 && fabs(eta)>3.0 );
     
     switch(level){
     case Loose:
         {
-            if(abs(eta)<=3.0 ) return jetID_barel_loose;
-            if(abs(eta)> 3.0 ) return jetID_foaward;
+            if(fabs(eta)<=2.7 ) return jetID_barrel_loose;
+            if(fabs(eta)<=3.0 ) return jetID_transition;
+            if(fabs(eta)> 3.0 ) return jetID_forward;
             
         }break;
     case Tight:
         {
-            if(abs(eta)<=3.0 ) return jetID_barel_tight;
-            if(abs(eta)> 3.0 ) return jetID_foaward;
+            if(fabs(eta)<=2.7 ) return jetID_barrel_tight;
+            if(fabs(eta)<=3.0 ) return jetID_transition;
+            if(fabs(eta)> 3.0 ) return jetID_forward;
         }break;
     default:
         {

--- a/Systematics/python/flashggJetSystematics_cfi.py
+++ b/Systematics/python/flashggJetSystematics_cfi.py
@@ -168,7 +168,7 @@ def createJetSystematicsForTag(process,jetInputTag):
                                                            NSigmas = cms.vint32(-1,1),
                                                            OverallRange = cms.string("abs(eta)<5.0&&pt>20.0"),
                                                            BinList  = PUJIDShiftBins,
-                                                           ApplyCentralValue = cms.bool(True),
+                                                           ApplyCentralValue = cms.bool(False),
                                                            Debug = cms.untracked.bool(False)
                                                            ),
                                                  cms.PSet( MethodName = cms.string("FlashggJetWeight"),

--- a/Taggers/plugins/TTHHadronicTagProducer.cc
+++ b/Taggers/plugins/TTHHadronicTagProducer.cc
@@ -371,7 +371,7 @@ namespace flashgg {
             for( unsigned int jetIndex = 0; jetIndex < Jets[jetCollectionIndex]->size() ; jetIndex++ ) {
                 edm::Ptr<flashgg::Jet> thejet = Jets[jetCollectionIndex]->ptrAt( jetIndex );
                 if( fabs( thejet->eta() ) > jetEtaThreshold_ ) { continue; }
-                
+                if(!thejet->passesJetID  ( flashgg::Loose ) { continue; }
                 float dRPhoLeadJet = deltaR( thejet->eta(), thejet->phi(), dipho->leadingPhoton()->superCluster()->eta(), dipho->leadingPhoton()->superCluster()->phi() ) ;
                 float dRPhoSubLeadJet = deltaR( thejet->eta(), thejet->phi(), dipho->subLeadingPhoton()->superCluster()->eta(),
                                                 dipho->subLeadingPhoton()->superCluster()->phi() );

--- a/Taggers/plugins/TTHHadronicTagProducer.cc
+++ b/Taggers/plugins/TTHHadronicTagProducer.cc
@@ -371,7 +371,7 @@ namespace flashgg {
             for( unsigned int jetIndex = 0; jetIndex < Jets[jetCollectionIndex]->size() ; jetIndex++ ) {
                 edm::Ptr<flashgg::Jet> thejet = Jets[jetCollectionIndex]->ptrAt( jetIndex );
                 if( fabs( thejet->eta() ) > jetEtaThreshold_ ) { continue; }
-                if(!thejet->passesJetID  ( flashgg::Loose ) { continue; }
+                if(!thejet->passesJetID  ( flashgg::Loose ) ) { continue; }
                 float dRPhoLeadJet = deltaR( thejet->eta(), thejet->phi(), dipho->leadingPhoton()->superCluster()->eta(), dipho->leadingPhoton()->superCluster()->phi() ) ;
                 float dRPhoSubLeadJet = deltaR( thejet->eta(), thejet->phi(), dipho->subLeadingPhoton()->superCluster()->eta(),
                                                 dipho->subLeadingPhoton()->superCluster()->phi() );

--- a/Taggers/plugins/TTHLeptonicTagProducer.cc
+++ b/Taggers/plugins/TTHLeptonicTagProducer.cc
@@ -332,7 +332,7 @@ namespace flashgg {
                     for( unsigned int candIndex_outer = 0; candIndex_outer < Jets[jetCollectionIndex]->size() ; candIndex_outer++ ) {
                         edm::Ptr<flashgg::Jet> thejet = Jets[jetCollectionIndex]->ptrAt( candIndex_outer );
 
-                        if(!thejet->passesJetID  ( flashgg::Loose ) { continue; }
+                        if(!thejet->passesJetID  ( flashgg::Loose ) ) { continue; }
 
                         if( fabs( thejet->eta() ) > jetEtaThreshold_ ) { continue; }
 

--- a/Taggers/plugins/TTHLeptonicTagProducer.cc
+++ b/Taggers/plugins/TTHLeptonicTagProducer.cc
@@ -332,7 +332,7 @@ namespace flashgg {
                     for( unsigned int candIndex_outer = 0; candIndex_outer < Jets[jetCollectionIndex]->size() ; candIndex_outer++ ) {
                         edm::Ptr<flashgg::Jet> thejet = Jets[jetCollectionIndex]->ptrAt( candIndex_outer );
 
-                        if( !thejet->passesPuJetId( dipho ) ) { continue; }
+                        if(!thejet->passesJetID  ( flashgg::Loose ) { continue; }
 
                         if( fabs( thejet->eta() ) > jetEtaThreshold_ ) { continue; }
 

--- a/Taggers/plugins/VBFMVAProducer.cc
+++ b/Taggers/plugins/VBFMVAProducer.cc
@@ -241,12 +241,13 @@ namespace flashgg {
                     //std::cout << "VBFTagMVA::DEBUG  making the pujid --> "<< _pujid_wp_pt_bin_1.size() << std::endl;
                     bool pass=false;
                     for (UInt_t eta_bin=0; eta_bin < _pujid_wp_pt_bin_1.size(); eta_bin++ ){
-                        //std::cout << " eta-bin["<< eta_bin<< "] == " << eta_cuts_[eta_bin].first << "  :: "
-                        //          << eta_cuts_[eta_bin].second
-                        //          << " pt1: " << _pujid_wp_pt_bin_1[eta_bin]
-                        //          << " pt2: " << _pujid_wp_pt_bin_2[eta_bin]
-                        //          << " pt3: " << _pujid_wp_pt_bin_3[eta_bin]
-                        //          << std::endl;
+                        //                        std::cout << inputTagJets_[0] 
+                        //        << " eta-bin["<< eta_bin<< "] == " << eta_cuts_[eta_bin].first << "  :: "
+                        //        << eta_cuts_[eta_bin].second
+                        //        << " pt1: " << _pujid_wp_pt_bin_1[eta_bin]
+                        //        << " pt2: " << _pujid_wp_pt_bin_2[eta_bin]
+                        //        << " pt3: " << _pujid_wp_pt_bin_3[eta_bin]
+                        //        << std::endl;
                         if ( fabs( jet->eta() ) >  eta_cuts_[eta_bin].first &&
                              fabs( jet->eta() ) <= eta_cuts_[eta_bin].second){
                             if ( jet->pt() >  20 &&
@@ -261,7 +262,7 @@ namespace flashgg {
                             if (jet->pt() > 100) pass = true;
                         }
                     }
-                    //std::cout << "\t pt="<< jet->pt() << " :eta: "<< jet->eta() << " :mva: "<< jet->puJetIdMVA() << "  pass == " << pass << std::endl;
+                    //                    std::cout << inputTagJets_[0] << " pt="<< jet->pt() << " :eta: "<< jet->eta() << " :mva: "<< jet->puJetIdMVA() << "  pass == " << pass << std::endl;
                     if (!pass) continue;
                 }
                 // within eta 4.7?

--- a/Taggers/plugins/VHHadronicTagProducer.cc
+++ b/Taggers/plugins/VHHadronicTagProducer.cc
@@ -258,7 +258,7 @@ namespace flashgg {
 
                 edm::Ptr<flashgg::Jet> thejet = Jets[jetCollectionIndex]->ptrAt( ijet );
                 
-                if(!jet->passesJetID  ( flashgg::Loose ) { continue; }
+                if(!thejet->passesJetID  ( flashgg::Loose ) ) { continue; }
                 if( fabs( thejet->eta() ) > jetEtaThreshold_ )  { continue; }
                 if( thejet->pt() < jetPtThreshold_ )            { continue; }
 

--- a/Taggers/plugins/VHHadronicTagProducer.cc
+++ b/Taggers/plugins/VHHadronicTagProducer.cc
@@ -258,7 +258,7 @@ namespace flashgg {
 
                 edm::Ptr<flashgg::Jet> thejet = Jets[jetCollectionIndex]->ptrAt( ijet );
                 
-                if( !thejet->passesPuJetId( dipho ) )           { continue; }
+                if(!jet->passesJetID  ( flashgg::Loose ) { continue; }
                 if( fabs( thejet->eta() ) > jetEtaThreshold_ )  { continue; }
                 if( thejet->pt() < jetPtThreshold_ )            { continue; }
 

--- a/Taggers/plugins/VHLeptonicLoose.cc
+++ b/Taggers/plugins/VHLeptonicLoose.cc
@@ -399,7 +399,7 @@ namespace flashgg {
                 {
                     bool keepJet=true;
                     edm::Ptr<flashgg::Jet> thejet = Jets[jetCollectionIndex]->ptrAt( candIndex_outer );
-                    if( ! thejet->passesPuJetId( dipho ) ) { keepJet=false; }
+                    if(!thejet->passesJetID  ( flashgg::Loose ) { continue; }
                     if( fabs( thejet->eta() ) > jetEtaThreshold_ ) { keepJet=false; }
                     if( thejet->pt() < jetPtThreshold_ ) { keepJet=false; }
                     float dRPhoLeadJet = deltaR( thejet->eta(), thejet->phi(), dipho->leadingPhoton()->superCluster()->eta(), dipho->leadingPhoton()->superCluster()->phi() ) ;

--- a/Taggers/plugins/VHLeptonicLoose.cc
+++ b/Taggers/plugins/VHLeptonicLoose.cc
@@ -399,7 +399,7 @@ namespace flashgg {
                 {
                     bool keepJet=true;
                     edm::Ptr<flashgg::Jet> thejet = Jets[jetCollectionIndex]->ptrAt( candIndex_outer );
-                    if(!thejet->passesJetID  ( flashgg::Loose ) ) { continue; }
+                    if(!thejet->passesJetID  ( flashgg::Loose ) ) { keepJet=false; }
                     if( fabs( thejet->eta() ) > jetEtaThreshold_ ) { keepJet=false; }
                     if( thejet->pt() < jetPtThreshold_ ) { keepJet=false; }
                     float dRPhoLeadJet = deltaR( thejet->eta(), thejet->phi(), dipho->leadingPhoton()->superCluster()->eta(), dipho->leadingPhoton()->superCluster()->phi() ) ;

--- a/Taggers/plugins/VHLeptonicLoose.cc
+++ b/Taggers/plugins/VHLeptonicLoose.cc
@@ -399,7 +399,7 @@ namespace flashgg {
                 {
                     bool keepJet=true;
                     edm::Ptr<flashgg::Jet> thejet = Jets[jetCollectionIndex]->ptrAt( candIndex_outer );
-                    if(!thejet->passesJetID  ( flashgg::Loose ) { continue; }
+                    if(!thejet->passesJetID  ( flashgg::Loose ) ) { continue; }
                     if( fabs( thejet->eta() ) > jetEtaThreshold_ ) { keepJet=false; }
                     if( thejet->pt() < jetPtThreshold_ ) { keepJet=false; }
                     float dRPhoLeadJet = deltaR( thejet->eta(), thejet->phi(), dipho->leadingPhoton()->superCluster()->eta(), dipho->leadingPhoton()->superCluster()->phi() ) ;

--- a/Taggers/plugins/VHLooseTagProducer.cc
+++ b/Taggers/plugins/VHLooseTagProducer.cc
@@ -376,7 +376,7 @@ namespace flashgg {
                 {
                     bool keepJet=true;
                     edm::Ptr<flashgg::Jet> thejet = Jets[jetCollectionIndex]->ptrAt( candIndex_outer );
-                    if( ! thejet->passesPuJetId( dipho ) ) { keepJet=false; }
+                    if(!thejet->passesJetID  ( flashgg::Loose ) { continue; }
                     if( fabs( thejet->eta() ) > jetEtaThreshold_ ) { keepJet=false; }
                     if( thejet->pt() < jetPtThreshold_ ) { keepJet=false; }
                     float dRPhoLeadJet = deltaR( thejet->eta(), thejet->phi(), dipho->leadingPhoton()->superCluster()->eta(), dipho->leadingPhoton()->superCluster()->phi() ) ;

--- a/Taggers/plugins/VHLooseTagProducer.cc
+++ b/Taggers/plugins/VHLooseTagProducer.cc
@@ -376,7 +376,7 @@ namespace flashgg {
                 {
                     bool keepJet=true;
                     edm::Ptr<flashgg::Jet> thejet = Jets[jetCollectionIndex]->ptrAt( candIndex_outer );
-                    if(!thejet->passesJetID  ( flashgg::Loose ) ) { continue; }
+                    if(!thejet->passesJetID  ( flashgg::Loose ) ) { keepJet=false; }
                     if( fabs( thejet->eta() ) > jetEtaThreshold_ ) { keepJet=false; }
                     if( thejet->pt() < jetPtThreshold_ ) { keepJet=false; }
                     float dRPhoLeadJet = deltaR( thejet->eta(), thejet->phi(), dipho->leadingPhoton()->superCluster()->eta(), dipho->leadingPhoton()->superCluster()->phi() ) ;

--- a/Taggers/plugins/VHLooseTagProducer.cc
+++ b/Taggers/plugins/VHLooseTagProducer.cc
@@ -376,7 +376,7 @@ namespace flashgg {
                 {
                     bool keepJet=true;
                     edm::Ptr<flashgg::Jet> thejet = Jets[jetCollectionIndex]->ptrAt( candIndex_outer );
-                    if(!thejet->passesJetID  ( flashgg::Loose ) { continue; }
+                    if(!thejet->passesJetID  ( flashgg::Loose ) ) { continue; }
                     if( fabs( thejet->eta() ) > jetEtaThreshold_ ) { keepJet=false; }
                     if( thejet->pt() < jetPtThreshold_ ) { keepJet=false; }
                     float dRPhoLeadJet = deltaR( thejet->eta(), thejet->phi(), dipho->leadingPhoton()->superCluster()->eta(), dipho->leadingPhoton()->superCluster()->phi() ) ;

--- a/Taggers/plugins/VHMetTagProducer.cc
+++ b/Taggers/plugins/VHMetTagProducer.cc
@@ -277,7 +277,7 @@ namespace flashgg {
             for( unsigned int jetIndex = 0; jetIndex < Jets[jetCollectionIndex]->size() ; jetIndex++ )
                 {
                     edm::Ptr<flashgg::Jet> thejet = Jets[jetCollectionIndex]->ptrAt( jetIndex );
-                    if( ! thejet->passesPuJetId( dipho ) ) { continue; }
+                    if(!jet->passesJetID  ( flashgg::Loose ) { continue; }
                     if( fabs( thejet->eta() ) > jetEtaThreshold_ ) { continue; }
                     if( thejet->pt() < jetPtThreshold_ ) { continue; }
                     float dRPhoLeadJet = deltaR( thejet->eta(), thejet->phi(), diPhotons->ptrAt( candIndex )->leadingPhoton()->superCluster()->eta(), diPhotons->ptrAt( candIndex )->leadingPhoton()->superCluster()->phi() ) ;

--- a/Taggers/plugins/VHMetTagProducer.cc
+++ b/Taggers/plugins/VHMetTagProducer.cc
@@ -277,7 +277,7 @@ namespace flashgg {
             for( unsigned int jetIndex = 0; jetIndex < Jets[jetCollectionIndex]->size() ; jetIndex++ )
                 {
                     edm::Ptr<flashgg::Jet> thejet = Jets[jetCollectionIndex]->ptrAt( jetIndex );
-                    if(!jet->passesJetID  ( flashgg::Loose ) { continue; }
+                    if(!thejet->passesJetID  ( flashgg::Loose ) ) { continue; }
                     if( fabs( thejet->eta() ) > jetEtaThreshold_ ) { continue; }
                     if( thejet->pt() < jetPtThreshold_ ) { continue; }
                     float dRPhoLeadJet = deltaR( thejet->eta(), thejet->phi(), diPhotons->ptrAt( candIndex )->leadingPhoton()->superCluster()->eta(), diPhotons->ptrAt( candIndex )->leadingPhoton()->superCluster()->phi() ) ;

--- a/Taggers/plugins/VHTightTagProducer.cc
+++ b/Taggers/plugins/VHTightTagProducer.cc
@@ -474,7 +474,7 @@ namespace flashgg {
                 {
                     bool keepJet=true;
                     edm::Ptr<flashgg::Jet> thejet = Jets[jetCollectionIndex]->ptrAt( candIndex_outer );
-                    if(!jet->passesJetID  ( flashgg::Loose ) { keepJet=false; }
+                    if(!thejet->passesJetID  ( flashgg::Loose ) ) { keepJet=false; }
                     if( fabs( thejet->eta() ) > jetEtaThreshold_ ) { keepJet=false; }
                     if( thejet->pt() < jetPtThreshold_ ) { keepJet=false; }
                     float dRPhoLeadJet = deltaR( thejet->eta(), thejet->phi(), dipho->leadingPhoton()->superCluster()->eta(), dipho->leadingPhoton()->superCluster()->phi() ) ;

--- a/Taggers/plugins/VHTightTagProducer.cc
+++ b/Taggers/plugins/VHTightTagProducer.cc
@@ -474,7 +474,7 @@ namespace flashgg {
                 {
                     bool keepJet=true;
                     edm::Ptr<flashgg::Jet> thejet = Jets[jetCollectionIndex]->ptrAt( candIndex_outer );
-                    if( ! thejet->passesPuJetId( dipho ) ) { keepJet=false; }
+                    if(!jet->passesJetID  ( flashgg::Loose ) { keepJet=false; }
                     if( fabs( thejet->eta() ) > jetEtaThreshold_ ) { keepJet=false; }
                     if( thejet->pt() < jetPtThreshold_ ) { keepJet=false; }
                     float dRPhoLeadJet = deltaR( thejet->eta(), thejet->phi(), dipho->leadingPhoton()->superCluster()->eta(), dipho->leadingPhoton()->superCluster()->phi() ) ;

--- a/Taggers/plugins/WHLeptonicTagProducer.cc
+++ b/Taggers/plugins/WHLeptonicTagProducer.cc
@@ -372,7 +372,7 @@ namespace flashgg {
                 {
                     bool keepJet=true;
                     edm::Ptr<flashgg::Jet> thejet = Jets[jetCollectionIndex]->ptrAt( candIndex_outer );
-                    if(!thejet->passesJetID  ( flashgg::Loose ) { continue; }
+                    if(!thejet->passesJetID  ( flashgg::Loose ) ) { continue; }
                     if( fabs( thejet->eta() ) > jetEtaThreshold_ ) { keepJet=false; }
                     if( thejet->pt() < jetPtThreshold_ ) { keepJet=false; }
                     float dRPhoLeadJet = deltaR( thejet->eta(), thejet->phi(), dipho->leadingPhoton()->superCluster()->eta(), dipho->leadingPhoton()->superCluster()->phi() ) ;

--- a/Taggers/plugins/WHLeptonicTagProducer.cc
+++ b/Taggers/plugins/WHLeptonicTagProducer.cc
@@ -372,7 +372,7 @@ namespace flashgg {
                 {
                     bool keepJet=true;
                     edm::Ptr<flashgg::Jet> thejet = Jets[jetCollectionIndex]->ptrAt( candIndex_outer );
-                    if( ! thejet->passesPuJetId( dipho ) ) { keepJet=false; }
+                    if(!thejet->passesJetID  ( flashgg::Loose ) { continue; }
                     if( fabs( thejet->eta() ) > jetEtaThreshold_ ) { keepJet=false; }
                     if( thejet->pt() < jetPtThreshold_ ) { keepJet=false; }
                     float dRPhoLeadJet = deltaR( thejet->eta(), thejet->phi(), dipho->leadingPhoton()->superCluster()->eta(), dipho->leadingPhoton()->superCluster()->phi() ) ;

--- a/Taggers/plugins/ZPlusJetTagProducer.cc
+++ b/Taggers/plugins/ZPlusJetTagProducer.cc
@@ -120,7 +120,7 @@ namespace flashgg {
 
             for( unsigned jetLoop = 0; jetLoop < Jets[candIndex]->size() ; jetLoop++ ) {
                 Ptr<flashgg::Jet> jet  = Jets[candIndex]->ptrAt( jetLoop );
-                if(!jet->passesJetID  ( flashgg::Loose ) ) { continue; }
+                //                if(!jet->passesJetID  ( flashgg::Loose ) ) { continue; }
                 if (jet->pt() < 20.) continue;
 
                 // close to lead photon?

--- a/Taggers/plugins/ZPlusJetTagProducer.cc
+++ b/Taggers/plugins/ZPlusJetTagProducer.cc
@@ -120,7 +120,7 @@ namespace flashgg {
 
             for( unsigned jetLoop = 0; jetLoop < Jets[candIndex]->size() ; jetLoop++ ) {
                 Ptr<flashgg::Jet> jet  = Jets[candIndex]->ptrAt( jetLoop );
-                if(!jet->passesJetID  ( flashgg::Loose ) { continue; }
+                if(!jet->passesJetID  ( flashgg::Loose ) ) { continue; }
                 if (jet->pt() < 20.) continue;
 
                 // close to lead photon?

--- a/Taggers/plugins/ZPlusJetTagProducer.cc
+++ b/Taggers/plugins/ZPlusJetTagProducer.cc
@@ -120,7 +120,7 @@ namespace flashgg {
 
             for( unsigned jetLoop = 0; jetLoop < Jets[candIndex]->size() ; jetLoop++ ) {
                 Ptr<flashgg::Jet> jet  = Jets[candIndex]->ptrAt( jetLoop );
-
+                if(!jet->passesJetID  ( flashgg::Loose ) { continue; }
                 if (jet->pt() < 20.) continue;
 
                 // close to lead photon?


### PR DESCRIPTION
Three things are done in this PR:
* Update JetID prescription to include changed recommendation for transition region, see https://twiki.cern.ch/twiki/bin/view/CMS/JetID13TeVRun2016 
* Remove passesPuJetId call in tags, which always returns true anyway.
* Consistently put in Loose Jet ID for all tags using jets, per JME recommendations.  You can see in https://indico.cern.ch/event/592313/contributions/2398387/attachments/1384663/2106630/JetID_JMARmeeting_7_12_2016.pdf that efficiency is >99% throughout, so no impact is expected on the analysis.   (The exception is VBF, which needs Tight Jet ID.)