### PR TITLE
Met Filters for Run II

### DIFF
--- a/DataFormats/interface/Met.h
+++ b/DataFormats/interface/Met.h
@@ -16,21 +16,24 @@ namespace flashgg {
         ~Met();
 
         Met *clone() const { return ( new Met( *this ) ); }
-        
+
         void setCorPx(float mPx);
         void setCorPy(float mPy);
         void setCorPt(float mPt);
         void setCorPhi(float mPhi);
+        void setPassEcalBadCalibFilter(bool mPass);
         float getCorPx() const;
         float getCorPy() const;
         float getCorPhi() const;
         float getCorPt() const;
-        
+        bool getPassEcalBadCalibFilter() const;
+
     private:
         float corpx;
         float corpy;
         float corphi;
         float corpt;
+        bool passEcalBadCalibFilter;
     };
 }
 

--- a/DataFormats/src/Met.cc
+++ b/DataFormats/src/Met.cc
@@ -38,6 +38,11 @@ void Met::setCorPhi(float mPhi)
     corpy=mPhi;
 }
 
+void Met::setPassEcalBadCalibFilter(bool mPass)
+{
+    passEcalBadCalibFilter = mPass;
+}
+
 float Met::getCorPx() const
 {
     return(corpx);
@@ -55,7 +60,10 @@ float Met::getCorPt() const
     return(corpt);
 }
 
-
+bool Met::getPassEcalBadCalibFilter() const
+{
+    return(passEcalBadCalibFilter);
+}
 
 // Local Variables:
 // mode:c++

--- a/DataFormats/src/classes_def.xml
+++ b/DataFormats/src/classes_def.xml
@@ -261,9 +261,10 @@
 <class name="std::vector<flashgg::Jet>"/>
 <class name="edm::Ptr<flashgg::Jet>"/>
 
-<class name="flashgg::Met" ClassVersion="11">
+<class name="flashgg::Met" ClassVersion="12">
   <version ClassVersion="10" checksum="2272826605"/>
   <version ClassVersion="11" checksum="1231550995"/>
+  <version ClassVersion="12" checksum="597961085"/>
 </class>
 <class name="std::vector<flashgg::Met>"/>
 <class name="edm::Wrapper<std::vector<flashgg::Met> >"/>

--- a/MetaData/data/MetaConditions/Era2016_RR-17Jul2018_v1.json
+++ b/MetaData/data/MetaConditions/Era2016_RR-17Jul2018_v1.json
@@ -6,6 +6,30 @@
     },
 
     "flashggMETsFunction" : "runMETs2016",
+    "flashggMetFilters" :
+    {
+        "data" :
+        [
+            "Flag_goodVertices",
+            "Flag_globalSuperTightHalo2016Filter",
+            "Flag_HBHENoiseFilter",
+            "Flag_HBHENoiseIsoFilter",
+            "Flag_EcalDeadCellTriggerPrimitiveFilter",
+            "Flag_BadPFMuonFilter",
+            "Flag_eeBadScFilter"
+        ],
+        "mc" :
+        [
+            "Flag_goodVertices",
+            "Flag_globalSuperTightHalo2016Filter",
+            "Flag_HBHENoiseFilter",
+            "Flag_HBHENoiseIsoFilter",
+            "Flag_EcalDeadCellTriggerPrimitiveFilter",
+            "Flag_BadPFMuonFilter"
+        ]
+    },
+
+
     "DeepJet" : "rerun",
 
     "flashggPhotons" :

--- a/MetaData/data/MetaConditions/Era2016_RR-17Jul2018_v1.json
+++ b/MetaData/data/MetaConditions/Era2016_RR-17Jul2018_v1.json
@@ -8,6 +8,7 @@
     "flashggMETsFunction" : "runMETs2016",
     "flashggMetFilters" :
     {
+        "rerun_ecal_calib_filter" : false,
         "data" :
         [
             "Flag_goodVertices",

--- a/MetaData/data/MetaConditions/Era2017_RR-31Mar2018_v1.json
+++ b/MetaData/data/MetaConditions/Era2017_RR-31Mar2018_v1.json
@@ -8,6 +8,7 @@
     "flashggMETsFunction" : "runMETs2017",
     "flashggMetFilters" :
     {
+        "rerun_ecal_calib_filter" : true,
         "data" : 
         [
             "Flag_goodVertices", 

--- a/MetaData/data/MetaConditions/Era2017_RR-31Mar2018_v1.json
+++ b/MetaData/data/MetaConditions/Era2017_RR-31Mar2018_v1.json
@@ -6,6 +6,29 @@
     },
 
     "flashggMETsFunction" : "runMETs2017",
+    "flashggMetFilters" :
+    {
+        "data" : 
+        [
+            "Flag_goodVertices", 
+            "Flag_globalSuperTightHalo2016Filter", 
+            "Flag_HBHENoiseFilter", 
+            "Flag_HBHENoiseIsoFilter", 
+            "Flag_EcalDeadCellTriggerPrimitiveFilter",
+            "Flag_BadPFMuonFilter", 
+            "Flag_eeBadScFilter"
+        ],
+        "mc" : 
+        [
+            "Flag_goodVertices",
+            "Flag_globalSuperTightHalo2016Filter",
+            "Flag_HBHENoiseFilter",
+            "Flag_HBHENoiseIsoFilter",
+            "Flag_EcalDeadCellTriggerPrimitiveFilter",
+            "Flag_BadPFMuonFilter"
+        ]
+    },
+
     "DeepJet" : "rerun",
 
     "flashggPhotons" :

--- a/MetaData/data/MetaConditions/Era2018_Prompt_v1.json
+++ b/MetaData/data/MetaConditions/Era2018_Prompt_v1.json
@@ -6,6 +6,29 @@
     },
 
     "flashggMETsFunction" : "runMETs2016",
+    "flashggMetFilters" :
+    {
+        "data" :
+        [
+            "Flag_goodVertices",
+            "Flag_globalSuperTightHalo2016Filter",
+            "Flag_HBHENoiseFilter",
+            "Flag_HBHENoiseIsoFilter",
+            "Flag_EcalDeadCellTriggerPrimitiveFilter",
+            "Flag_BadPFMuonFilter",
+            "Flag_eeBadScFilter"
+        ],
+        "mc" :
+        [
+            "Flag_goodVertices",
+            "Flag_globalSuperTightHalo2016Filter",
+            "Flag_HBHENoiseFilter",
+            "Flag_HBHENoiseIsoFilter",
+            "Flag_EcalDeadCellTriggerPrimitiveFilter",
+            "Flag_BadPFMuonFilter"
+        ]
+    }, 
+
     "DeepJet" : "read",
 
     "flashggPhotons" :

--- a/MetaData/data/MetaConditions/Era2018_Prompt_v1.json
+++ b/MetaData/data/MetaConditions/Era2018_Prompt_v1.json
@@ -8,6 +8,7 @@
     "flashggMETsFunction" : "runMETs2016",
     "flashggMetFilters" :
     {
+        "rerun_ecal_calib_filter" : true,
         "data" :
         [
             "Flag_goodVertices",

--- a/MetaData/data/MetaConditions/Era2018_RR-17Sep2018_v1.json
+++ b/MetaData/data/MetaConditions/Era2018_RR-17Sep2018_v1.json
@@ -6,6 +6,29 @@
     },
 
     "flashggMETsFunction" : "runMETs2016",
+    "flashggMetFilters" :
+    {
+        "data" :
+        [
+            "Flag_goodVertices",
+            "Flag_globalSuperTightHalo2016Filter",
+            "Flag_HBHENoiseFilter",
+            "Flag_HBHENoiseIsoFilter",
+            "Flag_EcalDeadCellTriggerPrimitiveFilter",
+            "Flag_BadPFMuonFilter",
+            "Flag_eeBadScFilter"
+        ],
+        "mc" :
+        [
+            "Flag_goodVertices",
+            "Flag_globalSuperTightHalo2016Filter",
+            "Flag_HBHENoiseFilter",
+            "Flag_HBHENoiseIsoFilter",
+            "Flag_EcalDeadCellTriggerPrimitiveFilter",
+            "Flag_BadPFMuonFilter"
+        ]
+    },    
+
     "DeepJet" : "read",
 
     "flashggPhotons" :

--- a/MetaData/data/MetaConditions/Era2018_RR-17Sep2018_v1.json
+++ b/MetaData/data/MetaConditions/Era2018_RR-17Sep2018_v1.json
@@ -8,6 +8,7 @@
     "flashggMETsFunction" : "runMETs2016",
     "flashggMetFilters" :
     {
+        "rerun_ecal_calib_filter" : true,
         "data" :
         [
             "Flag_goodVertices",

--- a/MicroAOD/python/MicroAODCustomize.py
+++ b/MicroAOD/python/MicroAODCustomize.py
@@ -189,6 +189,7 @@ class MicroAODCustomize(object):
                 getattr(self,'customizeRunIIEGMPhoID')(process)
             # check if ok for 2016
             self.insertEGMSequence( process ) 
+        self.customizeMetFilters(process)
         print "Final customized process:",process.p
             
     # signal specific customization
@@ -647,11 +648,32 @@ class MicroAODCustomize(object):
         process.task = createTaskWithAllProducersAndFilters(process)
         process.p.associate(process.task)
 
-    def rereunEcalBadCalibFilter(self, process):
-        """
-        Rerun the ECAL bad calib filter (EE high eta noise)
-        ---NOT THE FINAL RECIPE---
-        """
+    def customizeMetFilters(self, process):
+        # All filters applied in workspaceStd.py
+        # Except for this filter, which must be applied on miniAOD directly. 
+        # Here we follow the recipe from:  https://twiki.cern.ch/twiki/bin/view/CMS/MissingETOptionalFiltersRun2#Analysis_Recommendations_for_ana
+        if self.metaConditions["flashggMetFilters"]["rerun_ecal_calib_filter"]:
+            process.load('RecoMET.METFilters.ecalBadCalibFilter_cfi')
+            baddetEcallist = cms.vuint32(
+            [872439604,872422825,872420274,872423218,
+             872423215,872416066,872435036,872439336,
+             872420273,872436907,872420147,872439731,
+             872436657,872420397,872439732,872439339,
+             872439603,872422436,872439861,872437051,
+             872437052,872420649,872422436,872421950,
+             872437185,872422564,872421566,872421695,
+             872421955,872421567,872437184,872421951,
+             872421694,872437056,872437057,872437313])
+            process.ecalBadCalibReducedMINIAODFilter = cms.EDFilter(
+                "EcalBadCalibFilter",
+                EcalRecHitSource = cms.InputTag("reducedEgamma:reducedEERecHits"),
+                ecalMinEt        = cms.double(50.),
+                baddetEcal    = baddetEcallist,
+                taggingMode = cms.bool(True),
+                debug = cms.bool(False)
+            )
+
+            process.p += process.ecalBadCalibReducedMINIAODFilter
         
         
 def createTaskWithAllProducersAndFilters(process):

--- a/MicroAOD/python/MicroAODCustomize.py
+++ b/MicroAOD/python/MicroAODCustomize.py
@@ -189,7 +189,6 @@ class MicroAODCustomize(object):
                 getattr(self,'customizeRunIIEGMPhoID')(process)
             # check if ok for 2016
             self.insertEGMSequence( process ) 
-        self.customizeMetFilters(process)
         print "Final customized process:",process.p
             
     # signal specific customization
@@ -648,33 +647,6 @@ class MicroAODCustomize(object):
         process.task = createTaskWithAllProducersAndFilters(process)
         process.p.associate(process.task)
 
-    def customizeMetFilters(self, process):
-        # All filters applied in workspaceStd.py
-        # Except for this filter, which must be applied on miniAOD directly. 
-        # Here we follow the recipe from:  https://twiki.cern.ch/twiki/bin/view/CMS/MissingETOptionalFiltersRun2#Analysis_Recommendations_for_ana
-        if self.metaConditions["flashggMetFilters"]["rerun_ecal_calib_filter"]:
-            process.load('RecoMET.METFilters.ecalBadCalibFilter_cfi')
-            baddetEcallist = cms.vuint32(
-            [872439604,872422825,872420274,872423218,
-             872423215,872416066,872435036,872439336,
-             872420273,872436907,872420147,872439731,
-             872436657,872420397,872439732,872439339,
-             872439603,872422436,872439861,872437051,
-             872437052,872420649,872422436,872421950,
-             872437185,872422564,872421566,872421695,
-             872421955,872421567,872437184,872421951,
-             872421694,872437056,872437057,872437313])
-            process.ecalBadCalibReducedMINIAODFilter = cms.EDFilter(
-                "EcalBadCalibFilter",
-                EcalRecHitSource = cms.InputTag("reducedEgamma:reducedEERecHits"),
-                ecalMinEt        = cms.double(50.),
-                baddetEcal    = baddetEcallist,
-                taggingMode = cms.bool(True),
-                debug = cms.bool(False)
-            )
-
-            process.p += process.ecalBadCalibReducedMINIAODFilter
-        
         
 def createTaskWithAllProducersAndFilters(process):
    from FWCore.ParameterSet.Config import Task

--- a/MicroAOD/python/flashggMETs_cff.py
+++ b/MicroAOD/python/flashggMETs_cff.py
@@ -10,6 +10,31 @@ if usePrivateSQlite:
     from CondCore.DBCommon.CondDBSetup_cfi import *
     import os
 
+# Store a flag in the flashgg MET to tell us if the event passes the ecalBadCalibFilter
+# This filter has to be rerun on top of miniAOD. All other MET filters implemented in workspaceStd.py
+# Here we follow the recipe from:  https://twiki.cern.ch/twiki/bin/view/CMS/MissingETOptionalFiltersRun2#Analysis_Recommendations_for_ana
+def runEcalBadCalibFilter(process, options):
+    process.load('RecoMET.METFilters.ecalBadCalibFilter_cfi')
+    baddetEcallist = cms.vuint32(
+    [872439604,872422825,872420274,872423218,
+     872423215,872416066,872435036,872439336,
+     872420273,872436907,872420147,872439731,
+     872436657,872420397,872439732,872439339,
+     872439603,872422436,872439861,872437051,
+     872437052,872420649,872422436,872421950,
+     872437185,872422564,872421566,872421695,
+     872421955,872421567,872437184,872421951,
+     872421694,872437056,872437057,872437313]) 
+    process.ecalBadCalibReducedMINIAODFilter = cms.EDFilter(
+        "EcalBadCalibFilter",
+        EcalRecHitSource = cms.InputTag("reducedEgamma:reducedEERecHits"),
+        ecalMinEt        = cms.double(50.),
+        baddetEcal    = baddetEcallist,
+        taggingMode = cms.bool(True),
+        debug = cms.bool(False)
+    )
+    process.p *= process.ecalBadCalibReducedMINIAODFilter
+    
 
 #============================================Apply MET correction and syst.=================================================#
 
@@ -46,7 +71,8 @@ def runMETs2016(process, options):
                                postfix="",
                                isData=(options.processType == "data"),
                            )
-       
+
+    runEcalBadCalibFilter(process, options)
     process.flashggMets = cms.EDProducer('FlashggMetProducer',
                                          verbose = cms.untracked.bool(False),
                                          metTag = cms.InputTag('slimmedMETs'),
@@ -65,13 +91,13 @@ def runMETs2017(process, options):
                                # will produce new MET collection: slimmedMETsModifiedMET
                                postfix = "",
                            )
-    
+
+    runEcalBadCalibFilter(process, options)
     process.flashggMets = cms.EDProducer('FlashggMetProducer',
                                          verbose = cms.untracked.bool(False),
                                          metTag = cms.InputTag('slimmedMETs'),
     )
     process.flashggMetSequence = cms.Sequence(process.fullPatMetSequence*process.flashggMets)
-
 
         
 #===========================================================================================================================#

--- a/MicroAOD/test/microAODstd.py
+++ b/MicroAOD/test/microAODstd.py
@@ -17,15 +17,15 @@ process.MessageLogger.cerr.FwkReport.reportEvery = cms.untracked.int32( 100 )
 import os
 ### 2016
 process.GlobalTag = GlobalTag(process.GlobalTag, '', '')
-process.source = cms.Source("PoolSource",
-                             fileNames=cms.untracked.vstring("/store/mc/RunIISummer16MiniAODv3/VBFHToGG_M125_13TeV_amcatnlo_pythia8_v2/MINIAODSIM/PUMoriond17_94X_mcRun2_asymptotic_v3-v1/50000/38128C3C-892D-E911-AC8E-008CFA0087C4.root"))
+#process.source = cms.Source("PoolSource",
+#                             fileNames=cms.untracked.vstring("/store/mc/RunIISummer16MiniAODv3/VBFHToGG_M125_13TeV_amcatnlo_pythia8_v2/MINIAODSIM/PUMoriond17_94X_mcRun2_asymptotic_v3-v1/50000/38128C3C-892D-E911-AC8E-008CFA0087C4.root"))
 #    process.GlobalTag = GlobalTag(process.GlobalTag,'80X_dataRun2_2016LegacyRepro_v4','')
 #    process.source = cms.Source("PoolSource",fileNames=cms.untracked.vstring("/store/data/Run2016B/SingleElectron/MINIAOD/07Aug17_ver1-v1/110000/0248293E-578B-E711-A639-44A842CFC9D9.root"))
 
 ### 2017
 #process.GlobalTag = GlobalTag(process.GlobalTag,'','')
-#process.source = cms.Source("PoolSource",
-#                             fileNames=cms.untracked.vstring("/store/mc/RunIIFall17MiniAODv2/GluGluHToGG_M-125_13TeV_powheg_pythia8/MINIAODSIM/PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/40000/0866D1A8-1941-E811-B61F-0CC47AF9B2E6.root"))
+process.source = cms.Source("PoolSource",
+                             fileNames=cms.untracked.vstring("/store/mc/RunIIFall17MiniAODv2/GluGluHToGG_M-125_13TeV_powheg_pythia8/MINIAODSIM/PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/40000/0866D1A8-1941-E811-B61F-0CC47AF9B2E6.root"))
 #    process.source = cms.Source("PoolSource",fileNames=cms.untracked.vstring('/store/mc/RunIISummer16MiniAODv2/GluGluHToGG_M-125_13TeV_powheg_pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/60000/024E4FA3-8BBC-E611-8E3D-00266CFFBE88.root'))
     #process.source = cms.Source("PoolSource",fileNames=cms.untracked.vstring('root://eoscms.cern.ch//eos/cms/store/mc/RunIIFall17MiniAOD/GJet_Pt-20to40_DoubleEMEnriched_MGG-80toInf_TuneCP5_13TeV_Pythia8/MINIAODSIM/94X_mc2017_realistic_v10-v1/40000/4A2ACB0A-1BD9-E711-AF54-141877410316.root'))
 #    process.source = cms.Source("PoolSource",fileNames=cms.untracked.vstring('root://eoscms.cern.ch//eos/cms/store/mc/RunIIFall17MiniAOD/GluGluToHHTo2B2G_node_SM_13TeV-madgraph/MINIAODSIM/94X_mc2017_realistic_v10-v1/00000/2E0E165D-8E05-E811-909C-FA163E80AE1F.root'))
@@ -89,20 +89,45 @@ process.out = cms.OutputModule("PoolOutputModule", fileName = cms.untracked.stri
 # All jets are now handled in MicroAODCustomize.py
 # Switch from PFCHS to PUPPI with puppi=1 argument (both if puppi=2)
 
-process.load('RecoMET.METFilters.BadChargedCandidateFilter_cfi')
-process.load('RecoMET.METFilters.globalTightHalo2016Filter_cfi')
-process.load('RecoMET.METFilters.BadPFMuonFilter_cfi')
+# Disable filters below, now applied through flashggMetFilters module in workspaceStd.py
+#process.load('RecoMET.METFilters.BadChargedCandidateFilter_cfi')
+#process.load('RecoMET.METFilters.globalTightHalo2016Filter_cfi')
+#process.load('RecoMET.METFilters.BadPFMuonFilter_cfi')
 
-process.BadChargedCandidateFilter.muons = cms.InputTag("slimmedMuons")
-process.BadChargedCandidateFilter.PFCandidates = cms.InputTag("packedPFCandidates")
-process.BadPFMuonFilter.muons = cms.InputTag("slimmedMuons")
-process.BadPFMuonFilter.PFCandidates = cms.InputTag("packedPFCandidates")
+#process.BadChargedCandidateFilter.muons = cms.InputTag("slimmedMuons")
+#process.BadChargedCandidateFilter.PFCandidates = cms.InputTag("packedPFCandidates")
+#process.BadPFMuonFilter.muons = cms.InputTag("slimmedMuons")
+#process.BadPFMuonFilter.PFCandidates = cms.InputTag("packedPFCandidates")
 
-process.flag_globalTightHalo2016Filter = cms.Path(process.globalTightHalo2016Filter)
-process.flag_BadChargedCandidateFilter = cms.Path(process.BadChargedCandidateFilter)
-process.flag_BadPFMuonFilter = cms.Path(process.BadPFMuonFilter)
+#process.flag_globalTightHalo2016Filter = cms.Path(process.globalTightHalo2016Filter)
+#process.flag_BadChargedCandidateFilter = cms.Path(process.BadChargedCandidateFilter)
+#process.flag_BadPFMuonFilter = cms.Path(process.BadPFMuonFilter)
 
-process.p = cms.Path(process.flashggMicroAODSequence)
+# Except for this filter, which must be applied on miniAOD directly.
+# Here we follow the recipe from:  https://twiki.cern.ch/twiki/bin/view/CMS/MissingETOptionalFiltersRun2#Analysis_Recommendations_for_ana
+process.load('RecoMET.METFilters.ecalBadCalibFilter_cfi')
+
+baddetEcallist = cms.vuint32(
+    [872439604,872422825,872420274,872423218,
+     872423215,872416066,872435036,872439336,
+     872420273,872436907,872420147,872439731,
+     872436657,872420397,872439732,872439339,
+     872439603,872422436,872439861,872437051,
+     872437052,872420649,872422436,872421950,
+     872437185,872422564,872421566,872421695,
+     872421955,872421567,872437184,872421951,
+     872421694,872437056,872437057,872437313])
+
+process.ecalBadCalibReducedMINIAODFilter = cms.EDFilter(
+    "EcalBadCalibFilter",
+    EcalRecHitSource = cms.InputTag("reducedEgamma:reducedEERecHits"),
+    ecalMinEt        = cms.double(50.),
+    baddetEcal    = baddetEcallist, 
+    taggingMode = cms.bool(True),
+    debug = cms.bool(False)
+)
+
+process.p = cms.Path(process.ecalBadCalibReducedMINIAODFilter*process.flashggMicroAODSequence)
 process.e = cms.EndPath(process.out)
 
 # Uncomment these lines to run the example commissioning module and send its output to root

--- a/MicroAOD/test/microAODstd.py
+++ b/MicroAOD/test/microAODstd.py
@@ -103,7 +103,7 @@ process.out = cms.OutputModule("PoolOutputModule", fileName = cms.untracked.stri
 #process.flag_BadChargedCandidateFilter = cms.Path(process.BadChargedCandidateFilter)
 #process.flag_BadPFMuonFilter = cms.Path(process.BadPFMuonFilter)
 
-# Except for this filter, which must be applied on miniAOD directly.
+# Except for this filter, which must be applied on miniAOD directly. Applied ONLY for 2017/2018
 # Here we follow the recipe from:  https://twiki.cern.ch/twiki/bin/view/CMS/MissingETOptionalFiltersRun2#Analysis_Recommendations_for_ana
 process.load('RecoMET.METFilters.ecalBadCalibFilter_cfi')
 
@@ -127,7 +127,7 @@ process.ecalBadCalibReducedMINIAODFilter = cms.EDFilter(
     debug = cms.bool(False)
 )
 
-process.p = cms.Path(process.ecalBadCalibReducedMINIAODFilter*process.flashggMicroAODSequence)
+process.p = cms.Path(process.flashggMicroAODSequence)
 process.e = cms.EndPath(process.out)
 
 # Uncomment these lines to run the example commissioning module and send its output to root
@@ -146,5 +146,8 @@ customize(process)
 
 if "DY" in customize.datasetName or "SingleElectron" in customize.datasetName or "DoubleEG" in customize.datasetName or "EGamma" in customize.datasetName:
     customize.customizeHLT(process)
+
+if "Era2017" in customize.options.conditionsJSON or "Era2018" in customize.options.conditionsJSON:
+    process.p += process.ecalBadCalibReducedMINIAODFilter
 
 #open('dump.py', 'w').write(process.dumpPython())

--- a/MicroAOD/test/microAODstd.py
+++ b/MicroAOD/test/microAODstd.py
@@ -25,7 +25,7 @@ process.source = cms.Source("PoolSource",
 ### 2017
 #process.GlobalTag = GlobalTag(process.GlobalTag,'','')
 #process.source = cms.Source("PoolSource",
-                             #fileNames=cms.untracked.vstring("/store/mc/RunIIFall17MiniAODv2/GluGluHToGG_M-125_13TeV_powheg_pythia8/MINIAODSIM/PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/40000/0866D1A8-1941-E811-B61F-0CC47AF9B2E6.root"))
+#                             fileNames=cms.untracked.vstring("/store/mc/RunIIFall17MiniAODv2/GluGluHToGG_M-125_13TeV_powheg_pythia8/MINIAODSIM/PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/40000/0866D1A8-1941-E811-B61F-0CC47AF9B2E6.root"))
 #    process.source = cms.Source("PoolSource",fileNames=cms.untracked.vstring('/store/mc/RunIISummer16MiniAODv2/GluGluHToGG_M-125_13TeV_powheg_pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/60000/024E4FA3-8BBC-E611-8E3D-00266CFFBE88.root'))
     #process.source = cms.Source("PoolSource",fileNames=cms.untracked.vstring('root://eoscms.cern.ch//eos/cms/store/mc/RunIIFall17MiniAOD/GJet_Pt-20to40_DoubleEMEnriched_MGG-80toInf_TuneCP5_13TeV_Pythia8/MINIAODSIM/94X_mc2017_realistic_v10-v1/40000/4A2ACB0A-1BD9-E711-AF54-141877410316.root'))
 #    process.source = cms.Source("PoolSource",fileNames=cms.untracked.vstring('root://eoscms.cern.ch//eos/cms/store/mc/RunIIFall17MiniAOD/GluGluToHHTo2B2G_node_SM_13TeV-madgraph/MINIAODSIM/94X_mc2017_realistic_v10-v1/00000/2E0E165D-8E05-E811-909C-FA163E80AE1F.root'))
@@ -89,44 +89,6 @@ process.out = cms.OutputModule("PoolOutputModule", fileName = cms.untracked.stri
 # All jets are now handled in MicroAODCustomize.py
 # Switch from PFCHS to PUPPI with puppi=1 argument (both if puppi=2)
 
-# Disable filters below, now applied through flashggMetFilters module in workspaceStd.py
-#process.load('RecoMET.METFilters.BadChargedCandidateFilter_cfi')
-#process.load('RecoMET.METFilters.globalTightHalo2016Filter_cfi')
-#process.load('RecoMET.METFilters.BadPFMuonFilter_cfi')
-
-#process.BadChargedCandidateFilter.muons = cms.InputTag("slimmedMuons")
-#process.BadChargedCandidateFilter.PFCandidates = cms.InputTag("packedPFCandidates")
-#process.BadPFMuonFilter.muons = cms.InputTag("slimmedMuons")
-#process.BadPFMuonFilter.PFCandidates = cms.InputTag("packedPFCandidates")
-
-#process.flag_globalTightHalo2016Filter = cms.Path(process.globalTightHalo2016Filter)
-#process.flag_BadChargedCandidateFilter = cms.Path(process.BadChargedCandidateFilter)
-#process.flag_BadPFMuonFilter = cms.Path(process.BadPFMuonFilter)
-
-# Except for this filter, which must be applied on miniAOD directly. Applied ONLY for 2017/2018
-# Here we follow the recipe from:  https://twiki.cern.ch/twiki/bin/view/CMS/MissingETOptionalFiltersRun2#Analysis_Recommendations_for_ana
-process.load('RecoMET.METFilters.ecalBadCalibFilter_cfi')
-
-baddetEcallist = cms.vuint32(
-    [872439604,872422825,872420274,872423218,
-     872423215,872416066,872435036,872439336,
-     872420273,872436907,872420147,872439731,
-     872436657,872420397,872439732,872439339,
-     872439603,872422436,872439861,872437051,
-     872437052,872420649,872422436,872421950,
-     872437185,872422564,872421566,872421695,
-     872421955,872421567,872437184,872421951,
-     872421694,872437056,872437057,872437313])
-
-process.ecalBadCalibReducedMINIAODFilter = cms.EDFilter(
-    "EcalBadCalibFilter",
-    EcalRecHitSource = cms.InputTag("reducedEgamma:reducedEERecHits"),
-    ecalMinEt        = cms.double(50.),
-    baddetEcal    = baddetEcallist, 
-    taggingMode = cms.bool(True),
-    debug = cms.bool(False)
-)
-
 process.p = cms.Path(process.flashggMicroAODSequence)
 process.e = cms.EndPath(process.out)
 
@@ -146,8 +108,5 @@ customize(process)
 
 if "DY" in customize.datasetName or "SingleElectron" in customize.datasetName or "DoubleEG" in customize.datasetName or "EGamma" in customize.datasetName:
     customize.customizeHLT(process)
-
-if "Era2017" in customize.options.conditionsJSON or "Era2018" in customize.options.conditionsJSON:
-    process.p += process.ecalBadCalibReducedMINIAODFilter
 
 #open('dump.py', 'w').write(process.dumpPython())

--- a/MicroAOD/test/microAODstd.py
+++ b/MicroAOD/test/microAODstd.py
@@ -17,15 +17,15 @@ process.MessageLogger.cerr.FwkReport.reportEvery = cms.untracked.int32( 100 )
 import os
 ### 2016
 process.GlobalTag = GlobalTag(process.GlobalTag, '', '')
-#process.source = cms.Source("PoolSource",
-#                             fileNames=cms.untracked.vstring("/store/mc/RunIISummer16MiniAODv3/VBFHToGG_M125_13TeV_amcatnlo_pythia8_v2/MINIAODSIM/PUMoriond17_94X_mcRun2_asymptotic_v3-v1/50000/38128C3C-892D-E911-AC8E-008CFA0087C4.root"))
+process.source = cms.Source("PoolSource",
+                             fileNames=cms.untracked.vstring("/store/mc/RunIISummer16MiniAODv3/VBFHToGG_M125_13TeV_amcatnlo_pythia8_v2/MINIAODSIM/PUMoriond17_94X_mcRun2_asymptotic_v3-v1/50000/38128C3C-892D-E911-AC8E-008CFA0087C4.root"))
 #    process.GlobalTag = GlobalTag(process.GlobalTag,'80X_dataRun2_2016LegacyRepro_v4','')
 #    process.source = cms.Source("PoolSource",fileNames=cms.untracked.vstring("/store/data/Run2016B/SingleElectron/MINIAOD/07Aug17_ver1-v1/110000/0248293E-578B-E711-A639-44A842CFC9D9.root"))
 
 ### 2017
 #process.GlobalTag = GlobalTag(process.GlobalTag,'','')
-process.source = cms.Source("PoolSource",
-                             fileNames=cms.untracked.vstring("/store/mc/RunIIFall17MiniAODv2/GluGluHToGG_M-125_13TeV_powheg_pythia8/MINIAODSIM/PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/40000/0866D1A8-1941-E811-B61F-0CC47AF9B2E6.root"))
+#process.source = cms.Source("PoolSource",
+                             #fileNames=cms.untracked.vstring("/store/mc/RunIIFall17MiniAODv2/GluGluHToGG_M-125_13TeV_powheg_pythia8/MINIAODSIM/PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/40000/0866D1A8-1941-E811-B61F-0CC47AF9B2E6.root"))
 #    process.source = cms.Source("PoolSource",fileNames=cms.untracked.vstring('/store/mc/RunIISummer16MiniAODv2/GluGluHToGG_M-125_13TeV_powheg_pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/60000/024E4FA3-8BBC-E611-8E3D-00266CFFBE88.root'))
     #process.source = cms.Source("PoolSource",fileNames=cms.untracked.vstring('root://eoscms.cern.ch//eos/cms/store/mc/RunIIFall17MiniAOD/GJet_Pt-20to40_DoubleEMEnriched_MGG-80toInf_TuneCP5_13TeV_Pythia8/MINIAODSIM/94X_mc2017_realistic_v10-v1/40000/4A2ACB0A-1BD9-E711-AF54-141877410316.root'))
 #    process.source = cms.Source("PoolSource",fileNames=cms.untracked.vstring('root://eoscms.cern.ch//eos/cms/store/mc/RunIIFall17MiniAOD/GluGluToHHTo2B2G_node_SM_13TeV-madgraph/MINIAODSIM/94X_mc2017_realistic_v10-v1/00000/2E0E165D-8E05-E811-909C-FA163E80AE1F.root'))

--- a/Systematics/interface/flashggMetFilters.h
+++ b/Systematics/interface/flashggMetFilters.h
@@ -1,0 +1,58 @@
+#ifndef flashggMetFilters_h
+#define flashggMetFilters_h
+
+// -*- C++ -*-
+//
+// Package:    flashggMetFilters
+// Class:      flashggMetFilters
+// 
+/* 
+ Description: filter events based on results of met filters 
+ Implementation: inherits from generic EDFilter
+     
+*/
+//
+// Original Author:  Samuel May 
+//         Created:  Fri Jul 12 12:06:00 CET 2019
+//
+
+
+// system include files
+#include <memory>
+#include <string>
+#include <iostream>
+
+// user include files
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/EDFilter.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+// MET Filters are stored as triggers in PAT, so need some trigger headers
+#include "DataFormats/Common/interface/TriggerResults.h"
+#include "FWCore/Common/interface/TriggerNames.h"
+
+//
+// class declaration
+//
+
+using namespace std;
+using namespace edm;
+
+class flashggMetFilters : public edm::EDFilter {
+    public:
+        explicit flashggMetFilters(const edm::ParameterSet&);
+        ~flashggMetFilters();
+
+        virtual bool filter(edm::Event&, const edm::EventSetup&);
+
+    private:
+        edm::InputTag filtersInputTag;
+        edm::EDGetTokenT<edm::TriggerResults> filtersToken;
+
+        std::vector<std::string> requiredFilterNames;
+
+        edm::Handle<edm::TriggerResults> filterResultsHandle;
+};
+#endif

--- a/Systematics/plugins/flashggMetFilters.cc
+++ b/Systematics/plugins/flashggMetFilters.cc
@@ -1,0 +1,48 @@
+#include "flashgg/Systematics/interface/flashggMetFilters.h"
+
+flashggMetFilters::flashggMetFilters(const edm::ParameterSet& iConfig)
+{
+    filtersInputTag = iConfig.getParameter<InputTag>("filtersInputTag");
+    filtersToken = consumes<edm::TriggerResults>(edm::InputTag(filtersInputTag.label(), "", "PAT")); 
+
+    requiredFilterNames = iConfig.getUntrackedParameter<std::vector<std::string>>("requiredFilterNames");
+}
+
+flashggMetFilters::~flashggMetFilters()
+{
+}
+
+// member functions
+//
+
+// ------------ method called on each new Event  ------------
+bool
+flashggMetFilters::filter(edm::Event& iEvent, const edm::EventSetup& iSetup)
+{
+    iEvent.getByToken(filtersToken, filterResultsHandle);
+
+    if (!filterResultsHandle.isValid()) {
+        throw cms::Exception("flashggMetFilters::filter: error getting TriggerResults from event!");
+    }
+
+    edm::TriggerNames filterNames = iEvent.triggerNames(*filterResultsHandle);
+
+    for (unsigned int i = 0; i < filterNames.size(); i++) {
+        if (std::find(requiredFilterNames.begin(), requiredFilterNames.end(), filterNames.triggerName(i)) != requiredFilterNames.end()) { // Required filter
+            if (filterResultsHandle->accept(i)) {
+                continue; 
+            }
+            else {
+                return false;
+            }
+        }
+        else {
+            continue;
+        }
+    }
+
+    return true; 
+
+}
+
+DEFINE_FWK_MODULE(flashggMetFilters);

--- a/Systematics/python/flashggMetFilters_cfi.py
+++ b/Systematics/python/flashggMetFilters_cfi.py
@@ -1,0 +1,6 @@
+import FWCore.ParameterSet.Config as cms
+
+flashggMetFilters = cms.EDFilter("flashggMetFilters",
+                                 filtersInputTag = cms.InputTag("TriggerResults"),
+                                 requiredFilterNames = cms.untracked.vstring(),
+)

--- a/Systematics/test/workspaceStd.py
+++ b/Systematics/test/workspaceStd.py
@@ -527,9 +527,10 @@ process.hltHighLevel= hltHighLevel.clone(HLTPaths = cms.vstring(hlt_paths))
 
 process.options = cms.untracked.PSet( wantSummary = cms.untracked.bool(True) )
 
+# Disable filters below, now applied through flashggMetFilters module
 # ee bad supercluster filter on data
-process.load('RecoMET.METFilters.eeBadScFilter_cfi')
-process.eeBadScFilter.EERecHitSource = cms.InputTag("reducedEgamma","reducedEERecHits") # Saved MicroAOD Collection (data only)
+#process.load('RecoMET.METFilters.eeBadScFilter_cfi')
+#process.eeBadScFilter.EERecHitSource = cms.InputTag("reducedEgamma","reducedEERecHits") # Saved MicroAOD Collection (data only)
 # Bad Muon filter LOADS WRONG IN 8_0_28, FIX LATER
 #process.load('RecoMET.METFilters.badGlobalMuonTaggersMiniAOD_cff')
 #process.badGlobalMuonTaggerMAOD.muons = cms.InputTag("flashggSelectedMuons")
@@ -537,7 +538,7 @@ process.eeBadScFilter.EERecHitSource = cms.InputTag("reducedEgamma","reducedEERe
 process.dataRequirements = cms.Sequence()
 if customize.processId == "Data":
         process.dataRequirements += process.hltHighLevel
-        process.dataRequirements += process.eeBadScFilter
+        #process.dataRequirements += process.eeBadScFilter
 #        if customize.doMuFilter:
 #            process.dataRequirements += process.noBadGlobalMuonsMAOD
 
@@ -575,9 +576,18 @@ if (customize.processId.count("qcd") or customize.processId.count("gjet")) and c
     else:
         raise Exception,"Mis-configuration of python for prompt-fake filter"
 
+# Met Filters
+process.load('flashgg/Systematics/flashggMetFilters_cfi')
 
+if customize.processId == "Data":
+    metFilterSelector = "data"
+else:
+    metFilterSelector = "mc"
+
+process.flashggMetFilters.requiredFilterNames = cms.untracked.vstring([filter.encode("ascii") for filter in metaConditions["flashggMetFilters"][metFilterSelector]])
 if customize.tthTagsOnly:
     process.p = cms.Path(process.dataRequirements*
+                         process.flashggMetFilters*
                          process.genFilter*
                          process.flashggDiPhotons* # needed for 0th vertex from microAOD
                          process.flashggUpdatedIdMVADiPhotons*
@@ -592,6 +602,7 @@ if customize.tthTagsOnly:
                          process.tagsDumper)
 else :
     process.p = cms.Path(process.dataRequirements*
+                         process.flashggMetFilters*
                          process.genFilter*
                          process.flashggUpdatedIdMVADiPhotons*
                          process.flashggDiPhotonSystematics*

--- a/Systematics/test/workspaceStd.py
+++ b/Systematics/test/workspaceStd.py
@@ -527,20 +527,9 @@ process.hltHighLevel= hltHighLevel.clone(HLTPaths = cms.vstring(hlt_paths))
 
 process.options = cms.untracked.PSet( wantSummary = cms.untracked.bool(True) )
 
-# Disable filters below, now applied through flashggMetFilters module
-# ee bad supercluster filter on data
-#process.load('RecoMET.METFilters.eeBadScFilter_cfi')
-#process.eeBadScFilter.EERecHitSource = cms.InputTag("reducedEgamma","reducedEERecHits") # Saved MicroAOD Collection (data only)
-# Bad Muon filter LOADS WRONG IN 8_0_28, FIX LATER
-#process.load('RecoMET.METFilters.badGlobalMuonTaggersMiniAOD_cff')
-#process.badGlobalMuonTaggerMAOD.muons = cms.InputTag("flashggSelectedMuons")
-#process.cloneGlobalMuonTaggerMAOD.muons = cms.InputTag("flashggSelectedMuons")
 process.dataRequirements = cms.Sequence()
 if customize.processId == "Data":
         process.dataRequirements += process.hltHighLevel
-        #process.dataRequirements += process.eeBadScFilter
-#        if customize.doMuFilter:
-#            process.dataRequirements += process.noBadGlobalMuonsMAOD
 
 # Split WH and ZH
 process.genFilter = cms.Sequence()
@@ -585,6 +574,7 @@ else:
     metFilterSelector = "mc"
 
 process.flashggMetFilters.requiredFilterNames = cms.untracked.vstring([filter.encode("ascii") for filter in metaConditions["flashggMetFilters"][metFilterSelector]])
+
 if customize.tthTagsOnly:
     process.p = cms.Path(process.dataRequirements*
                          process.flashggMetFilters*

--- a/Taggers/test/ttH_TagAndDump.py
+++ b/Taggers/test/ttH_TagAndDump.py
@@ -152,6 +152,17 @@ if ISDATA:
 
 process.genFilter = cms.Sequence()
 
+# Met Filters
+process.load('flashgg/Systematics/flashggMetFilters_cfi')
+if ISDATA:
+    metFilterSelector = "data" 
+else:
+    metFilterSelector = "mc"
+process.flashggMetFilters.requiredFilterNames = cms.untracked.vstring([filter.encode("ascii") for filter in metaConditions["flashggMetFilters"][metFilterSelector]])
+#process.flashggMetFilters.requiredFilterNames = cms.vstring(metaConditions["flashggMetFilters"]["data"])
+#else:
+#    process.flashggMetFilters.requiredFilterNames = cms.vstring(metaConditions["flashggMetFilters"]["mc"])
+
 process.load("flashgg/Taggers/flashggTagSequence_cfi")
 process.load("flashgg/Taggers/flashggTagTester_cfi")
 
@@ -492,6 +503,7 @@ cfgTools.addCategories(process.tthHadronicTagDumper,
 )
 
 process.p = cms.Path(process.dataRequirements*
+                         process.flashggMetFilters*
                          #process.genFilter* # revisit later, this looks like it's only needed for other signal modes than ttH
                          process.flashggDiPhotons* # needed for 0th vertex from microAOD
                          process.flashggUpdatedIdMVADiPhotons*
@@ -500,8 +512,8 @@ process.p = cms.Path(process.dataRequirements*
                          process.flashggMuonSystematics*process.flashggElectronSystematics*
                          (process.flashggUnpackedJets*process.jetSystematicsSequence)*
                          (process.flashggTagSequence*process.systematicsTagSequences)*
-			 process.flashggSystTagMerger*
-			 process.flashggTagSequence*
+			             process.flashggSystTagMerger*
+			             process.flashggTagSequence*
                          process.flashggTagTester*
-		         (process.tthLeptonicTagDumper
+		                 (process.tthLeptonicTagDumper
                           +process.tthHadronicTagDumper))


### PR DESCRIPTION
* Application of MET filters now performed through `flashggMetFilters` module.
* All filters, except 1, are applied at the workspace production level.
* List of filters is configurable by year and for data/MC. Currently set to the recommendations provided in [1].
* The one filter that is not applied at workspace production level is done at microAOD production level because it must be rerun on top of miniAOD. I follow the recipe given in [1].

[1] https://twiki.cern.ch/twiki/bin/view/CMS/MissingETOptionalFiltersRun2#Analysis_Recommendations_for_ana