### PR TITLE
updates for VHLeptonic tags

### DIFF
--- a/MetaData/data/cross_sections.json
+++ b/MetaData/data/cross_sections.json
@@ -138,6 +138,7 @@
         "GJets_HT-200To400_TuneCUETP8M1_13TeV-madgraphMLM-pythia8" : { "xs" : 2280.0,  "itype" : 6 },
         "GJets_HT-400To600_TuneCUETP8M1_13TeV-madgraphMLM-pythia8" : { "xs" :273.0 , "itype" : 7 },
         "GJets_HT-600ToInf_TuneCUETP8M1_13TeV-madgraphMLM-pythia8" : { "xs" :94.5 , "itype" : 8 },
+        "TTJets_TuneCUETP8M2T4_13TeV-amcatnloFXFX-pythia8" : { "xs" : 830 },
         "TTJets_TuneCUETP8M1_13TeV-madgraphMLM-pythia8" : { "xs" : 665 },
         "TTGJets_TuneCUETP8M1_13TeV-amcatnloFXFX-madspin-pythia8" : { "xs" : 3.819 },
         "TTGG_0Jets_TuneCUETP8M1_13TeV_amcatnlo_madspin_pythia8" : { "xs" : 0.01731 },
@@ -145,7 +146,13 @@
         "THQ_HToGG_13TeV-madgraph-pythia8_TuneCUETP8M1" : { "xs" : 0.07096,   "br" : 0.00227 },
         "THW_HToGG_13TeV-madgraph-pythia8_TuneCUETP8M1" : { "xs" : 0.01561,   "br" : 0.00227 },
         "bbHToGG_M-125_4FS_yb2_13TeV_amcatnlo" : { "xs" : 0.532892,   "br" : 0.00227 },
-        "bbHToGG_M-125_4FS_ybyt_13TeV_amcatnlo" : { "xs" : 0.0448916,   "br" : 0.00227 }
+        "bbHToGG_M-125_4FS_ybyt_13TeV_amcatnlo" : { "xs" : 0.0448916,   "br" : 0.00227 },
+	"ZGTo2LG_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8"         : {"xs" : 117.864, "br" : 1.0},
+	"WGToLNuG_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8"        : {"xs" : 489.0, "br" : 1.0 },
+	"ZZTo2L2Q_13TeV_amcatnloFXFX_madspin_pythia8"             : {"xs" : 3.38, "br" : 1.0},
+	"WZTo2L2Q_13TeV_amcatnloFXFX_madspin_pythia8"             : {"xs" : 5.52, "br" : 1.0},
+	"WW_TuneCUETP8M1_13TeV-pythia8"                           : {"xs" : 63.21, "br" : 1.0}
+
 
 
 }

--- a/Taggers/interface/TagsDumpers.h
+++ b/Taggers/interface/TagsDumpers.h
@@ -10,6 +10,9 @@
 #include "flashgg/DataFormats/interface/VHTightTag.h"
 #include "flashgg/DataFormats/interface/VHHadronicTag.h"
 #include "flashgg/DataFormats/interface/ZPlusJetTag.h"
+#include "flashgg/DataFormats/interface/VHLeptonicLooseTag.h"
+#include "flashgg/DataFormats/interface/WHLeptonicTag.h"
+#include "flashgg/DataFormats/interface/ZHLeptonicTag.h"
 
 #include "flashgg/Taggers/interface/CollectionDumper.h"
 
@@ -41,6 +44,15 @@ namespace flashgg {
     typedef CollectionDumper<std::vector<ZPlusJetTag>,
             ZPlusJetTag,
             CutBasedClassifier<ZPlusJetTag> > CutBasedZPlusJetTagDumper;
+    typedef CollectionDumper<std::vector<WHLeptonicTag>,
+            WHLeptonicTag,
+            CutBasedClassifier<WHLeptonicTag> > CutBasedWHLeptonicTagDumper;
+    typedef CollectionDumper<std::vector<VHLeptonicLooseTag>,
+            VHLeptonicLooseTag,
+            CutBasedClassifier<VHLeptonicLooseTag> > CutBasedVHLeptonicLooseTagDumper;
+    typedef CollectionDumper<std::vector<ZHLeptonicTag>,
+            ZHLeptonicTag,
+            CutBasedClassifier<ZHLeptonicTag> > CutBasedZHLeptonicTagDumper;
 }
 
 #endif

--- a/Taggers/plugins/EDTagsDumpers.cc
+++ b/Taggers/plugins/EDTagsDumpers.cc
@@ -11,6 +11,9 @@ typedef edm::AnalyzerWrapper<flashgg::CutBasedVHLooseTagDumper> CutBasedVHLooseT
 typedef edm::AnalyzerWrapper<flashgg::CutBasedVHTightTagDumper> CutBasedVHTightTagDumper;
 typedef edm::AnalyzerWrapper<flashgg::CutBasedVHHadronicTagDumper> CutBasedVHHadronicTagDumper;
 typedef edm::AnalyzerWrapper<flashgg::CutBasedZPlusJetTagDumper> CutBasedZPlusJetTagDumper;
+typedef edm::AnalyzerWrapper<flashgg::CutBasedWHLeptonicTagDumper> CutBasedWHLeptonicTagDumper;
+typedef edm::AnalyzerWrapper<flashgg::CutBasedVHLeptonicLooseTagDumper> CutBasedVHLeptonicLooseTagDumper;
+typedef edm::AnalyzerWrapper<flashgg::CutBasedZHLeptonicTagDumper> CutBasedZHLeptonicTagDumper;
 
 DEFINE_FWK_MODULE( CutBasedUntaggedTagDumper );
 DEFINE_FWK_MODULE( CutBasedVBFTagDumper );
@@ -20,6 +23,9 @@ DEFINE_FWK_MODULE( CutBasedVHLooseTagDumper );
 DEFINE_FWK_MODULE( CutBasedVHTightTagDumper );
 DEFINE_FWK_MODULE( CutBasedVHHadronicTagDumper );
 DEFINE_FWK_MODULE( CutBasedZPlusJetTagDumper );
+DEFINE_FWK_MODULE( CutBasedWHLeptonicTagDumper );
+DEFINE_FWK_MODULE( CutBasedVHLeptonicLooseTagDumper );
+DEFINE_FWK_MODULE( CutBasedZHLeptonicTagDumper );
 
 // Local Variables:
 // mode:c++

--- a/Taggers/plugins/ZHLeptonicTagProducer.cc
+++ b/Taggers/plugins/ZHLeptonicTagProducer.cc
@@ -283,8 +283,8 @@ namespace flashgg {
             //check for two good muons
             if( tagMuonsTemp.size() >= 2 ) 
                 {
-                    for(uint i=0;i<tagMuonsTemp.size()-1;i++)
-                        for(uint j=1;j<tagMuonsTemp.size();j++)
+                    for(uint i=0;i<tagMuonsTemp.size();i++)
+                        for(uint j=i+1;j<tagMuonsTemp.size();j++)
                             {
                                 math::XYZTLorentzVector leptonPair = tagMuonsTemp[i]->p4()+tagMuonsTemp[j]->p4();
                                 
@@ -299,8 +299,8 @@ namespace flashgg {
             //check for two good electrons
             if( tagElectronsTemp.size() >= 2 ) 
                 {
-                    for(uint i=0;i<tagElectronsTemp.size()-1;i++)
-                        for(uint j=1;j<tagElectronsTemp.size();j++)
+                    for(uint i=0;i<tagElectronsTemp.size();i++)
+                        for(uint j=i+1;j<tagElectronsTemp.size();j++)
                             {
                                 math::XYZTLorentzVector leptonPair = tagElectronsTemp[i]->p4()+tagElectronsTemp[j]->p4();
                                 if( leptonPair.M() < invMassLepHighThreshold_  && leptonPair.M() > invMassLepLowThreshold_ ) 

--- a/Taggers/python/tagsDumpers_cfi.py
+++ b/Taggers/python/tagsDumpers_cfi.py
@@ -20,4 +20,7 @@ dict = {'UntaggedTag': 'untagged',
         'VHLooseTag': 'vh',
         'VHTightTag': 'vh',
         'VHHadronicTag': 'vh',
-        'ZPlusJetTag':'zjet'}
+        'ZPlusJetTag':'zjet',
+        'WHLeptonicTag': 'vh',
+        'VHLeptonicLooseTag': 'vh',
+        'ZHLeptonicTag': 'vh'}

--- a/Taggers/src/TagsDumpers.cc
+++ b/Taggers/src/TagsDumpers.cc
@@ -12,6 +12,9 @@ namespace flashgg {
         PLUGGABLE_ANALYZER( CutBasedVHHadronicTagDumper );
         PLUGGABLE_ANALYZER( CutBasedVBFTagDumper );
         PLUGGABLE_ANALYZER( CutBasedZPlusJetTagDumper );
+        PLUGGABLE_ANALYZER( CutBasedWHLeptonicTagDumper );
+        PLUGGABLE_ANALYZER( CutBasedVHLeptonicLooseTagDumper );
+        PLUGGABLE_ANALYZER( CutBasedZHLeptonicTagDumper );
     }
 }
 


### PR DESCRIPTION
Changes:
- added dumpers for VH leptonic tags
- added cross sections for some backgrounds samples
- modified ZHLeptonicTagProducer to take into account all possible muons or electrons pairs (i,j) except the pair built from the same lepton (i,i). This modification does not affect the results, as there was a minimum threshold (70 GeV) on the invariant mass of the lepton pair.

