### PR TITLE
Add more jet information in microAOD to use resolve toptagger & add flags in TTHLeptonic tag to do overlap removal

### DIFF
--- a/DataFormats/interface/TTHLeptonicTag.h
+++ b/DataFormats/interface/TTHLeptonicTag.h
@@ -29,7 +29,25 @@ namespace flashgg {
         const std::vector<double>  leptonsPhi() const { return lepPhi_;}
         const std::vector<double>  leptonsEta() const { return lepEta_;}
         const std::vector<int>  leptonsType() const { return lepType_;}
-        
+
+        int leadPrompt() const { return leadPrompt_; }
+        int subleadPrompt() const { return subleadPrompt_; }        
+        int leadMad() const { return leadMad_; }
+        int subleadMad() const { return subleadMad_; }
+        int leadPythia() const { return leadPythia_; }
+        int subleadPythia() const { return subleadPythia_; }
+        int leadSimpleMomID() const { return lead_simpleMotherID_; }
+        int leadSimpleMomStatus() const { return lead_simpleMotherStatus_; }
+        int leadMomID() const { return lead_motherID_; }
+        int leadMomMomID() const { return lead_motherMotherID_; }
+        int leadPassFrix() const { return lead_passFrix_; }
+        double leadSmallestDr() const { return lead_smallestDr_; }
+        int subleadSimpleMomID() const { return sublead_simpleMotherID_; }
+        int subleadSimpleMomStatus() const { return sublead_simpleMotherStatus_; }
+        int subleadMomID() const { return sublead_motherID_; }
+        int subleadMomMomID() const { return sublead_motherMotherID_; }
+        int subleadPassFrix() const { return sublead_passFrix_; }
+        double subleadSmallestDr() const { return sublead_smallestDr_; }
 
         void setJets( std::vector<edm::Ptr<Jet> > Jets ) { Jets_ = Jets; }
         void setBJets( std::vector<edm::Ptr<Jet> > BJets )  { BJets_ = BJets;}
@@ -40,6 +58,25 @@ namespace flashgg {
         void setLepEta( std::vector<double> lepEta) { lepEta_ = lepEta; }
         void setLepPhi( std::vector<double> lepPhi) { lepPhi_ = lepPhi; }
         void setLepType( std::vector<int> lepType) { lepType_ = lepType; }
+
+        void setLeadPrompt(int leadPrompt) { leadPrompt_ = leadPrompt; }
+        void setSubleadPrompt(int subleadPrompt) { subleadPrompt_ = subleadPrompt; }
+        void setLeadMad(int leadMad) { leadMad_ = leadMad; }
+        void setSubleadMad(int subleadMad) { subleadMad_ = subleadMad; }
+        void setLeadPythia(int leadPythia) { leadPythia_ = leadPythia; }
+        void setSubleadPythia(int subleadPythia) { subleadPythia_ = subleadPythia; }
+        void setLeadSimpleMomID(int lead_simpleMotherID) { lead_simpleMotherID_ = lead_simpleMotherID; }
+        void setLeadSimpleMomStatus(int lead_simpleMotherStatus) { lead_simpleMotherStatus_ = lead_simpleMotherStatus; }
+        void setLeadMomID(int lead_motherID) { lead_motherID_ = lead_motherID; }
+        void setLeadMomMomID(int lead_motherMotherID) { lead_motherMotherID_ = lead_motherMotherID; }
+        void setLeadPassFrix(int lead_passFrix) { lead_passFrix_ = lead_passFrix; }
+        void setLeadSmallestDr(double lead_smallestDr) { lead_smallestDr_ = lead_smallestDr; }
+        void setSubleadSimpleMomID(int sublead_simpleMotherID) { sublead_simpleMotherID_ = sublead_simpleMotherID; }
+        void setSubleadSimpleMomStatus(int sublead_simpleMotherStatus) { sublead_simpleMotherStatus_ = sublead_simpleMotherStatus; }
+        void setSubleadMomID(int sublead_motherID) { sublead_motherID_ = sublead_motherID; }
+        void setSubleadMomMomID(int sublead_motherMotherID) { sublead_motherMotherID_ = sublead_motherMotherID; }
+        void setSubleadPassFrix(int sublead_passFrix) { sublead_passFrix_ = sublead_passFrix; }
+        void setSubleadSmallestDr(double sublead_smallestDr) { sublead_smallestDr_ = sublead_smallestDr; }
 
         DiPhotonTagBase::tag_t tagEnum() const override {return DiPhotonTagBase::kTTHLeptonic; }
 
@@ -57,6 +94,25 @@ namespace flashgg {
         std::vector<double> lepEta_;
         std::vector<double> lepPhi_;
         std::vector<int>    lepType_;
+
+        int leadPrompt_;
+        int subleadPrompt_;
+        int leadMad_;
+        int subleadMad_;
+        int leadPythia_;
+        int subleadPythia_;
+        int lead_simpleMotherID_;
+        int lead_simpleMotherStatus_;
+        int lead_motherID_;
+        int lead_motherMotherID_;
+        int lead_passFrix_;
+        double lead_smallestDr_;
+        int sublead_simpleMotherID_;
+        int sublead_simpleMotherStatus_;
+        int sublead_motherID_;
+        int sublead_motherMotherID_;
+        int sublead_passFrix_;
+        double sublead_smallestDr_;
 
         float mvaRes_;
     };

--- a/MicroAOD/plugins/JetProducer.cc
+++ b/MicroAOD/plugins/JetProducer.cc
@@ -198,7 +198,7 @@ namespace flashgg {
                 int nSecVertices = pjet->tagInfoCandSecondaryVertex("pfSecondaryVertex")->nVertices();
                 float vtxMass = 0, vtxPx = 0, vtxPy = 0, vtxPz = 0, vtx3DVal = 0, vtx3DSig = 0, vtxPosX = 0, vtxPosY = 0, vtxPosZ = 0;
                 int vtxNTracks = 0;
-                float ptD=0.;
+                //float ptD=0.;
 
                 if(nSecVertices > 0){
                     vtxNTracks = pjet->tagInfoCandSecondaryVertex("pfSecondaryVertex")->secondaryVertex(0).numberOfSourceCandidatePtrs();
@@ -228,17 +228,56 @@ namespace flashgg {
                 fjet.addUserFloat("vtx3DVal", vtx3DVal);
                 fjet.addUserFloat("vtx3DSig", vtx3DSig);
 
+                float ptD(0.0), totalMult(0.0), axis1(0.0), axis2(0.0);
+                float sum_dEta(0.0), sum_dPhi(0.0), sum_dEta2(0.0), sum_dPhi2(0.0), sum_dEta_dPhi(0.0), sum_weight(0.0), sum_pt(0.0);
 
-                //ptD of the jet
-                float sumWeight=0;
-                float sumPt=0;
-                for(const auto & d : pjet->daughterPtrVector()){
-                    sumWeight+=(d->pt())*(d->pt());
-                    sumPt+=d->pt();
+                for(const auto & d : pjet->getJetConstituentsQuick()){
+                    if (d->charge()) { // charged particles
+                        auto p = dynamic_cast<const pat::PackedCandidate*>(d);
+                        if (!p) std::cout << "ERROR: QGTagging variables cannot be computed for these jets!" << std::endl;
+                        if (!(p->fromPV() > 1 && p->trackHighPurity())) continue;
+                        ++totalMult;
+                    }   else { // neutral particles
+                        if (d->pt() < 1.0) continue;
+                        ++totalMult;
+                    } // charged, neutral particles
+
+                    float dEta   = d->eta() - pjet->eta();
+                    float dPhi   = reco::deltaPhi(d->phi(), pjet->phi());
+                    float pT = d->pt();
+                    float weight = pT*pT;
+
+                    sum_dEta      += dEta      * weight;
+                    sum_dPhi      += dPhi      * weight;
+                    sum_dEta2     += dEta*dEta * weight;
+                    sum_dEta_dPhi += dEta*dPhi * weight;
+                    sum_dPhi2     += dPhi*dPhi * weight;
+                    sum_weight     += pT*pT; //(d->pt())*(d->pt());
+                    sum_pt         += pT; //d->pt();
+
                 }
-                ptD = (sumWeight > 0 ? sqrt(sumWeight)/sumPt : 0);
-                fjet.addUserFloat("ptD", ptD);                    
 
+                // calculate axis2 and ptD
+                if (sum_weight > 0) {
+                    ptD = sqrt(sum_weight)/sum_pt;
+                    float ave_dEta  = sum_dEta  / sum_weight;
+                    float ave_dPhi  = sum_dPhi  / sum_weight;
+                    float ave_dEta2 = sum_dEta2 / sum_weight;
+                    float ave_dPhi2 = sum_dPhi2 / sum_weight;
+                    float a = ave_dEta2 - ave_dEta*ave_dEta;
+                    float b = ave_dPhi2 - ave_dPhi*ave_dPhi;
+                    float c = -(sum_dEta_dPhi/sum_weight - ave_dEta*ave_dPhi);
+                    float delta = sqrt(fabs( (a-b)*(a-b) + 4*c*c ));
+                    if(a+b-delta > 0) axis2 = sqrt(0.5*(a+b-delta));
+                    else              axis2 = 0.0;
+                    if(a+b+delta > 0) axis1 = sqrt(0.5*(a+b+delta));
+                    else              axis1 = 0.0;
+                }
+                
+                fjet.addUserFloat("ptD", ptD);                    
+                fjet.addUserFloat("totalMult", totalMult);                    
+                fjet.addUserFloat("axis1", axis1);                    
+                fjet.addUserFloat("axis2", axis2);                    
 
                 if (debug_) { std::cout << " end of computeRegVars" << std::endl; }
 


### PR DESCRIPTION
commit 4ab377d is based on the previous PR: https://github.com/cms-analysis/flashgg/pull/1072
This new commit only adds flags in TTHLeptonic tagger to do overlap removal for ttgg/ttg/tt madgraph samples

commit b443999 adds more jet information in microAOD, so one can use resolved topTagger as described in slide 20 of https://indico.cern.ch/event/762838/contributions/3176550/attachments/1734127/2804005/ttHgg_Run2Studies_15Oct2018_SamuelMay.pdf

Both commits have been tested, they don't interfere with running flashgg workflow(use current test_cmds.sh), and the increase of mircoAOD size is less than 0.5%.