### PR TITLE
Recovered past features

### DIFF
--- a/Taggers/plugins/TTHLeptonicTagProducer.cc
+++ b/Taggers/plugins/TTHLeptonicTagProducer.cc
@@ -49,7 +49,7 @@ namespace flashgg {
         TTHLeptonicTagProducer( const ParameterSet & );
     private:
         void produce( Event &, const EventSetup & ) override;
-        int  chooseCategory( float );
+        int  chooseCategory( float tthmvavalue , bool debug_ );
 
         const  reco::GenParticle* motherID(const reco::GenParticle* gp);
         bool PassFrixione(Handle<View<reco::GenParticle> > genParticles, const reco::GenParticle* gp, int nBinsForFrix, double cone_frix);
@@ -79,7 +79,6 @@ namespace flashgg {
         EDGetTokenT<int> stage0catToken_, stage1catToken_, njetsToken_;
         EDGetTokenT<HTXS::HiggsClassification> newHTXSToken_;
         EDGetTokenT<float> pTHToken_,pTVToken_;
-        EDGetTokenT<double> rhoTag_;
         string systLabel_;
 
         typedef std::vector<edm::Handle<edm::View<flashgg::Jet> > > JetCollectionVector;
@@ -102,6 +101,12 @@ namespace flashgg {
         double ElePhotonZMassCut_;
         double DeltaRTrkEle_;
 
+        double LeptonsZMassCut_;
+
+        double DiLeptonJetThreshold_;
+        double DiLeptonbJetThreshold_;
+        double DiLeptonMVAThreshold_;
+
         double leadPhoOverMassThreshold_;
         double subleadPhoOverMassThreshold_;
         vector<double> MVAThreshold_;
@@ -119,6 +124,7 @@ namespace flashgg {
 
         bool UseCutBasedDiphoId_;
         bool debug_;
+        bool SplitDiLeptEv_;
         vector<double> CutBasedDiphoId_;
 
         float leadeta_;
@@ -308,7 +314,6 @@ namespace flashgg {
         mvaResultToken_( consumes<View<flashgg::DiPhotonMVAResult> >( iConfig.getParameter<InputTag> ( "MVAResultTag" ) ) ),
         vertexToken_( consumes<View<reco::Vertex> >( iConfig.getParameter<InputTag> ( "VertexTag" ) ) ),
         genParticleToken_( consumes<View<reco::GenParticle> >( iConfig.getParameter<InputTag> ( "GenParticleTag" ) ) ),
-        rhoTag_( consumes<double>( iConfig.getParameter<InputTag>( "rhoTag" ) ) ),
         systLabel_( iConfig.getParameter<string> ( "SystLabel" ) )
     {
         leadPhoOverMassThreshold_ = iConfig.getParameter<double>( "leadPhoOverMassThreshold");
@@ -336,6 +341,12 @@ namespace flashgg {
         ElePhotonZMassCut_ = iConfig.getParameter<double>( "ElePhotonZMassCut");
         DeltaRTrkEle_ = iConfig.getParameter<double>( "DeltaRTrkEle");
 
+        LeptonsZMassCut_ = iConfig.getParameter<double>( "LeptonsZMassCut");
+
+        DiLeptonJetThreshold_ = iConfig.getParameter<double>( "DiLeptonJetThreshold");
+        DiLeptonbJetThreshold_ = iConfig.getParameter<double>( "DiLeptonbJetThreshold");
+        DiLeptonMVAThreshold_ = iConfig.getParameter<double>( "DiLeptonMVAThreshold");
+
         deltaRJetLeadPhoThreshold_ = iConfig.getParameter<double>( "deltaRJetLeadPhoThreshold");
         deltaRJetSubLeadPhoThreshold_ = iConfig.getParameter<double>( "deltaRJetSubLeadPhoThreshold");
 
@@ -344,6 +355,7 @@ namespace flashgg {
 
         UseCutBasedDiphoId_ = iConfig.getParameter<bool>( "UseCutBasedDiphoId" );
         debug_ = iConfig.getParameter<bool>( "debug" );
+        SplitDiLeptEv_ = iConfig.getParameter<bool>( "SplitDiLeptEv" );
         CutBasedDiphoId_ = iConfig.getParameter<std::vector<double>>( "CutBasedDiphoId" );
 
         ParameterSet HTXSps = iConfig.getParameterSet( "HTXSTags" );
@@ -391,13 +403,20 @@ namespace flashgg {
         produces<vector<TagTruthBase> >();
     }
 
-    int TTHLeptonicTagProducer::chooseCategory( float tthmvavalue )
+    int TTHLeptonicTagProducer::chooseCategory( float tthmvavalue , bool debug_)
     {
         // should return 0 if mva above all the numbers, 1 if below the first, ..., boundaries.size()-N if below the Nth, ...
         int n;
         for( n = 0 ; n < ( int )MVAThreshold_.size() ; n++ ) {
             if( ( double )tthmvavalue > MVAThreshold_[MVAThreshold_.size() - n - 1] ) { return n; }
         }
+
+      if(debug_)
+        {   cout << "Checking class, thresholds: ";
+            for(unsigned int i=0; i<MVAThreshold_.size(); ++i)
+                cout << MVAThreshold_[i] << " ";
+        }
+
         return -1; // Does not pass, object will not be produced
     }
 
@@ -430,10 +449,6 @@ namespace flashgg {
 
         Handle<View<flashgg::Electron> > theElectrons;
         evt.getByToken( electronToken_, theElectrons );
-
-        edm::Handle<double>  rho;
-        evt.getByToken(rhoTag_,rho);
-        double rho_    = *rho;
 
         Handle<View<flashgg::DiPhotonMVAResult> > mvaResults;
         evt.getByToken( mvaResultToken_, mvaResults );
@@ -504,6 +519,9 @@ namespace flashgg {
 
             if(!passDiphotonSelection) continue;
 
+            if(debug_)
+                cout << "Passed photon selection, checking leptons: " << idmva1 << " " << idmva2 << endl;
+
             std::vector<edm::Ptr<flashgg::Muon> >     Muons;
             std::vector<edm::Ptr<flashgg::Electron> > Electrons;
 
@@ -517,9 +535,87 @@ namespace flashgg {
                 Muons = selectMuons(theMuons->ptrs(), dipho, vertices->ptrs(), MuonPtCut_, MuonEtaCut_, MuonIsoCut_, MuonPhotonDrCut_, debug_);
             if(theElectrons->size()>0)
                 Electrons = selectElectrons(theElectrons->ptrs(), dipho, ElePtCut_, EleEtaCuts_, ElePhotonDrCut_, ElePhotonZMassCut_, DeltaRTrkEle_, debug_);
+ 
+
+            //If 2 same flavour leptons are found remove the pairs with mass compatible with a Z boson
+
+            if(Muons.size()>=2)
+            {
+                std::vector<edm::Ptr<flashgg::Muon>> Muons_0;
+                Muons_0 = Muons;
+                std::vector<int> badIndexes;
+
+                for(unsigned int i=0; i<Muons_0.size(); ++i)
+                {
+                    for(unsigned int j=i+1; j<Muons_0.size(); ++j)
+                    {
+                        TLorentzVector l1, l2;
+                        l1.SetPtEtaPhiE(Muons_0[i]->pt(), Muons_0[i]->eta(), Muons_0[i]->phi(), Muons_0[i]->energy());
+                        l2.SetPtEtaPhiE(Muons_0[j]->pt(), Muons_0[j]->eta(), Muons_0[j]->phi(), Muons_0[j]->energy());
+
+                        if(fabs((l1+l2).M() - 91.187) < LeptonsZMassCut_)
+                        {
+                            badIndexes.push_back(i);
+                            badIndexes.push_back(j);
+                        }
+                    }
+                }
+
+                if(badIndexes.size()!=0)
+                {
+                    Muons.clear();
+                    for(unsigned int i=0; i<Muons_0.size(); ++i)
+                    {
+                       bool isBad = false;
+                       for(unsigned int j=0; j<badIndexes.size(); ++j)
+                       {
+                          if(badIndexes[j]==(int)i)
+                               isBad = true;
+                      }
+                      if(!isBad) Muons.push_back(Muons_0[i]);
+                    }
+                }
+            }        
+
+            if(Electrons.size()>=2)
+            {
+                std::vector<int> badIndexes;
+                std::vector<edm::Ptr<flashgg::Electron> > Electrons_0;
+                Electrons_0 = Electrons;
+                for(unsigned int i=0; i<Electrons_0.size(); ++i)
+                {
+                    for(unsigned int j=i+1; j<Electrons_0.size(); ++j)
+                    {
+                        TLorentzVector l1, l2;
+                        l1.SetPtEtaPhiE(Electrons_0[i]->pt(), Electrons_0[i]->eta(), Electrons_0[i]->phi(), Electrons_0[i]->energy());
+                        l2.SetPtEtaPhiE(Electrons_0[j]->pt(), Electrons_0[j]->eta(), Electrons_0[j]->phi(), Electrons_0[j]->energy());
+
+                        if(fabs((l1+l2).M() - 91.187) < LeptonsZMassCut_)
+                        {
+                            badIndexes.push_back(i);
+                            badIndexes.push_back(j);
+                        }
+                    }
+                }
+                if(badIndexes.size()!=0)
+                {
+                    Electrons.clear();
+
+                    for(unsigned int i=0; i<Electrons_0.size(); ++i)
+                    {
+                         bool isBad = false;
+                         for(unsigned int j=0; j<badIndexes.size(); ++j)
+                         {
+                             if(badIndexes[j]==(int)i)
+                                 isBad = true;
+                         }
+                         if(!isBad) Electrons.push_back(Electrons_0[i]);
+                    }
+                 }
+             }        
 
             if( (Muons.size() + Electrons.size()) < (unsigned) MinNLep_ || (Muons.size() + Electrons.size()) > (unsigned) MaxNLep_) continue;
- 
+
             // Fill lepton vectors            
             // ===================
             
@@ -715,7 +811,7 @@ namespace flashgg {
 
             if( theMet_ -> size() != 1 )
                 std::cout << "WARNING number of MET is not equal to 1" << std::endl;
-             MetPt_ = theMet_->ptrAt( 0 ) -> pt();
+             MetPt_ = theMet_->ptrAt( 0 ) -> getCorPt();
 
             int leadMuIndex = 0;
             float leadMuPt = -1;
@@ -757,7 +853,25 @@ namespace flashgg {
 
             float mvaValue = DiphotonMva_-> EvaluateMVA( "BDT" );
             int catNumber = -1;
-            catNumber = chooseCategory( mvaValue );  
+            catNumber = chooseCategory( mvaValue , debug_);  
+
+          if(debug_)
+                cout << "I'm going to check selections, mva value: " << mvaValue << endl;
+
+            if(SplitDiLeptEv_ && lepPt.size()>1 && njet_ >= DiLeptonJetThreshold_ && njets_btagmedium_ >= DiLeptonbJetThreshold_ && mvaValue > DiLeptonMVAThreshold_ ) 
+            // Check DiLepton selection and assigne to purest cat if splitting is True
+            {    catNumber = 0;
+                 if(debug_)
+                    cout << "DiLepton event with: " << njet_ << "jets, (threshold " << DiLeptonJetThreshold_ << ") " << njets_btagmedium_ << " bjets, (threshold " << DiLeptonbJetThreshold_  << ")" << mvaValue << " mva (threshold " << DiLeptonMVAThreshold_ << endl;
+
+            }
+            
+            else if(lepPt.size()==1 && njet_ >= jetsNumberThreshold_ && njets_btagmedium_ >= bjetsNumberThreshold_) 
+            // Check single lepton selections
+            {    catNumber = chooseCategory( mvaValue, debug_ );  
+               if(debug_)
+                    cout << "Single lepton event with: "<< njet_ << " jets, (threshold " << DiLeptonJetThreshold_ << ") " << njets_btagmedium_ << " bjets, (threshold " << DiLeptonbJetThreshold_  << ")" << mvaValue << " mva (thresholds "  << endl;
+            }
 
             if(debug_)
             { 
@@ -787,7 +901,6 @@ namespace flashgg {
                 for( unsigned int i = 0; i < tagJets.size(); ++i )
                 {
                     tthltags_obj.includeWeightsByLabel( *tagJets[i] , "JetBTagReshapeWeight");
-                    tthltags_obj.includeWeightsByLabel( *tagJets[i] , "JetBTagCutWeight");
                 }
 
 

--- a/Taggers/python/flashggTags_cff.py
+++ b/Taggers/python/flashggTags_cff.py
@@ -1,3 +1,4 @@
+
 import FWCore.ParameterSet.Config as cms
 from flashgg.MicroAOD.flashggJets_cfi import flashggBTag, flashggDeepCSV, maxJetCollections
 
@@ -190,7 +191,7 @@ flashggTTHLeptonicTag = cms.EDProducer("FlashggTTHLeptonicTagProducer",
                                        bDiscriminator = bDiscriminator94X, #bDiscriminator76X,
                                        bTag = cms.string(flashggDeepCSV),
                                        MinNLep = cms.int32(1),
-                                       MaxNLep = cms.int32(1),
+                                       MaxNLep = cms.int32(10),
 				       MuonEtaCut = cms.double(2.4),
 				       MuonPtCut = cms.double(5),
 				       MuonIsoCut = cms.double(0.25),
@@ -199,12 +200,16 @@ flashggTTHLeptonicTag = cms.EDProducer("FlashggTTHLeptonicTagProducer",
 				       ElePtCut = cms.double(10),
 				       ElePhotonDrCut = cms.double(0.2),
 				       ElePhotonZMassCut = cms.double(5),
+				       LeptonsZMassCut = cms.double(5),
+				       DiLeptonJetThreshold = cms.double(1),
+				       DiLeptonbJetThreshold = cms.double(1),
+				       DiLeptonMVAThreshold = cms.double(0.5),
 				       DeltaRTrkEle = cms.double(0.35),
 				       UseCutBasedDiphoId = cms.bool(False),
+				       SplitDiLeptEv = cms.bool(True),
 				       debug = cms.bool(False),
 				       CutBasedDiphoId = cms.vdouble(0.4,0.3,0.0,-0.5,2.0,2.5),    # pT/m lead, pT/m sublead, leadIdMVA, subleadIdMVA, DeltaEta, DeltaPhi
                                        HTXSTags     = HTXSInputTags
-
 )
 
 flashggTTHDiLeptonTag = cms.EDProducer("FlashggTTHDiLeptonTagProducer",


### PR DESCRIPTION
Recovering of a few features were lost in the past PR but present in the 2017 ttH analysis:
 - Met correction are now applied
 - BTag scale factors are applied in the correct way
 - Events with 2 leptons can be included in the purest category with a bool flag in flashggTags