### PR TITLE
Allow compilation in CMSSW_9_2_0

### DIFF
--- a/DataFormats/src/classes_def_920.xml
+++ b/DataFormats/src/classes_def_920.xml
@@ -1,0 +1,349 @@
+<lcgdict>
+<class name="flashgg::WeightedObject" ClassVersion="10">
+  <version ClassVersion="10" checksum="1340095011"/>
+</class>
+<class name="flashgg::PDFWeightObject" ClassVersion="14">
+  <version ClassVersion="14" checksum="2888861521"/>
+  <version ClassVersion="13" checksum="3868816395"/>
+  <version ClassVersion="12" checksum="3929296232"/>
+  <version ClassVersion="11" checksum="103726048"/>
+  <version ClassVersion="10" checksum="92077144"/>
+</class>
+<class name="edm::Ptr<flashgg::PDFWeightObject>"/>
+<class name="std::vector<flashgg::PDFWeightObject>"/>
+<class name="edm::Wrapper<std::vector<flashgg::PDFWeightObject> >"/>
+<class name="flashgg::DiPhotonMVAResult" ClassVersion="11">
+  <version ClassVersion="11" checksum="1225448115"/>
+</class>
+<class name="std::vector<flashgg::DiPhotonMVAResult>"/>
+<class name="edm::Wrapper<std::vector<flashgg::DiPhotonMVAResult> >"/>
+<class name="flashgg::ZPlusJetTag"/>
+<class name="std::vector<flashgg::ZPlusJetTag>"/>
+<class name="edm::Wrapper<std::vector<flashgg::ZPlusJetTag> >"/>
+<class name="flashgg::VBFMVAResult" ClassVersion="13">
+  <version ClassVersion="13" checksum="3046935215"/>
+</class>
+<class name="std::vector<flashgg::VBFMVAResult>"/>
+<class name="edm::Wrapper<std::vector<flashgg::VBFMVAResult> >"/>
+<class name="flashgg::VBFDiPhoDiJetMVAResult" ClassVersion="10">
+  <version ClassVersion="10" checksum="2695563001"/>
+</class>
+<class name="std::vector<flashgg::VBFDiPhoDiJetMVAResult>"/>
+<class name="edm::Wrapper<std::vector<flashgg::VBFDiPhoDiJetMVAResult> >"/>
+<class name="flashgg::DiPhotonTagBase" ClassVersion="12">
+ <version ClassVersion="12" checksum="2747850133"/>
+ <version ClassVersion="11" checksum="232592888"/>
+  <version ClassVersion="10" checksum="2111686847"/>
+</class>
+<class name="std::vector<flashgg::DiPhotonTagBase>"/>
+<class name="edm::Wrapper<std::vector<flashgg::DiPhotonTagBase> >"/>
+<class name="flashgg::UntaggedTag" ClassVersion="12">
+ <version ClassVersion="12" checksum="3256565386"/>
+ <version ClassVersion="11" checksum="741308141"/>
+  <version ClassVersion="10" checksum="2620402100"/>
+</class>
+<class name="std::vector<flashgg::UntaggedTag>"/>
+<class name="edm::Wrapper<std::vector<flashgg::UntaggedTag> >"/>
+<class name="flashgg::NoTag"/>
+<class name="std::vector<flashgg::NoTag>"/>
+<class name="edm::Wrapper<std::vector<flashgg::NoTag> >"/>
+<class name="flashgg::SigmaMpTTag" ClassVersion="0">
+  <version ClassVersion="0" checksum="3974770049"/>
+</class>
+<class name="std::vector<flashgg::SigmaMpTTag>"/>
+<class name="edm::Wrapper<std::vector<flashgg::SigmaMpTTag> >"/>
+
+<class name="flashgg::VBFTag" ClassVersion="13">
+ <version ClassVersion="13" checksum="2763928631"/>
+ <version ClassVersion="12" checksum="3071493064"/>
+ <version ClassVersion="11" checksum="1094465099"/>
+  <version ClassVersion="10" checksum="19580082"/>
+</class>
+<class name="std::vector<flashgg::VBFTag>"/>
+<class name="edm::Wrapper<std::vector<flashgg::VBFTag> >"/>
+<class name="flashgg::TTHLeptonicTag" ClassVersion="12">
+ <version ClassVersion="12" checksum="1015665249"/>
+ <version ClassVersion="11" checksum="2848650298"/>
+  <version ClassVersion="10" checksum="727624063"/>
+</class>
+<class name="std::vector<flashgg::TTHLeptonicTag>"/>
+<class name="edm::Wrapper<std::vector<flashgg::TTHLeptonicTag> >"/>
+<class name="std::vector<pat::Muon>"/>
+<class name="edm::Ptr<reco::GenParticle>"/>
+<class name="flashgg::TTHHadronicTag" ClassVersion="14">
+ <version ClassVersion="14" checksum="3454620804"/>
+ <version ClassVersion="13" checksum="3956710497"/>
+ <version ClassVersion="12" checksum="3228179576"/>
+ <version ClassVersion="11" checksum="1031304475"/>
+  <version ClassVersion="10" checksum="3253508898"/>
+</class>
+<class name="std::vector<flashgg::TTHHadronicTag>"/>
+<class name="edm::Wrapper<std::vector<flashgg::TTHHadronicTag> >"/>
+<class name="flashgg::VHMetTag" ClassVersion="11">
+   <version ClassVersion="10" checksum="3643272763"/>
+   <version ClassVersion="11" checksum="619869289"/>
+</class>
+<class name="std::vector<flashgg::VHMetTag>"/>
+<class name="edm::Wrapper<std::vector<flashgg::VHMetTag> >"/>
+
+<class name="flashgg::WHLeptonicTag" ClassVersion="11">
+  <version ClassVersion="11" checksum="1465473074"/>
+  <version ClassVersion="10" checksum="1904294291"/>
+</class>
+<class name="std::vector<flashgg::WHLeptonicTag>"/>
+<class name="edm::Wrapper<std::vector<flashgg::WHLeptonicTag> >"/>
+
+<class name="flashgg::ZHLeptonicTag" ClassVersion="11">
+  <version ClassVersion="11" checksum="1904294291"/>
+  <version ClassVersion="10" checksum="1465473074"/>
+</class>
+<class name="std::vector<flashgg::ZHLeptonicTag>"/>
+<class name="edm::Wrapper<std::vector<flashgg::ZHLeptonicTag> >"/>
+
+<class name="flashgg::VHLeptonicLooseTag" ClassVersion="10">
+  <version ClassVersion="10" checksum="27685197"/>
+</class>
+<class name="std::vector<flashgg::VHLeptonicLooseTag>"/>
+<class name="edm::Wrapper<std::vector<flashgg::VHLeptonicLooseTag> >"/>
+
+<class name="flashgg::VHEtTag" ClassVersion="13">
+ <version ClassVersion="13" checksum="2125676410"/>
+ <version ClassVersion="12" checksum="1192814105"/>
+ <version ClassVersion="11" checksum="884120660"/>
+  <version ClassVersion="10" checksum="1061507347"/>
+</class>
+<class name="std::vector<flashgg::VHEtTag>"/>
+<class name="edm::Wrapper<std::vector<flashgg::VHEtTag> >"/>
+<class name="std::vector<edm::Ptr<flashgg::Jet> >"/>
+<class name="edm::OwnVector<flashgg::DiPhotonTagBase, edm::ClonePolicy<flashgg::DiPhotonTagBase> >" />
+<class name="edm::Wrapper<edm::OwnVector<flashgg::DiPhotonTagBase, edm::ClonePolicy<flashgg::DiPhotonTagBase> > >" />
+<class name="flashgg::VBFTagTruth" ClassVersion="12">
+ <version ClassVersion="12" checksum="2475891424"/>
+  <version ClassVersion="11" checksum="2745005875"/>
+</class>
+<class name="std::vector<flashgg::VBFTagTruth>"/>
+<class name="edm::Wrapper<std::vector<flashgg::VBFTagTruth> >"/>
+<class name="flashgg::VHLooseTag" ClassVersion="14">
+ <version ClassVersion="14" checksum="1861363899"/>
+ <version ClassVersion="13" checksum="3345591704"/>
+ <version ClassVersion="12" checksum="2427728431"/>
+ <version ClassVersion="11" checksum="3802982704"/>
+  <version ClassVersion="10" checksum="1025135485"/>
+</class>
+
+<class name="flashgg::VHTagTruth" ClassVersion="11">
+ <version ClassVersion="11" checksum="641304440"/>
+  <version ClassVersion="10" checksum="2764404041"/>
+</class>
+<class name="std::vector<flashgg::VHTagTruth>"/>
+<class name="edm::Wrapper<std::vector<flashgg::VHTagTruth> >"/>
+
+<class name="std::vector<flashgg::VHLooseTag>"/>
+<class name="edm::Wrapper<std::vector<flashgg::VHLooseTag> >"/>
+<class name="flashgg::VHTightTag" ClassVersion="14">
+ <version ClassVersion="14" checksum="3413794279"/>
+ <version ClassVersion="13" checksum="1140450204"/>
+ <version ClassVersion="12" checksum="1711188723"/>
+ <version ClassVersion="11" checksum="3086442996"/>
+  <version ClassVersion="10" checksum="308595777"/>
+</class>
+<class name="std::vector<flashgg::VHTightTag>"/>
+<class name="edm::Wrapper<std::vector<flashgg::VHTightTag> >"/>
+<class name="flashgg::VHHadronicTag" ClassVersion="12">
+ <version ClassVersion="12" checksum="1541512627"/>
+ <version ClassVersion="11" checksum="1986614206"/>
+  <version ClassVersion="10" checksum="2760911373"/>
+</class>
+<class name="std::vector<flashgg::VHHadronicTag>"/>
+<class name="edm::Wrapper<std::vector<flashgg::VHHadronicTag> >"/>
+<class name="edm::Ptr<flashgg::DiPhotonTagBase>"/>
+<class name="edm::Wrapper<edm::Ptr<flashgg::DiPhotonTagBase> >"/>
+<class name="edm::Ptr<reco::Vertex>"/> 
+<class name="std::vector<edm::Ptr<reco::Vertex> >"/> 
+<class name="flashgg::Photon" ClassVersion="12">
+ <version ClassVersion="12" checksum="1503356172"/>
+   <version ClassVersion="10" checksum="563539605"/>
+  <version ClassVersion="11" checksum="3279104383"/>
+</class>
+<class name="edm::Ptr<flashgg::Photon>"/>
+<class name="std::vector<flashgg::Photon>"/>
+<class name="edm::Wrapper<std::vector<flashgg::Photon> >"/>
+<class name="flashgg::DiPhotonCandidate" ClassVersion="13">
+  <version ClassVersion="10" checksum="2243573479"/>
+  <version ClassVersion="11" checksum="3086156793"/>
+  <version ClassVersion="12" checksum="2290346388"/>
+  <version ClassVersion="13" checksum="226153243"/>
+</class>
+<class name="std::vector<flashgg::DiPhotonCandidate>"/>
+<class name="edm::Wrapper<std::vector<flashgg::DiPhotonCandidate> >"/>
+<class name="edm::Ptr<flashgg::DiPhotonCandidate>"/>
+<class name="edm::Wrapper<edm::Ptr<flashgg::DiPhotonCandidate> >"/>
+<class name="std::vector<edm::Ptr<flashgg::DiPhotonCandidate> >"/>
+<class name="edm::Wrapper<std::vector<edm::Ptr<flashgg::DiPhotonCandidate> > >"/>
+<class name="flashgg::GenDiPhoton" ClassVersion="12">
+    <version ClassVersion="10" checksum="3743016204"/>
+    <version ClassVersion="11" checksum="3762840980"/>
+    <version ClassVersion="12" checksum="618509360"/>
+</class>
+
+<class name="edm::Wrapper<flashgg::DiPhotonMVAResult>"/>
+<class name="std::pair<edm::Ptr<flashgg::DiPhotonCandidate>,flashgg::DiPhotonMVAResult>"/>
+<class name="std::map<edm::Ptr<flashgg::DiPhotonCandidate>,flashgg::DiPhotonMVAResult>"/>
+<class name="edm::Wrapper<std::pair<edm::Ptr<flashgg::DiPhotonCandidate>,flashgg::DiPhotonMVAResult> >"/>
+<class name="edm::Wrapper<std::map<edm::Ptr<flashgg::DiPhotonCandidate>,flashgg::DiPhotonMVAResult> >"/>
+<class name="edm::reftobase::BaseHolder<flashgg::Photon>"/>
+<class name="edm::RefToBase<flashgg::Photon>"/>
+<class name="edm::reftobase::IndirectHolder<flashgg::Photon>" />
+<class name="edm::RefToBaseProd<flashgg::Photon>" />
+<class name="edm::RefToBaseVector<flashgg::Photon>" />
+<class name="edm::Wrapper<edm::RefToBaseVector<flashgg::Photon> >" />
+<class name="edm::reftobase::BaseVectorHolder<flashgg::Photon>" />
+<class name="edm::Ref<std::vector<flashgg::Photon>,flashgg::Photon,edm::refhelper::FindUsingAdvance<std::vector<flashgg::Photon>,flashgg::Photon> >"/>
+<class name="edm::RefProd<std::vector<flashgg::Photon> >"/>
+<class name="edm::RefVector<std::vector<flashgg::Photon>,flashgg::Photon,edm::refhelper::FindUsingAdvance<std::vector<flashgg::Photon>,flashgg::Photon> >"/>
+<class name="edm::Wrapper<edm::RefVector<std::vector<flashgg::Photon>,flashgg::Photon,edm::refhelper::FindUsingAdvance<std::vector<flashgg::Photon>,flashgg::Photon> > >"/>
+
+
+
+
+
+<class name="std::vector<flashgg::GenDiPhoton>"/>
+<class name="edm::Wrapper<std::vector<flashgg::GenDiPhoton> >"/>
+<class name="edm::Ptr<flashgg::GenDiPhoton>"/>
+<class name="edm::Wrapper<edm::Ptr<flashgg::GenDiPhoton> >"/>
+<class name="std::vector<edm::Ptr<flashgg::GenDiPhoton> >"/>
+<class name="edm::Wrapper<std::vector<edm::Ptr<flashgg::GenDiPhoton> > >"/>
+<class name="flashgg::SinglePhotonView" ClassVersion="10">
+  <version ClassVersion="10" checksum="853874792"/>
+  <field name="pho_" transient="true"/>
+</class>
+<ioread sourceClass = "flashgg::SinglePhotonView" version="[1-]" targetClass="flashgg::SinglePhotonView" source="" target="hasPhoton_">
+	<![CDATA[ hasPhoton_ = false;
+	]]>
+</ioread>
+<class name="edm::Ptr<flashgg::SinglePhotonView>"/>
+<class name="std::vector<flashgg::SinglePhotonView>"/>
+<class name="edm::Wrapper<std::vector<flashgg::SinglePhotonView> >"/>
+<class name="flashgg::SingleVertexView" ClassVersion="10">
+  <version ClassVersion="10" checksum="1012448319"/>
+</class>
+<class name="edm::Ptr<flashgg::SingleVertexView>"/>
+<class name="std::vector<flashgg::SingleVertexView>"/>
+<class name="edm::Wrapper<std::vector<flashgg::SingleVertexView> >"/>
+<class name="flashgg::MinimalPileupJetIdentifier" ClassVersion="10">
+  <version ClassVersion="10" checksum="3973513942"/>
+</class>
+<class name="std::pair<edm::Ptr<reco::Vertex>,flashgg::MinimalPileupJetIdentifier>"/>
+<class name="std::map<edm::Ptr<reco::Vertex>,flashgg::MinimalPileupJetIdentifier>"/>
+<class name="flashgg::Jet" ClassVersion="13">
+ <version ClassVersion="13" checksum="2175929989"/>
+  <version ClassVersion="12" checksum="1532368094"/>
+  <version ClassVersion="11" checksum="3459570589"/>
+  <version ClassVersion="10" checksum="2045570510"/>
+</class>
+<class name="std::vector<flashgg::Jet>"/>
+<class name="edm::Ptr<flashgg::Jet>"/>
+
+<class name="flashgg::Met" ClassVersion="11">
+  <version ClassVersion="10" checksum="2272826605"/>
+  <version ClassVersion="11" checksum="1231550995"/>
+</class>
+<class name="std::vector<flashgg::Met>"/>
+<class name="edm::Wrapper<std::vector<flashgg::Met> >"/>
+<class name="std::vector<std::vector<flashgg::Met> >"/>
+<class name="edm::Wrapper<std::vector<std::vector<flashgg::Met> > >"/>
+<class name="edm::Ptr<flashgg::Met>"/>
+<class name="std::vector<edm::Ptr<flashgg::Met> >"/>
+<class name="edm::Wrapper<std::vector<edm::Ptr<flashgg::Met> > >"/>
+<class name="std::map<edm::Ptr<reco::Vertex>,float>"/>
+<class name="std::pair<edm::Ptr<reco::Vertex>,float>"/>
+<class name="std::map<std::string,std::map<edm::Ptr<reco::Vertex>,float>>"/>
+<class name="std::pair<std::string,std::map<edm::Ptr<reco::Vertex>,float>>"/>
+<class name="edm::Wrapper<std::vector<flashgg::Jet> >"/>
+<class name="std::vector<std::vector<flashgg::Jet> >"/>
+<class name="edm::Wrapper<std::vector<std::vector<flashgg::Jet> > >"/>
+<class name="flashgg::Electron" ClassVersion="14">
+ <version ClassVersion="14" checksum="1838216375"/>
+ <version ClassVersion="13" checksum="1505067635"/>
+  <version ClassVersion="12" checksum="1018193332"/>
+  <version ClassVersion="11" checksum="2620301447"/>
+  <version ClassVersion="10" checksum="3162935784"/>
+</class>
+<class name="edm::Ptr<flashgg::Electron>"/>
+<class name="std::vector<flashgg::Electron>"/>
+<class name="edm::Wrapper<std::vector<flashgg::Electron> >"/>
+<class name="flashgg::Muon" ClassVersion="14">
+ <version ClassVersion="14" checksum="3026555456"/>
+ <version ClassVersion="13" checksum="3043647910"/>
+  <version ClassVersion="12" checksum="3130885816"/>
+  <version ClassVersion="11" checksum="3269337733"/>
+  <version ClassVersion="10" checksum="1803852641"/>
+</class>
+<class name="edm::Ptr<flashgg::Muon>"/>
+<class name="std::vector<flashgg::Muon>"/>
+<class name="edm::Wrapper<std::vector<flashgg::Muon> >"/>
+<class name="flashgg::TagTruthBase" ClassVersion="11">
+ <version ClassVersion="11" checksum="647547459"/>
+ <version ClassVersion="10" checksum="2663548356"/>
+</class>
+<class name="std::vector<flashgg::TagTruthBase>"/>
+<class name="edm::Wrapper<std::vector<flashgg::TagTruthBase> >"/>
+<!-- <class pattern="edm::Ref<std::vector<flashgg::TagTruthBase>,*>"/> -->
+<class name="edm::OwnVector<flashgg::TagTruthBase, edm::ClonePolicy<flashgg::TagTruthBase> >" />
+<class name="edm::Wrapper<edm::OwnVector<flashgg::TagTruthBase, edm::ClonePolicy<flashgg::TagTruthBase> > >" />
+<!-- <class pattern="edm::Ref<edm::OwnVector<flashgg::TagTruthBase, edm::ClonePolicy<flashgg::TagTruthBase> >,* >" /> -->
+<class name="edm::Ptr<flashgg::TagTruthBase>"/>
+<class name="edm::Ptr<pat::PackedGenParticle>"/>
+<class name="flashgg::GenPhotonExtra" ClassVersion="10">
+  <version ClassVersion="10" checksum="3440189854"/>
+</class>
+<class name="edm::Ptr<flashgg::GenPhotonExtra>"/>
+<class name="std::vector<flashgg::GenPhotonExtra>"/>
+<class name="edm::Wrapper<std::vector<flashgg::GenPhotonExtra> >"/>
+<class name="std::pair<edm::Ptr<reco::Vertex>,edm::Ptr<pat::PackedCandidate> >"/>
+<class name="std::vector<std::pair<edm::Ptr<reco::Vertex>,edm::Ptr<pat::PackedCandidate> > >"/>
+<class name="edm::Wrapper<std::vector<std::pair<edm::Ptr<reco::Vertex>,edm::Ptr<pat::PackedCandidate> > > >"/>
+<class name="std::vector<edm::Ptr<pat::Muon> >"/>
+<class name="edm::Wrapper<std::vector<edm::Ptr<pat::Muon> > >"/>
+<class name="std::vector<edm::Ptr<flashgg::Electron> >"/>
+<class name="edm::Wrapper<std::vector<edm::Ptr<flashgg::Electron> > >"/>
+<class name="std::vector<edm::Ptr<flashgg::Muon> >"/>
+<class name="edm::Wrapper<std::vector<edm::Ptr<flashgg::Muon> > >"/>
+<class name="std::vector<edm::Ptr<pat::MET> >"/>
+<class name="edm::Wrapper<std::vector<edm::Ptr<pat::MET> > >"/>
+
+<class name="flashgg::DiMuonCandidate" ClassVersion="10">
+  <version ClassVersion="10" checksum="1852293607"/>
+</class>
+<class name="std::vector<flashgg::DiMuonCandidate>"/>
+<class name="edm::Wrapper<std::vector<flashgg::DiMuonCandidate> >"/>
+<class name="edm::Ptr<flashgg::DiMuonCandidate>"/>
+<class name="edm::Wrapper<edm::Ptr<flashgg::DiMuonCandidate> >"/>
+<class name="std::vector<edm::Ptr<flashgg::DiMuonCandidate> >"/>
+<class name="edm::Wrapper<std::vector<edm::Ptr<flashgg::DiMuonCandidate> > >"/>
+
+<class name="flashgg::MuMuGammaCandidate" ClassVersion="10">
+  <version ClassVersion="10" checksum="1087604778"/>
+</class>
+<class name="std::vector<flashgg::MuMuGammaCandidate>"/>
+<class name="edm::Wrapper<std::vector<flashgg::MuMuGammaCandidate> >"/>
+<class name="edm::Ptr<flashgg::MuMuGammaCandidate>"/>
+<class name="edm::Wrapper<edm::Ptr<flashgg::MuMuGammaCandidate> >"/>
+<class name="std::vector<edm::Ptr<flashgg::MuMuGammaCandidate> >"/>
+<class name="edm::Wrapper<std::vector<edm::Ptr<flashgg::MuMuGammaCandidate> > >"/>
+
+<class name="flashgg::PhotonJetCandidate" ClassVersion="11">
+  <version ClassVersion="11" checksum="4247679146"/>
+</class>
+<class name="std::vector<flashgg::PhotonJetCandidate>"/>
+<class name="edm::Wrapper<std::vector<flashgg::PhotonJetCandidate> >"/>
+<class name="edm::Ptr<flashgg::PhotonJetCandidate>"/>
+<class name="edm::Wrapper<edm::Ptr<flashgg::PhotonJetCandidate> >"/>
+<class name="std::vector<edm::Ptr<flashgg::PhotonJetCandidate> >"/>
+<class name="edm::Wrapper<std::vector<edm::Ptr<flashgg::PhotonJetCandidate> > >"/>
+
+<class name="flashgg::TagCandidate" ClassVersion="0">
+</class>
+<class name="std::vector<flashgg::TagCandidate>"/>
+<class name="edm::Wrapper<std::vector<flashgg::TagCandidate> >"/>
+</lcgdict>

--- a/MetaData/plugins/WeightProducer.cc
+++ b/MetaData/plugins/WeightProducer.cc
@@ -122,7 +122,7 @@ WeightProducer::produce( edm::Event &iEvent, const edm::EventSetup &iSetup )
 
     }
 
-    iEvent.put( pweight );
+    iEvent.put( std::move( pweight ) );
     return;
 }
 

--- a/MetaData/plugins/WeightProducer.cc
+++ b/MetaData/plugins/WeightProducer.cc
@@ -81,7 +81,7 @@ WeightProducer::produce( edm::Event &iEvent, const edm::EventSetup &iSetup )
 {
     edm::Handle<GenEventInfoProduct> genInfo;
     edm::Handle<std::vector<PileupSummaryInfo> > puInfo;
-    auto_ptr<double> pweight( new double( 1. ) );
+    unique_ptr<double> pweight( new double( 1. ) );
 
     if( ! iEvent.isRealData() ) {
         ( *pweight ) = lumiWeight_;

--- a/MicroAOD/interface/CutBasedDiPhotonObjectSelector.h
+++ b/MicroAOD/interface/CutBasedDiPhotonObjectSelector.h
@@ -28,6 +28,7 @@ namespace flashgg {
         CutBasedDiPhotonObjectSelector( const edm::ParameterSet &config, edm::ConsumesCollector &cc );
 
         bool operator()( const DiPhotonCandidate &cand, const edm::EventBase &ev ) const;
+        bool operator()( const edm::Ref<edm::View<DiPhotonCandidate> > candref, const edm::EventBase &ev ) const;
 
     private:
         selector_type selector_;

--- a/MicroAOD/interface/CutBasedElectronObjectSelector.h
+++ b/MicroAOD/interface/CutBasedElectronObjectSelector.h
@@ -7,7 +7,7 @@
 
 namespace flashgg {
 
-	typedef CutBasedGenericObjectSelector<flashgg::Electron> CutBasedElectronObjectSelector;
+	typedef CutBasedGenericObjectSelector<edm::View<flashgg::Electron> > CutBasedElectronObjectSelector;
 
 }
 

--- a/MicroAOD/interface/CutBasedGenericObjectSelector.h
+++ b/MicroAOD/interface/CutBasedGenericObjectSelector.h
@@ -16,20 +16,23 @@
 #include <map>
 
 namespace flashgg {
-    template<class T>
+    template<class InputCollection>
     class CutBasedGenericObjectSelector
     {
 
     public:
+        typedef typename InputCollection::value_type T;
         typedef T object_type;
         typedef CutBasedClassifier<T> classifier_type;
         typedef StringObjectFunction<T> functor_type;
         typedef StepWiseFunctor<T> stepwise_functor_type;
         typedef StringCutObjectSelector<T, true> selector_type;
+        typedef edm::Ref<InputCollection> ref_type;
 
         CutBasedGenericObjectSelector( const edm::ParameterSet &config, edm::ConsumesCollector &cc );
 
         bool operator()( const object_type &cand, const edm::EventBase &ev ) const;
+        bool operator()( const ref_type candref, const edm::EventBase &ev ) const;
 
     protected:
         typedef std::pair<bool,double> limit_type;

--- a/MicroAOD/interface/CutBasedPhotonObjectSelector.h
+++ b/MicroAOD/interface/CutBasedPhotonObjectSelector.h
@@ -29,6 +29,7 @@ namespace flashgg {
         CutBasedPhotonObjectSelector( const edm::ParameterSet &config, edm::ConsumesCollector &cc );
 
         bool operator()( const Photon &cand, const edm::EventBase &ev ) const;
+        bool operator()( const edm::Ref<edm::View<Photon> > candref, const edm::EventBase &ev ) const;
 
     protected:
         typedef std::shared_ptr<functor_type> functor_ptr;

--- a/MicroAOD/interface/CutBasedPhotonViewSelector.h
+++ b/MicroAOD/interface/CutBasedPhotonViewSelector.h
@@ -26,7 +26,7 @@ namespace flashgg {
         CutBasedPhotonViewSelector( const edm::ParameterSet &config, edm::ConsumesCollector &cc );
 
         bool operator()( const SinglePhotonView &cand, const edm::EventBase &ev ) const;
-
+        bool operator()( const edm::Ref<edm::View<SinglePhotonView> > candref, const edm::EventBase &ev ) const;
     };
 
 }

--- a/MicroAOD/interface/HadronicActivityProducer.h
+++ b/MicroAOD/interface/HadronicActivityProducer.h
@@ -105,7 +105,7 @@ namespace flashgg {
         AddFourMomenta addP4;
         addP4.set(out);
         
-        iEvent.put(outPtr);
+        iEvent.put(std::move(outPtr));
     }
 }
 

--- a/MicroAOD/interface/HadronicActivityProducer.h
+++ b/MicroAOD/interface/HadronicActivityProducer.h
@@ -77,7 +77,7 @@ namespace flashgg {
     template <class T, class V>
     void HadronicActivityProducer<T,V>::produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const {
         
-        std::auto_ptr<std::vector<reco::CompositeCandidate> > outPtr(new std::vector<reco::CompositeCandidate>(1));
+        std::unique_ptr<std::vector<reco::CompositeCandidate> > outPtr(new std::vector<reco::CompositeCandidate>(1));
         
         auto & out = outPtr->at(0);
         

--- a/MicroAOD/interface/RandomizedObjectProducer.h
+++ b/MicroAOD/interface/RandomizedObjectProducer.h
@@ -60,7 +60,7 @@ namespace flashgg {
                     out_obj->push_back(o);
             }
         }
-        evt.put(out_obj);
+        evt.put(std::move(out_obj));
     }
 }
 

--- a/MicroAOD/interface/RandomizedObjectProducer.h
+++ b/MicroAOD/interface/RandomizedObjectProducer.h
@@ -50,7 +50,7 @@ namespace flashgg {
         evt.getByToken( token_, objects );
 
         CLHEP::HepRandomEngine & engine = rng->getEngine( evt.streamID() );
-        auto_ptr<std::vector<pat_object> > out_obj( new std::vector<pat_object>() );
+        unique_ptr<std::vector<pat_object> > out_obj( new std::vector<pat_object>() );
         CLHEP::RandGauss::shoot(&engine, 0., 1.);
 
         for (const auto & obj : *objects) {

--- a/MicroAOD/plugins/CHSLegacyVertexCandidateProducer.cc
+++ b/MicroAOD/plugins/CHSLegacyVertexCandidateProducer.cc
@@ -123,7 +123,7 @@ namespace flashgg {
 
 
 
-        evt.put( result );
+        evt.put( std::move( result ) );
     }
 }
 typedef flashgg::CHSLegacyVertexCandidateProducer FlashggCHSLegacyVertexCandidateProducer;

--- a/MicroAOD/plugins/CHSLegacyVertexCandidateProducer.cc
+++ b/MicroAOD/plugins/CHSLegacyVertexCandidateProducer.cc
@@ -102,7 +102,7 @@ namespace flashgg {
             }
         }
 
-        std::auto_ptr<vector<pat::PackedCandidate> > result( new vector<pat::PackedCandidate>() );
+        std::unique_ptr<vector<pat::PackedCandidate> > result( new vector<pat::PackedCandidate>() );
 
         for( unsigned int pfCandLoop = 0 ; pfCandLoop < pfCandidates->size() ; pfCandLoop++ ) {
             edm::Ptr<pat::PackedCandidate> cand = pfCandidates->ptrAt( pfCandLoop );

--- a/MicroAOD/plugins/DiMuonProducer.cc
+++ b/MicroAOD/plugins/DiMuonProducer.cc
@@ -54,7 +54,7 @@ namespace flashgg {
         const std::vector<edm::Ptr<pat::Muon> > &muonPointers = muons->ptrs();
 
 
-        auto_ptr<vector<flashgg::DiMuonCandidate> > diMuonColl( new vector<flashgg::DiMuonCandidate> );
+        unique_ptr<vector<flashgg::DiMuonCandidate> > diMuonColl( new vector<flashgg::DiMuonCandidate> );
         //    cout << "evt.id().event()= " << evt.id().event() << "\tevt.isRealData()= " << evt.isRealData() << "\tmuonPointers.size()= " << muonPointers.size() << "\tpvPointers.size()= " << pvPointers.size() << endl;
 
         for( unsigned int i = 0 ; i < muonPointers.size() ; i++ ) {

--- a/MicroAOD/plugins/DiMuonProducer.cc
+++ b/MicroAOD/plugins/DiMuonProducer.cc
@@ -97,7 +97,7 @@ namespace flashgg {
                 diMuonColl->push_back( dimu );
             }
         }
-        evt.put( diMuonColl );
+        evt.put( std::move( diMuonColl ) );
 
     }
 }

--- a/MicroAOD/plugins/DiPhotonGenZProducer.cc
+++ b/MicroAOD/plugins/DiPhotonGenZProducer.cc
@@ -69,7 +69,7 @@ namespace flashgg {
             diPhotonColl->push_back( dipho );
         }
 
-        evt.put( diPhotonColl );
+        evt.put( std::move( diPhotonColl ) );
     }
 }
 

--- a/MicroAOD/plugins/DiPhotonGenZProducer.cc
+++ b/MicroAOD/plugins/DiPhotonGenZProducer.cc
@@ -60,7 +60,7 @@ namespace flashgg {
             }
         }
 
-        auto_ptr<vector<DiPhotonCandidate> > diPhotonColl( new vector<DiPhotonCandidate> );
+        unique_ptr<vector<DiPhotonCandidate> > diPhotonColl( new vector<DiPhotonCandidate> );
 
         for( unsigned int i = 0 ; i < diphotons->size() ; i++ ) {
 

--- a/MicroAOD/plugins/DiPhotonProducer.cc
+++ b/MicroAOD/plugins/DiPhotonProducer.cc
@@ -158,7 +158,7 @@ namespace flashgg {
             }
         }
 
-        evt.put( diPhotonColl );
+        evt.put( std::move( diPhotonColl ) );
     }
 }
 

--- a/MicroAOD/plugins/DiPhotonProducer.cc
+++ b/MicroAOD/plugins/DiPhotonProducer.cc
@@ -102,7 +102,7 @@ namespace flashgg {
         evt.getByToken( conversionTokenSingleLeg_, conversionsSingleLeg );
         //const PtrVector<reco::Conversion>& conversionPointersSingleLeg = conversionsSingleLeg->ptrVector();
 
-        auto_ptr<vector<DiPhotonCandidate> > diPhotonColl( new vector<DiPhotonCandidate> );
+        unique_ptr<vector<DiPhotonCandidate> > diPhotonColl( new vector<DiPhotonCandidate> );
 //    cout << "evt.id().event()= " << evt.id().event() << "\tevt.isRealData()= " << evt.isRealData() << "\tphotons->size()= " << photons->size() << "\tprimaryVertices->size()= " << primaryVertices->size() << endl;
 
         for( unsigned int i = 0 ; i < photons->size() ; i++ ) {

--- a/MicroAOD/plugins/DzVertexMapProducer.cc
+++ b/MicroAOD/plugins/DzVertexMapProducer.cc
@@ -88,7 +88,7 @@ namespace flashgg {
             }
         } // end of !useEachTrackOnce_
         std::stable_sort( assoc->begin(), assoc->end(), flashgg::compare_by_vtx() );
-        evt.put( assoc );
+        evt.put( std::move( assoc ) );
     }
 }
 

--- a/MicroAOD/plugins/DzVertexMapProducer.cc
+++ b/MicroAOD/plugins/DzVertexMapProducer.cc
@@ -47,7 +47,7 @@ namespace flashgg {
         evt.getByToken( pfcandidateToken_, pfCandidates );
         //const PtrVector<pat::PackedCandidate>& pfPtrs = pfCandidates->ptrVector();
 
-        std::auto_ptr<VertexCandidateMap> assoc( new VertexCandidateMap );
+        std::unique_ptr<VertexCandidateMap> assoc( new VertexCandidateMap );
 
         if( useEachTrackOnce_ ) {
             // Associate a track to the closest vertex only, and only if dz < maxAllowedDz_

--- a/MicroAOD/plugins/DzVertexMapProducerForCHS.cc
+++ b/MicroAOD/plugins/DzVertexMapProducerForCHS.cc
@@ -86,7 +86,7 @@ namespace flashgg {
 
         //        flashgg::print_track_count( *assoc, "FlashggDzVertexMapProducerForCHS" );
 
-        evt.put( assoc );
+        evt.put( std::move( assoc ) );
     } // produce method
 } // namespace flashgg
 

--- a/MicroAOD/plugins/DzVertexMapProducerForCHS.cc
+++ b/MicroAOD/plugins/DzVertexMapProducerForCHS.cc
@@ -50,7 +50,7 @@ namespace flashgg {
         evt.getByToken( pfcandidateToken_, pfCandidates );
         // const PtrVector<pat::PackedCandidate>& pfPtrs = pfCandidates->ptrVector();
 
-        std::auto_ptr<VertexCandidateMap> assoc( new VertexCandidateMap );
+        std::unique_ptr<VertexCandidateMap> assoc( new VertexCandidateMap );
 
         // Create empty vector for each vertex in advance
         //    for (unsigned int j = 0 ; j < primaryVertices->size() ; j++) {

--- a/MicroAOD/plugins/EGammaMinimizer.cc
+++ b/MicroAOD/plugins/EGammaMinimizer.cc
@@ -208,11 +208,11 @@ namespace flashgg {
 
         }
 
-        evt.put( scColl, superClusterCollectionName_ );
-        evt.put( photonCoreColl, photonCoreCollectionName_ );
-        evt.put( photonColl, photonCollectionName_ );
-        evt.put( electronCoreColl, electronCoreCollectionName_ );
-        evt.put( electronColl, electronCollectionName_ );
+        evt.put( std::move( scColl) , superClusterCollectionName_ );
+        evt.put( std::move( photonCoreColl) , photonCoreCollectionName_ );
+        evt.put( std::move( photonColl) , photonCollectionName_ );
+        evt.put( std::move( electronCoreColl) , electronCoreCollectionName_ );
+        evt.put( std::move( electronColl) , electronCollectionName_ );
 
         if( debug_ ) {
             std::cout << " We put the photons in, now we check diphoton pt before and after recomputation: " << std::endl;
@@ -223,7 +223,7 @@ namespace flashgg {
             }
         }
 
-        evt.put( diPhotonColl, diPhotonCollectionName_ );
+        evt.put( std::move( diPhotonColl) , diPhotonCollectionName_ );
     }
 }
 

--- a/MicroAOD/plugins/EGammaMinimizer.cc
+++ b/MicroAOD/plugins/EGammaMinimizer.cc
@@ -73,12 +73,12 @@ namespace flashgg {
         Handle<View<Electron> > electrons;
         evt.getByToken( electronToken_, electrons );
 
-        auto_ptr<vector<DiPhotonCandidate> > diPhotonColl( new vector<DiPhotonCandidate> );
-        auto_ptr<vector<Photon> > photonColl( new vector<Photon> );
-        auto_ptr<vector<reco::SuperCluster> > scColl( new vector<reco::SuperCluster> );
-        auto_ptr<vector<reco::PhotonCore> > photonCoreColl( new vector<reco::PhotonCore> );
-        auto_ptr<vector<Electron> > electronColl( new vector<Electron> );
-        auto_ptr<vector<reco::GsfElectronCore> > electronCoreColl( new vector<reco::GsfElectronCore> );
+        unique_ptr<vector<DiPhotonCandidate> > diPhotonColl( new vector<DiPhotonCandidate> );
+        unique_ptr<vector<Photon> > photonColl( new vector<Photon> );
+        unique_ptr<vector<reco::SuperCluster> > scColl( new vector<reco::SuperCluster> );
+        unique_ptr<vector<reco::PhotonCore> > photonCoreColl( new vector<reco::PhotonCore> );
+        unique_ptr<vector<Electron> > electronColl( new vector<Electron> );
+        unique_ptr<vector<reco::GsfElectronCore> > electronCoreColl( new vector<reco::GsfElectronCore> );
 
         edm::RefProd<vector<Photon> > rPhoton = evt.getRefBeforePut<vector<Photon> >( photonCollectionName_ );
         edm::RefProd<vector<reco::SuperCluster> > rSuperCluster = evt.getRefBeforePut<vector<reco::SuperCluster> >( superClusterCollectionName_ );

--- a/MicroAOD/plugins/ElectronProducer.cc
+++ b/MicroAOD/plugins/ElectronProducer.cc
@@ -149,7 +149,7 @@ namespace flashgg {
         evt.getByToken( pfcandidateToken_, pfcandidates );
         const std::vector<edm::Ptr<pat::PackedCandidate> > &pfcands = pfcandidates->ptrs();
 
-        std::auto_ptr<vector<flashgg::Electron> > elecColl( new vector<flashgg::Electron> );
+        std::unique_ptr<vector<flashgg::Electron> > elecColl( new vector<flashgg::Electron> );
 
         for( unsigned int elecIndex = 0; elecIndex < pelectrons->size(); elecIndex++ ) {
             Ptr<pat::Electron> pelec = pelectrons->ptrAt( elecIndex );

--- a/MicroAOD/plugins/ElectronProducer.cc
+++ b/MicroAOD/plugins/ElectronProducer.cc
@@ -248,7 +248,7 @@ namespace flashgg {
             elecColl->push_back( felec );
            
         }
-        evt.put( elecColl );
+        evt.put( std::move( elecColl ) );
     }
 }
 

--- a/MicroAOD/plugins/GenDiPhotonDijetProducer.cc
+++ b/MicroAOD/plugins/GenDiPhotonDijetProducer.cc
@@ -74,7 +74,7 @@ namespace flashgg {
             }
         }
         
-        evt.put( diphotons );
+        evt.put( std::move( diphotons ) );
     }
 }
 

--- a/MicroAOD/plugins/GenDiPhotonDijetProducer.cc
+++ b/MicroAOD/plugins/GenDiPhotonDijetProducer.cc
@@ -48,7 +48,7 @@ namespace flashgg {
         Handle<View<reco::GenJet> > jets;
         evt.getByToken( genJetToken_, jets );
 
-        std::auto_ptr<vector<GenDiPhoton> > diphotons( new vector<GenDiPhoton> );
+        std::unique_ptr<vector<GenDiPhoton> > diphotons( new vector<GenDiPhoton> );
         
         std::vector<edm::Ptr<reco::GenJet> > seljets;
         for( size_t ij = 0 ; ij < jets->size() ; ++ij ) {

--- a/MicroAOD/plugins/GenDiPhotonProducer.cc
+++ b/MicroAOD/plugins/GenDiPhotonProducer.cc
@@ -53,7 +53,7 @@ namespace flashgg {
             }
         }
         
-        evt.put( diphotons );
+        evt.put( std::move( diphotons ) );
     }
 }
 

--- a/MicroAOD/plugins/GenDiPhotonProducer.cc
+++ b/MicroAOD/plugins/GenDiPhotonProducer.cc
@@ -43,7 +43,7 @@ namespace flashgg {
         Handle<View<flashgg::GenPhotonExtra> > photons;
         evt.getByToken( genPhotonToken_, photons );
 
-        std::auto_ptr<vector<GenDiPhoton> > diphotons( new vector<GenDiPhoton> );
+        std::unique_ptr<vector<GenDiPhoton> > diphotons( new vector<GenDiPhoton> );
 
         for( size_t ii = 0 ; ii < photons->size() ; ++ii ) {
             auto pi = photons->ptrAt( ii );

--- a/MicroAOD/plugins/GenPhotonExtraProducer.cc
+++ b/MicroAOD/plugins/GenPhotonExtraProducer.cc
@@ -55,7 +55,7 @@ namespace flashgg {
         evt.getByToken( genPhotonsToken_, genPhotons );
         evt.getByToken( genParticlesToken_, genParticles );
 
-        auto_ptr<vector<flashgg::GenPhotonExtra> > extraColl( new vector<flashgg::GenPhotonExtra> );
+        unique_ptr<vector<flashgg::GenPhotonExtra> > extraColl( new vector<flashgg::GenPhotonExtra> );
 
         auto genPhotonPointers = genPhotons->ptrs();
         for( auto &genPho : genPhotonPointers ) {

--- a/MicroAOD/plugins/GenPhotonExtraProducer.cc
+++ b/MicroAOD/plugins/GenPhotonExtraProducer.cc
@@ -66,7 +66,7 @@ namespace flashgg {
             extraColl->push_back( extra );
         }
 
-        evt.put( extraColl );
+        evt.put( std::move( extraColl ) );
 
         /// orig_collection = 0;
     }

--- a/MicroAOD/plugins/JetProducer.cc
+++ b/MicroAOD/plugins/JetProducer.cc
@@ -357,7 +357,7 @@ namespace flashgg {
             jetColl->push_back( fjet );
         }
 
-        evt.put( jetColl );
+        evt.put( std::move( jetColl ) );
     }
 }
 

--- a/MicroAOD/plugins/JetProducer.cc
+++ b/MicroAOD/plugins/JetProducer.cc
@@ -123,7 +123,7 @@ namespace flashgg {
         evt.getByToken( rhoToken_, rhoHandle);
         double rho = *rhoHandle;
         
-        auto_ptr<vector<flashgg::Jet> > jetColl( new vector<flashgg::Jet> );
+        unique_ptr<vector<flashgg::Jet> > jetColl( new vector<flashgg::Jet> );
 
         if (debug_) {
             for( unsigned int i = 0 ; i < debugJets->size() ; i++ ) {

--- a/MicroAOD/plugins/MetProducer.cc
+++ b/MicroAOD/plugins/MetProducer.cc
@@ -38,7 +38,7 @@ namespace flashgg {
     {
         edm::Handle<edm::View<pat::MET> >  pmets;
         evt.getByToken( metToken_, pmets );
-        std::auto_ptr<vector<flashgg::Met> > metColl( new vector<flashgg::Met> );
+        std::unique_ptr<vector<flashgg::Met> > metColl( new vector<flashgg::Met> );
 
         for( unsigned int metIndex = 0; metIndex < pmets->size(); metIndex++ ) 
             {

--- a/MicroAOD/plugins/MetProducer.cc
+++ b/MicroAOD/plugins/MetProducer.cc
@@ -46,7 +46,7 @@ namespace flashgg {
                 flashgg::Met fmet = flashgg::Met( *pmet );
                 metColl->push_back(fmet);
             }
-        evt.put(metColl );
+        evt.put( std::move(metColl ) );
     }
 }
 

--- a/MicroAOD/plugins/MuMuGammaProducer.cc
+++ b/MicroAOD/plugins/MuMuGammaProducer.cc
@@ -140,7 +140,7 @@ namespace flashgg {
                 MuMuGammaColl->push_back( mumugamma );
             }
         }
-        evt.put( MuMuGammaColl );
+        evt.put( std::move( MuMuGammaColl ) );
 
     }
 }

--- a/MicroAOD/plugins/MuMuGammaProducer.cc
+++ b/MicroAOD/plugins/MuMuGammaProducer.cc
@@ -62,7 +62,7 @@ namespace flashgg {
         const std::vector<edm::Ptr<flashgg::Photon> > &photonPointers = photons->ptrs();
 
 
-        auto_ptr<vector<flashgg::MuMuGammaCandidate> > MuMuGammaColl( new vector<flashgg::MuMuGammaCandidate> );
+        unique_ptr<vector<flashgg::MuMuGammaCandidate> > MuMuGammaColl( new vector<flashgg::MuMuGammaCandidate> );
         //    cout << "evt.id().event()= " << evt.id().event() << "\tevt.isRealData()= " << evt.isRealData() << "\tdimuonPointers.size()= " << dimuonPointers.size() << "\tpvPointers.size()= " << pvPointers.size() << endl;
 
         for( unsigned int i = 0 ; i < dimuonPointers.size() ; i++ ) {

--- a/MicroAOD/plugins/MultiCHSLegVertexCandProducer.cc
+++ b/MicroAOD/plugins/MultiCHSLegVertexCandProducer.cc
@@ -132,7 +132,7 @@ namespace flashgg {
                                    << std::endl;
 
         if( debug_ ) { std::cout << setw( 13 ) << "-----------------------------" << std::endl; }
-        evt.put( result );
+        evt.put( std::move( result ) );
         eventNb++;
     }
 

--- a/MicroAOD/plugins/MultiCHSLegVertexCandProducer.cc
+++ b/MicroAOD/plugins/MultiCHSLegVertexCandProducer.cc
@@ -107,7 +107,7 @@ namespace flashgg {
             }
         }
 
-        std::auto_ptr<vector<pat::PackedCandidate> > result( new vector<pat::PackedCandidate>() );
+        std::unique_ptr<vector<pat::PackedCandidate> > result( new vector<pat::PackedCandidate>() );
         if( keep_event ) {
             for( unsigned int pfCandLoop = 0 ; pfCandLoop < pfCandidates->size() ; pfCandLoop++ ) {
                 edm::Ptr<pat::PackedCandidate> cand = pfCandidates->ptrAt( pfCandLoop );

--- a/MicroAOD/plugins/MuonProducer.cc
+++ b/MicroAOD/plugins/MuonProducer.cc
@@ -136,7 +136,7 @@ namespace flashgg {
 
             muColl->push_back( fmu );
         }
-        evt.put( muColl );
+        evt.put( std::move( muColl ) );
     }
 }
 

--- a/MicroAOD/plugins/MuonProducer.cc
+++ b/MicroAOD/plugins/MuonProducer.cc
@@ -68,7 +68,7 @@ namespace flashgg {
 
         //        std::cout << "calling produce function " << std::endl;
 
-        std::auto_ptr<vector<flashgg::Muon> > muColl( new vector<flashgg::Muon> );
+        std::unique_ptr<vector<flashgg::Muon> > muColl( new vector<flashgg::Muon> );
 
         for( unsigned int muIndex = 0; muIndex < pmuons->size(); muIndex++ ) {
             Ptr<pat::Muon> pmu = pmuons->ptrAt( muIndex );//retain the same index as patMuon;

--- a/MicroAOD/plugins/PDFWeightObjectProducer.cc
+++ b/MicroAOD/plugins/PDFWeightObjectProducer.cc
@@ -421,7 +421,7 @@ namespace flashgg {
         
 		PDFWeight->push_back( pdfWeight );
 
-		evt.put( PDFWeight );
+		evt.put( std::move( PDFWeight ) );
         
         /*
         cout << "FINAL pdf_weight_container size " <<pdfWeight.pdf_weight_container.size() << endl;

--- a/MicroAOD/plugins/PDFWeightObjectProducer.cc
+++ b/MicroAOD/plugins/PDFWeightObjectProducer.cc
@@ -18,6 +18,8 @@
 #include "DataFormats/PatCandidates/interface/libminifloat.h"
 #include "PhysicsTools/HepMCCandAlgos/interface/PDFWeightsHelper.h"
 #include "FWCore/Utilities/interface/EDMException.h"
+#include "FWCore/Framework/interface/Run.h"
+
 
 #include <boost/property_tree/ptree.hpp>
 #include <boost/property_tree/xml_parser.hpp>

--- a/MicroAOD/plugins/PDFWeightObjectProducer.cc
+++ b/MicroAOD/plugins/PDFWeightObjectProducer.cc
@@ -316,7 +316,7 @@ namespace flashgg {
         //cout << "gen weight = " << gen_weight <<endl;
 
 
-		std::auto_ptr<vector<flashgg::PDFWeightObject> > PDFWeight( new vector<flashgg::PDFWeightObject> );
+		std::unique_ptr<vector<flashgg::PDFWeightObject> > PDFWeight( new vector<flashgg::PDFWeightObject> );
 
 		inpdfweights.clear(); 
 

--- a/MicroAOD/plugins/PerPhotonMVADiPhotonProducer.cc
+++ b/MicroAOD/plugins/PerPhotonMVADiPhotonProducer.cc
@@ -45,7 +45,7 @@ namespace flashgg {
                 computer_.fill( dipho.getSubLeadingPhoton() );
                 output->push_back( dipho );
             }
-            evt.put( output );
+            evt.put( std::move( output ) );
         };
 
     private:

--- a/MicroAOD/plugins/PerPhotonMVADiPhotonProducer.cc
+++ b/MicroAOD/plugins/PerPhotonMVADiPhotonProducer.cc
@@ -37,7 +37,7 @@ namespace flashgg {
         {
             Handle<View<flashgg::DiPhotonCandidate> > input;
             evt.getByToken( srcToken_, input );
-            auto_ptr<vector<DiPhotonCandidate> > output( new vector<DiPhotonCandidate> );
+            unique_ptr<vector<DiPhotonCandidate> > output( new vector<DiPhotonCandidate> );
             computer_.update( evt );
             for( auto dipho : *input ) {
                 dipho.makePhotonsPersistent();

--- a/MicroAOD/plugins/PhotonJetProducer.cc
+++ b/MicroAOD/plugins/PhotonJetProducer.cc
@@ -237,7 +237,7 @@ namespace flashgg {
             
         }// end loop over photons
         
-        evt.put(PhotonJetColl);
+        evt.put( std::move(PhotonJetColl) );
         
     }
 }

--- a/MicroAOD/plugins/PhotonJetProducer.cc
+++ b/MicroAOD/plugins/PhotonJetProducer.cc
@@ -140,7 +140,7 @@ namespace flashgg {
         evt.getByToken(rhoTag_,rho);
         double rho_    = *rho;
 
-        auto_ptr<vector<PhotonJetCandidate> > PhotonJetColl( new vector<PhotonJetCandidate> );
+        unique_ptr<vector<PhotonJetCandidate> > PhotonJetColl( new vector<PhotonJetCandidate> );
 
         // --- Photon selection (min pt, photon id)
         for ( unsigned int i = 0 ; i < photons->size() ; i++ ){

--- a/MicroAOD/plugins/PhotonProducer.cc
+++ b/MicroAOD/plugins/PhotonProducer.cc
@@ -348,7 +348,7 @@ namespace flashgg {
             photonColl->push_back( fg );
         }
 
-        evt.put( photonColl );
+        evt.put( std::move( photonColl ) );
 
         /// orig_collection = 0;
     }

--- a/MicroAOD/plugins/PhotonProducer.cc
+++ b/MicroAOD/plugins/PhotonProducer.cc
@@ -205,7 +205,7 @@ namespace flashgg {
         const double rhoFixedGrd = *( rhoHandle.product() );
         const reco::Vertex *neutVtx = ( useVtx0ForNeutralIso_ ? &vertices->at( 0 ) : 0 );
 
-        auto_ptr<vector<flashgg::Photon> > photonColl( new vector<flashgg::Photon> );
+        unique_ptr<vector<flashgg::Photon> > photonColl( new vector<flashgg::Photon> );
 
         //// // this is hacky and dangerous
         //// const reco::VertexCollection* orig_collection = static_cast<const reco::VertexCollection*>(vertices->product());

--- a/MicroAOD/plugins/RandomizedPerPhotonDiPhotonProducer.cc
+++ b/MicroAOD/plugins/RandomizedPerPhotonDiPhotonProducer.cc
@@ -56,7 +56,7 @@ namespace flashgg {
         evt.getByToken( token_, objects );
 
         CLHEP::HepRandomEngine & engine = rng->getEngine( evt.streamID() );
-        auto_ptr<std::vector<flashgg::DiPhotonCandidate> > out_obj( new std::vector<flashgg::DiPhotonCandidate>() );
+        unique_ptr<std::vector<flashgg::DiPhotonCandidate> > out_obj( new std::vector<flashgg::DiPhotonCandidate>() );
         CLHEP::RandGauss::shoot(&engine, 0., 1.);
 
         for (const auto & obj : *objects) {

--- a/MicroAOD/plugins/RandomizedPerPhotonDiPhotonProducer.cc
+++ b/MicroAOD/plugins/RandomizedPerPhotonDiPhotonProducer.cc
@@ -68,7 +68,7 @@ namespace flashgg {
                     out_obj->push_back(o);
             }
         }
-        evt.put(out_obj);
+        evt.put( std::move(out_obj) );
     }
 }
 

--- a/MicroAOD/plugins/SinglePhotonViewProducer.cc
+++ b/MicroAOD/plugins/SinglePhotonViewProducer.cc
@@ -59,7 +59,7 @@ namespace flashgg {
         //// if( photonViews->size() != 0 ) {
         //// 	cout << photonViews->size() << endl;
         //// }
-        evt.put( photonViews );
+        evt.put( std::move( photonViews ) );
 
     }
 }

--- a/MicroAOD/plugins/SinglePhotonViewProducer.cc
+++ b/MicroAOD/plugins/SinglePhotonViewProducer.cc
@@ -44,7 +44,7 @@ namespace flashgg {
         Handle<View<flashgg::DiPhotonCandidate> > diPhotons;
         evt.getByToken( diPhotonToken_, diPhotons );
 
-        std::auto_ptr<vector<SinglePhotonView> > photonViews( new vector<SinglePhotonView> );
+        std::unique_ptr<vector<SinglePhotonView> > photonViews( new vector<SinglePhotonView> );
 
         int nCand = maxCandidates_;
         //for(auto & dipho : diPhotons) {

--- a/MicroAOD/plugins/SingleVertexViewProducer.cc
+++ b/MicroAOD/plugins/SingleVertexViewProducer.cc
@@ -90,7 +90,7 @@ namespace flashgg {
         //// if( vertexViews->size() != 0 ) {
         //// 	cout << vertexViews->size() << endl;
         //// }
-        evt.put( vertexViews );
+        evt.put( std::move( vertexViews ) );
 
     }
 }

--- a/MicroAOD/plugins/SingleVertexViewProducer.cc
+++ b/MicroAOD/plugins/SingleVertexViewProducer.cc
@@ -65,7 +65,7 @@ namespace flashgg {
             assert( found );
         }
 
-        std::auto_ptr<vector<SingleVertexView> > vertexViews( new vector<SingleVertexView> );
+        std::unique_ptr<vector<SingleVertexView> > vertexViews( new vector<SingleVertexView> );
         std::map<float, int> sortViews;
 
         int nCand = maxCandidates_;

--- a/MicroAOD/plugins/TagCandidateProducer.cc
+++ b/MicroAOD/plugins/TagCandidateProducer.cc
@@ -47,7 +47,7 @@ namespace flashgg {
     void TagCandidateProducer::produce( Event &evt, const EventSetup & )
     {
         
-        auto_ptr<std::vector<flashgg::TagCandidate> > tagsColl( new std::vector<flashgg::TagCandidate> );
+        unique_ptr<std::vector<flashgg::TagCandidate> > tagsColl( new std::vector<flashgg::TagCandidate> );
         
         Handle<edm::OwnVector<flashgg::DiPhotonTagBase> > tagSorter;
         evt.getByToken( tagSorterToken_, tagSorter );

--- a/MicroAOD/plugins/TagCandidateProducer.cc
+++ b/MicroAOD/plugins/TagCandidateProducer.cc
@@ -80,7 +80,7 @@ namespace flashgg {
             tagsColl->push_back( tags );
         }
  
-        evt.put( tagsColl );                               
+        evt.put( std::move( tagsColl ) );                               
     }
 }
 

--- a/MicroAOD/plugins/TagCandidateProducer.cc
+++ b/MicroAOD/plugins/TagCandidateProducer.cc
@@ -6,6 +6,7 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/EDMException.h"
 #include "FWCore/Common/interface/TriggerNames.h"
+#include "DataFormats/Common/interface/TriggerResults.h"
 #include "CommonTools/UtilAlgos/interface/TFileService.h"
 #include "DataFormats/Common/interface/Handle.h"
 

--- a/MicroAOD/plugins/VectorVectorJetCollector.cc
+++ b/MicroAOD/plugins/VectorVectorJetCollector.cc
@@ -43,7 +43,7 @@ namespace flashgg {
 
     void VectorVectorJetCollector::produce( Event &evt, const EventSetup & )
     {
-        auto_ptr<vector<vector<Jet> > > result( new vector<vector<Jet> > );
+        unique_ptr<vector<vector<Jet> > > result( new vector<vector<Jet> > );
 
         size_t output_size = 0;
         JetViewVector Jets( inputTagJets_.size() );

--- a/MicroAOD/plugins/VectorVectorJetCollector.cc
+++ b/MicroAOD/plugins/VectorVectorJetCollector.cc
@@ -61,7 +61,7 @@ namespace flashgg {
             }
         }
 
-        evt.put( result );
+        evt.put( std::move( result ) );
     }
 }
 typedef flashgg::VectorVectorJetCollector FlashggVectorVectorJetCollector;

--- a/MicroAOD/plugins/VertexMapFromCandidateProducer.cc
+++ b/MicroAOD/plugins/VertexMapFromCandidateProducer.cc
@@ -91,7 +91,7 @@ namespace flashgg {
 
         //        flashgg::print_track_count( *assoc, "FlashggVertexMapFromCandidateProducer" );
 
-        evt.put( assoc );
+        evt.put( std::move( assoc ) );
     } // produce method
 } // namespace flashgg
 

--- a/MicroAOD/plugins/VertexMapFromCandidateProducer.cc
+++ b/MicroAOD/plugins/VertexMapFromCandidateProducer.cc
@@ -52,7 +52,7 @@ namespace flashgg {
         Handle<View<pat::PackedCandidate> > pfCandidates;
         evt.getByToken( pfcandidateToken_, pfCandidates );
 
-        std::auto_ptr<VertexCandidateMap> assoc( new VertexCandidateMap );
+        std::unique_ptr<VertexCandidateMap> assoc( new VertexCandidateMap );
 
         for( unsigned int i = 0 ; i < pfCandidates->size() ; i++ ) {
             Ptr<pat::PackedCandidate> cand = pfCandidates->ptrAt( i );

--- a/MicroAOD/plugins/VertexMapValidator.cc
+++ b/MicroAOD/plugins/VertexMapValidator.cc
@@ -266,7 +266,7 @@ namespace flashgg {
 
         //		if (trkCounter > trackNumber) { std::cout << " [ISSUE] " << std::endl;}
         std::stable_sort( assoc->begin(), assoc->end(), flashgg::compare_by_vtx() );
-        evt.put( assoc );
+        evt.put( std::move( assoc ) );
 
         cout << trackNumber << "	" << trackNumberMiniAOD << "	" << matchCounter << std::endl;
     }

--- a/MicroAOD/plugins/VertexMapValidator.cc
+++ b/MicroAOD/plugins/VertexMapValidator.cc
@@ -94,7 +94,7 @@ namespace flashgg {
         }
 
         //used to store the final association from miniAOD vertice to miniAOD tracks (packed candidates)
-        std::auto_ptr<VertexCandidateMap> assoc( new VertexCandidateMap );
+        std::unique_ptr<VertexCandidateMap> assoc( new VertexCandidateMap );
 
         // print ifno for debugging
         std::cout << "AOD vtxs:  " <<  primaryVerticesAOD->size() << ", miniAOD vtxs: " << primaryVertices->size() << ", AOD tracks: " << trackNumber <<

--- a/MicroAOD/src/CutBasedDiPhotonObjectSelector.cc
+++ b/MicroAOD/src/CutBasedDiPhotonObjectSelector.cc
@@ -14,6 +14,11 @@ namespace flashgg {
         }
     }
 
+    bool CutBasedDiPhotonObjectSelector::operator()( const edm::Ref<edm::View<DiPhotonCandidate> > candref, const edm::EventBase &ev ) const 
+    {
+        return operator()( *candref,ev );
+    }
+
     bool CutBasedDiPhotonObjectSelector::operator()( const DiPhotonCandidate &cand, const EventBase &ev ) const
     {
         if( ! selector_( cand ) ) { return false; }

--- a/MicroAOD/src/CutBasedGenericObjectSelector.icc
+++ b/MicroAOD/src/CutBasedGenericObjectSelector.icc
@@ -5,8 +5,8 @@ using namespace edm;
 using namespace std;
 
 namespace flashgg {
-    template<class T>
-    CutBasedGenericObjectSelector<T>::CutBasedGenericObjectSelector( const ParameterSet &cfg, edm::ConsumesCollector &cc ) :
+    template<class InputCollection>
+    CutBasedGenericObjectSelector<InputCollection>::CutBasedGenericObjectSelector( const ParameterSet &cfg, edm::ConsumesCollector &cc ) :
         classifier_( cfg ),
         rhoToken_( cc.consumes<double>( cfg.getParameter<InputTag>( "rho" ) ) ),
         selector_( cfg.getParameter<string>( "cut" ) )
@@ -66,8 +66,8 @@ namespace flashgg {
         }
     }
 
-    template<class T>
-    void CutBasedGenericObjectSelector<T>::handle( const EventBase &ev ) const
+    template<class InputCollection>
+    void CutBasedGenericObjectSelector<InputCollection>::handle( const EventBase &ev ) const
     {
         edm::Handle<double> rho;
         const Event *ee = dynamic_cast<const Event *>( &ev );
@@ -76,8 +76,14 @@ namespace flashgg {
         rho_ = *rho;
     }
 
-    template<class T>
-    bool CutBasedGenericObjectSelector<T>::operator()( const T &cand, const EventBase &ev ) const
+    template<class InputCollection>
+    bool CutBasedGenericObjectSelector<InputCollection>::operator()( const Ref<InputCollection> candref, const EventBase &ev ) const
+    {
+        return operator()(*candref,ev);
+    }
+
+    template<class InputCollection>
+    bool CutBasedGenericObjectSelector<InputCollection>::operator()( const CutBasedGenericObjectSelector<InputCollection>::object_type &cand, const EventBase &ev ) const
     {
         if( ! selector_( cand ) ) { return false; }
         handle( ev );
@@ -90,8 +96,8 @@ namespace flashgg {
     }
 
 
-    template<class T>
-    bool CutBasedGenericObjectSelector<T>::passInverted( const T &pho ) const
+    template<class InputCollection>
+    bool CutBasedGenericObjectSelector<InputCollection>::passInverted( const CutBasedGenericObjectSelector<InputCollection>::object_type &pho ) const
     {
         auto cat = classifier_( pho );
         auto isel = selections_.find( cat.first );
@@ -112,8 +118,8 @@ namespace flashgg {
         return true;
     }
 
-    template<class T>
-    bool CutBasedGenericObjectSelector<T>::pass( const T &pho ) const
+    template<class InputCollection>
+    bool CutBasedGenericObjectSelector<InputCollection>::pass( const CutBasedGenericObjectSelector<InputCollection>::object_type &pho ) const
     {
         auto cat = classifier_( pho );
         auto isel = selections_.find( cat.first );

--- a/MicroAOD/src/CutBasedPhotonObjectSelector.cc
+++ b/MicroAOD/src/CutBasedPhotonObjectSelector.cc
@@ -69,6 +69,10 @@ namespace flashgg {
         rho_ = *rho;
     }
 
+    bool CutBasedPhotonObjectSelector::operator()( const edm::Ref<edm::View<Photon> > candref, const edm::EventBase &ev ) const {
+        return operator()(*candref,ev);
+    }
+
     bool CutBasedPhotonObjectSelector::operator()( const Photon &cand, const EventBase &ev ) const
     {
         if( ! selector_( cand ) ) { return false; }

--- a/MicroAOD/src/CutBasedPhotonViewSelector.cc
+++ b/MicroAOD/src/CutBasedPhotonViewSelector.cc
@@ -10,6 +10,11 @@ namespace flashgg {
     {
     }
 
+    bool CutBasedPhotonViewSelector::operator()( const edm::Ref<edm::View<SinglePhotonView> > candref, const edm::EventBase &ev ) const 
+    {
+        return operator()( *candref, ev );
+    }
+    
     bool CutBasedPhotonViewSelector::operator()( const SinglePhotonView &cand, const EventBase &ev ) const
     {
         return CutBasedPhotonObjectSelector::operator()( *cand.photon(), ev );

--- a/MicroAOD/test/microAODstd.py
+++ b/MicroAOD/test/microAODstd.py
@@ -17,6 +17,10 @@ process.MessageLogger.cerr.FwkReport.reportEvery = cms.untracked.int32( 1000 )
 import os
 if os.environ["CMSSW_VERSION"].count("CMSSW_8_0"):
     process.GlobalTag = GlobalTag(process.GlobalTag,'80X_mcRun2_asymptotic_2016_TrancheIV_v7','')
+    process.source = cms.Source("PoolSource",fileNames=cms.untracked.vstring("/store/mc/RunIISummer16MiniAODv2/GluGluHToGG_M-125_13TeV_powheg_pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/60000/024E4FA3-8BBC-E611-8E3D-00266CFFBE88.root"))
+elif os.environ["CMSSW_VERSION"].count("CMSSW_9_2"):
+    process.GlobalTag = GlobalTag(process.GlobalTag,'92X_dataRun2_Prompt_v4','')
+    process.source = cms.Source("PoolSource",fileNames=cms.untracked.vstring("/store/data/Run2017A/DoubleEG/MINIAOD/PromptReco-v2/000/296/173/00000/C24ABCFB-644C-E711-8A5E-02163E01A21C.root"))
 else:
     raise Exception,"The default setup for microAODstd.py does not support releases other than 80X"
 
@@ -25,11 +29,14 @@ process.RandomNumberGeneratorService.flashggRandomizedPhotons = cms.PSet(
           initialSeed = cms.untracked.uint32(16253245)
         )
 
+# 2017 Data
+#process.source = cms.Source("PoolSource",fileNames=cms.untracked.vstring("/store/data/Run2017A/DoubleEG/MINIAOD/PromptReco-v2/000/296/173/00000/C24ABCFB-644C-E711-8A5E-02163E01A21C.root"))
+
 # Legacy ReReco
 #process.source = cms.Source("PoolSource",fileNames=cms.untracked.vstring("/store/data/Run2016B/SingleElectron/MINIAOD/18Apr2017_ver1-v1/120000/40167FB6-6237-E711-934A-001E67E69E05.root"))
 
 #Moriond17 MC
-process.source = cms.Source("PoolSource",fileNames=cms.untracked.vstring("/store/mc/RunIISummer16MiniAODv2/GluGluHToGG_M-125_13TeV_powheg_pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/60000/024E4FA3-8BBC-E611-8E3D-00266CFFBE88.root"))
+#process.source = cms.Source("PoolSource",fileNames=cms.untracked.vstring("/store/mc/RunIISummer16MiniAODv2/GluGluHToGG_M-125_13TeV_powheg_pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/60000/024E4FA3-8BBC-E611-8E3D-00266CFFBE88.root"))
 
 #80x reminiAOD data
 #process.source = cms.Source("PoolSource",fileNames=cms.untracked.vstring("/store/data/Run2016G/DoubleEG/MINIAOD/03Feb2017-v1/100000/002F14FF-D0EA-E611-952E-008CFA197AF4.root"))

--- a/Systematics/interface/ObjectSystematicProducer.h
+++ b/Systematics/interface/ObjectSystematicProducer.h
@@ -263,7 +263,7 @@ namespace flashgg {
         
         // Build central collection
         std::vector<float> centralWeights;
-        auto_ptr<output_container<flashgg_object> > centralObjectColl( new output_container<flashgg_object> );
+        unique_ptr<output_container<flashgg_object> > centralObjectColl( new output_container<flashgg_object> );
         for( unsigned int i = 0; i < objects->size(); i++ ) {
             flashgg_object *p_obj = objects->ptrAt( i )->clone();
             flashgg_object obj = *p_obj;
@@ -278,13 +278,13 @@ namespace flashgg {
         //        std::cout << " after producing central" << std::endl;
 
         // build 2N shifted collections
-        // A dynamically allocated array of auto_ptrs may be a bit "unsafe" to maintain,
+        // A dynamically allocated array of unique_ptrs may be a bit "unsafe" to maintain,
         // although I think I have done it correctly - the delete[] statement below is vital
-        // Problem: vector<auto_ptr> is not allowed
+        // Problem: vector<unique_ptr> is not allowed
         // Possible alternate solutions: map, multimap, vector<unique_ptr> + std::move ??
-        std::auto_ptr<output_container<flashgg_object> > *all_shifted_collections;
+        std::unique_ptr<output_container<flashgg_object> > *all_shifted_collections;
         unsigned int total_shifted_collections = collectionLabelsNonCentral_.size();
-        all_shifted_collections = new std::auto_ptr<output_container<flashgg_object> >[total_shifted_collections];
+        all_shifted_collections = new std::unique_ptr<output_container<flashgg_object> >[total_shifted_collections];
         for( unsigned int ncoll = 0 ; ncoll < total_shifted_collections ; ncoll++ ) {
             all_shifted_collections[ncoll].reset( new output_container<flashgg_object> );
         }
@@ -325,7 +325,7 @@ namespace flashgg {
             evt.put( all_shifted_collections[ncoll], collectionLabelsNonCentral_[ncoll] );
         }
 
-        // See note above about array of auto_ptr
+        // See note above about array of unique_ptr
         delete[] all_shifted_collections;
 
     } // end of event

--- a/Systematics/interface/ObjectSystematicProducer.h
+++ b/Systematics/interface/ObjectSystematicProducer.h
@@ -273,7 +273,7 @@ namespace flashgg {
             centralWeights.push_back( obj.centralWeight() );
             centralObjectColl->push_back( obj );
         }
-        evt.put( centralObjectColl ); // put central collection in event
+        evt.put( std::move(centralObjectColl) ); // put central collection in event
 
         //        std::cout << " after producing central" << std::endl;
 
@@ -322,7 +322,7 @@ namespace flashgg {
 
         // Put shifted collections in event
         for( unsigned int ncoll = 0 ; ncoll < total_shifted_collections ; ncoll++ ) {
-            evt.put( all_shifted_collections[ncoll], collectionLabelsNonCentral_[ncoll] );
+            evt.put( std::move(all_shifted_collections[ncoll]), collectionLabelsNonCentral_[ncoll] );
         }
 
         // See note above about array of unique_ptr

--- a/Taggers/plugins/DiPhotonMVAProducer.cc
+++ b/Taggers/plugins/DiPhotonMVAProducer.cc
@@ -199,8 +199,8 @@ namespace flashgg {
         double dummy[1]={0.};
 
  
-        //    std::auto_ptr<DiPhotonMVAResultMap> assoc(new DiPhotonMVAResultMap);
-        std::auto_ptr<vector<DiPhotonMVAResult> > results( new vector<DiPhotonMVAResult> ); // one per diphoton, always in same order, vector is more efficient than map
+        //    std::unique_ptr<DiPhotonMVAResultMap> assoc(new DiPhotonMVAResultMap);
+        std::unique_ptr<vector<DiPhotonMVAResult> > results( new vector<DiPhotonMVAResult> ); // one per diphoton, always in same order, vector is more efficient than map
 
         for( unsigned int candIndex = 0; candIndex < diPhotons->size() ; candIndex++ ) {
             flashgg::DiPhotonMVAResult mvares;

--- a/Taggers/plugins/DiPhotonMVAProducer.cc
+++ b/Taggers/plugins/DiPhotonMVAProducer.cc
@@ -322,7 +322,7 @@ namespace flashgg {
 
             results->push_back( mvares );
         }
-        evt.put( results );
+        evt.put( std::move( results ) );
     }
 }
 

--- a/Taggers/plugins/DiPhotonWithUpdatedPhoIdMVAProducer.cc
+++ b/Taggers/plugins/DiPhotonWithUpdatedPhoIdMVAProducer.cc
@@ -287,7 +287,7 @@ namespace flashgg {
             out_obj->push_back(*new_obj);
             delete new_obj;
         }
-        evt.put(out_obj);
+        evt.put( std::move(out_obj) );
     }
 }
 

--- a/Taggers/plugins/DiPhotonWithUpdatedPhoIdMVAProducer.cc
+++ b/Taggers/plugins/DiPhotonWithUpdatedPhoIdMVAProducer.cc
@@ -208,7 +208,7 @@ namespace flashgg {
             }
         }
         
-        auto_ptr<std::vector<flashgg::DiPhotonCandidate> > out_obj( new std::vector<flashgg::DiPhotonCandidate>() );
+        unique_ptr<std::vector<flashgg::DiPhotonCandidate> > out_obj( new std::vector<flashgg::DiPhotonCandidate>() );
 
         for (const auto & obj : *objects) {
             flashgg::DiPhotonCandidate *new_obj = obj.clone();

--- a/Taggers/plugins/SigmaMpTTagProducer.cc
+++ b/Taggers/plugins/SigmaMpTTagProducer.cc
@@ -102,8 +102,8 @@ namespace flashgg {
 
         Handle<View<reco::GenParticle> > genParticles;
 
-        std::auto_ptr<vector<SigmaMpTTag> > tags( new vector<SigmaMpTTag> );
-        std::auto_ptr<vector<TagTruthBase> > truths( new vector<TagTruthBase> );
+        std::unique_ptr<vector<SigmaMpTTag> > tags( new vector<SigmaMpTTag> );
+        std::unique_ptr<vector<TagTruthBase> > truths( new vector<TagTruthBase> );
 
         Point higgsVtx;
         if( ! evt.isRealData() ) {

--- a/Taggers/plugins/SigmaMpTTagProducer.cc
+++ b/Taggers/plugins/SigmaMpTTagProducer.cc
@@ -159,8 +159,8 @@ namespace flashgg {
                 }
             }
         }
-        evt.put( tags );
-        evt.put( truths );
+        evt.put( std::move( tags ) );
+        evt.put( std::move( truths ) );
     }
 }
 

--- a/Taggers/plugins/TTHHadronicTagProducer.cc
+++ b/Taggers/plugins/TTHHadronicTagProducer.cc
@@ -495,8 +495,8 @@ namespace flashgg {
                 // count++;
             }
         }
-        evt.put( tthhtags );
-        evt.put( truths );
+        evt.put( std::move( tthhtags ) );
+        evt.put( std::move( truths ) );
         // cout << "tagged events = " << count << endl;
     }
 }

--- a/Taggers/plugins/TTHHadronicTagProducer.cc
+++ b/Taggers/plugins/TTHHadronicTagProducer.cc
@@ -263,8 +263,8 @@ namespace flashgg {
 
         Handle<View<reco::GenParticle> > genParticles;
 
-        std::auto_ptr<vector<TTHHadronicTag> > tthhtags( new vector<TTHHadronicTag> );
-        std::auto_ptr<vector<TagTruthBase> > truths( new vector<TagTruthBase> );
+        std::unique_ptr<vector<TTHHadronicTag> > tthhtags( new vector<TTHHadronicTag> );
+        std::unique_ptr<vector<TagTruthBase> > truths( new vector<TagTruthBase> );
 
         Point higgsVtx;
         if( ! evt.isRealData() ) {

--- a/Taggers/plugins/TTHLeptonicTagProducer.cc
+++ b/Taggers/plugins/TTHLeptonicTagProducer.cc
@@ -212,12 +212,12 @@ namespace flashgg {
 
         Handle<View<reco::GenParticle> > genParticles;
 
-        std::auto_ptr<vector<TTHLeptonicTag> > tthltags( new vector<TTHLeptonicTag> );
+        std::unique_ptr<vector<TTHLeptonicTag> > tthltags( new vector<TTHLeptonicTag> );
 
         Handle<View<reco::Vertex> > vertices;
         evt.getByToken( vertexToken_, vertices );
 
-        std::auto_ptr<vector<TagTruthBase> > truths( new vector<TagTruthBase> );
+        std::unique_ptr<vector<TagTruthBase> > truths( new vector<TagTruthBase> );
 
         Point higgsVtx;
 

--- a/Taggers/plugins/TTHLeptonicTagProducer.cc
+++ b/Taggers/plugins/TTHLeptonicTagProducer.cc
@@ -598,8 +598,8 @@ namespace flashgg {
             }
 
         }//diPho loop end !
-        evt.put( tthltags );
-        evt.put( truths );
+        evt.put( std::move( tthltags ) );
+        evt.put( std::move( truths ) );
     }
 
 }

--- a/Taggers/plugins/TagSorter.cc
+++ b/Taggers/plugins/TagSorter.cc
@@ -128,8 +128,8 @@ namespace flashgg {
 
     void TagSorter::produce( Event &evt, const EventSetup & )
     {
-        auto_ptr<edm::OwnVector<flashgg::DiPhotonTagBase> > SelectedTag( new edm::OwnVector<flashgg::DiPhotonTagBase> );
-        auto_ptr<edm::OwnVector<flashgg::TagTruthBase> > SelectedTagTruth( new edm::OwnVector<flashgg::TagTruthBase> );
+        unique_ptr<edm::OwnVector<flashgg::DiPhotonTagBase> > SelectedTag( new edm::OwnVector<flashgg::DiPhotonTagBase> );
+        unique_ptr<edm::OwnVector<flashgg::TagTruthBase> > SelectedTagTruth( new edm::OwnVector<flashgg::TagTruthBase> );
 
         // Cache other tags for each event; but do not use the old ones next time
         otherTags_.clear(); 

--- a/Taggers/plugins/TagSorter.cc
+++ b/Taggers/plugins/TagSorter.cc
@@ -339,8 +339,8 @@ namespace flashgg {
                 std::cout << "******************************" << std::endl;
             }
         }
-        evt.put( SelectedTag );
-        evt.put( SelectedTagTruth );
+        evt.put( std::move( SelectedTag ) );
+        evt.put( std::move( SelectedTagTruth ) );
     }
 
     string TagSorter::tagName(DiPhotonTagBase::tag_t tagEnumVal) const {

--- a/Taggers/plugins/TaggedGenDiPhotonProducer.cc
+++ b/Taggers/plugins/TaggedGenDiPhotonProducer.cc
@@ -62,7 +62,7 @@ namespace flashgg {
         
         Handle<View<flashgg::GenDiPhoton> > src;
         evt.getByToken( src_, src );
-        std::auto_ptr<vector<GenDiPhoton> > diphotons( new vector<GenDiPhoton> );
+        std::unique_ptr<vector<GenDiPhoton> > diphotons( new vector<GenDiPhoton> );
         
         for(auto & dipho : *src) {
             GenDiPhoton newdipho = dipho;

--- a/Taggers/plugins/TaggedGenDiPhotonProducer.cc
+++ b/Taggers/plugins/TaggedGenDiPhotonProducer.cc
@@ -74,7 +74,7 @@ namespace flashgg {
             /// cout << "TaggedGenDiPhotonProducer dipho " << newdipho.categoryNumber() << " " << (int)newdipho << endl;
         }
         
-        evt.put( diphotons );
+        evt.put( std::move( diphotons ) );
     }
 }
 

--- a/Taggers/plugins/UntaggedTagProducer.cc
+++ b/Taggers/plugins/UntaggedTagProducer.cc
@@ -162,8 +162,8 @@ namespace flashgg {
                 }
             }
         }
-        evt.put( tags );
-        evt.put( truths );
+        evt.put( std::move( tags ) );
+        evt.put( std::move( truths ) );
     }
 }
 

--- a/Taggers/plugins/UntaggedTagProducer.cc
+++ b/Taggers/plugins/UntaggedTagProducer.cc
@@ -97,8 +97,8 @@ namespace flashgg {
 
         Handle<View<reco::GenParticle> > genParticles;
 
-        std::auto_ptr<vector<UntaggedTag> > tags( new vector<UntaggedTag> );
-        std::auto_ptr<vector<TagTruthBase> > truths( new vector<TagTruthBase> );
+        std::unique_ptr<vector<UntaggedTag> > tags( new vector<UntaggedTag> );
+        std::unique_ptr<vector<TagTruthBase> > truths( new vector<TagTruthBase> );
 
         Point higgsVtx;
         if( ! evt.isRealData() ) {

--- a/Taggers/plugins/VBFDiPhoDiJetMVAProducer.cc
+++ b/Taggers/plugins/VBFDiPhoDiJetMVAProducer.cc
@@ -125,7 +125,7 @@ namespace flashgg {
             
             vbfDiPhoDiJet_results->push_back( mvares );
         }
-        evt.put( vbfDiPhoDiJet_results );
+        evt.put( std::move( vbfDiPhoDiJet_results ) );
     }
 }
 

--- a/Taggers/plugins/VBFDiPhoDiJetMVAProducer.cc
+++ b/Taggers/plugins/VBFDiPhoDiJetMVAProducer.cc
@@ -90,7 +90,7 @@ namespace flashgg {
         evt.getByToken( mvaResultToken_, mvaResults );
 //		const PtrVector<flashgg::DiPhotonMVAResult>& mvaResultPointers = mvaResults->ptrVector();
         
-        std::auto_ptr<vector<VBFDiPhoDiJetMVAResult> > vbfDiPhoDiJet_results( new vector<VBFDiPhoDiJetMVAResult> );
+        std::unique_ptr<vector<VBFDiPhoDiJetMVAResult> > vbfDiPhoDiJet_results( new vector<VBFDiPhoDiJetMVAResult> );
         // one per diphoton, always in same order, vector is more efficient than map
 
         for( unsigned int candIndex = 0; candIndex < diPhotons->size() ; candIndex++ ) {

--- a/Taggers/plugins/VBFMVAProducer.cc
+++ b/Taggers/plugins/VBFMVAProducer.cc
@@ -167,7 +167,7 @@ namespace flashgg {
             evt.getByToken( tokenJets_[j], Jets[j] );
         }
         
-        std::auto_ptr<vector<VBFMVAResult> > vbf_results( new vector<VBFMVAResult> );
+        std::unique_ptr<vector<VBFMVAResult> > vbf_results( new vector<VBFMVAResult> );
         for( unsigned int candIndex = 0; candIndex < diPhotons->size() ; candIndex++ ) {
             
             flashgg::VBFMVAResult mvares;

--- a/Taggers/plugins/VBFMVAProducer.cc
+++ b/Taggers/plugins/VBFMVAProducer.cc
@@ -454,7 +454,7 @@ namespace flashgg {
             
             vbf_results->push_back( mvares );
         }
-        evt.put( vbf_results );
+        evt.put( std::move( vbf_results ) );
     }
 }
 

--- a/Taggers/plugins/VBFTagProducer.cc
+++ b/Taggers/plugins/VBFTagProducer.cc
@@ -130,8 +130,8 @@ namespace flashgg {
             evt.getByToken( WeightToken_, WeightHandle );
         }
 
-        std::auto_ptr<vector<VBFTag> >      tags  ( new vector<VBFTag> );
-        std::auto_ptr<vector<VBFTagTruth> > truths( new vector<VBFTagTruth> );
+        std::unique_ptr<vector<VBFTag> >      tags  ( new vector<VBFTag> );
+        std::unique_ptr<vector<VBFTagTruth> > truths( new vector<VBFTagTruth> );
 
         unsigned int idx = 0;
         edm::RefProd<vector<VBFTagTruth> > rTagTruth = evt.getRefBeforePut<vector<VBFTagTruth> >();

--- a/Taggers/plugins/VBFTagProducer.cc
+++ b/Taggers/plugins/VBFTagProducer.cc
@@ -581,8 +581,8 @@ namespace flashgg {
             }
         }
 
-        evt.put( tags );
-        evt.put( truths );
+        evt.put( std::move( tags ) );
+        evt.put( std::move( truths ) );
     }
 }
 

--- a/Taggers/plugins/VHEtTagProducer.cc
+++ b/Taggers/plugins/VHEtTagProducer.cc
@@ -306,8 +306,8 @@ namespace flashgg {
                    vhettags->back().setTagTruth( edm::refToPtr( edm::Ref<vector<VHTagTruth> >( rTagTruth, idx++ ) ) );
                }
         }
-        evt.put( vhettags );
-        evt.put( truths );
+        evt.put( std::move( vhettags ) );
+        evt.put( std::move( truths ) );
     }
 }
 

--- a/Taggers/plugins/VHEtTagProducer.cc
+++ b/Taggers/plugins/VHEtTagProducer.cc
@@ -100,8 +100,8 @@ namespace flashgg {
 
         Handle<View<reco::GenParticle> > genParticles;
 
-        std::auto_ptr<vector<VHEtTag> > vhettags( new vector<VHEtTag> );
-        std::auto_ptr<vector<VHTagTruth> > truths( new vector<VHTagTruth> );
+        std::unique_ptr<vector<VHEtTag> > vhettags( new vector<VHEtTag> );
+        std::unique_ptr<vector<VHTagTruth> > truths( new vector<VHTagTruth> );
         
         Point higgsVtx;
         bool associatedZ=0;

--- a/Taggers/plugins/VHHadronicTagProducer.cc
+++ b/Taggers/plugins/VHHadronicTagProducer.cc
@@ -147,8 +147,8 @@ namespace flashgg {
 
         Handle<View<reco::GenParticle> > genParticles;
 
-        std::auto_ptr<vector<VHHadronicTag> > vhhadtags( new vector<VHHadronicTag> );
-        std::auto_ptr<vector<VHTagTruth> > truths( new vector<VHTagTruth> );
+        std::unique_ptr<vector<VHHadronicTag> > vhhadtags( new vector<VHHadronicTag> );
+        std::unique_ptr<vector<VHTagTruth> > truths( new vector<VHTagTruth> );
         
         Point higgsVtx;
         bool associatedZ=0;

--- a/Taggers/plugins/VHHadronicTagProducer.cc
+++ b/Taggers/plugins/VHHadronicTagProducer.cc
@@ -330,8 +330,8 @@ namespace flashgg {
                 vhhadtags->back().setTagTruth( edm::refToPtr( edm::Ref<vector<VHTagTruth> >( rTagTruth, idx++ ) ) );
             }
         }
-        evt.put( vhhadtags );
-        evt.put( truths );
+        evt.put( std::move( vhhadtags ) );
+        evt.put( std::move( truths ) );
     }
 
 

--- a/Taggers/plugins/VHLeptonicLoose.cc
+++ b/Taggers/plugins/VHLeptonicLoose.cc
@@ -205,8 +205,8 @@ namespace flashgg {
 
         Handle<View<reco::GenParticle> > genParticles;
 
-        std::auto_ptr<vector<VHLeptonicLooseTag> > VHLeptonicLooseTags( new vector<VHLeptonicLooseTag> );
-        std::auto_ptr<vector<VHTagTruth> > truths( new vector<VHTagTruth> );
+        std::unique_ptr<vector<VHLeptonicLooseTag> > VHLeptonicLooseTags( new vector<VHLeptonicLooseTag> );
+        std::unique_ptr<vector<VHTagTruth> > truths( new vector<VHTagTruth> );
 
         Point higgsVtx;
         bool associatedZ=0;

--- a/Taggers/plugins/VHLeptonicLoose.cc
+++ b/Taggers/plugins/VHLeptonicLoose.cc
@@ -471,8 +471,8 @@ namespace flashgg {
                 }
             }
         }
-        evt.put( VHLeptonicLooseTags );
-        evt.put( truths );
+        evt.put( std::move( VHLeptonicLooseTags ) );
+        evt.put( std::move( truths ) );
     }
 
 }

--- a/Taggers/plugins/VHLooseTagProducer.cc
+++ b/Taggers/plugins/VHLooseTagProducer.cc
@@ -198,7 +198,7 @@ namespace flashgg {
         Handle<View<reco::GenParticle> > genParticles;
 
         //const PtrVector<flashgg::DiPhotonMVAResult>& mvaResultPointers = mvaResults->ptrVector();
-        std::auto_ptr<vector<VHLooseTag> > vhloosetags( new vector<VHLooseTag> );
+        std::unique_ptr<vector<VHLooseTag> > vhloosetags( new vector<VHLooseTag> );
 
         Handle<View<flashgg::Met> > METs;
         evt.getByToken( METToken_, METs );
@@ -210,7 +210,7 @@ namespace flashgg {
 
         assert( diPhotons->size() == mvaResults->size() );
 
-        std::auto_ptr<vector<VHTagTruth> > truths( new vector<VHTagTruth> );
+        std::unique_ptr<vector<VHTagTruth> > truths( new vector<VHTagTruth> );
         Point higgsVtx;
         bool associatedZ=0;
         bool associatedW=0;

--- a/Taggers/plugins/VHLooseTagProducer.cc
+++ b/Taggers/plugins/VHLooseTagProducer.cc
@@ -435,8 +435,8 @@ namespace flashgg {
                     }
             }
         }
-        evt.put( vhloosetags );
-        evt.put( truths );
+        evt.put( std::move( vhloosetags ) );
+        evt.put( std::move( truths ) );
     }
 
 }

--- a/Taggers/plugins/VHMetTagProducer.cc
+++ b/Taggers/plugins/VHMetTagProducer.cc
@@ -144,8 +144,8 @@ namespace flashgg {
 
         Handle<View<reco::GenParticle> > genParticles;
 
-        std::auto_ptr<vector<VHMetTag> > vhettags( new vector<VHMetTag> );
-        std::auto_ptr<vector<VHTagTruth> > truths( new vector<VHTagTruth> );
+        std::unique_ptr<vector<VHMetTag> > vhettags( new vector<VHMetTag> );
+        std::unique_ptr<vector<VHTagTruth> > truths( new vector<VHTagTruth> );
         
         Point higgsVtx;
         bool associatedZ=0;

--- a/Taggers/plugins/VHMetTagProducer.cc
+++ b/Taggers/plugins/VHMetTagProducer.cc
@@ -330,8 +330,8 @@ namespace flashgg {
                     vhettags->back().setTagTruth( edm::refToPtr( edm::Ref<vector<VHTagTruth> >( rTagTruth, idx++ ) ) );
                 }
         }
-        evt.put( vhettags );
-        evt.put( truths );
+        evt.put( std::move( vhettags ) );
+        evt.put( std::move( truths ) );
     }
 }
 

--- a/Taggers/plugins/VHTightTagProducer.cc
+++ b/Taggers/plugins/VHTightTagProducer.cc
@@ -212,8 +212,8 @@ namespace flashgg {
 
         Handle<View<reco::GenParticle> > genParticles;
 
-        std::auto_ptr<vector<VHTightTag> > VHTightTags( new vector<VHTightTag> );
-        std::auto_ptr<vector<VHTagTruth> > truths( new vector<VHTagTruth> );
+        std::unique_ptr<vector<VHTightTag> > VHTightTags( new vector<VHTightTag> );
+        std::unique_ptr<vector<VHTagTruth> > truths( new vector<VHTagTruth> );
 
         Point higgsVtx;
         bool associatedZ=0;

--- a/Taggers/plugins/VHTightTagProducer.cc
+++ b/Taggers/plugins/VHTightTagProducer.cc
@@ -536,8 +536,8 @@ namespace flashgg {
                 }
             }
         }
-        evt.put( VHTightTags );
-        evt.put( truths );
+        evt.put( std::move( VHTightTags ) );
+        evt.put( std::move( truths ) );
     }
 
 }

--- a/Taggers/plugins/VectorVectorJetUnpacker.cc
+++ b/Taggers/plugins/VectorVectorJetUnpacker.cc
@@ -59,7 +59,7 @@ namespace flashgg {
         }
 
         for( unsigned int i = 0 ; i < nCollections_ ; i++ ) {
-            auto_ptr<vector<Jet> > result( new vector<Jet> );
+            unique_ptr<vector<Jet> > result( new vector<Jet> );
             if( theJets->size() > i ) {
                 for( unsigned int j = 0 ; j < theJets->at( i ).size() ; j++ ) {
                     result->push_back( theJets->at( i )[j] );

--- a/Taggers/plugins/VectorVectorJetUnpacker.cc
+++ b/Taggers/plugins/VectorVectorJetUnpacker.cc
@@ -67,7 +67,7 @@ namespace flashgg {
             }
             char number[2];
             sprintf( number, "%u", i );
-            evt.put( result, number );
+            evt.put( std::move( result) , number );
         }
     }
 }

--- a/Taggers/plugins/WHLeptonicTagProducer.cc
+++ b/Taggers/plugins/WHLeptonicTagProducer.cc
@@ -442,8 +442,8 @@ namespace flashgg {
                     }
             }
         }
-        evt.put( whleptonictags );
-        evt.put( truths );
+        evt.put( std::move( whleptonictags ) );
+        evt.put( std::move( truths ) );
     }
 
 }

--- a/Taggers/plugins/WHLeptonicTagProducer.cc
+++ b/Taggers/plugins/WHLeptonicTagProducer.cc
@@ -204,7 +204,7 @@ namespace flashgg {
 
         Handle<View<reco::GenParticle> > genParticles;
 
-        std::auto_ptr<vector<WHLeptonicTag> > whleptonictags( new vector<WHLeptonicTag> );
+        std::unique_ptr<vector<WHLeptonicTag> > whleptonictags( new vector<WHLeptonicTag> );
 
         Handle<View<flashgg::Met> > METs;
         evt.getByToken( METToken_, METs );
@@ -214,7 +214,7 @@ namespace flashgg {
 
         assert( diPhotons->size() == mvaResults->size() );
 
-        std::auto_ptr<vector<VHTagTruth> > truths( new vector<VHTagTruth> );
+        std::unique_ptr<vector<VHTagTruth> > truths( new vector<VHTagTruth> );
         Point higgsVtx;
         bool associatedZ=0;
         bool associatedW=0;

--- a/Taggers/plugins/ZHLeptonicTagProducer.cc
+++ b/Taggers/plugins/ZHLeptonicTagProducer.cc
@@ -350,8 +350,8 @@ namespace flashgg {
                 }
             }
         }
-        evt.put( ZHLeptonicTags );
-        evt.put( truths );
+        evt.put( std::move( ZHLeptonicTags ) );
+        evt.put( std::move( truths ) );
     }
 }
 typedef flashgg::ZHLeptonicTagProducer FlashggZHLeptonicTagProducer;

--- a/Taggers/plugins/ZHLeptonicTagProducer.cc
+++ b/Taggers/plugins/ZHLeptonicTagProducer.cc
@@ -171,8 +171,8 @@ namespace flashgg {
 
         Handle<View<reco::GenParticle> > genParticles;
 
-        std::auto_ptr<vector<ZHLeptonicTag> > ZHLeptonicTags( new vector<ZHLeptonicTag> );
-        std::auto_ptr<vector<VHTagTruth> > truths( new vector<VHTagTruth> );
+        std::unique_ptr<vector<ZHLeptonicTag> > ZHLeptonicTags( new vector<ZHLeptonicTag> );
+        std::unique_ptr<vector<VHTagTruth> > truths( new vector<VHTagTruth> );
 
         Point higgsVtx;
         bool associatedZ=0;

--- a/Taggers/plugins/ZPlusJetTagProducer.cc
+++ b/Taggers/plugins/ZPlusJetTagProducer.cc
@@ -162,8 +162,8 @@ namespace flashgg {
             }
         }
 
-        evt.put( tags );
-        //        evt.put( truths );
+        evt.put( std::move( tags ) );
+        //        evt.put( std::move( truths ) );
     }
 }
 

--- a/Taggers/plugins/ZPlusJetTagProducer.cc
+++ b/Taggers/plugins/ZPlusJetTagProducer.cc
@@ -82,8 +82,8 @@ namespace flashgg {
             evt.getByToken( tokenJets_[j], Jets[j] );
         }
        
-        std::auto_ptr<vector<ZPlusJetTag> >      tags  ( new vector<ZPlusJetTag> );
-        //        std::auto_ptr<vector<ZPlusJetTagTruth> > truths( new vector<ZPlusJetTagTruth> );
+        std::unique_ptr<vector<ZPlusJetTag> >      tags  ( new vector<ZPlusJetTag> );
+        //        std::unique_ptr<vector<ZPlusJetTagTruth> > truths( new vector<ZPlusJetTagTruth> );
 
         //        unsigned int idx = 0;
         //        edm::RefProd<vector<ZPlusJetTagTruth> > rTagTruth = evt.getRefBeforePut<vector<ZPlusJetTagTruth> >();

--- a/Validation/plugins/FlashggSampleInfoTree.cc
+++ b/Validation/plugins/FlashggSampleInfoTree.cc
@@ -59,11 +59,11 @@ void tnp::FlashggSampleInfoTree::endLuminosityBlock(edm::LuminosityBlock const& 
 void tnp::FlashggSampleInfoTree::endLuminosityBlockProduce(edm::LuminosityBlock & theLuminosityBlock, const edm::EventSetup & theSetup) {
   //LogTrace("WeightsCounting") << "endLumi: adding " << weightProcessedInLumi_ << " events" << endl;
   
-  std::auto_ptr<edm::MergeableDouble> numWeightssPtr(new edm::MergeableDouble);
+  std::unique_ptr<edm::MergeableDouble> numWeightssPtr(new edm::MergeableDouble);
   numWeightssPtr->value = sumWeight_;
   theLuminosityBlock.put(numWeightssPtr, "totalGenWeight");
   
-  std::auto_ptr<edm::MergeableDouble> numEventsPtr(new edm::MergeableDouble);
+  std::unique_ptr<edm::MergeableDouble> numEventsPtr(new edm::MergeableDouble);
   numEventsPtr->value = nEvents_;
   theLuminosityBlock.put(numEventsPtr, "totalEvent");
   //return;

--- a/Validation/plugins/FlashggSampleInfoTree.cc
+++ b/Validation/plugins/FlashggSampleInfoTree.cc
@@ -61,11 +61,11 @@ void tnp::FlashggSampleInfoTree::endLuminosityBlockProduce(edm::LuminosityBlock 
   
   std::unique_ptr<edm::MergeableDouble> numWeightssPtr(new edm::MergeableDouble);
   numWeightssPtr->value = sumWeight_;
-  theLuminosityBlock.put(numWeightssPtr, "totalGenWeight");
+  theLuminosityBlock.put( std::move(numWeightssPtr) , "totalGenWeight");
   
   std::unique_ptr<edm::MergeableDouble> numEventsPtr(new edm::MergeableDouble);
   numEventsPtr->value = nEvents_;
-  theLuminosityBlock.put(numEventsPtr, "totalEvent");
+  theLuminosityBlock.put( std::move(numEventsPtr) , "totalEvent");
   //return;
   //addTree_->Fill();
   

--- a/Validation/plugins/PhotonFromDiPhotonProducer.cc
+++ b/Validation/plugins/PhotonFromDiPhotonProducer.cc
@@ -50,7 +50,7 @@ namespace flashgg {
         std::vector<bool> preselValues;
         evt.getByToken(diPhotonToken_, diPhotons);
 
-        std::auto_ptr<std::vector<flashgg::Photon> > photonColl(new std::vector<flashgg::Photon>);
+        std::unique_ptr<std::vector<flashgg::Photon> > photonColl(new std::vector<flashgg::Photon>);
 
         // MATTEO FIXME IN THE MICROAOD PRODUCER
         if (!diPhotons.failedToGet()) {
@@ -94,13 +94,13 @@ namespace flashgg {
         
         edm::OrphanHandle<std::vector<flashgg::Photon> > photonCollH = evt.put(photonColl); 
         
-        std::auto_ptr<edm::ValueMap<float> > idValMap(new edm::ValueMap<float>());
+        std::unique_ptr<edm::ValueMap<float> > idValMap(new edm::ValueMap<float>());
         edm::ValueMap<float>::Filler idFiller(*idValMap);
         idFiller.insert(photonCollH, idValues.begin(), idValues.end());
         idFiller.fill();
         evt.put(idValMap, "idmva");
 
-        std::auto_ptr<edm::ValueMap<bool> > preselValMap(new edm::ValueMap<bool>());
+        std::unique_ptr<edm::ValueMap<bool> > preselValMap(new edm::ValueMap<bool>());
         edm::ValueMap<bool>::Filler preselFiller(*preselValMap);
         preselFiller.insert(photonCollH, preselValues.begin(), preselValues.end());
         preselFiller.fill();

--- a/Validation/plugins/PhotonFromDiPhotonProducer.cc
+++ b/Validation/plugins/PhotonFromDiPhotonProducer.cc
@@ -92,19 +92,19 @@ namespace flashgg {
             
         }
         
-        edm::OrphanHandle<std::vector<flashgg::Photon> > photonCollH = evt.put(photonColl); 
+        edm::OrphanHandle<std::vector<flashgg::Photon> > photonCollH = evt.put( std::move(photonColl) ); 
         
         std::unique_ptr<edm::ValueMap<float> > idValMap(new edm::ValueMap<float>());
         edm::ValueMap<float>::Filler idFiller(*idValMap);
         idFiller.insert(photonCollH, idValues.begin(), idValues.end());
         idFiller.fill();
-        evt.put(idValMap, "idmva");
+        evt.put( std::move(idValMap) , "idmva");
 
         std::unique_ptr<edm::ValueMap<bool> > preselValMap(new edm::ValueMap<bool>());
         edm::ValueMap<bool>::Filler preselFiller(*preselValMap);
         preselFiller.insert(photonCollH, preselValues.begin(), preselValues.end());
         preselFiller.fill();
-        evt.put(preselValMap, "preselection");        
+        evt.put( std::move(preselValMap) , "preselection");        
     }
 }
 

--- a/setup_9_2_0.sh
+++ b/setup_9_2_0.sh
@@ -1,0 +1,170 @@
+#!/bin/bash
+
+SETUP_REMOTES=false
+
+echo
+echo "Welcome to the FLASHgg automagic setup script!"
+
+if [ ! -f $CMSSW_BASE/src/.git/HEAD ];
+then
+  echo "CMSSW area appears not to be set up correctly. Check README carefully."
+  echo
+  return 1
+fi
+
+NFILES=`ls -1 ${CMSSW_BASE}/src | wc -l`
+if [ ! ${NFILES} = "1" ]
+then
+  echo "CMSSW area appears to have extra files already. Start over and check README carefully."
+  echo "You can remove this condition from the setup script if you wish, but proceed with caution!"
+  echo
+  return 1
+fi
+
+echo
+echo "You should have checked out from cms-analysis/flashgg. Renaming this to upstream for convenience of existing developers..."
+cd $CMSSW_BASE/src/flashgg
+git remote rename origin upstream
+git remote set-url --push upstream DISALLOWED
+GITHUBUSERNAME=`git config user.github`
+echo "Setting up a new origin repo, assuming your fork name is ${GITHUBUSERNAME} - check this!"
+git remote add origin git@github.com:${GITHUBUSERNAME}/flashgg.git
+git config branch.master.remote origin
+git config merge.renamelimit 2000
+
+if ${SETUP_REMOTES} ; then
+  echo "Setting up remotes listed in setup script..."
+  cd $CMSSW_BASE/src/flashgg
+  git remote add abeschi https://github.com/abeschi/flashgg
+  git remote add andreh7 https://github.com/andreh7/flashgg
+  git remote add andreypz https://github.com/andreypz/flashgg
+  git remote add ArnabPurohit https://github.com/ArnabPurohit/flashgg
+  git remote add bcourbon https://github.com/bcourbon/flashgg
+  git remote add bmarzocc https://github.com/bmarzocc/flashgg
+  git remote add camendola https://github.com/camendola/flashgg
+  git remote add camilocarrillo https://github.com/camilocarrillo/flashgg
+  git remote add cathatino https://github.com/cathatino/flashgg
+  git remote add cms-flashgg https://github.com/cms-flashgg/flashgg
+  git remote add CMSttHggAnalysis https://github.com/CMSttHggAnalysis/flashgg
+  git remote add crovelli https://github.com/crovelli/flashgg
+  git remote add edjtscott https://github.com/edjtscott/flashgg
+  git remote add fabriciojm https://github.com/fabriciojm/flashgg
+  git remote add famargar https://github.com/famargar/flashgg
+  git remote add favaro https://github.com/favaro/flashgg
+  git remote add fcouderc https://github.com/fcouderc/flashgg
+  git remote add fedmante https://github.com/fedmante/flashgg
+  git remote add ferriff https://github.com/ferriff/flashgg
+  git remote add ffede https://github.com/ffede/flashgg
+  git remote add forthommel https://github.com/forthommel/flashgg
+  git remote add fravera https://github.com/fravera/flashgg
+  git remote add GiuseppeFasanella https://github.com/GiuseppeFasanella/flashgg
+  git remote add gourangakole https://github.com/gourangakole/flashgg
+  git remote add hbakhshi https://github.com/hbakhshi/flashgg
+  git remote add HZgamma https://github.com/HZgamma/flashgg
+  git remote add InnaKucher https://github.com/InnaKucher/flashgg
+  git remote add ishvetso https://github.com/ishvetso/flashgg
+  git remote add itopsisg https://github.com/itopsisg/flashgg
+  git remote add J-C-Wright https://github.com/J-C-Wright/flashgg
+  git remote add JunquanTao https://github.com/JunquanTao/flashgg
+  git remote add khoumani https://github.com/khoumani/flashgg
+  git remote add kmcdermo https://github.com/kmcdermo/flashgg
+  git remote add kmondal https://github.com/kmondal/flashgg
+  git remote add ldcorpe https://github.com/ldcorpe/flashgg
+  git remote add lgray https://github.com/lgray/flashgg
+  git remote add lsoffi https://github.com/lsoffi/flashgg
+  git remote add malcles https://github.com/malcles/flashgg
+  git remote add martinamalberti https://github.com/martinamalberti/flashgg
+  git remote add matteosan1 https://github.com/matteosan1/flashgg
+  git remote add mdonega https://github.com/mdonega/flashgg
+  git remote add mez34 https://github.com/mez34/flashgg
+  git remote add mmachet https://github.com/mmachet/flashgg
+  git remote add molmedon https://github.com/molmedon/flashgg
+  git remote add mplaner https://github.com/mplaner/flashgg
+  git remote add musella https://github.com/musella/flashgg
+  git remote add nancymarinelli https://github.com/nancymarinelli/flashgg
+  git remote add OlivierBondu https://github.com/OlivierBondu/flashgg
+  git remote add pmeridian https://github.com/pmeridian/flashgg
+  git remote add gfasanel https://github.com/gfasanel/flashgg
+  git remote add quittnat https://github.com/quittnat/flashgg
+  git remote add rateixei https://github.com/rateixei/flashgg
+  git remote add rdangovs https://github.com/rdangovs/flashgg
+  git remote add ResonantHbbHgg https://github.com/ResonantHbbHgg/flashgg
+  git remote add saghosh https://github.com/saghosh/flashgg
+  git remote add sethzenz https://github.com/sethzenz/flashgg
+  git remote add simonepigazzini https://github.com/simonepigazzini/flashgg
+  git remote add vciriolo https://github.com/vciriolo/flashgg
+  git remote add swagata87 https://github.com/swagata87/flashgg
+  git remote add tklijnsma https://github.com/tklijnsma/flashgg
+  git remote add vtavolar https://github.com/vtavolar/flashgg
+  git remote add yhaddad https://github.com/yhaddad/flashgg
+  git remote add upstream-writable git@github.com:cms-analysis/flashgg.git
+else
+  echo "Not setting up additional remote names (default)"
+fi
+
+cd $CMSSW_BASE/src
+
+# Still needed, 8_0_28
+# Temporarily removed, 9_2_0
+#echo "EGM Pho ID recipe, Summer16"
+#git cms-merge-topic ikrav:egm_id_80X_v3_photons
+
+# Tag updated for 8_0_28 and may require further investigation
+# Temporarily removed, 9_2_0
+#echo "grabbing MET topic updates..."
+#git cms-merge-topic cms-met:METRecipe_8020_for80Xintegration -u
+
+# Straightofrward update for 8_0_28
+echo "Setting up QGL..."
+git cms-addpkg RecoJets/JetProducers
+git cms-merge-topic -u sethzenz:for-flashgg-QGL-vertexIndex-9_2_0
+
+# TnP tools removed for 8_0_28, so Validation does not compile
+# To be investigated
+#echo "Setting up TnP tools..."
+#git cms-merge-topic -u sethzenz:for-flashgg-egm_tnp-8_0_26
+
+echo "Setting up weight stuff..."
+git cms-merge-topic -u sethzenz:for-flashgg-smearer-conv-weights-9_2_0
+git cms-addpkg CommonTools/UtilAlgos
+git cms-merge-topic -u sethzenz:for-flashgg-weightscount-9_2_0
+
+# Updated for 8_0_28, and compiles and runs, but NOT checked by experts
+# Update built from sethzenz:for-flashgg-smearer-conv-weights-8_0_26 and shervin86:Hgg_Gain_v1
+echo "Setting up EGM stuff..."
+git cms-merge-topic -u sethzenz:for-flashgg-smearer-conv-9_2_0
+
+# Straightforward update for 8_0_28
+# Temporarily removed from 9_2_0
+#echo "Setting up Higgs Simplified Template Cross Sections..."
+#git cms-merge-topic -u sethzenz:rivet_hepmc-8_0_28
+
+# Straightforward update for 8_0_28
+echo "Tweaking ConfigToolBase.py to avoid assuming soft link path..."
+git cms-addpkg FWCore/GuiBrowsers #temp-by hand
+git cms-merge-topic -u sethzenz:for-flashgg-toolbase-9_2_0
+
+echo "copy databases for local running (consistency with crab)"
+cp $CMSSW_BASE/src/flashgg/Systematics/data/JEC/Summer16_23Sep2016*db $CMSSW_BASE/src/flashgg/
+cp $CMSSW_BASE/src/flashgg/MicroAOD/data/QGL_80X.db $CMSSW_BASE/src/flashgg
+
+echo "copy smearing files stored in flashgg into egamma tools"
+#cp $CMSSW_BASE/src/flashgg/Systematics/data/Golden*.dat $CMSSW_BASE/src/EgammaAnalysis/ElectronTools/data
+#cp $CMSSW_BASE/src/flashgg/Systematics/data/80X_DCS05July_plus_Golden22_s*.dat $CMSSW_BASE/src/EgammaAnalysis/ElectronTools/data
+#cp $CMSSW_BASE/src/flashgg/Systematics/data/80X_ichepV1_2016_pho_s* $CMSSW_BASE/src/EgammaAnalysis/ElectronTools/data
+#cp $CMSSW_BASE/src/flashgg/Systematics/data/80X_ichepV2_2016_pho_s* $CMSSW_BASE/src/EgammaAnalysis/ElectronTools/data
+#cp $CMSSW_BASE/src/flashgg/Systematics/data/Winter_2016_reReco_v1_ele_scales.dat $CMSSW_BASE/src/EgammaAnalysis/ElectronTools/data
+#cp $CMSSW_BASE/src/flashgg/Systematics/data/Winter_2016_reReco_v1_ele_smearings.dat $CMSSW_BASE/src/EgammaAnalysis/ElectronTools/data
+#cp $CMSSW_BASE/src/flashgg/Systematics/data/Moriond17_74x_pho_scales.dat $CMSSW_BASE/src/EgammaAnalysis/ElectronTools/data
+#cp $CMSSW_BASE/src/flashgg/Systematics/data/Moriond17_74x_pho_smearings.dat $CMSSW_BASE/src/EgammaAnalysis/ElectronTools/data
+
+echo "copying over updated classdef for release 9"
+mv $CMSSW_BASE/src/flashgg/DataFormats/src/classes_def_920.xml $CMSSW_BASE/src/flashgg/DataFormats/src/classes_def.xml
+
+echo "adding hook for indentation"
+ln -s $CMSSW_BASE/src/flashgg/Validation/scripts/flashgg_indent_check.sh $CMSSW_BASE/src/flashgg/.git/hooks/pre-commit
+
+echo
+echo "Done with setup script! You still need to build!"
+# echo "After building, run afterbuild_setup.sh"
+echo


### PR DESCRIPTION
Numerous code changes to allow compilation in CMSSW_9_2_0.  They are designed to have no impact on the code compiling and running in CMSSW_8_0_28.

Biggest changes are:

* auto_ptr changed to unique_ptr everywhere
* std::move added inside put command everywhere
* selectors that are used in templates built off of SingleElementCollectionSelectorPlusEvent now need an operator() method that takes a Ref instead of a const object.  This required some changes to how things were templated, especially the CutBasedGenericObjectSelector 
 and CutBasedElectronObjectSelector
* Special DataFormats xml file to reflect changes in pat objects, which is copied into place by setup_9_2_0.sh
* Special setup_9_2_0.sh file which accesses updated branches

Many thanks to @lgray for helping with an elegant fix to the template issue, which also happens to have been created by him: https://github.com/cms-sw/cmssw/blame/09c3fce6626f70fd04223e7dacebf0b485f73f54/CommonTools/UtilAlgos/interface/SingleElementCollectionSelectorPlusEvent.h#L35

Note that the code will still require changes to run.  The one I'm sure of is removing special EGM id from customization, since those tags haven't been ported yet to CMSSW 9 as far as I know.