### PR TITLE
fix python logic bug: do not apply gain central twice on data

### DIFF
--- a/Systematics/python/SystematicsCustomize.py
+++ b/Systematics/python/SystematicsCustomize.py
@@ -153,7 +153,7 @@ def customizeSystematicsForData(process):
 def customizeVPSetForData(systs, phScaleBins):
     newvpset = cms.VPSet()
     for pset in systs:
-        if pset.Label.value().count("Scale") or pset.Label.value().count("SigmaEOverESmearing"):
+        if (pset.Label.value().count("Scale") or pset.Label.value().count("SigmaEOverESmearing")) and not pset.Label.value().count("Gain"):
             pset.ApplyCentralValue = cms.bool(True) # Turn on central shift for data (it is off for MC)
             if type(pset.NSigmas) == type(cms.vint32()):
                 pset.NSigmas = cms.vint32() # Do not perform shift


### PR DESCRIPTION
Bug fix for bug described on slide 10 here: https://indico.cern.ch/event/668514/contributions/2772445/attachments/1549448/2433712/FinalFitsUpdate30Oct17.pdf

Due to python logic error (my fault) the Gain1 and Gain6 corrections were applied twice.