### PR TITLE
Update PhotonScaleEGMTool.cc

### DIFF
--- a/Systematics/plugins/PhotonScaleEGMTool.cc
+++ b/Systematics/plugins/PhotonScaleEGMTool.cc
@@ -70,7 +70,7 @@ namespace flashgg {
         if(y.hasSwitchToGain6()) gain=6;
         if( overall_range_( y ) ) {
             auto shift_val = scaler_.scaleCorr(run_number_, y.et(), y.superCluster()->eta(), y.full5x5_r9(), gain);
-            auto shift_err = scaler_.scaleCorrUncert(run_number_, y.et(), y.superCluster()->eta(), y.full5x5_r9(), gain);            
+            auto shift_err = scaler_.scaleCorrUncert(run_number_, y.et(), y.superCluster()->eta(), y.full5x5_r9(), gain, uncBitMask_);            
             if (!applyCentralValue()) shift_val = 1.;
             float scale = shift_val + syst_shift * shift_err;
             if( debug_ ) {


### PR DESCRIPTION
Without uncBitMask this tool pushes 0 error for scales in the signal workspaces.
Validated to be working from a mass measurement with Legacy 2016(Not explicitly validated for 2017).