### PR TITLE
Update to 8 0 28

### DIFF
--- a/MicroAOD/python/flashggMet_RunCorrectionAndUncertainties_cff.py
+++ b/MicroAOD/python/flashggMet_RunCorrectionAndUncertainties_cff.py
@@ -94,28 +94,32 @@ def runMETs(process,isMC):
                 process.patPFMetT1ElectronEnDownFullMETClean+process.patPFMetT1PhotonEnDownFullMETClean+
                 process.patPFMetT1MuonEnDownFullMETClean+process.patPFMetT1TauEnDownFullMETClean+
                 process.patPFMetT1UnclusteredEnDownFullMETClean+process.slimmedMETsFullMETClean)
-            process.flashggMetsMuons = cms.EDProducer('FlashggMetProducer',
+            process.flashggMets = cms.EDProducer('FlashggMetProducer',
                              verbose = cms.untracked.bool(False),
                              metTag = cms.InputTag('slimmedMETs'),
                              )
-            process.flashggMetsEG = cms.EDProducer('FlashggMetProducer',
-                             verbose = cms.untracked.bool(False),
-                             metTag = cms.InputTag('slimmedMETsEGClean'),
-                             )
-            process.flashggMets = cms.EDProducer('FlashggMetProducer',
-                             verbose = cms.untracked.bool(False),
-                             metTag = cms.InputTag('slimmedMETsFullMETClean'),
-                             )
-            process.flashggMetsEGmuon = cms.EDProducer('FlashggMetProducer',
-                                         verbose = cms.untracked.bool(False),
-                                         metTag = cms.InputTag('slimmedMETsMuEGClean'),
-                                         )
-            process.flashggMetsUncorr = cms.EDProducer('FlashggMetProducer',
-                             verbose = cms.untracked.bool(False),
-                             metTag = cms.InputTag('slimmedMETsUncorrected'),
-                             )
-            process.flashggMetSequence = cms.Sequence(process.flashggMetsMuons *process.flashggMetsEGmuon*process.flashggMets*process.flashggMetsUncorr)
-        
+#            process.flashggMetsMuons = cms.EDProducer('FlashggMetProducer',
+#                             verbose = cms.untracked.bool(False),
+#                             metTag = cms.InputTag('slimmedMETs'),
+#                             )
+#            process.flashggMetsEG = cms.EDProducer('FlashggMetProducer',
+#                             verbose = cms.untracked.bool(False),
+#                             metTag = cms.InputTag('slimmedMETsEGClean'),
+#                             )
+#            process.flashggMets = cms.EDProducer('FlashggMetProducer',
+#                             verbose = cms.untracked.bool(False),
+#                             metTag = cms.InputTag('slimmedMETsFullMETClean'),
+#                             )
+#            process.flashggMetsEGmuon = cms.EDProducer('FlashggMetProducer',
+#                                         verbose = cms.untracked.bool(False),
+#                                         metTag = cms.InputTag('slimmedMETsMuEGClean'),
+#                                         )
+#            process.flashggMetsUncorr = cms.EDProducer('FlashggMetProducer',
+#                             verbose = cms.untracked.bool(False),
+#                             metTag = cms.InputTag('slimmedMETsUncorrected'),
+#                             )
+#            process.flashggMetSequence = cms.Sequence(process.flashggMetsMuons *process.flashggMetsEGmuon*process.flashggMets*process.flashggMetsUncorr)
+            process.flashggMetSequence = cms.Sequence(process.flashggMets)       
         
 
         

--- a/MicroAOD/test/microAODstd.py
+++ b/MicroAOD/test/microAODstd.py
@@ -25,6 +25,9 @@ process.RandomNumberGeneratorService.flashggRandomizedPhotons = cms.PSet(
           initialSeed = cms.untracked.uint32(16253245)
         )
 
+# Legacy ReReco
+#process.source = cms.Source("PoolSource",fileNames=cms.untracked.vstring("/store/data/Run2016B/SingleElectron/MINIAOD/18Apr2017_ver1-v1/120000/40167FB6-6237-E711-934A-001E67E69E05.root"))
+
 #Moriond17 MC
 process.source = cms.Source("PoolSource",fileNames=cms.untracked.vstring("/store/mc/RunIISummer16MiniAODv2/GluGluHToGG_M-125_13TeV_powheg_pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/60000/024E4FA3-8BBC-E611-8E3D-00266CFFBE88.root"))
 

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ Before you start, **please take note** of these warnings and comments:
 Get everything you need, starting from a clean area:
 
  ```
- cmsrel CMSSW_8_0_26_patch1
- cd CMSSW_8_0_26_patch1/src
+ cmsrel CMSSW_8_0_28
+ cd CMSSW_8_0_28/src
  cmsenv
  git cms-init
  cd $CMSSW_BASE/src 
@@ -19,10 +19,10 @@ Get everything you need, starting from a clean area:
  source flashgg/setup.sh
  ```
 
-If everything now looks reasonable, you can build:
+If everything now looks reasonable, you can build (note flashgg/Validation does not compile right now):
  ```
  cd $CMSSW_BASE/src
- scram b -j 9
+ SCRAM_IGNORE_PACKAGES="flashgg/Validation" scram b -j 3
  ```
 And a very basic workflow test:
  ```
@@ -30,7 +30,7 @@ And a very basic workflow test:
  cmsRun MicroAOD/test/microAODstd.py processType=sig datasetName=glugluh
  cmsRun Taggers/test/simple_Tag_test.py
  cmsRun Taggers/test/diphotonsDumper_cfg.py
- cmsRun Systematics/test/workspaceStd.py processId=wzh_125
+ cmsRun Systematics/test/workspaceStd.py processId=ggh_125
  ```
 
 These are just some test examples; the first makes MicroAOD from a MiniAOD file accessed via xrootd, 

--- a/Systematics/test/workspaceStd.py
+++ b/Systematics/test/workspaceStd.py
@@ -435,16 +435,16 @@ process.options = cms.untracked.PSet( wantSummary = cms.untracked.bool(True) )
 # ee bad supercluster filter on data
 process.load('RecoMET.METFilters.eeBadScFilter_cfi')
 process.eeBadScFilter.EERecHitSource = cms.InputTag("reducedEgamma","reducedEERecHits") # Saved MicroAOD Collection (data only)
-# Bad Muon filter
-process.load('RecoMET.METFilters.badGlobalMuonTaggersMiniAOD_cff')
-process.badGlobalMuonTaggerMAOD.muons = cms.InputTag("flashggSelectedMuons")
-process.cloneGlobalMuonTaggerMAOD.muons = cms.InputTag("flashggSelectedMuons")
+# Bad Muon filter LOADS WRONG IN 8_0_28, FIX LATER
+#process.load('RecoMET.METFilters.badGlobalMuonTaggersMiniAOD_cff')
+#process.badGlobalMuonTaggerMAOD.muons = cms.InputTag("flashggSelectedMuons")
+#process.cloneGlobalMuonTaggerMAOD.muons = cms.InputTag("flashggSelectedMuons")
 process.dataRequirements = cms.Sequence()
 if customize.processId == "Data":
         process.dataRequirements += process.hltHighLevel
         process.dataRequirements += process.eeBadScFilter
-        if customize.doMuFilter:
-            process.dataRequirements += process.noBadGlobalMuonsMAOD
+#        if customize.doMuFilter:
+#            process.dataRequirements += process.noBadGlobalMuonsMAOD
 
 # Split WH and ZH
 process.genFilter = cms.Sequence()

--- a/setup.sh
+++ b/setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+v#!/bin/bash
 
 SETUP_REMOTES=false
 
@@ -104,31 +104,42 @@ fi
 
 cd $CMSSW_BASE/src
 
+# Still needed, 8_0_28
 echo "EGM Pho ID recipe, Summer16"
 git cms-merge-topic ikrav:egm_id_80X_v3_photons
 
+# Tag updated for 8_0_28 and may require further investigation
 echo "grabbing MET topic updates..."
-git cms-merge-topic cms-met:METRecipe_8020 -u
+git cms-merge-topic cms-met:METRecipe_8020_for80Xintegration -u
 
+# Straightofrward update for 8_0_28
 echo "Setting up QGL..."
 git cms-addpkg RecoJets/JetProducers
-git cms-merge-topic -u sethzenz:for-flashgg-QGL-vertexIndex-8_0_26
+git cms-merge-topic -u sethzenz:for-flashgg-QGL-vertexIndex-8_0_28
 
-echo "Setting up TnP tools..."
-git cms-merge-topic -u sethzenz:for-flashgg-egm_tnp-8_0_26
+# TnP tools removed for 8_0_28, so Validation does not compile
+# To be investigated
+#echo "Setting up TnP tools..."
+#git cms-merge-topic -u sethzenz:for-flashgg-egm_tnp-8_0_26
 
-echo "Setting up misc egm and weight stuff..."
-git cms-merge-topic -u sethzenz:for-flashgg-smearer-conv-weights-8_0_26
+echo "Setting up weight stuff..."
+#git cms-merge-topic -u sethzenz:for-flashgg-smearer-conv-weights-8_0_28
+git cms-addpkg CommonTools/UtilAlgos
+git cms-merge-topic -u sethzenz:for-flashgg-weightscount-8_0_28
 
+# Updated for 8_0_28, and compiles and runs, but NOT checked by experts
+# Update built from sethzenz:for-flashgg-smearer-conv-weights-8_0_26 and shervin86:Hgg_Gain_v1
+echo "Setting up EGM stuff..."
+git cms-merge-topic -u sethzenz:for-flashgg-smearer-conv-8_0_28
+
+# Straightforward update for 8_0_28
 echo "Setting up Higgs Simplified Template Cross Sections..."
-git cms-merge-topic -u sethzenz:rivet_hepmc-8_0_26
+git cms-merge-topic -u sethzenz:rivet_hepmc-8_0_28
 
+# Straightforward update for 8_0_28
 echo "Tweaking ConfigToolBase.py to avoid assuming soft link path..."
 git cms-addpkg FWCore/GuiBrowsers
-git cms-merge-topic -u sethzenz:for-flashgg-toolbase-8_0_26
-
-echo "Importing modifications to EGM tools for gain switch categories and uncertainties..."
-git cms-merge-topic shervin86:Hgg_Gain_v1 -u
+git cms-merge-topic -u sethzenz:for-flashgg-toolbase-8_0_28
 
 echo "copy databases for local running (consistency with crab)"
 cp $CMSSW_BASE/src/flashgg/Systematics/data/JEC/Summer16_23Sep2016*db $CMSSW_BASE/src/flashgg/


### PR DESCRIPTION
Update flashgg so that it:
  * Compiles under CMSSW_8_0_28 (excluding Validation)
  * Runs Legacy ReReco

The following issues are outstanding from the update:
  * MET collections from reMiniAOD removed, and badMuonFilter removed because it has python issues.  MET update requires further investigation: https://hypernews.cern.ch/HyperNews/CMS/get/met/535/1/1.html
  * Tag and Probe removed, so Validation directory does not compile
  * EGM scale and smearing CMSSW tags assembled based on guesswork from two older messier tags.  The update requires investigation from experts to make sure it performs as expected: sethzenz:for-flashgg-smearer-conv-8_0_28