### PR TITLE
fix to have process.dumpPython() working in CMSSW_10_2_1

### DIFF
--- a/MetaData/python/JobConfig.py
+++ b/MetaData/python/JobConfig.py
@@ -350,6 +350,12 @@ class JobConfig(object):
                     target = target.__sub__(lumisToSkip)                    
                 process.source.lumisToProcess = target.getVLuminosityBlockRange()
 
+                # workaround for https://github.com/cms-sw/cmssw/issues/23774
+                # until https://github.com/cms-sw/cmssw/pull/24168 becomes effective (CMSSW 10_3_X ?)
+                #
+                # convert unicode LS ranges to string objects, otherwise process.dumpPython() fails
+                process.source.lumisToProcess = [ str(part) for part in process.source.lumisToProcess ]
+
             if isdata:    
                 print process.source.lumisToProcess
             


### PR DESCRIPTION
As discovered by @ArnabPurohit , `process.dumpPython()` fails with CMSSW_10_2_1.

It turns out that this has been found elsewhere in CMSSW (see https://github.com/cms-sw/cmssw/issues/23774 ) but as far as we understood will the fix (https://github.com/cms-sw/cmssw/pull/24168) will only be available in `CMSSW_10_3_X` (according to https://github.com/cms-sw/cmssw/pull/24168#issuecomment-409904682 ). 

We therefore propose a workaround which can be removed once flashgg moves to `CMSSW_10_3_X`.
