### PR TITLE
Correct the e-veto SFs for 2016 legacy and 2017 dataset

### DIFF
--- a/Systematics/python/flashggDiPhotonSystematics2016_cfi.py
+++ b/Systematics/python/flashggDiPhotonSystematics2016_cfi.py
@@ -22,14 +22,14 @@ preselBins = cms.PSet(
         )
     )
 
-# JTao: slide 11 of https://indico.cern.ch/event/605406/contributions/2487608/attachments/1417110/2170077/201702ZmmgEVetoPhotonValidations.pdf from the update with 2016 full 35.9/fb data and the final showershpae correction
+# JTao: slide 2 of https://indico.cern.ch/event/762183/contributions/3181242/attachments/1736403/2823204/201810_2016Legacy_e-veto_etc.pdf with 2016 legacy data samples, small changes on teh SFs wrt previous results with 2016 rereco data samples 
 electronVetoBins = cms.PSet(
     variables = cms.vstring("abs(superCluster.eta)","full5x5_r9"),
     bins = cms.VPSet(
-        cms.PSet( lowBounds = cms.vdouble( 0.0, 0.00 ) , upBounds = cms.vdouble( 1.5, 0.85 ) , values = cms.vdouble( 0.9945 ) , uncertainties = cms.vdouble( 0.0023 )  ) ,
-        cms.PSet( lowBounds = cms.vdouble( 0.0, 0.85 ) , upBounds = cms.vdouble( 1.5, 999. ) , values = cms.vdouble( 0.9958 ) , uncertainties = cms.vdouble( 0.0006 )  ) ,
-        cms.PSet( lowBounds = cms.vdouble( 1.5, 0.00 ) , upBounds = cms.vdouble( 6.0, 0.90 ) , values = cms.vdouble( 0.9777 ) , uncertainties = cms.vdouble( 0.0065 )  ) ,
-        cms.PSet( lowBounds = cms.vdouble( 1.5, 0.90 ) , upBounds = cms.vdouble( 6.0, 999. ) , values = cms.vdouble( 0.9924 ) , uncertainties = cms.vdouble( 0.0017 )  ) 
+        cms.PSet( lowBounds = cms.vdouble( 0.0, 0.00 ) , upBounds = cms.vdouble( 1.5, 0.85 ) , values = cms.vdouble( 0.9939 ) , uncertainties = cms.vdouble( 0.0023 )  ) ,
+        cms.PSet( lowBounds = cms.vdouble( 0.0, 0.85 ) , upBounds = cms.vdouble( 1.5, 999. ) , values = cms.vdouble( 0.9955 ) , uncertainties = cms.vdouble( 0.0006 )  ) ,
+        cms.PSet( lowBounds = cms.vdouble( 1.5, 0.00 ) , upBounds = cms.vdouble( 6.0, 0.90 ) , values = cms.vdouble( 0.9709 ) , uncertainties = cms.vdouble( 0.0068 )  ) ,
+        cms.PSet( lowBounds = cms.vdouble( 1.5, 0.90 ) , upBounds = cms.vdouble( 6.0, 999. ) , values = cms.vdouble( 0.9916 ) , uncertainties = cms.vdouble( 0.0017 )  ) 
         )
     )
 

--- a/Systematics/python/flashggDiPhotonSystematics2017_cfi.py
+++ b/Systematics/python/flashggDiPhotonSystematics2017_cfi.py
@@ -26,9 +26,9 @@ preselBins = cms.PSet(
 electronVetoBins = cms.PSet(
     variables = cms.vstring("abs(superCluster.eta)","full5x5_r9"),
     bins = cms.VPSet(
-        cms.PSet( lowBounds = cms.vdouble( 0.0, 0.00 ) , upBounds = cms.vdouble( 1.5, 0.85 ) , values = cms.vdouble( 0.9863 ) , uncertainties = cms.vdouble( 0.0022 )  ) ,
-        cms.PSet( lowBounds = cms.vdouble( 0.0, 0.85 ) , upBounds = cms.vdouble( 1.5, 999. ) , values = cms.vdouble( 0.9926 ) , uncertainties = cms.vdouble( 0.0006 )  ) ,
-        cms.PSet( lowBounds = cms.vdouble( 1.5, 0.00 ) , upBounds = cms.vdouble( 6.0, 0.90 ) , values = cms.vdouble( 0.9765 ) , uncertainties = cms.vdouble( 0.0073 )  ) ,
+        cms.PSet( lowBounds = cms.vdouble( 0.0, 0.00 ) , upBounds = cms.vdouble( 1.5, 0.85 ) , values = cms.vdouble( 0.9864 ) , uncertainties = cms.vdouble( 0.0022 )  ) ,
+        cms.PSet( lowBounds = cms.vdouble( 0.0, 0.85 ) , upBounds = cms.vdouble( 1.5, 999. ) , values = cms.vdouble( 0.9925 ) , uncertainties = cms.vdouble( 0.0006 )  ) ,
+        cms.PSet( lowBounds = cms.vdouble( 1.5, 0.00 ) , upBounds = cms.vdouble( 6.0, 0.90 ) , values = cms.vdouble( 0.9771 ) , uncertainties = cms.vdouble( 0.0074 )  ) ,
         cms.PSet( lowBounds = cms.vdouble( 1.5, 0.90 ) , upBounds = cms.vdouble( 6.0, 999. ) , values = cms.vdouble( 0.9855 ) , uncertainties = cms.vdouble( 0.0018 )  )
         )
     )


### PR DESCRIPTION

1)  Correct the e-veto SFs for 2016 legacy in Systematics/python/flashggDiPhotonSystematics2016_cfi.py , according to slide 2 of https://indico.cern.ch/event/762183/contributions/3181242/attachments/1736403/2823204/201810_2016Legacy_e-veto_etc.pdf with 2016 legacy data samples, small changes on the SFs wrt previous results with 2016 rereco data samples.

2)  Correct  the e-veto SFs for 2017 analyssi in Systematics/python/flashggDiPhotonSystematics2017_cfi.py : the e-veto scale factors for "dev_legacy_runII" 2017 dataset in are not the latest updated ones used for 2017 ttH (public for HC2018) [1] and 2017 STXS (public for Moriond2019) [2].  In [1] the numbers are the older ones before the PR#1089 [3].



[1] https://github.com/cms-analysis/flashgg/blob/master/Systematics/python/flashggDiPhotonSystematics_cfi.py#L26

[2] https://github.com/edjtscott/flashgg/blob/STXSstage1/Systematics/python/flashggDiPhotonSystematics_cfi.py#L26

[3] https://github.com/cms-analysis/flashgg/pull/1089/files
