### PR TITLE
fixing basic workflow test

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ If everything now looks reasonable, you can build:
 And a very basic workflow test:
  ```
  cd $CMSSW_BASE/src/flashgg
- cmsRun MicroAOD/test/microAODstd.py
+ cmsRun MicroAOD/test/microAODstd.py processType=sig datasetName=glugluh
  cmsRun Taggers/test/simple_Tag_test.py
  cmsRun Taggers/test/diphotonsDumper_cfg.py
  cmsRun Systematics/test/workspaceStd.py processId=wzh_125

--- a/Taggers/test/diphotonsDumper_cfg.py
+++ b/Taggers/test/diphotonsDumper_cfg.py
@@ -2,6 +2,7 @@
 
 import FWCore.ParameterSet.Config as cms
 import FWCore.Utilities.FileUtils as FileUtils
+import os
 
 process = cms.Process("Analysis")
 
@@ -13,6 +14,17 @@ process.source = cms.Source("PoolSource",
 )
 process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(-1) )
 process.MessageLogger.cerr.FwkReport.reportEvery = cms.untracked.int32( 1000 )
+
+process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_condDBv2_cff")
+from Configuration.AlCa.GlobalTag import GlobalTag
+if os.environ["CMSSW_VERSION"].count("CMSSW_7_6"):
+    process.GlobalTag.globaltag = '76X_mcRun2_asymptotic_v12'
+elif os.environ["CMSSW_VERSION"].count("CMSSW_7_4"):
+    process.GlobalTag.globaltag = '74X_mcRun2_asymptotic_v4' 
+elif os.environ["CMSSW_VERSION"].count("CMSSW_8_0"):
+    process.GlobalTag.globaltag = '80X_mcRun2_asymptotic_2016_miniAODv2'
+else:
+    raise Exception,"Could not find a sensible CMSSW_VERSION for default globaltag"
 
 process.TFileService = cms.Service("TFileService",
                                    fileName = cms.string("test.root")
@@ -57,9 +69,9 @@ cfgTools.addCategories(process.diphotonDumper,
                        ## categories definition
                        ## cuts are applied in cascade. Events getting to these categories have already failed the "Reject" selection
                        [("EBHighR9","max(abs(leadingPhoton.superCluster.eta),abs(leadingPhoton.superCluster.eta))<1.4442"
-                         "&& min(leadingPhoton.r9,subLeadingPhoton.r9)>0.94",0), ## EB high R9
+                         "&& min(leadingPhoton.full5x5_r9,subLeadingPhoton.full5x5_r9)>0.94",0), ## EB high R9
                         ("EBLowR9","max(abs(leadingPhoton.superCluster.eta),abs(leadingPhoton.superCluster.eta))<1.4442",0), ## remaining EB is low R9
-                        ("EEHighR9","min(leadingPhoton.r9,subLeadingPhoton.r9)>0.94",0), ## then EE high R9
+                        ("EEHighR9","min(leadingPhoton.full5x5_r9,subLeadingPhoton.full5x5_r9)>0.94",0), ## then EE high R9
                         ("EELowR9","1",0), ## evereything elese is EE low R9
                         ],
                        ## variables to be dumped in trees/datasets. Same variables for all categories
@@ -67,7 +79,7 @@ cfgTools.addCategories(process.diphotonDumper,
                        variables=["CMS_hgg_mass[320,100,180]:=mass", 
                                   "leadPt                   :=leadingPhoton.pt",
                                   "subleadPt                :=subLeadingPhoton.pt",
-                                  "minR9                    :=min(leadingPhoton.r9,subLeadingPhoton.r9)",
+                                  "minR9                    :=min(leadingPhoton.full5x5_r9,subLeadingPhoton.full5x5_r9)",
                                   "maxEta                   :=max(abs(leadingPhoton.superCluster.eta),abs(leadingPhoton.superCluster.eta))",
                                   "leadIDMVA                :=leadingView.phoIdMvaWrtChosenVtx",
                                   "subleadIDMVA             :=subLeadingView.phoIdMvaWrtChosenVtx",


### PR DESCRIPTION
Ciao,
today I've run flashgg for the first time. I've run the examples of flashgg and they do not run out of the box, since there are some errors. I fixed them, if you think is useful (to avoid the debugging to new users) merge the pull request.

I've changed three things:
= In the Readme there is "cmsRun MicroAOD/test/microAODstd.py", if you don't specify the options "processType=sig datasetName=glugluh" the second step crashes
= cmsRun Taggers/test/diphotonsDumper_cfg.py doesn't work because:
1. the global tag was missing, causing an error related to GBRDWrapperRcd class
2. the variable r9 has changed name (r9->"old_r9" or "full5x5_r9")