### PR TITLE
Applying sigmaE/E systematic shift after smearing corrections

### DIFF
--- a/Systematics/plugins/PhotonSigEoverESmearingEGMTool.cc
+++ b/Systematics/plugins/PhotonSigEoverESmearingEGMTool.cc
@@ -10,24 +10,19 @@
 
 namespace flashgg {
     
-    class PhotonSigEoverESmearingEGMTool: public BaseSystMethod<flashgg::Photon, std::pair<int, int> >
+    class PhotonSigEoverESmearingEGMTool: public BaseSystMethod<flashgg::Photon, int >
     {
         
     public:
         typedef StringCutObjectSelector<Photon, true> selector_type;
         
         PhotonSigEoverESmearingEGMTool( const edm::ParameterSet &conf, edm::ConsumesCollector && iC, const GlobalVariablesComputer *gv );
-        void applyCorrection( flashgg::Photon &y, std::pair<int, int> syst_shift ) override;
-        std::string shiftLabel( std::pair<int, int> ) const override;
+        void applyCorrection( flashgg::Photon &y, int syst_shift ) override;
+        std::string shiftLabel( int ) const override;
         void eventInitialize( const edm::Event &iEvent, const edm::EventSetup & iSetup ) override;
-        
-        const std::string &firstParameterName() const { return label1_; }
-        const std::string &secondParameterName() const { return label2_; }
         
     private:
         selector_type overall_range_;
-        const std::string label1_;
-        const std::string label2_;
         EnergyScaleCorrection_class scaler_;
         bool exaggerateShiftUp_; // debugging
         unsigned run_number_;
@@ -41,8 +36,6 @@ namespace flashgg {
     PhotonSigEoverESmearingEGMTool::PhotonSigEoverESmearingEGMTool( const edm::ParameterSet &conf, edm::ConsumesCollector && iC, const GlobalVariablesComputer *gv ) :
         BaseSystMethod( conf, std::forward<edm::ConsumesCollector>(iC) ),
         overall_range_( conf.getParameter<std::string>( "OverallRange" ) ),
-        label1_( conf.getParameter<std::string>( "FirstParameterName" ) ), // default: "Rho"
-        label2_( conf.getParameter<std::string>( "SecondParameterName" ) ), // default; "Phi"
         scaler_(conf.getParameter<std::string>( "CorrectionFile" )),
         exaggerateShiftUp_( conf.getParameter<bool>( "ExaggerateShiftUp" ) ), // default: false
         debug_( conf.getUntrackedParameter<bool>("Debug", false) )
@@ -51,21 +44,16 @@ namespace flashgg {
         else scaler_.doSmearings = true;
     }
     
-    std::string PhotonSigEoverESmearingEGMTool::shiftLabel( std::pair<int, int> syst_value ) const
+    std::string PhotonSigEoverESmearingEGMTool::shiftLabel( int syst_value ) const
     {
-        std::string result = label();
-        if( syst_value.first == 0 && syst_value.second == 0 ) {
-            result += "Central";
-        } else {
-            if( syst_value.first > 0 ) { result += Form( "%sUp%.2dsigma", firstParameterName().c_str(), syst_value.first ); }
-            if( syst_value.first < 0 ) { result += Form( "%sDown%.2dsigma", firstParameterName().c_str(), -1 * syst_value.first ); }
-            if( syst_value.second > 0 ) { result += Form( "%sUp%.2dsigma", secondParameterName().c_str(), syst_value.second ); }
-            if( syst_value.second < 0 ) { result += Form( "%sDown%.2dsigma", secondParameterName().c_str(), -1 * syst_value.second ); }
+        std::string result;
+        if( syst_value == 0 ) {
+            result = Form( "%s", label().c_str() );
         }
         return result;
     }
     
-    void PhotonSigEoverESmearingEGMTool::applyCorrection( flashgg::Photon &y, std::pair<int, int> syst_shift )
+    void PhotonSigEoverESmearingEGMTool::applyCorrection( flashgg::Photon &y, int syst_shift )
     {
         if( overall_range_( y ) ) {
             // Nothing will happen, with no warning, if the bin count doesn't match expected options
@@ -73,12 +61,11 @@ namespace flashgg {
             
             // the combination of central value + NSigma * sigma is already
             // computed by getSmearingSigma(...)
-            auto sigma = scaler_.getSmearingSigma(run_number_, y.isEB(), y.full5x5_r9(), y.superCluster()->eta(), y.et(), syst_shift.first, syst_shift.second);
+            auto sigma = scaler_.getSmearingSigma(run_number_, y.isEB(), y.full5x5_r9(), y.superCluster()->eta(), y.et(), 0., 0.); // never apply systematic shift
 
             if( debug_ ) { 
                 std::cout << "  " << shiftLabel( syst_shift ) << ": Photon has pt= " << y.pt() << " eta=" << y.superCluster()->eta() << " full5x5_r9=" << y.full5x5_r9()
                     << " and we apply a sigmaEoverE smearing of " << sigma << std::endl;
-                std::cout << " syst_shift.first: " << syst_shift.first << " syst_shift.second: " << syst_shift.second <<std::endl;
                 std::cout << "     sigE/E VALUE BEFORE: ";
                 auto beforeSigEoE = y.sigEOverE();
                 std::cout << beforeSigEoE << " ";
@@ -99,7 +86,7 @@ namespace flashgg {
     }
 }
 
-DEFINE_EDM_PLUGIN( FlashggSystematicPhotonMethodsFactory2D,
+DEFINE_EDM_PLUGIN( FlashggSystematicPhotonMethodsFactory,
                    flashgg::PhotonSigEoverESmearingEGMTool,
                    "FlashggPhotonSigEoverESmearingEGMTool" );
 

--- a/Systematics/python/SystematicsCustomize.py
+++ b/Systematics/python/SystematicsCustomize.py
@@ -219,7 +219,7 @@ def useEGMTools(process):
         process.flashggDiPhotonSystematics.SystMethods.insert(0, isyst)
 
     # remove old smearings
-    for isyst in [ process.MCSmearHighR9EE, process.MCSmearLowR9EE, process.MCSmearHighR9EB, process.MCSmearLowR9EB, process.SigmaEOverESmearing ]:
+    for isyst in [ process.MCSmearHighR9EE, process.MCSmearLowR9EE, process.MCSmearHighR9EB, process.MCSmearLowR9EB, process.SigmaEOverESmearing, process.SigmaEOverEShift ]:
             process.flashggDiPhotonSystematics.SystMethods.remove(isyst)
 
     # add EGM smearings (2D)
@@ -228,4 +228,8 @@ def useEGMTools(process):
             process.MCSmearLowR9EE_EGM,
             process.MCSmearHighR9EB_EGM,
             process.MCSmearLowR9EB_EGM,
-            process.SigmaEOverESmearing_EGM])
+            ])
+    
+    # add sigmaE/E correction and systematics
+    process.flashggDiPhotonSystematics.SystMethods.extend( [process.SigmaEOverESmearing_EGM, process.SigmaEOverEShift] )
+    

--- a/Systematics/python/flashggDiPhotonSystematics_cfi.py
+++ b/Systematics/python/flashggDiPhotonSystematics_cfi.py
@@ -562,13 +562,10 @@ SigmaEOverESmearing = cms.PSet( PhotonMethodName = cms.string("FlashggPhotonSigE
           )
 
 SigmaEOverESmearing_EGM = cms.PSet( PhotonMethodName = cms.string("FlashggPhotonSigEoverESmearingEGMTool"),
-          MethodName = cms.string("FlashggDiPhotonFromPhoton2D"),
+          MethodName = cms.string("FlashggDiPhotonFromPhoton"),
           Label = cms.string("SigmaEOverESmearing"),
-          FirstParameterName = cms.string("Rho"),
-          SecondParameterName = cms.string("Phi"),
           CorrectionFile = scalesAndSmearingsPrefixForSigmaEOverE,
-          NSigmas = cms.PSet( firstVar = cms.vint32(),
-                            secondVar = cms.vint32()),
+          NSigmas = cms.vint32(),
           OverallRange = cms.string("1"),
           BinList = emptyBins,
           Debug = cms.untracked.bool(False),


### PR DESCRIPTION
Hello,

this PR fixes the logic of the systematic shift of the sigmaE/E, applying it after the smearing corrections have been applied. This ensures that the nominal size of the shift is propagated to the smeared sigmaE/E.

Let me know if you have comments or questions,

Vittorio