### PR TITLE
Replace ttH sample with correct config

### DIFF
--- a/Systematics/test/tth_sig_jobs.json
+++ b/Systematics/test/tth_sig_jobs.json
@@ -10,7 +10,7 @@
                        { "args" :["outputFile=output_ttHJetToGG_M123_13TeV_amcatnloFXFX_madspin_pythia8.root"] } ] ],
        "tth_124"  : [ [ "/ttHJetToGG_M124_13TeV_amcatnloFXFX_madspin_pythia8",
                        { "args" :["outputFile=output_ttHJetToGG_M124_13TeV_amcatnloFXFX_madspin_pythia8.root"] } ] ],
-       "tth_126"  : [ [ "/ttHJetToGG_M126_13TeV_amcatnloFXFX_madspin_pythia8",
+       "tth_126"  : [ [ "/ttHJetToGG_M126_13TeV_amcatnloFXFX_madspin_pythia8/sethzenz-RunIISummer16-2_4_1fix-25ns_Moriond17-2_4_1fix-v0-RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1-a441a93bb50ffde2d33d432edd33f748/USER",
                        { "args" :["outputFile=output_ttHJetToGG_M126_13TeV_amcatnloFXFX_madspin_pythia8.root"] } ] ],
        "tth_127"  : [ [ "/ttHJetToGG_M127_13TeV_amcatnloFXFX_madspin_pythia8",
                        { "args" :["outputFile=output_ttHJetToGG_M127_13TeV_amcatnloFXFX_madspin_pythia8.root"] } ] ]


### PR DESCRIPTION
The ttH 126 sample had the wrong configuration.  This is fixed in this catalog change.     (Note there is still a catalog update needed for replaced material samples with the same issue, but I separate this PR because it's the only sample that affects the final workspaces.)