### PR TITLE
Missing PU prob values for some MC bkg and low-mass signal samples in…

### DIFF
--- a/MetaData/python/PU_MixFiles_2017_miniaodv2_310/mix_2017MC_DiPhotonJetsBox_M40_80-Sherpa.py
+++ b/MetaData/python/PU_MixFiles_2017_miniaodv2_310/mix_2017MC_DiPhotonJetsBox_M40_80-Sherpa.py
@@ -1,0 +1,41 @@
+import FWCore.ParameterSet.Config as cms
+
+# configuration to model pileup for initial physics phase
+from SimGeneral.MixingModule.mixObjects_cfi import theMixObjects
+from SimGeneral.MixingModule.mixPoolSource_cfi import *
+from SimGeneral.MixingModule.digitizers_cfi import *
+
+mix = cms.EDProducer("MixingModule",
+    digitizers = cms.PSet(theDigitizers),
+    LabelPlayback = cms.string(''),
+    maxBunch = cms.int32(3),
+    minBunch = cms.int32(-12), ## in terms of 25 nsec
+
+    bunchspace = cms.int32(25), ##ns
+    mixProdStep1 = cms.bool(False),
+    mixProdStep2 = cms.bool(False),
+
+    playback = cms.untracked.bool(False),
+    useCurrentProcessOnly = cms.bool(False),
+
+    input = cms.SecSource("EmbeddedRootSource",
+        type = cms.string('probFunction'),
+        nbPileupEvents = cms.PSet(
+          probFunctionVariable = cms.vint32(0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83,84,85,86,87,88,89,90,91,92,93,94,95,96,97,98,99),
+            probValue = cms.vdouble(
+                3.06504e-05, 9.87048e-06, 1.63642e-05, 3.55857e-05, 5.68851e-05, 8.00028e-05, 0.000118705, 0.000135849, 0.000354038, 0.000348584, 0.000714051, 0.00135537, 0.00238034, 0.00391468, 0.00590696, 0.00858108, 0.0116986, 0.0149153, 0.0178762, 0.020962, 0.0232569, 0.025025, 0.0262269, 0.0272269, 0.0283527, 0.0294553, 0.0301626, 0.0309042, 0.0309502, 0.0309588, 0.0310658, 0.0310972, 0.0309432, 0.031106, 0.0306429, 0.0299366, 0.0288397, 0.0273363, 0.0265669, 0.0256051, 0.0234806, 0.0214849, 0.0196274, 0.0177297, 0.0161582, 0.0145626, 0.0134324, 0.0128908, 0.0124381, 0.0124295, 0.0122973, 0.0125456, 0.0124472, 0.0124358, 0.0123984, 0.0124701, 0.0122978, 0.0122355, 0.0117448, 0.0108082, 0.00965203, 0.00838497, 0.00686778, 0.00541084, 0.00416041, 0.0036874, 0.0031718, 0.00227566, 0.00164785, 0.00112212, 0.000779768, 0.000527032, 0.000357935, 0.000236632, 0.000193254, 0.000149096, 0.000112212, 7.01324e-05, 4.00014e-05, 2.64944e-05, 2.10397e-05, 1.09095e-05, 7.27298e-06, 7.53273e-06, 5.97424e-06, 2.59749e-06, 1.5585e-06, 1.29875e-06, 1.039e-06, 5.19499e-07, 7.79248e-07, 0, 2.59749e-07, 0, 0, 2.59749e-07, 0, 0, 0, 0
+                ),
+          histoFileName = cms.untracked.string('histProbFunction.root'),
+        ),
+                          sequential = cms.untracked.bool(False),
+                          manage_OOT = cms.untracked.bool(True),  ## manage out-of-time pileup
+                          ## setting this to True means that the out-of-time pileup
+        ## will have a different distribution than in-time, given
+        ## by what is described on the next line:
+        OOT_type = cms.untracked.string('Poisson'),  ## generate OOT with a Poisson matching the number chosen for in-time
+        #OOT_type = cms.untracked.string('fixed'),  ## generate OOT with a fixed distribution
+        #intFixed_OOT = cms.untracked.int32(2),
+        fileNames = FileNames
+    ),
+    mixObjects = cms.PSet(theMixObjects)
+)

--- a/MetaData/python/PU_MixFiles_2017_miniaodv2_310/mix_2017MC_DiPhotonJetsBox_MGG-80toInf_13TeV-Sherpa.py
+++ b/MetaData/python/PU_MixFiles_2017_miniaodv2_310/mix_2017MC_DiPhotonJetsBox_MGG-80toInf_13TeV-Sherpa.py
@@ -1,0 +1,41 @@
+import FWCore.ParameterSet.Config as cms
+
+# configuration to model pileup for initial physics phase
+from SimGeneral.MixingModule.mixObjects_cfi import theMixObjects
+from SimGeneral.MixingModule.mixPoolSource_cfi import *
+from SimGeneral.MixingModule.digitizers_cfi import *
+
+mix = cms.EDProducer("MixingModule",
+    digitizers = cms.PSet(theDigitizers),
+    LabelPlayback = cms.string(''),
+    maxBunch = cms.int32(3),
+    minBunch = cms.int32(-12), ## in terms of 25 nsec
+
+    bunchspace = cms.int32(25), ##ns
+    mixProdStep1 = cms.bool(False),
+    mixProdStep2 = cms.bool(False),
+
+    playback = cms.untracked.bool(False),
+    useCurrentProcessOnly = cms.bool(False),
+
+    input = cms.SecSource("EmbeddedRootSource",
+        type = cms.string('probFunction'),
+        nbPileupEvents = cms.PSet(
+          probFunctionVariable = cms.vint32(0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83,84,85,86,87,88,89,90,91,92,93,94,95,96,97,98,99),
+            probValue = cms.vdouble(
+                3.26777e-05, 6.85405e-06, 1.35871e-05, 3.53387e-05, 6.06785e-05, 9.23885e-05, 0.000117749, 0.000129562, 0.000360725, 0.000359414, 0.000705362, 0.00135279, 0.00239233, 0.00389848, 0.00595183, 0.00856647, 0.0116702, 0.0148918, 0.017971, 0.0208698, 0.0232566, 0.0249577, 0.0262321, 0.0273188, 0.028307, 0.0294292, 0.0302919, 0.0309576, 0.0309133, 0.0310445, 0.0309276, 0.0310518, 0.0310053, 0.0310816, 0.0308109, 0.0300332, 0.0288562, 0.0273382, 0.0264614, 0.0255926, 0.0235757, 0.0215459, 0.019547, 0.0177379, 0.0160384, 0.0145823, 0.0133747, 0.0129583, 0.0124985, 0.0124419, 0.0123811, 0.0124056, 0.0124209, 0.0124457, 0.0123283, 0.0124554, 0.012328, 0.0122115, 0.0117078, 0.0108403, 0.00962105, 0.0082907, 0.00682476, 0.0054551, 0.00420171, 0.00367661, 0.00313674, 0.00228488, 0.00162715, 0.00113689, 0.000784244, 0.000531451, 0.000358729, 0.000241605, 0.000195199, 0.000159901, 0.000103536, 6.86211e-05, 4.34426e-05, 2.88676e-05, 1.79213e-05, 1.1289e-05, 7.55961e-06, 6.10817e-06, 5.28165e-06, 2.92305e-06, 1.95542e-06, 1.29017e-06, 8.06359e-07, 6.85405e-07, 5.03974e-07, 2.0159e-07, 2.82226e-07, 2.21749e-07, 2.0159e-08, 2.0159e-08, 0, 0, 0, 0
+                ),
+          histoFileName = cms.untracked.string('histProbFunction.root'),
+        ),
+                          sequential = cms.untracked.bool(False),
+                          manage_OOT = cms.untracked.bool(True),  ## manage out-of-time pileup
+                          ## setting this to True means that the out-of-time pileup
+        ## will have a different distribution than in-time, given
+        ## by what is described on the next line:
+        OOT_type = cms.untracked.string('Poisson'),  ## generate OOT with a Poisson matching the number chosen for in-time
+        #OOT_type = cms.untracked.string('fixed'),  ## generate OOT with a fixed distribution
+        #intFixed_OOT = cms.untracked.int32(2),
+        fileNames = FileNames
+    ),
+    mixObjects = cms.PSet(theMixObjects)
+)

--- a/MetaData/python/PU_MixFiles_2017_miniaodv2_310/mix_2017MC_GJet_Pt-40toInf_DoubleEMEnriched_MGG-80toInf_TuneCP5_13TeV_Pythia8.py
+++ b/MetaData/python/PU_MixFiles_2017_miniaodv2_310/mix_2017MC_GJet_Pt-40toInf_DoubleEMEnriched_MGG-80toInf_TuneCP5_13TeV_Pythia8.py
@@ -1,0 +1,41 @@
+import FWCore.ParameterSet.Config as cms
+
+# configuration to model pileup for initial physics phase
+from SimGeneral.MixingModule.mixObjects_cfi import theMixObjects
+from SimGeneral.MixingModule.mixPoolSource_cfi import *
+from SimGeneral.MixingModule.digitizers_cfi import *
+
+mix = cms.EDProducer("MixingModule",
+    digitizers = cms.PSet(theDigitizers),
+    LabelPlayback = cms.string(''),
+    maxBunch = cms.int32(3),
+    minBunch = cms.int32(-12), ## in terms of 25 nsec
+
+    bunchspace = cms.int32(25), ##ns
+    mixProdStep1 = cms.bool(False),
+    mixProdStep2 = cms.bool(False),
+
+    playback = cms.untracked.bool(False),
+    useCurrentProcessOnly = cms.bool(False),
+
+    input = cms.SecSource("EmbeddedRootSource",
+        type = cms.string('probFunction'),
+        nbPileupEvents = cms.PSet(
+          probFunctionVariable = cms.vint32(0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83,84,85,86,87,88,89,90,91,92,93,94,95,96,97,98,99),
+            probValue = cms.vdouble(
+                3.35498e-05, 7.28102e-06, 1.35886e-05, 3.47958e-05, 5.93254e-05, 9.24729e-05, 0.00012126, 0.000128956, 0.000361806, 0.000362818, 0.000702625, 0.00134224, 0.00238063, 0.00388251, 0.00592804, 0.00857455, 0.0116362, 0.0148929, 0.0179643, 0.0208729, 0.0232647, 0.0249865, 0.0262338, 0.0272966, 0.0283354, 0.0294124, 0.030313, 0.0309948, 0.0308487, 0.0310496, 0.0309301, 0.0310789, 0.0310334, 0.031093, 0.0308082, 0.0299932, 0.0288579, 0.0272907, 0.0264461, 0.0255469, 0.0235967, 0.0215759, 0.0195451, 0.0177381, 0.0160444, 0.014614, 0.0134111, 0.0129762, 0.0125186, 0.0124327, 0.0123523, 0.0124, 0.0124238, 0.0124496, 0.0123667, 0.0124019, 0.0123217, 0.0122283, 0.0117049, 0.010839, 0.0096362, 0.00825809, 0.00685314, 0.00542299, 0.00421572, 0.00367936, 0.00315048, 0.00228499, 0.00162716, 0.001142, 0.000794423, 0.000534344, 0.000358172, 0.000242467, 0.000196354, 0.000157197, 0.000102544, 6.76966e-05, 4.40106e-05, 2.79041e-05, 1.79884e-05, 1.16808e-05, 7.35889e-06, 6.85273e-06, 4.73721e-06, 2.62169e-06, 2.36211e-06, 1.24595e-06, 7.91698e-07, 5.06167e-07, 2.72552e-07, 1.29786e-07, 3.24466e-07, 1.9468e-07, 3.89359e-08, 5.19146e-08, 0, 0, 0, 0
+                ),
+          histoFileName = cms.untracked.string('histProbFunction.root'),
+        ),
+                          sequential = cms.untracked.bool(False),
+                          manage_OOT = cms.untracked.bool(True),  ## manage out-of-time pileup
+                          ## setting this to True means that the out-of-time pileup
+        ## will have a different distribution than in-time, given
+        ## by what is described on the next line:
+        OOT_type = cms.untracked.string('Poisson'),  ## generate OOT with a Poisson matching the number chosen for in-time
+        #OOT_type = cms.untracked.string('fixed'),  ## generate OOT with a fixed distribution
+        #intFixed_OOT = cms.untracked.int32(2),
+        fileNames = FileNames
+    ),
+    mixObjects = cms.PSet(theMixObjects)
+)

--- a/MetaData/python/PU_MixFiles_2017_miniaodv2_310/mix_2017MC_GluGluHToGG_M105_13TeV_amcatnloFXFX_pythia8.py
+++ b/MetaData/python/PU_MixFiles_2017_miniaodv2_310/mix_2017MC_GluGluHToGG_M105_13TeV_amcatnloFXFX_pythia8.py
@@ -1,0 +1,41 @@
+import FWCore.ParameterSet.Config as cms
+
+# configuration to model pileup for initial physics phase
+from SimGeneral.MixingModule.mixObjects_cfi import theMixObjects
+from SimGeneral.MixingModule.mixPoolSource_cfi import *
+from SimGeneral.MixingModule.digitizers_cfi import *
+
+mix = cms.EDProducer("MixingModule",
+    digitizers = cms.PSet(theDigitizers),
+    LabelPlayback = cms.string(''),
+    maxBunch = cms.int32(3),
+    minBunch = cms.int32(-12), ## in terms of 25 nsec
+
+    bunchspace = cms.int32(25), ##ns
+    mixProdStep1 = cms.bool(False),
+    mixProdStep2 = cms.bool(False),
+
+    playback = cms.untracked.bool(False),
+    useCurrentProcessOnly = cms.bool(False),
+
+    input = cms.SecSource("EmbeddedRootSource",
+        type = cms.string('probFunction'),
+        nbPileupEvents = cms.PSet(
+          probFunctionVariable = cms.vint32(0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83,84,85,86,87,88,89,90,91,92,93,94,95,96,97,98,99),
+            probValue = cms.vdouble(
+               4.15313e-05, 0, 1.66125e-05, 1.66125e-05, 3.32251e-05, 6.64501e-05, 9.1369e-05, 0.0001329, 0.000332251, 0.000307332, 0.000838933, 0.00127086, 0.00240051, 0.00399532, 0.00600543, 0.0083478, 0.0108231, 0.0149098, 0.0176342, 0.0206245, 0.022701, 0.0248607, 0.0263558, 0.0270867, 0.0282164, 0.030077, 0.0300022, 0.0303843, 0.0312565, 0.0306667, 0.0313977, 0.0316469, 0.0309575, 0.0311568, 0.030999, 0.0295454, 0.0285071, 0.0274273, 0.0267213, 0.0250102, 0.0240051, 0.0219452, 0.020043, 0.018415, 0.0157653, 0.014943, 0.0137136, 0.0131737, 0.0121105, 0.0119444, 0.0119693, 0.0125591, 0.0126504, 0.0127917, 0.012393, 0.0123597, 0.0122268, 0.0121853, 0.0116205, 0.0111719, 0.00974325, 0.00844747, 0.00672808, 0.00568979, 0.00408668, 0.00339726, 0.00318961, 0.00242543, 0.00171109, 0.00108812, 0.000847239, 0.000581439, 0.000340557, 0.000257494, 0.000166125, 0.0001329, 9.96752e-05, 9.96752e-05, 4.98376e-05, 1.66125e-05, 2.49188e-05, 0, 8.30627e-06, 0, 0, 0, 1.66125e-05, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
+                ),
+          histoFileName = cms.untracked.string('histProbFunction.root'),
+        ),
+                          sequential = cms.untracked.bool(False),
+                          manage_OOT = cms.untracked.bool(True),  ## manage out-of-time pileup
+                          ## setting this to True means that the out-of-time pileup
+        ## will have a different distribution than in-time, given
+        ## by what is described on the next line:
+        OOT_type = cms.untracked.string('Poisson'),  ## generate OOT with a Poisson matching the number chosen for in-time
+        #OOT_type = cms.untracked.string('fixed'),  ## generate OOT with a fixed distribution
+        #intFixed_OOT = cms.untracked.int32(2),
+        fileNames = FileNames
+    ),
+    mixObjects = cms.PSet(theMixObjects)
+)

--- a/MetaData/python/PU_MixFiles_2017_miniaodv2_310/mix_2017MC_GluGluHToGG_M115_13TeV_amcatnloFXFX_pythia8.py
+++ b/MetaData/python/PU_MixFiles_2017_miniaodv2_310/mix_2017MC_GluGluHToGG_M115_13TeV_amcatnloFXFX_pythia8.py
@@ -1,0 +1,41 @@
+import FWCore.ParameterSet.Config as cms
+
+# configuration to model pileup for initial physics phase
+from SimGeneral.MixingModule.mixObjects_cfi import theMixObjects
+from SimGeneral.MixingModule.mixPoolSource_cfi import *
+from SimGeneral.MixingModule.digitizers_cfi import *
+
+mix = cms.EDProducer("MixingModule",
+    digitizers = cms.PSet(theDigitizers),
+    LabelPlayback = cms.string(''),
+    maxBunch = cms.int32(3),
+    minBunch = cms.int32(-12), ## in terms of 25 nsec
+
+    bunchspace = cms.int32(25), ##ns
+    mixProdStep1 = cms.bool(False),
+    mixProdStep2 = cms.bool(False),
+
+    playback = cms.untracked.bool(False),
+    useCurrentProcessOnly = cms.bool(False),
+
+    input = cms.SecSource("EmbeddedRootSource",
+        type = cms.string('probFunction'),
+        nbPileupEvents = cms.PSet(
+          probFunctionVariable = cms.vint32(0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83,84,85,86,87,88,89,90,91,92,93,94,95,96,97,98,99),
+            probValue = cms.vdouble(
+               2.50424e-05, 8.34745e-06, 3.33898e-05, 5.84322e-05, 7.51271e-05, 8.34745e-05, 0.000133559, 0.000116864, 0.000325551, 0.000383983, 0.000742923, 0.0014608, 0.00231224, 0.0040986, 0.00583487, 0.00855614, 0.0111605, 0.0150087, 0.0185564, 0.0210606, 0.0223628, 0.0255599, 0.026378, 0.0274297, 0.0287152, 0.029191, 0.0307353, 0.0307353, 0.0311444, 0.0312529, 0.0316452, 0.0311527, 0.0307103, 0.0306519, 0.0301176, 0.0299173, 0.0285566, 0.0275716, 0.0263195, 0.0248838, 0.0234146, 0.0217618, 0.0190739, 0.0175213, 0.0159269, 0.014583, 0.0133559, 0.01278, 0.0123041, 0.012037, 0.0123041, 0.0126297, 0.0123208, 0.0124461, 0.0121038, 0.013214, 0.0125963, 0.0120287, 0.0115863, 0.0110687, 0.00995851, 0.00890673, 0.00707864, 0.0052589, 0.00421546, 0.00365618, 0.0032889, 0.00231224, 0.00164445, 0.00112691, 0.000767966, 0.000500847, 0.000342246, 0.000300508, 0.000141907, 0.000141907, 7.51271e-05, 6.67796e-05, 2.50424e-05, 2.50424e-05, 2.50424e-05, 0, 8.34745e-06, 0, 8.34745e-06, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
+                ),
+          histoFileName = cms.untracked.string('histProbFunction.root'),
+        ),
+                          sequential = cms.untracked.bool(False),
+                          manage_OOT = cms.untracked.bool(True),  ## manage out-of-time pileup
+                          ## setting this to True means that the out-of-time pileup
+        ## will have a different distribution than in-time, given
+        ## by what is described on the next line:
+        OOT_type = cms.untracked.string('Poisson'),  ## generate OOT with a Poisson matching the number chosen for in-time
+        #OOT_type = cms.untracked.string('fixed'),  ## generate OOT with a fixed distribution
+        #intFixed_OOT = cms.untracked.int32(2),
+        fileNames = FileNames
+    ),
+    mixObjects = cms.PSet(theMixObjects)
+)

--- a/MetaData/python/PU_MixFiles_2017_miniaodv2_310/mix_2017MC_VBFHToGG_M105_13TeV_amcatnlo_pythia8.py
+++ b/MetaData/python/PU_MixFiles_2017_miniaodv2_310/mix_2017MC_VBFHToGG_M105_13TeV_amcatnlo_pythia8.py
@@ -1,0 +1,41 @@
+import FWCore.ParameterSet.Config as cms
+
+# configuration to model pileup for initial physics phase
+from SimGeneral.MixingModule.mixObjects_cfi import theMixObjects
+from SimGeneral.MixingModule.mixPoolSource_cfi import *
+from SimGeneral.MixingModule.digitizers_cfi import *
+
+mix = cms.EDProducer("MixingModule",
+    digitizers = cms.PSet(theDigitizers),
+    LabelPlayback = cms.string(''),
+    maxBunch = cms.int32(3),
+    minBunch = cms.int32(-12), ## in terms of 25 nsec
+
+    bunchspace = cms.int32(25), ##ns
+    mixProdStep1 = cms.bool(False),
+    mixProdStep2 = cms.bool(False),
+
+    playback = cms.untracked.bool(False),
+    useCurrentProcessOnly = cms.bool(False),
+
+    input = cms.SecSource("EmbeddedRootSource",
+        type = cms.string('probFunction'),
+        nbPileupEvents = cms.PSet(
+          probFunctionVariable = cms.vint32(0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83,84,85,86,87,88,89,90,91,92,93,94,95,96,97,98,99),
+            probValue = cms.vdouble(
+                2e-05, 3.33333e-06, 1.66667e-05, 2.33333e-05, 2.33333e-05, 8.66667e-05, 0.00014, 0.00015, 0.000356667, 0.00036, 0.000763333, 0.00130333, 0.00236667, 0.00388, 0.00604, 0.00872333, 0.0120167, 0.0150167, 0.0179833, 0.0210333, 0.0232733, 0.02505, 0.0261833, 0.0270467, 0.02856, 0.0294333, 0.03074, 0.0309267, 0.0308267, 0.0310767, 0.0305033, 0.0309033, 0.0313833, 0.0308333, 0.03107, 0.0293467, 0.0289433, 0.02762, 0.0264367, 0.0260767, 0.0232133, 0.02195, 0.0197933, 0.0174533, 0.01577, 0.0146933, 0.0135433, 0.0128933, 0.0124433, 0.0124067, 0.0120533, 0.0122633, 0.01249, 0.01244, 0.0123833, 0.01248, 0.0123867, 0.01182, 0.0120567, 0.0108233, 0.00939333, 0.00808, 0.0069, 0.00531, 0.00417667, 0.00363, 0.00305667, 0.00212667, 0.00161333, 0.00118333, 0.000933333, 0.000536667, 0.00032, 0.000223333, 0.000223333, 0.0001, 7.66667e-05, 9.66667e-05, 3.66667e-05, 3.66667e-05, 1.33333e-05, 6.66667e-06, 0, 1.33333e-05, 6.66667e-06, 3.33333e-06, 0, 6.66667e-06, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 
+                ),
+          histoFileName = cms.untracked.string('histProbFunction.root'),
+        ),
+                          sequential = cms.untracked.bool(False),
+                          manage_OOT = cms.untracked.bool(True),  ## manage out-of-time pileup
+                          ## setting this to True means that the out-of-time pileup
+        ## will have a different distribution than in-time, given
+        ## by what is described on the next line:
+        OOT_type = cms.untracked.string('Poisson'),  ## generate OOT with a Poisson matching the number chosen for in-time
+        #OOT_type = cms.untracked.string('fixed'),  ## generate OOT with a fixed distribution
+        #intFixed_OOT = cms.untracked.int32(2),
+        fileNames = FileNames
+    ),
+    mixObjects = cms.PSet(theMixObjects)
+)

--- a/MetaData/python/PU_MixFiles_2017_miniaodv2_310/mix_2017MC_VBFHToGG_M115_13TeV_amcatnlo_pythia8.py
+++ b/MetaData/python/PU_MixFiles_2017_miniaodv2_310/mix_2017MC_VBFHToGG_M115_13TeV_amcatnlo_pythia8.py
@@ -1,0 +1,41 @@
+import FWCore.ParameterSet.Config as cms
+
+# configuration to model pileup for initial physics phase
+from SimGeneral.MixingModule.mixObjects_cfi import theMixObjects
+from SimGeneral.MixingModule.mixPoolSource_cfi import *
+from SimGeneral.MixingModule.digitizers_cfi import *
+
+mix = cms.EDProducer("MixingModule",
+    digitizers = cms.PSet(theDigitizers),
+    LabelPlayback = cms.string(''),
+    maxBunch = cms.int32(3),
+    minBunch = cms.int32(-12), ## in terms of 25 nsec
+
+    bunchspace = cms.int32(25), ##ns
+    mixProdStep1 = cms.bool(False),
+    mixProdStep2 = cms.bool(False),
+
+    playback = cms.untracked.bool(False),
+    useCurrentProcessOnly = cms.bool(False),
+
+    input = cms.SecSource("EmbeddedRootSource",
+        type = cms.string('probFunction'),
+        nbPileupEvents = cms.PSet(
+          probFunctionVariable = cms.vint32(0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83,84,85,86,87,88,89,90,91,92,93,94,95,96,97,98,99),
+            probValue = cms.vdouble(
+                4e-05, 1e-05, 1.66667e-05, 7e-05, 5.33333e-05, 0.00011, 9e-05, 0.000156667, 0.000366667, 0.00032, 0.000673333, 0.00129333, 0.00228, 0.0037, 0.00590667, 0.00855333, 0.0121267, 0.01484, 0.01796, 0.0209167, 0.02334, 0.02488, 0.02697, 0.02718, 0.02823, 0.0287767, 0.0299967, 0.0311967, 0.0310233, 0.0309667, 0.0313933, 0.0309367, 0.03122, 0.03071, 0.0306633, 0.03, 0.0295933, 0.02728, 0.0268967, 0.0255233, 0.0232933, 0.0219967, 0.0197933, 0.0176033, 0.01608, 0.0144967, 0.0131433, 0.01286, 0.01234, 0.0126167, 0.0128433, 0.0125433, 0.0125433, 0.0119967, 0.0121533, 0.0123133, 0.0123967, 0.0121233, 0.01179, 0.01059, 0.00953333, 0.00812, 0.00657333, 0.00552, 0.00422333, 0.00352333, 0.00304, 0.00227667, 0.00170667, 0.00117333, 0.000813333, 0.00052, 0.000333333, 0.000226667, 0.000153333, 0.000163333, 9.66667e-05, 8.33333e-05, 3.33333e-05, 4.33333e-05, 1.33333e-05, 1.66667e-05, 6.66667e-06, 6.66667e-06, 1e-05, 6.66667e-06, 3.33333e-06, 0, 3.33333e-06, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
+                ),
+          histoFileName = cms.untracked.string('histProbFunction.root'),
+        ),
+                          sequential = cms.untracked.bool(False),
+                          manage_OOT = cms.untracked.bool(True),  ## manage out-of-time pileup
+                          ## setting this to True means that the out-of-time pileup
+        ## will have a different distribution than in-time, given
+        ## by what is described on the next line:
+        OOT_type = cms.untracked.string('Poisson'),  ## generate OOT with a Poisson matching the number chosen for in-time
+        #OOT_type = cms.untracked.string('fixed'),  ## generate OOT with a fixed distribution
+        #intFixed_OOT = cms.untracked.int32(2),
+        fileNames = FileNames
+    ),
+    mixObjects = cms.PSet(theMixObjects)
+)

--- a/MetaData/python/PU_MixFiles_2017_miniaodv2_310/mix_2017MC_VBFHToGG_M85_13TeV_amcatnlo_pythia8.py
+++ b/MetaData/python/PU_MixFiles_2017_miniaodv2_310/mix_2017MC_VBFHToGG_M85_13TeV_amcatnlo_pythia8.py
@@ -1,0 +1,41 @@
+import FWCore.ParameterSet.Config as cms
+
+# configuration to model pileup for initial physics phase
+from SimGeneral.MixingModule.mixObjects_cfi import theMixObjects
+from SimGeneral.MixingModule.mixPoolSource_cfi import *
+from SimGeneral.MixingModule.digitizers_cfi import *
+
+mix = cms.EDProducer("MixingModule",
+    digitizers = cms.PSet(theDigitizers),
+    LabelPlayback = cms.string(''),
+    maxBunch = cms.int32(3),
+    minBunch = cms.int32(-12), ## in terms of 25 nsec
+
+    bunchspace = cms.int32(25), ##ns
+    mixProdStep1 = cms.bool(False),
+    mixProdStep2 = cms.bool(False),
+
+    playback = cms.untracked.bool(False),
+    useCurrentProcessOnly = cms.bool(False),
+
+    input = cms.SecSource("EmbeddedRootSource",
+        type = cms.string('probFunction'),
+        nbPileupEvents = cms.PSet(
+          probFunctionVariable = cms.vint32(0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83,84,85,86,87,88,89,90,91,92,93,94,95,96,97,98,99),
+            probValue = cms.vdouble(
+                5.33333e-05, 1.66667e-05, 6.66667e-06, 7.66667e-05, 5.33333e-05, 0.0001, 0.000126667, 0.00012, 0.00034, 0.00037, 0.000713333, 0.00134667, 0.00244333, 0.00378, 0.00604, 0.00841, 0.0115533, 0.01497, 0.0177267, 0.0210367, 0.02321, 0.02489, 0.0260633, 0.0273467, 0.0288967, 0.0293467, 0.0297867, 0.0309233, 0.0312633, 0.0311667, 0.0303767, 0.0309333, 0.03123, 0.0312233, 0.0310167, 0.0299033, 0.0288033, 0.02738, 0.0271533, 0.0255433, 0.02402, 0.02157, 0.0195267, 0.0174933, 0.0158767, 0.0145233, 0.01324, 0.01257, 0.01257, 0.01276, 0.01252, 0.0127567, 0.0122533, 0.0123, 0.0122967, 0.0126, 0.01221, 0.0125333, 0.01166, 0.0105567, 0.00975333, 0.00811667, 0.00681333, 0.00547, 0.00414667, 0.00351667, 0.003, 0.00209333, 0.0017, 0.00121667, 0.000826667, 0.000533333, 0.000363333, 0.00026, 0.00019, 0.000136667, 9.66667e-05, 7.33333e-05, 4e-05, 2.33333e-05, 6.66667e-06, 3.33333e-06, 1e-05, 1e-05, 6.66667e-06, 6.66667e-06, 6.66667e-06, 0, 3.33333e-06, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
+                ),
+          histoFileName = cms.untracked.string('histProbFunction.root'),
+        ),
+                          sequential = cms.untracked.bool(False),
+                          manage_OOT = cms.untracked.bool(True),  ## manage out-of-time pileup
+                          ## setting this to True means that the out-of-time pileup
+        ## will have a different distribution than in-time, given
+        ## by what is described on the next line:
+        OOT_type = cms.untracked.string('Poisson'),  ## generate OOT with a Poisson matching the number chosen for in-time
+        #OOT_type = cms.untracked.string('fixed'),  ## generate OOT with a fixed distribution
+        #intFixed_OOT = cms.untracked.int32(2),
+        fileNames = FileNames
+    ),
+    mixObjects = cms.PSet(theMixObjects)
+)

--- a/MetaData/python/PU_MixFiles_2017_miniaodv2_310/mix_2017MC_VHToGG_M105_13TeV_amcatnloFXFX_madspin_pythia8.py
+++ b/MetaData/python/PU_MixFiles_2017_miniaodv2_310/mix_2017MC_VHToGG_M105_13TeV_amcatnloFXFX_madspin_pythia8.py
@@ -1,0 +1,41 @@
+import FWCore.ParameterSet.Config as cms
+
+# configuration to model pileup for initial physics phase
+from SimGeneral.MixingModule.mixObjects_cfi import theMixObjects
+from SimGeneral.MixingModule.mixPoolSource_cfi import *
+from SimGeneral.MixingModule.digitizers_cfi import *
+
+mix = cms.EDProducer("MixingModule",
+    digitizers = cms.PSet(theDigitizers),
+    LabelPlayback = cms.string(''),
+    maxBunch = cms.int32(3),
+    minBunch = cms.int32(-12), ## in terms of 25 nsec
+
+    bunchspace = cms.int32(25), ##ns
+    mixProdStep1 = cms.bool(False),
+    mixProdStep2 = cms.bool(False),
+
+    playback = cms.untracked.bool(False),
+    useCurrentProcessOnly = cms.bool(False),
+
+    input = cms.SecSource("EmbeddedRootSource",
+        type = cms.string('probFunction'),
+        nbPileupEvents = cms.PSet(
+          probFunctionVariable = cms.vint32(0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83,84,85,86,87,88,89,90,91,92,93,94,95,96,97,98,99),
+            probValue = cms.vdouble(
+               3.8513e-05, 5.25178e-06, 2.62589e-05, 5.07672e-05, 6.30213e-05, 0.00011904, 0.000136546, 0.000145299, 0.000376377, 0.000362373, 0.000684482, 0.00136196, 0.00234579, 0.00391608, 0.005903, 0.00838009, 0.0116677, 0.0150411, 0.0180451, 0.0207813, 0.0233722, 0.0248584, 0.0261906, 0.0273653, 0.0283368, 0.0293907, 0.0302923, 0.0305864, 0.0310275, 0.0311255, 0.0310573, 0.0312516, 0.0312341, 0.0312638, 0.0307229, 0.0304673, 0.0288043, 0.0273898, 0.026441, 0.0256304, 0.0235682, 0.0213187, 0.0194911, 0.0181572, 0.0160862, 0.0144336, 0.0136284, 0.0125745, 0.012529, 0.0123172, 0.0123049, 0.0124922, 0.0123329, 0.0124345, 0.0121596, 0.0124082, 0.0120546, 0.0122839, 0.0117132, 0.0104493, 0.00964577, 0.00814026, 0.00689208, 0.00560715, 0.00415766, 0.00376903, 0.00305654, 0.00233354, 0.00167707, 0.00111163, 0.00079652, 0.000558439, 0.000360622, 0.000222325, 0.000218824, 0.000143549, 8.92802e-05, 8.40285e-05, 4.37648e-05, 2.62589e-05, 2.62589e-05, 1.22542e-05, 1.05036e-05, 7.00237e-06, 5.25178e-06, 1.75059e-06, 1.75059e-06, 0, 0, 1.75059e-06, 1.75059e-06, 1.75059e-06, 0, 0, 0, 0, 0, 0, 0, 0
+                ),
+          histoFileName = cms.untracked.string('histProbFunction.root'),
+        ),
+                          sequential = cms.untracked.bool(False),
+                          manage_OOT = cms.untracked.bool(True),  ## manage out-of-time pileup
+                          ## setting this to True means that the out-of-time pileup
+        ## will have a different distribution than in-time, given
+        ## by what is described on the next line:
+        OOT_type = cms.untracked.string('Poisson'),  ## generate OOT with a Poisson matching the number chosen for in-time
+        #OOT_type = cms.untracked.string('fixed'),  ## generate OOT with a fixed distribution
+        #intFixed_OOT = cms.untracked.int32(2),
+        fileNames = FileNames
+    ),
+    mixObjects = cms.PSet(theMixObjects)
+)

--- a/MetaData/python/PU_MixFiles_2017_miniaodv2_310/mix_2017MC_VHToGG_M115_13TeV_amcatnloFXFX_madspin_pythia8.py
+++ b/MetaData/python/PU_MixFiles_2017_miniaodv2_310/mix_2017MC_VHToGG_M115_13TeV_amcatnloFXFX_madspin_pythia8.py
@@ -1,0 +1,41 @@
+import FWCore.ParameterSet.Config as cms
+
+# configuration to model pileup for initial physics phase
+from SimGeneral.MixingModule.mixObjects_cfi import theMixObjects
+from SimGeneral.MixingModule.mixPoolSource_cfi import *
+from SimGeneral.MixingModule.digitizers_cfi import *
+
+mix = cms.EDProducer("MixingModule",
+    digitizers = cms.PSet(theDigitizers),
+    LabelPlayback = cms.string(''),
+    maxBunch = cms.int32(3),
+    minBunch = cms.int32(-12), ## in terms of 25 nsec
+
+    bunchspace = cms.int32(25), ##ns
+    mixProdStep1 = cms.bool(False),
+    mixProdStep2 = cms.bool(False),
+
+    playback = cms.untracked.bool(False),
+    useCurrentProcessOnly = cms.bool(False),
+
+    input = cms.SecSource("EmbeddedRootSource",
+        type = cms.string('probFunction'),
+        nbPileupEvents = cms.PSet(
+          probFunctionVariable = cms.vint32(0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83,84,85,86,87,88,89,90,91,92,93,94,95,96,97,98,99),
+            probValue = cms.vdouble(
+               4.26205e-05, 1.21773e-05, 1.21773e-05, 2.2325e-05, 5.88568e-05, 9.13296e-05, 0.000107566, 0.000129891, 0.000318639, 0.0003572, 0.000720489, 0.00134965, 0.00246184, 0.00393529, 0.00576797, 0.00864993, 0.0116577, 0.0148664, 0.0177788, 0.0207379, 0.023078, 0.0251887, 0.0263597, 0.0276262, 0.0283507, 0.0291727, 0.0303255, 0.0311617, 0.0308024, 0.0306441, 0.0308795, 0.031119, 0.0307537, 0.0315615, 0.030496, 0.0299541, 0.0288135, 0.0274334, 0.0261527, 0.0254424, 0.0237721, 0.0215761, 0.0198307, 0.0173628, 0.015869, 0.014633, 0.0134315, 0.012912, 0.0127192, 0.0123782, 0.0124005, 0.0124878, 0.0126745, 0.0123681, 0.0126197, 0.0126948, 0.0120941, 0.0122564, 0.0117795, 0.0108033, 0.00969717, 0.00831708, 0.00683145, 0.00553051, 0.00419101, 0.00367145, 0.00303214, 0.00218785, 0.00161146, 0.00122179, 0.000797612, 0.000507387, 0.000387643, 0.000221221, 0.000251664, 0.000156275, 0.000121773, 6.49455e-05, 5.27682e-05, 3.24727e-05, 1.62364e-05, 1.62364e-05, 1.01477e-05, 4.05909e-06, 6.08864e-06, 0, 0, 0, 0, 0, 0, 0, 2.02955e-06, 0, 2.02955e-06, 0, 0, 0, 0, 0
+                ),
+          histoFileName = cms.untracked.string('histProbFunction.root'),
+        ),
+                          sequential = cms.untracked.bool(False),
+                          manage_OOT = cms.untracked.bool(True),  ## manage out-of-time pileup
+                          ## setting this to True means that the out-of-time pileup
+        ## will have a different distribution than in-time, given
+        ## by what is described on the next line:
+        OOT_type = cms.untracked.string('Poisson'),  ## generate OOT with a Poisson matching the number chosen for in-time
+        #OOT_type = cms.untracked.string('fixed'),  ## generate OOT with a fixed distribution
+        #intFixed_OOT = cms.untracked.int32(2),
+        fileNames = FileNames
+    ),
+    mixObjects = cms.PSet(theMixObjects)
+)

--- a/MetaData/python/PU_MixFiles_2017_miniaodv2_310/mix_2017MC_ttHJetToGG_M105_13TeV_amcatnloFXFX_madspin_pythia8.py
+++ b/MetaData/python/PU_MixFiles_2017_miniaodv2_310/mix_2017MC_ttHJetToGG_M105_13TeV_amcatnloFXFX_madspin_pythia8.py
@@ -1,0 +1,41 @@
+import FWCore.ParameterSet.Config as cms
+
+# configuration to model pileup for initial physics phase
+from SimGeneral.MixingModule.mixObjects_cfi import theMixObjects
+from SimGeneral.MixingModule.mixPoolSource_cfi import *
+from SimGeneral.MixingModule.digitizers_cfi import *
+
+mix = cms.EDProducer("MixingModule",
+    digitizers = cms.PSet(theDigitizers),
+    LabelPlayback = cms.string(''),
+    maxBunch = cms.int32(3),
+    minBunch = cms.int32(-12), ## in terms of 25 nsec
+
+    bunchspace = cms.int32(25), ##ns
+    mixProdStep1 = cms.bool(False),
+    mixProdStep2 = cms.bool(False),
+
+    playback = cms.untracked.bool(False),
+    useCurrentProcessOnly = cms.bool(False),
+
+    input = cms.SecSource("EmbeddedRootSource",
+        type = cms.string('probFunction'),
+        nbPileupEvents = cms.PSet(
+          probFunctionVariable = cms.vint32(0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83,84,85,86,87,88,89,90,91,92,93,94,95,96,97,98,99),
+            probValue = cms.vdouble(
+                4.1277e-05, 4.85611e-06, 1.21403e-05, 2.67086e-05, 4.85611e-05, 9.71223e-05, 0.000128687, 0.000148111, 0.000378777, 0.000354496, 0.000735701, 0.00125045, 0.00228237, 0.00411798, 0.0059366, 0.00845449, 0.0115745, 0.0147286, 0.0179798, 0.0207162, 0.0229694, 0.0251255, 0.0263396, 0.0273351, 0.0279979, 0.0292775, 0.0304745, 0.030982, 0.0303143, 0.0314409, 0.0311204, 0.0312467, 0.0315599, 0.0312224, 0.0303167, 0.029734, 0.0283281, 0.0277236, 0.0266552, 0.0256743, 0.0238265, 0.0216388, 0.0191039, 0.0176423, 0.0164671, 0.0144712, 0.0134247, 0.0129245, 0.0121573, 0.0122665, 0.0126113, 0.0123491, 0.0124122, 0.0122665, 0.0123637, 0.0124729, 0.0125263, 0.0122204, 0.0118246, 0.0111521, 0.00979478, 0.00835251, 0.00670144, 0.00547041, 0.00424667, 0.00373921, 0.00305207, 0.00228966, 0.00164865, 0.00118489, 0.000803687, 0.000534172, 0.00034964, 0.000223381, 0.000196673, 0.000172392, 0.000106834, 6.07014e-05, 3.88489e-05, 1.94245e-05, 1.45683e-05, 7.28417e-06, 4.85611e-06, 2.42806e-06, 0, 2.42806e-06, 2.42806e-06, 2.42806e-06, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
+                ),
+          histoFileName = cms.untracked.string('histProbFunction.root'),
+        ),
+                          sequential = cms.untracked.bool(False),
+                          manage_OOT = cms.untracked.bool(True),  ## manage out-of-time pileup
+                          ## setting this to True means that the out-of-time pileup
+        ## will have a different distribution than in-time, given
+        ## by what is described on the next line:
+        OOT_type = cms.untracked.string('Poisson'),  ## generate OOT with a Poisson matching the number chosen for in-time
+        #OOT_type = cms.untracked.string('fixed'),  ## generate OOT with a fixed distribution
+        #intFixed_OOT = cms.untracked.int32(2),
+        fileNames = FileNames
+    ),
+    mixObjects = cms.PSet(theMixObjects)
+)

--- a/MetaData/python/PU_MixFiles_2017_miniaodv2_310/mix_2017MC_ttHJetToGG_M115_13TeV_amcatnloFXFX_madspin_pythia8.py
+++ b/MetaData/python/PU_MixFiles_2017_miniaodv2_310/mix_2017MC_ttHJetToGG_M115_13TeV_amcatnloFXFX_madspin_pythia8.py
@@ -1,0 +1,41 @@
+import FWCore.ParameterSet.Config as cms
+
+# configuration to model pileup for initial physics phase
+from SimGeneral.MixingModule.mixObjects_cfi import theMixObjects
+from SimGeneral.MixingModule.mixPoolSource_cfi import *
+from SimGeneral.MixingModule.digitizers_cfi import *
+
+mix = cms.EDProducer("MixingModule",
+    digitizers = cms.PSet(theDigitizers),
+    LabelPlayback = cms.string(''),
+    maxBunch = cms.int32(3),
+    minBunch = cms.int32(-12), ## in terms of 25 nsec
+
+    bunchspace = cms.int32(25), ##ns
+    mixProdStep1 = cms.bool(False),
+    mixProdStep2 = cms.bool(False),
+
+    playback = cms.untracked.bool(False),
+    useCurrentProcessOnly = cms.bool(False),
+
+    input = cms.SecSource("EmbeddedRootSource",
+        type = cms.string('probFunction'),
+        nbPileupEvents = cms.PSet(
+          probFunctionVariable = cms.vint32(0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83,84,85,86,87,88,89,90,91,92,93,94,95,96,97,98,99),
+            probValue = cms.vdouble(
+                2.66841e-05, 1.21291e-05, 1.45549e-05, 3.39615e-05, 5.5794e-05, 8.2478e-05, 9.94588e-05, 0.000143124, 0.000339615, 0.000356596, 0.000727747, 0.00139, 0.00243068, 0.00385949, 0.00590931, 0.00864564, 0.0117264, 0.0149455, 0.0181282, 0.0208184, 0.0233316, 0.0248623, 0.0263857, 0.0270989, 0.0289619, 0.0293549, 0.0295441, 0.0312543, 0.0304926, 0.0310045, 0.0307425, 0.0311694, 0.0312034, 0.0314217, 0.0306139, 0.0296072, 0.0289231, 0.0272687, 0.0262765, 0.0255658, 0.0236809, 0.0215874, 0.0194139, 0.0176867, 0.0163137, 0.0145719, 0.0132426, 0.0128108, 0.0124226, 0.012493, 0.0124469, 0.0122165, 0.0124372, 0.0124906, 0.0123766, 0.0122213, 0.0124372, 0.0122917, 0.0116124, 0.0110836, 0.00982216, 0.00850979, 0.00694756, 0.00557212, 0.00415786, 0.00377216, 0.00311718, 0.00224874, 0.00153312, 0.00115227, 0.000802948, 0.000446352, 0.000368725, 0.000201343, 0.000189214, 0.000169808, 0.000109162, 7.27747e-05, 4.36648e-05, 3.15357e-05, 2.42582e-05, 1.21291e-05, 4.85165e-06, 4.85165e-06, 1.69808e-05, 0, 2.42582e-06, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
+                ),
+          histoFileName = cms.untracked.string('histProbFunction.root'),
+        ),
+                          sequential = cms.untracked.bool(False),
+                          manage_OOT = cms.untracked.bool(True),  ## manage out-of-time pileup
+                          ## setting this to True means that the out-of-time pileup
+        ## will have a different distribution than in-time, given
+        ## by what is described on the next line:
+        OOT_type = cms.untracked.string('Poisson'),  ## generate OOT with a Poisson matching the number chosen for in-time
+        #OOT_type = cms.untracked.string('fixed'),  ## generate OOT with a fixed distribution
+        #intFixed_OOT = cms.untracked.int32(2),
+        fileNames = FileNames
+    ),
+    mixObjects = cms.PSet(theMixObjects)
+)

--- a/MetaData/python/PU_MixFiles_2017_miniaodv2_310/mix_2017MC_ttHJetToGG_M85_13TeV_amcatnloFXFX_madspin_pythia8.py
+++ b/MetaData/python/PU_MixFiles_2017_miniaodv2_310/mix_2017MC_ttHJetToGG_M85_13TeV_amcatnloFXFX_madspin_pythia8.py
@@ -1,0 +1,41 @@
+import FWCore.ParameterSet.Config as cms
+
+# configuration to model pileup for initial physics phase
+from SimGeneral.MixingModule.mixObjects_cfi import theMixObjects
+from SimGeneral.MixingModule.mixPoolSource_cfi import *
+from SimGeneral.MixingModule.digitizers_cfi import *
+
+mix = cms.EDProducer("MixingModule",
+    digitizers = cms.PSet(theDigitizers),
+    LabelPlayback = cms.string(''),
+    maxBunch = cms.int32(3),
+    minBunch = cms.int32(-12), ## in terms of 25 nsec
+
+    bunchspace = cms.int32(25), ##ns
+    mixProdStep1 = cms.bool(False),
+    mixProdStep2 = cms.bool(False),
+
+    playback = cms.untracked.bool(False),
+    useCurrentProcessOnly = cms.bool(False),
+
+    input = cms.SecSource("EmbeddedRootSource",
+        type = cms.string('probFunction'),
+        nbPileupEvents = cms.PSet(
+          probFunctionVariable = cms.vint32(0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83,84,85,86,87,88,89,90,91,92,93,94,95,96,97,98,99),
+            probValue = cms.vdouble(
+                3.1718e-05, 0, 1.46391e-05, 3.1718e-05, 4.39172e-05, 8.53946e-05, 0.000104913, 0.000129312, 0.000373296, 0.00031962, 0.000714875, 0.00134435, 0.00245448, 0.00368661, 0.00602642, 0.00841259, 0.0114941, 0.014744, 0.0181427, 0.02089, 0.0235518, 0.0244643, 0.0261551, 0.0278118, 0.0288634, 0.0297076, 0.0302882, 0.0314252, 0.0306908, 0.0308982, 0.0313447, 0.0312227, 0.03123, 0.03123, 0.0304712, 0.0299637, 0.0287292, 0.0270091, 0.0264333, 0.0253402, 0.0231053, 0.0211803, 0.0195163, 0.0176254, 0.0162347, 0.0146635, 0.0131288, 0.0129092, 0.012492, 0.0124286, 0.0122993, 0.0126506, 0.0123944, 0.0124017, 0.0125603, 0.0126408, 0.0123261, 0.0122431, 0.0116307, 0.0107304, 0.00967399, 0.00839551, 0.00679497, 0.00532618, 0.00417946, 0.0035085, 0.00319132, 0.00229101, 0.00168349, 0.00126872, 0.000768551, 0.000556285, 0.000402575, 0.000241545, 0.000173229, 0.000182988, 9.5154e-05, 6.83157e-05, 5.85563e-05, 2.92781e-05, 2.92781e-05, 9.75938e-06, 4.87969e-06, 7.31954e-06, 9.75938e-06, 7.31954e-06, 0, 0, 2.43985e-06, 0, 0, 0, 2.43985e-06, 0, 0, 0, 0, 0, 0, 0
+                ),
+          histoFileName = cms.untracked.string('histProbFunction.root'),
+        ),
+                          sequential = cms.untracked.bool(False),
+                          manage_OOT = cms.untracked.bool(True),  ## manage out-of-time pileup
+                          ## setting this to True means that the out-of-time pileup
+        ## will have a different distribution than in-time, given
+        ## by what is described on the next line:
+        OOT_type = cms.untracked.string('Poisson'),  ## generate OOT with a Poisson matching the number chosen for in-time
+        #OOT_type = cms.untracked.string('fixed'),  ## generate OOT with a fixed distribution
+        #intFixed_OOT = cms.untracked.int32(2),
+        fileNames = FileNames
+    ),
+    mixObjects = cms.PSet(theMixObjects)
+)


### PR DESCRIPTION
Missing PU probability values in MetaData/python/PU_MixFiles_2017_miniaodv2_310/ used for the per-sample PU reweighting, for some MC samples including:

1) MC bkg

GJet_Pt-40toInf_DoubleEMEnriched_MGG-80toInf_TuneCP5_13TeV_Pythia8
DiPhotonJetsBox_M40_80-Sherpa
DiPhotonJetsBox_MGG-80toInf_13TeV-Sherpa

2) MC low-mass sig

GluGluHToGG_M105_13TeV_amcatnloFXFX_pythia8
GluGluHToGG_M115_13TeV_amcatnloFXFX_pythia8

VBFHToGG_M85_13TeV_amcatnlo_pythia8
VBFHToGG_M105_13TeV_amcatnlo_pythia8
VBFHToGG_M115_13TeV_amcatnlo_pythia8

VHToGG_M105_13TeV_amcatnloFXFX_madspin_pythia8
VHToGG_M115_13TeV_amcatnloFXFX_madspin_pythia8

ttHJetToGG_M85_13TeV_amcatnloFXFX_madspin_pythia8
ttHJetToGG_M105_13TeV_amcatnloFXFX_madspin_pythia8
ttHJetToGG_M115_13TeV_amcatnloFXFX_madspin_pythia8

Most of the prob values for the missing samples were discussed at the Hgg working meeting on 13 September 2018 :  https://indico.cern.ch/event/754295/contributions/3138406/attachments/1714963/2767685/201809FewSlidePU.pdf

Cheers,

Junquan Tao