### PR TITLE
Added extra info for b-jet regression

### DIFF
--- a/DataFormats/interface/Jet.h
+++ b/DataFormats/interface/Jet.h
@@ -44,12 +44,23 @@ namespace flashgg {
         bool passesJetID( JetIDLevel level = Loose ) const; 
 
         const bool hasGenMatch() const { return (genJet() != 0); }
+        
+        const std::vector<float>& chEnergies() const { return chEnergies_; }
+        const std::vector<float>& emEnergies() const { return emEnergies_; } 
+        const std::vector<float>& neEnergies() const { return neEnergies_; } 
+        const std::vector<float>& muEnergies() const { return muEnergies_; }
+
+        void setChEnergies(std::vector<float> val) { chEnergies_ = val; }
+        void setEmEnergies(std::vector<float> val) { emEnergies_ = val; } 
+        void setNeEnergies(std::vector<float> val) { neEnergies_ = val; } 
+        void setMuEnergies(std::vector<float> val) { muEnergies_ = val; }
 
     private:
         std::map<edm::Ptr<reco::Vertex>, MinimalPileupJetIdentifier> puJetId_;
         float qglikelihood_;
         float simpleRMS_; // simpler storage for PFCHS where this is not vertex-dependent
         float simpleMVA_;
+        std::vector<float> chEnergies_, emEnergies_, neEnergies_, muEnergies_;
     };
 }
 

--- a/DataFormats/src/classes_def_80X.xml
+++ b/DataFormats/src/classes_def_80X.xml
@@ -234,7 +234,8 @@
 </class>
 <class name="std::pair<edm::Ptr<reco::Vertex>,flashgg::MinimalPileupJetIdentifier>"/>
 <class name="std::map<edm::Ptr<reco::Vertex>,flashgg::MinimalPileupJetIdentifier>"/>
-<class name="flashgg::Jet" ClassVersion="13">
+<class name="flashgg::Jet" ClassVersion="14">
+ <version ClassVersion="14" checksum="2400716629"/>
  <version ClassVersion="13" checksum="2175929989"/>
   <version ClassVersion="12" checksum="1532368094"/>
   <version ClassVersion="11" checksum="3459570589"/>

--- a/DataFormats/src/classes_def_940.xml
+++ b/DataFormats/src/classes_def_940.xml
@@ -235,7 +235,8 @@
 </class>
 <class name="std::pair<edm::Ptr<reco::Vertex>,flashgg::MinimalPileupJetIdentifier>"/>
 <class name="std::map<edm::Ptr<reco::Vertex>,flashgg::MinimalPileupJetIdentifier>"/>
-<class name="flashgg::Jet" ClassVersion="13">
+<class name="flashgg::Jet" ClassVersion="14">
+  <version ClassVersion="14" checksum="2400716629"/>
  <version ClassVersion="13" checksum="2175929989"/>
   <version ClassVersion="12" checksum="1532368094"/>
   <version ClassVersion="11" checksum="3459570589"/>

--- a/MicroAOD/plugins/JetProducer.cc
+++ b/MicroAOD/plugins/JetProducer.cc
@@ -210,7 +210,8 @@ namespace flashgg {
                 std::vector<float> emEnergies(ncone_boundaries+1,0.); 
                 std::vector<float> neEnergies(ncone_boundaries+1,0.); 
                 std::vector<float> muEnergies(ncone_boundaries+1,0.);
-                
+                int numDaug03 = 0;
+
                 for ( unsigned k = 0; k < fjet.numberOfSourceCandidatePtrs(); ++k ) {
                     reco::CandidatePtr pfJetConstituent = fjet.sourceCandidatePtr(k);
                     
@@ -222,6 +223,7 @@ namespace flashgg {
                     sumPtDrSq += candPt*candPt*candDr*candDr;
                     sumPtSq += candPt*candPt;
 
+                    if( candPt > 0.3 ) { ++numDaug03; }
                     if(lPack->charge() != 0 && candPt > leadTrackPt_) leadTrackPt_ = candPt;
 
                     if(abs(lPack->pdgId()) == 11 || abs(lPack->pdgId()) == 13) {
@@ -266,8 +268,9 @@ namespace flashgg {
                     fjet.addUserFloat("softLepPt", softLepPt);
                     fjet.addUserFloat("softLepRatio", softLepRatio);
                     fjet.addUserFloat("softLepDr", softLepDr);
-                    fjet.addUserFloat("softLepPtRel", softLepPtRel);
-                    
+                    fjet.addUserFloat("softLepPtRel", softLepPtRel); 
+                    fjet.addUserInt("numDaug03", numDaug03);
+                   
                     /// for(size_t icone = 0; icone < ncone_boundaries+1; ++icone) {
                     ///     std::cout << "icone " << icone << " " << emEnergies[icone] << " " << muEnergies[icone] << " " << chEnergies[icone] << " " << neEnergies[icone] << std::endl;
                     /// }

--- a/MicroAOD/plugins/JetProducer.cc
+++ b/MicroAOD/plugins/JetProducer.cc
@@ -47,6 +47,8 @@ namespace flashgg {
         bool debug_;
         unsigned pudebug_matched_badrms_, pudebug_matched_;
         bool doPuJetID_;
+        float minPtForEneSum_, maxEtaForEneSum_;
+        unsigned int nJetsForEneSum_;
     };
 
 
@@ -64,7 +66,10 @@ namespace flashgg {
         rhoToken_( consumes<double>(iConfig.getParameter<edm::InputTag>("rho") ) ),
         jetDebugToken_( consumes<View<pat::Jet> >( iConfig.getUntrackedParameter<InputTag> ( "JetDebugTag",edm::InputTag("slimmedJets") ) ) ),
         debug_( iConfig.getUntrackedParameter<bool>( "Debug",false ) ),
-        doPuJetID_( iConfig.getParameter<bool>( "DoPuJetID") )
+        doPuJetID_( iConfig.getParameter<bool>( "DoPuJetID") ),
+        minPtForEneSum_( iConfig.getParameter<double>("MinPtForEneSum") ),
+        maxEtaForEneSum_( iConfig.getParameter<double>("MaxEtaForEneSum") ),
+        nJetsForEneSum_( iConfig.getParameter<unsigned int>("NJetsForEneSum") )
         //        usePuppi( iConfig.getUntrackedParameter<bool>( "UsePuppi", false ) )
     {
         pileupJetIdAlgo_.reset( new PileupJetIdAlgo( pileupJetIdParameters_, true ) );
@@ -152,7 +157,6 @@ namespace flashgg {
 
             //store btagging userfloats
             if (computeRegVars) {
-
                 if (debug_) { std::cout << " start of computeRegVars" << std::endl; }
 
                 int nSecVertices = pjet->tagInfoCandSecondaryVertex("pfSecondaryVertex")->nVertices();
@@ -171,6 +175,9 @@ namespace flashgg {
                     vtx3DVal = pjet->tagInfoCandSecondaryVertex("pfSecondaryVertex")->flightDistance(0).value();
                     vtx3DSig = pjet->tagInfoCandSecondaryVertex("pfSecondaryVertex")->flightDistance(0).significance();
                 }
+
+                
+                
 
                 fjet.addUserFloat("nSecVertices", nSecVertices);
                 fjet.addUserFloat("vtxNTracks", vtxNTracks);
@@ -195,6 +202,15 @@ namespace flashgg {
                 float leadTrackPt_ = 0, softLepPt = 0, softLepRatio = 0, softLepDr = 0;
                 float sumPtDrSq = 0.;
                 float sumPtSq = 0.;
+                float softLepPtRel = 0.;
+                
+                float cone_boundaries[] = { 0.05, 0.1, 0.2, 0.3 }; // hardcoded boundaries: should be made configurable
+                size_t ncone_boundaries = sizeof(cone_boundaries)/sizeof(float);
+                std::vector<float> chEnergies(ncone_boundaries+1,0.);
+                std::vector<float> emEnergies(ncone_boundaries+1,0.); 
+                std::vector<float> neEnergies(ncone_boundaries+1,0.); 
+                std::vector<float> muEnergies(ncone_boundaries+1,0.);
+                
                 for ( unsigned k = 0; k < fjet.numberOfSourceCandidatePtrs(); ++k ) {
                     reco::CandidatePtr pfJetConstituent = fjet.sourceCandidatePtr(k);
                     
@@ -213,10 +229,31 @@ namespace flashgg {
                             softLepPt = candPt;
                             softLepRatio = candPt/pjet->pt();
                             softLepDr = candDr;
+                            softLepPtRel = ( pjet->px()*lPack->px() + pjet->py()*lPack->py() + pjet->pz()*lPack->pz() ) / pjet->p();
+                            softLepPtRel = sqrt( lPack->p()*lPack->p() - softLepPtRel*softLepPtRel );
                         }
                     }
+                    
+                    int pdgid = abs(lPack->pdgId());
+                    size_t icone = std::lower_bound(&cone_boundaries[0],&cone_boundaries[ncone_boundaries],candDr) - &cone_boundaries[0];
+                    float candEnergy = kcand->energy();
+                    // std::cout << "pdgId " << pdgid << " candDr " << candDr << " icone " << icone << " " << candEnergy << std::endl; 
+                    if( pdgid == 22 || pdgid == 11 ) {
+                        // std::cout << " fill EM" << std::endl;
+                        emEnergies[icone] += candEnergy;
+                    } else if ( pdgid == 13 ) { 
+                        // std::cout << " fill mu" << std::endl;
+                        muEnergies[icone] += candEnergy;
+                    } else if ( lPack-> charge() != 0 ) {
+                        // std::cout << " fill ch" << std::endl;
+                        chEnergies[icone] += candEnergy;
+                    } else {
+                        // std::cout << " fill ne" << std::endl;
+                        neEnergies[icone] += candEnergy;
+                    }
                 }
-
+                
+                
                 if (debug_) { std::cout << " before set in  computeSimpleRMS || computeRegVars" << std::endl; }
                 
                 if (computeSimpleRMS) {
@@ -229,6 +266,19 @@ namespace flashgg {
                     fjet.addUserFloat("softLepPt", softLepPt);
                     fjet.addUserFloat("softLepRatio", softLepRatio);
                     fjet.addUserFloat("softLepDr", softLepDr);
+                    fjet.addUserFloat("softLepPtRel", softLepPtRel);
+                    
+                    /// for(size_t icone = 0; icone < ncone_boundaries+1; ++icone) {
+                    ///     std::cout << "icone " << icone << " " << emEnergies[icone] << " " << muEnergies[icone] << " " << chEnergies[icone] << " " << neEnergies[icone] << std::endl;
+                    /// }
+                    
+                    if( fjet.pt() > minPtForEneSum_ && abs(fjet.eta()) < maxEtaForEneSum_ && ( nJetsForEneSum_ == 0 || i <= nJetsForEneSum_ ) ) {
+                        /// std::cout << "saving cones " << std::endl;
+                        fjet.setChEnergies(chEnergies);
+                        fjet.setEmEnergies(emEnergies);
+                        fjet.setNeEnergies(neEnergies);
+                        fjet.setMuEnergies(muEnergies);
+                    }
                 }
 
                 if (debug_) { std::cout << " end of computeSimpleRMS || computeRegVars" << std::endl; }

--- a/MicroAOD/python/MicroAODCustomize.py
+++ b/MicroAOD/python/MicroAODCustomize.py
@@ -248,6 +248,7 @@ class MicroAODCustomize(object):
         delattr(process,"flashggPrunedGenParticles") # will be run due to unscheduled mode unless deleted
         delattr(process,"flashggGenPhotons") # will be run due to unscheduled mode unless deleted
         delattr(process,"flashggGenPhotonsExtra") # will be run due to unscheduled mode unless deleted
+        delattr(process,"flashggGenNeutrinos") # will be run due to unscheduled mode unless deleted
         from flashgg.MicroAOD.flashggJets_cfi import maxJetCollections
         for vtx in range(0,maxJetCollections):
 #            getattr(process,"flashggPFCHSJets%i"%vtx).Debug = True

--- a/MicroAOD/python/flashggGenNeutrinos_cfi.py
+++ b/MicroAOD/python/flashggGenNeutrinos_cfi.py
@@ -1,0 +1,7 @@
+import FWCore.ParameterSet.Config as cms
+
+flashggGenNeutrinos = cms.EDFilter("PackedGenParticleSelector",
+                                    src = cms.InputTag("packedGenParticles"),
+                                    cut = cms.string("( abs(pdgId) == 12 || abs(pdgId) == 14  || abs(pdgId) == 16 )")
+                                    )
+

--- a/MicroAOD/python/flashggJets_cfi.py
+++ b/MicroAOD/python/flashggJets_cfi.py
@@ -137,12 +137,15 @@ def addFlashggPFCHSJets(process,
                                VertexCandidateMapTag = cms.InputTag("flashggVertexMapForCHS"),
                                qgVariablesInputTag   = cms.InputTag('QGTaggerPFCHS'+label, 'qgLikelihood'),
                                ComputeSimpleRMS = cms.bool(True),
-                               ComputeRegVars = cms.bool(True),
                                PileupJetIdParameters = full_80x_chs,
                                rho     = cms.InputTag("fixedGridRhoFastjetAll"),
                                JetCollectionIndex = cms.uint32(vertexIndex),
                                Debug = cms.untracked.bool(False),
-                               DoPuJetID = cms.bool(False)
+                               DoPuJetID = cms.bool(False),
+                               ComputeRegVars = cms.bool(True),
+                               MinPtForEneSum = cms.double(0.),
+                               MaxEtaForEneSum = cms.double(2.5),
+                               NJetsForEneSum = cms.uint32(0),
                                )
   setattr( process, 'flashggPFCHSJets'+ label, flashggJets)
 

--- a/MicroAOD/python/flashggMicroAODGenSequence_cff.py
+++ b/MicroAOD/python/flashggMicroAODGenSequence_cff.py
@@ -1,8 +1,9 @@
 import FWCore.ParameterSet.Config as cms
 from flashgg.MicroAOD.flashggPrunedGenParticles_cfi import flashggPrunedGenParticles
 from flashgg.MicroAOD.flashggGenPhotons_cfi import flashggGenPhotons
+from flashgg.MicroAOD.flashggGenNeutrinos_cfi import flashggGenNeutrinos
 from flashgg.MicroAOD.flashggGenPhotonsExtra_cfi import flashggGenPhotonsExtra
 
 
-flashggMicroAODGenSequence = cms.Sequence(flashggPrunedGenParticles+flashggGenPhotons*flashggGenPhotonsExtra
+flashggMicroAODGenSequence = cms.Sequence(flashggPrunedGenParticles+flashggGenPhotons*flashggGenPhotonsExtra+flashggGenNeutrinos
                                         )

--- a/MicroAOD/python/flashggMicroAODOutputCommands_cff.py
+++ b/MicroAOD/python/flashggMicroAODOutputCommands_cff.py
@@ -26,7 +26,7 @@ microAODDefaultOutputCommand = cms.untracked.vstring("drop *",
                                                      "keep *_flashggDiPhotons_*_*", # STILL NEEDED
                                                      "keep *_slimmedAddPileupInfo_*_*", # Was huge in old MiniAod - hopefully better now
                                                      "keep *GsfElectronCore*_reducedEgamma_*_*", # needed by at least one Tag
-
+                                                     
                                                      "keep *_flashggSelected*_*_*",
                                                      "keep *_flashggMets*_*_*",
                                                      # Drop intermediate collections in favor of selected/final collections


### PR DESCRIPTION
- energy in rings for jets
- added gen neutrinos
- leptonPtRel

After addition the first few branches in the event have the following sizes:
File myMicroAODOutputFile.root Events 100
Branch Name | Average Uncompressed Size (Bytes/Event) | Average Compressed Size (Bytes/Event) 
patTriggerObjectStandAlones_selectedPatTrigger__PAT. 76790.7 8690.47
flashggPhotons_flashggRandomizedPhotons__FLASHggMicroAOD. 11072.8 4636.34
flashggElectrons_flashggSelectedElectrons__FLASHggMicroAOD. 4985.69 3217.8
flashggMuons_flashggSelectedMuons__FLASHggMicroAOD. 3227.53 2224.52
flashggJetss_flashggFinalJets__FLASHggMicroAOD. 13487.1 2162.4 ***** Jets are here *******
recoVertexs_offlineSlimmedPrimaryVertices__PAT. 1584.68 896.62
