### PR TITLE
Move diphotons earlier in sequence, stop processing unles pt cut passed

### DIFF
--- a/MicroAOD/plugins/FLASHggObjectSelector.cc
+++ b/MicroAOD/plugins/FLASHggObjectSelector.cc
@@ -7,6 +7,7 @@ DEFINE_FWK_MODULE( FLASHggPhotonSelector );
 DEFINE_FWK_MODULE( FLASHggMuonSelector );
 DEFINE_FWK_MODULE( FLASHggElectronSelector );
 DEFINE_FWK_MODULE( FLASHggJetSelector );
+DEFINE_FWK_MODULE( FLASHggDiPhotonSelector );
 
 // Local Variables:
 // mode:c++

--- a/MicroAOD/plugins/FLASHggObjectSelector.h
+++ b/MicroAOD/plugins/FLASHggObjectSelector.h
@@ -5,6 +5,7 @@
 #include "flashgg/DataFormats/interface/Muon.h"
 #include "flashgg/DataFormats/interface/Photon.h"
 #include "flashgg/DataFormats/interface/Jet.h"
+#include "flashgg/DataFormats/interface/DiPhotonCandidate.h"
 
 #include "CommonTools/UtilAlgos/interface/StringCutObjectSelector.h"
 #include "CommonTools/UtilAlgos/interface/SingleObjectSelector.h"
@@ -33,6 +34,12 @@ namespace flashgg {
     std::vector<Jet>,
         StringCutObjectSelector<Jet>
         > FLASHggJetSelector;
+
+    typedef SingleObjectSelector <
+        std::vector<DiPhotonCandidate>,
+        StringCutObjectSelector<DiPhotonCandidate>
+        > FLASHggDiPhotonSelector;
+    
 
 }
 

--- a/MicroAOD/python/MicroAODCustomize.py
+++ b/MicroAOD/python/MicroAODCustomize.py
@@ -390,6 +390,8 @@ class MicroAODCustomize(object):
         process.diPhotonFilter.src = "flashggSelectedMuons"
         process.diPhotonFilter.minNumber = 2
         process.flashggDiPhotonFilterSequence.remove(process.diPhotonSelector)
+        process.flashggDiPhotonFilterSequence.remove(process.diPhotonFilter)
+        process.flashggMuonFilterSequence += process.diPhotonFilter
 
     def customizeHighMassIsolations(self,process):
         # for isolation cones

--- a/MicroAOD/python/MicroAODCustomize.py
+++ b/MicroAOD/python/MicroAODCustomize.py
@@ -298,7 +298,9 @@ class MicroAODCustomize(object):
             delattr(process,"patJetPartonMatchAK4PFCHSLeg%i"%vtx)
         self.customizeHighMassIsolations(process)
         process.load("flashgg/MicroAOD/flashggDiPhotonFilter_cfi")
-        process.p1 = cms.Path(process.diPhotonFilter) # Do not save events with 0 diphotons
+        process.flashggDiPhotonFilterSequence += process.diPhotonSelector
+        process.flashggDiPhotonFilterSequence += process.diPhotonFilter # Do not continue running events with 0 diphotons passing pt cuts
+        process.p1 = cms.Path(process.diPhotonFilter) # Do not save events with 0 diphotons passing pt cuts
         process.out.SelectEvents = cms.untracked.PSet(SelectEvents=cms.vstring('p1'))
 
     def customizeDec2016Regression(self,process):
@@ -387,6 +389,7 @@ class MicroAODCustomize(object):
     def customizeDataMuons(self,process):
         process.diPhotonFilter.src = "flashggSelectedMuons"
         process.diPhotonFilter.minNumber = 2
+        process.flashggDiPhotonFilterSequence.remove(process.diPhotonSelector)
 
     def customizeHighMassIsolations(self,process):
         # for isolation cones

--- a/MicroAOD/python/flashggDiPhotonFilter_cfi.py
+++ b/MicroAOD/python/flashggDiPhotonFilter_cfi.py
@@ -1,6 +1,11 @@
 import FWCore.ParameterSet.Config as cms
 
+diPhotonSelector = cms.EDFilter("FLASHggDiPhotonSelector",
+                                src = cms.InputTag("flashggDiPhotons"),
+                                cut = cms.string("leadingPhoton().pt > 25. && subLeadingPhoton().pt > 15.")
+                                )
+
 diPhotonFilter = cms.EDFilter("CandViewCountFilter",
-    src = cms.InputTag("flashggDiPhotons"),
+    src = cms.InputTag("diPhotonSelector"),
     minNumber = cms.uint32(1)
 )

--- a/MicroAOD/python/flashggMicroAODSequence_cff.py
+++ b/MicroAOD/python/flashggMicroAODSequence_cff.py
@@ -38,6 +38,7 @@ weightsCount = cms.EDProducer("WeightsCountProducer",
 flashggPrePhotonSequence80X = cms.Sequence(photonMVAValueMapProducer * egmPhotonIDs)
 
 flashggDiPhotonFilterSequence = cms.Sequence()
+flashggMuonFilterSequence = cms.Sequence()
 
 flashggMicroAODSequence = cms.Sequence( eventCount+weightsCount
                                        +flashggVertexMapUnique+flashggVertexMapNonUnique
@@ -46,6 +47,7 @@ flashggMicroAODSequence = cms.Sequence( eventCount+weightsCount
                                        +flashggDiPhotonFilterSequence
                                        +electronMVAValueMapProducer*egmGsfElectronIDs*flashggElectrons*flashggSelectedElectrons
                                        +flashggMuons*flashggSelectedMuons
+                                       +flashggMuonFilterSequence
                                        +flashggVertexMapForCHS*flashggFinalJets
                                        +flashggVertexMapForPUPPI*flashggFinalPuppiJets
                                         )

--- a/MicroAOD/python/flashggMicroAODSequence_cff.py
+++ b/MicroAOD/python/flashggMicroAODSequence_cff.py
@@ -37,12 +37,15 @@ weightsCount = cms.EDProducer("WeightsCountProducer",
 
 flashggPrePhotonSequence80X = cms.Sequence(photonMVAValueMapProducer * egmPhotonIDs)
 
+flashggDiPhotonFilterSequence = cms.Sequence()
+
 flashggMicroAODSequence = cms.Sequence( eventCount+weightsCount
                                        +flashggVertexMapUnique+flashggVertexMapNonUnique
-                                       +electronMVAValueMapProducer*egmGsfElectronIDs*flashggElectrons*flashggSelectedElectrons
-                                       +flashggMuons*flashggSelectedMuons
                                        +flashggMicroAODGenSequence
                                        +flashggPrePhotonSequence80X * flashggPhotons * flashggRandomizedPhotons * flashggDiPhotons
+                                       +flashggDiPhotonFilterSequence
+                                       +electronMVAValueMapProducer*egmGsfElectronIDs*flashggElectrons*flashggSelectedElectrons
+                                       +flashggMuons*flashggSelectedMuons
                                        +flashggVertexMapForCHS*flashggFinalJets
                                        +flashggVertexMapForPUPPI*flashggFinalPuppiJets
                                         )


### PR DESCRIPTION
Improves the previous filtering scheme for data by:
* Requiring diphoton pt > 25,15 GeV for events to be stored (previously, no cut)
* Stopping sequence processing immediately if no such diphoton exists

The former saves space, 20% on a random data file from SingleElectron 2017A.
The latter should save some CPU time (jet, electron, and muon sequences).