### PR TITLE
comments and parameter names for charged photon isolation calculation

### DIFF
--- a/MicroAOD/interface/PhotonIdUtils.h
+++ b/MicroAOD/interface/PhotonIdUtils.h
@@ -68,6 +68,8 @@ namespace flashgg {
                                            const flashgg::VertexCandidateMap vtxcandmap,
                                            float coneSize, float coneVetoBarrel, float coneVetoEndcap, float ptMin);
 
+        /** calculates the charged particle flow isolation for a single photon with respect to all given
+            vertices. See pfIsoChgWrtVtx(..) for details about the parameters. */
         std::map<edm::Ptr<reco::Vertex>, float> pfIsoChgWrtAllVtx( const edm::Ptr<pat::Photon> &photon,
                 const std::vector<edm::Ptr<reco::Vertex> > &vertices,
                 const flashgg::VertexCandidateMap vtxcandmap,

--- a/MicroAOD/interface/PhotonIdUtils.h
+++ b/MicroAOD/interface/PhotonIdUtils.h
@@ -42,6 +42,27 @@ namespace flashgg {
 
         void               initialize( );
 
+        /** calculates photon isolation (sum of pt's) from tracks (particle flow candidates).
+
+            @param photon the photon candidate for which the isolation is calculated
+
+            @param vtx the vertex to which tracks taken into account in the isolation value must be associated to
+
+            @param vtxcandmap the list of track to vertex associations
+
+            @param coneSize the size of the (outer) delta R cone around the supercluster direction in which the tracks
+                   are taken into account
+
+            @param coneVetoBarrel the size of the (inner) delta R cone around the supercluster direction
+                   in which tracks are ignored for barrel photons
+
+            @param coneVetoEndcap the size of the (inner) delta R cone around the supercluster direction
+                   in which tracks are ignored for endcap photons
+
+            @param ptMin the minimum pt below which tracks are ignored
+
+            @return the sum of pt of the tracks (particle flow candidates) passing the above criteria
+        */
         float              pfIsoChgWrtVtx( const edm::Ptr<pat::Photon> &photon,
                                            const edm::Ptr<reco::Vertex> vtx,
                                            const flashgg::VertexCandidateMap vtxcandmap,

--- a/MicroAOD/interface/PhotonIdUtils.h
+++ b/MicroAOD/interface/PhotonIdUtils.h
@@ -67,10 +67,11 @@ namespace flashgg {
                                            const edm::Ptr<reco::Vertex> vtx,
                                            const flashgg::VertexCandidateMap vtxcandmap,
                                            float coneSize, float coneVetoBarrel, float coneVetoEndcap, float ptMin);
-        std::map<edm::Ptr<reco::Vertex>, float> pfIsoChgWrtAllVtx( const edm::Ptr<pat::Photon> &,
-                const std::vector<edm::Ptr<reco::Vertex> > &,
-                const flashgg::VertexCandidateMap,
-                float, float, float, float );
+
+        std::map<edm::Ptr<reco::Vertex>, float> pfIsoChgWrtAllVtx( const edm::Ptr<pat::Photon> &photon,
+                const std::vector<edm::Ptr<reco::Vertex> > &vertices,
+                const flashgg::VertexCandidateMap vtxcandmap,
+                float coneSize, float coneVetoBarrel, float coneVetoEndcap, float ptMin);
 
         float              pfIsoChgWrtWorstVtx( std::map<edm::Ptr<reco::Vertex>, float> & );
 

--- a/MicroAOD/interface/PhotonIdUtils.h
+++ b/MicroAOD/interface/PhotonIdUtils.h
@@ -42,10 +42,10 @@ namespace flashgg {
 
         void               initialize( );
 
-        float              pfIsoChgWrtVtx( const edm::Ptr<pat::Photon> &,
-                                           const edm::Ptr<reco::Vertex>,
-                                           const flashgg::VertexCandidateMap,
-                                           float, float, float, float );
+        float              pfIsoChgWrtVtx( const edm::Ptr<pat::Photon> &photon,
+                                           const edm::Ptr<reco::Vertex> vtx,
+                                           const flashgg::VertexCandidateMap vtxcandmap,
+                                           float coneSize, float coneVetoBarrel, float coneVetoEndcap, float ptMin);
         std::map<edm::Ptr<reco::Vertex>, float> pfIsoChgWrtAllVtx( const edm::Ptr<pat::Photon> &,
                 const std::vector<edm::Ptr<reco::Vertex> > &,
                 const flashgg::VertexCandidateMap,

--- a/MicroAOD/plugins/PhotonProducer.cc
+++ b/MicroAOD/plugins/PhotonProducer.cc
@@ -272,6 +272,10 @@ namespace flashgg {
 
             phoTools_.removeOverlappingCandidates( doOverlapRemovalForIsolation_ );
 
+            //                                                                                                                  outer cone size
+            //                                                                                                                       inner (veto) cone size barrel
+            //                                                                                                                             inner (veto) cone size endcap
+            //                                                                                                                                   min track pt
             std::map<edm::Ptr<reco::Vertex>, float> isomap04 = phoTools_.pfIsoChgWrtAllVtx( pp, vertices->ptrs(), vtxToCandMap, 0.4, 0.02, 0.02, 0.1 );
             std::map<edm::Ptr<reco::Vertex>, float> isomap03 = phoTools_.pfIsoChgWrtAllVtx( pp, vertices->ptrs(), vtxToCandMap, 0.3, 0.02, 0.02, 0.1 );
             fg.setpfChgIso04( isomap04 );


### PR DESCRIPTION
- no code changes
- added comments with parameter descriptions for calculating charged isolation w.r.t vertices
- added parameter names in header files, taken from .cc file (e.g. `float, float, float, float` -> `float coneSize, float coneVetoBarrel, float coneVetoEndcap, float ptMin`)