### PR TITLE
generalized to njets>=0 case for ZPlusJetTagProducer

### DIFF
--- a/DataFormats/interface/ZPlusJetTag.h
+++ b/DataFormats/interface/ZPlusJetTag.h
@@ -22,22 +22,22 @@ namespace flashgg {
         edm::Ptr<Jet> jet() const { return theJet_; }
         unsigned nJets() const { return njets_; }
 
-        const float jetPt() const { return theJet_->pt(); }
-        const float jetEta() const { return theJet_->eta(); }
-        const float jetPhi() const { return theJet_->phi(); }
+        const float jetPt() const { if (njets_>0) {return theJet_->pt();} else return -999;}
+        const float jetEta() const { if (njets_>0) {return theJet_->eta();} else return -999; }
+        const float jetPhi() const { if (njets_>0) {return theJet_->phi();} else return -999; }
 
-        const float jet_HFHadronEnergyFraction() const { return theJet_->HFHadronEnergyFraction(); }
-        const float jet_HFHadronEnergy() const { return theJet_->HFHadronEnergy(); }
-        const float jet_HFHadronMultiplicity() const { return theJet_->HFHadronMultiplicity(); }
-        const float jet_HFEMEnergyFraction() const { return theJet_->HFEMEnergyFraction(); }
-        const float jet_HFEMEnergy() const { return theJet_->HFEMEnergy(); }
-        const float jet_HFEMMultiplicity() const { return theJet_->HFEMMultiplicity(); }
+        const float jet_HFHadronEnergyFraction() const { if (njets_>0) {return theJet_->HFHadronEnergyFraction();} else return -999; }
+        const float jet_HFHadronEnergy() const { if (njets_>0) {return theJet_->HFHadronEnergy();} else return -999; }
+        const float jet_HFHadronMultiplicity() const { if (njets_>0) {return theJet_->HFHadronMultiplicity();} else return -999; }
+        const float jet_HFEMEnergyFraction() const { if (njets_>0) {return theJet_->HFEMEnergyFraction();} else return -999; }
+        const float jet_HFEMEnergy() const { if (njets_>0) {return theJet_->HFEMEnergy();} else return -999; }
+        const float jet_HFEMMultiplicity() const { if (njets_>0) {return theJet_->HFEMMultiplicity();} else return -999; }
  
-        const float jet_rms() const { return theJet_->rms(); }
-        const float jet_QGL() const { return theJet_->QGL(); }
-        const float jet_rawPt() const { return theJet_->correctedJet("Uncorrected").pt(); }
+        const float jet_rms() const { if (njets_>0) {return theJet_->rms();} else return -999; }
+        const float jet_QGL() const { if (njets_>0) {return theJet_->QGL();} else return -999; }
+        const float jet_rawPt() const { if (njets_>0) {return theJet_->correctedJet("Uncorrected").pt();} else return -999; }
 
-        const bool jet_match() const { return (theJet_->genJet() != 0); }
+        const bool jet_match() const { if (njets_>0) { return (theJet_->genJet() != 0);} else return -999; }
 
         edm::Ptr<DiPhotonCandidate> theZ() const { return diPhoton(); }
         const float zMass() const { return diPhoton()->mass(); }
@@ -45,7 +45,7 @@ namespace flashgg {
         const float zEta() const { return diPhoton()->eta(); }
         const float zPhi() const { return diPhoton()->phi(); }
 
-        const float deltaPhiZJet() const { return deltaPhi( diPhoton()->phi(), theJet_->phi() ) ; } // not the absolute value
+        const float deltaPhiZJet() const { if (njets_>0) { return deltaPhi( diPhoton()->phi(), theJet_->phi() ) ;} else return -999; } // not the absolute value
 
         const int smartIndex() const { return diPhoton()->jetCollectionIndex(); }
 

--- a/DataFormats/src/ZPlusJetTag.cc
+++ b/DataFormats/src/ZPlusJetTag.cc
@@ -11,7 +11,7 @@ ZPlusJetTag::~ZPlusJetTag() {}
 ZPlusJetTag::ZPlusJetTag( edm::Ptr<DiPhotonCandidate> diPho, edm::Ptr<DiPhotonMVAResult> mvaRes, edm::Ptr<Jet> theJet, unsigned njets) :
     DiPhotonTagBase::DiPhotonTagBase( diPho, mvaRes ) 
 {
-    theJet_ = theJet;
+    if (njets>0) theJet_ = theJet;
     njets_ = njets;
 }
 

--- a/Taggers/plugins/ZPlusJetTagProducer.cc
+++ b/Taggers/plugins/ZPlusJetTagProducer.cc
@@ -139,13 +139,14 @@ namespace flashgg {
                 njets++;
             }
 
-            if (njets > 0) {
+            //if (njets > 0) {
                     ZPlusJetTag tag_obj( dipho, mvares, leadingJet, njets );
                     tag_obj.setDiPhotonIndex( candIndex );
                     tag_obj.setSystLabel    ( systLabel_ );
                     tag_obj.setIsGold ( evt.run() );
                     tag_obj.includeWeights( *dipho );
-                    tag_obj.includeWeights( *leadingJet );
+                    if (njets > 0) 
+                        tag_obj.includeWeights( *leadingJet );
                     
                     //truth_obj.setGenPV( higgsVtx );
 
@@ -159,9 +160,8 @@ namespace flashgg {
                     //                    truths->push_back( truth_obj );
                     //                    tags->back().setTagTruth( edm::refToPtr( edm::Ref<vector<ZPlusJetTagTruth> >( rTagTruth, idx++ ) ) );
                     //                }
-            }
+                    // }
         }
-
         evt.put( std::move( tags ) );
         //        evt.put( std::move( truths ) );
     }


### PR DESCRIPTION
Hi @sethzenz 

here a PR to generalize the ZPlusJetTagProducer for the Njets>=0 case [1]; currently it stores only info when Njets>0 [2].

[1] /afs/cern.ch/user/g/gkrintir/public/ForSeth/output_AtLeast0Jets.root

[2] /afs/cern.ch/user/g/gkrintir/public/ForSeth/output_AtLeast1Jets.root