### PR TITLE
Update handling of jets in microAOD

### DIFF
--- a/MicroAOD/python/flashggJets_cfi.py
+++ b/MicroAOD/python/flashggJets_cfi.py
@@ -92,7 +92,7 @@ def addFlashggPFCHSJets(process,
     process.QGPoolDBESSource = cms.ESSource("PoolDBESSource",
                                             CondDBSetup,
                                             toGet = cms.VPSet(),
-                                            connect = cms.string('sqlite:QGL_'+qgDatabaseVersion+'.db') 
+                                            connect = cms.string('sqlite:MicroAOD/data/QGL_'+qgDatabaseVersion+'.db') 
                                             )
     process.es_prefer_qg = cms.ESPrefer('PoolDBESSource','QGPoolDBESSource')
   

--- a/MicroAOD/python/flashggTriggerFilter.py
+++ b/MicroAOD/python/flashggTriggerFilter.py
@@ -12,7 +12,8 @@ def getMicroAODHLTFilter(datasetName, options):
         triggerConditions = cms.vstring()
         for trg in trgs:
             triggerConditions.append(str(trg))
-        if re.search(tag, datasetName):
+        #if re.search(tag, datasetName):
+        if tag.count(datasetName):
             print 'Only events from these path will be processed: '
             print triggerConditions
             triggerSelectionModule = cms.EDFilter("TriggerResultsFilter",


### PR DESCRIPTION
This PR simply updates the jet treatment in microAOD to be the same as it already was in 2017. Performed tests to check that the zeroth vertex jets agree with the miniAOD jets, and that the jets from the other vertices are sensible. These tests were done on 2016 & 2018 miniAOD for data, Drell-Yan and signal. 

The second commit has two minor adjustments that were needed to get these local tests to work - I don't know if they will be required or wanted in the main repo. 

At some point we expect further updates for the QGL and PUJID, but for now the code should be up-to-date. 