### PR TITLE
Load parent and secondary dataset files in JobConfig 

### DIFF
--- a/MetaData/python/JobConfig.py
+++ b/MetaData/python/JobConfig.py
@@ -70,6 +70,11 @@ class JobConfig(object):
                                VarParsing.VarParsing.multiplicity.singleton, # singleton or list
                                VarParsing.VarParsing.varType.bool,          # string, int, or float
                                "useParentDataset")
+        self.options.register ('secondaryDataset',
+                               False, # default value
+                               VarParsing.VarParsing.multiplicity.singleton, # singleton or list
+                               VarParsing.VarParsing.varType.string,         # string, int, or float
+                               "secondaryDataset")
         self.options.register ('targetLumi',
                                1.e+3, # default value
                                VarParsing.VarParsing.multiplicity.singleton, # singleton or list
@@ -197,6 +202,10 @@ class JobConfig(object):
     # process customization
     def customize(self,process):
         self.parse()
+
+        # keep useParent and secondaryDataset as exclusive options for the moment
+        if self.options.useParentDataset and self.options.secondaryDataset != "":
+            raise Exception("useParentDataset cannot be set together with a secondaryDataset")
 
         isFwlite = False
         hasOutput = False
@@ -371,15 +380,33 @@ class JobConfig(object):
             
         flist = []
         sflist = []
+        
+        # get the runs and lumis contained in each file of the secondary dataset
+        if self.options.secondaryDataset:
+            secondary_files = [fdata['file'][0]['name'] for fdata in das_query("file dataset=%s instance=prod/phys03" % self.options.secondaryDataset)['data']]
+            runs_and_lumis = {}
+            for s in secondary_files:
+                runs_and_lumis[str(s)] = {lumi['run_number'] : lumi['lumi_section_num'] for lumi in das_query("lumi file=%s instance=prod/phys03" % s)['data'][0]['lumi']}
+
         for f in files:
             if len(f.split(":",1))>1:
                 flist.append(str(f))
             else:
                 flist.append(str("%s%s" % (self.filePrepend,f)))
+            # keep useParent and secondaryDataset as exclusive options for the moment
             if self.options.useParentDataset:
                 parent_files = das_query("parent file=%s instance=prod/phys03" % f)['data'][0]['parent']
                 for parent_f in parent_files:
-                    sflist.append(str(parent_f['name']))
+                    sflist.append('root://cms-xrd-global.cern.ch/'+str(parent_f['name']) if 'root://' not in str(parent_f['name']) else str(parent_f['name']))
+            elif self.options.secondaryDataset != "":
+                # match primary file to the corresponding secondary file(s)
+                f_runs_and_lumis = {lumi['run_number'] : lumi['lumi_section_num'] for lumi in das_query("lumi file=%s instance=prod/phys03" % f)['data'][0]['lumi']}
+                for s_name, s_runs_and_lumis in runs_and_lumis.items():
+                    matched_runs = set(f_runs_and_lumis.keys()).intersection(s_runs_and_lumis.keys())
+                    for run in matched_runs:                        
+                        if any(lumi in f_runs_and_lumis[run] for lumi in s_runs_and_lumis[run]):
+                            sflist.append(s_name)
+                
         if len(flist) > 0:
             ## fwlite
             if isFwlite:
@@ -389,7 +416,7 @@ class JobConfig(object):
             else:
                 ## process.source.fileNames.extend([ str("%s%s" % (self.filePrepend,f)) for f in  files])
                 process.source.fileNames = flist
-                if self.options.useParentDataset and len(sflist) > 0:
+                if len(sflist) > 0:
                     process.source.secondaryFileNames = cms.untracked.vstring(sflist)
  
         ## fwlite

--- a/MetaData/python/JobConfig.py
+++ b/MetaData/python/JobConfig.py
@@ -71,7 +71,7 @@ class JobConfig(object):
                                VarParsing.VarParsing.varType.bool,          # string, int, or float
                                "useParentDataset")
         self.options.register ('secondaryDataset',
-                               False, # default value
+                               "", # default value
                                VarParsing.VarParsing.multiplicity.singleton, # singleton or list
                                VarParsing.VarParsing.varType.string,         # string, int, or float
                                "secondaryDataset")

--- a/MicroAOD/src/GlobalVariablesComputer.cc
+++ b/MicroAOD/src/GlobalVariablesComputer.cc
@@ -71,7 +71,12 @@ namespace flashgg {
                 puWeight_ = cfg.getParameter<std::vector<double> >("dataPu");
                 auto mcpu = cfg.getParameter<std::vector<double> >("mcPu");
 
-                assert( puWeight_.size() == mcpu.size() );
+                if( puWeight_.size() != mcpu.size() )
+                {
+                    std::ostringstream msg;
+                    msg << "PU weight size: " << puWeight_.size() << " \n MC PU size: " << mcpu.size();
+                    throw std::logic_error(msg.str());
+                }
                 if ( puWeight_.size() != puBins_.size()-1 ) {
                     puBins_.resize(puWeight_.size()+1);
                     for (unsigned int i=0; i<puBins_.size(); ++i)

--- a/Systematics/python/SystematicsCustomize.py
+++ b/Systematics/python/SystematicsCustomize.py
@@ -283,3 +283,21 @@ def useEGMTools(process):
     # add sigmaE/E correction and systematics
     process.flashggDiPhotonSystematics.SystMethods.extend( [process.SigmaEOverESmearing_EGM, process.SigmaEOverEShift] )
 
+def runRivetSequence(process, options):
+    process.load("SimGeneral.HepPDTESSource.pythiapdt_cfi")
+    process.rivetProducerHTXS = cms.EDProducer('HTXSRivetProducer',
+                                               HepMCCollection = cms.InputTag('myGenerator','unsmeared'),
+                                               LHERunInfo = cms.InputTag('externalLHEProducer'),
+                                               ProductionMode = cms.string('AUTO'),
+    )
+    
+    process.mergedGenParticles = cms.EDProducer("MergedGenParticleProducer",
+                                                inputPruned = cms.InputTag("prunedGenParticles"),
+                                                inputPacked = cms.InputTag("packedGenParticles"),
+                                            )
+    process.myGenerator = cms.EDProducer("GenParticles2HepMCConverter",
+                                         genParticles = cms.InputTag("mergedGenParticles"),
+                                         genEventInfo = cms.InputTag("generator"),
+                                         signalParticlePdgIds = cms.vint32(25), ## for the Higgs analysis
+                                     )
+    process.p.insert(0, process.mergedGenParticles*process.myGenerator*process.rivetProducerHTXS)

--- a/Systematics/test/workspaceStd.py
+++ b/Systematics/test/workspaceStd.py
@@ -688,7 +688,8 @@ process.flashggTagSorter.StoreOtherTagInfo = True
 process.flashggTagSorter.BlindedSelectionPrintout = True
 
 ### Rerun microAOD sequence on top of microAODs using the parent dataset
-runRivetSequence(process, customize.metaConditions)
+if customize.useParentDataset:
+    runRivetSequence(process, customize.metaConditions)
 
 
 #### BELOW HERE IS MOSTLY DEBUGGING STUFF

--- a/Systematics/test/workspaceStd.py
+++ b/Systematics/test/workspaceStd.py
@@ -687,6 +687,10 @@ printSystematicInfo(process)
 process.flashggTagSorter.StoreOtherTagInfo = True
 process.flashggTagSorter.BlindedSelectionPrintout = True
 
+### Rerun microAOD sequence on top of microAODs using the parent dataset
+runRivetSequence(process, customize.metaConditions)
+
+
 #### BELOW HERE IS MOSTLY DEBUGGING STUFF
 
 #####################################################################


### PR DESCRIPTION
- useParentDataset: load miniAOD collection while running on microAODs, add example for STXS 1.1 bin re-evaluation
- secondaryDataset: load collections from user specified dataset (needed by H->4g analysis).

The two options are exclusive, useParentDataset has been tested by Ed and Jonathon while secondaryDataset might need further debug.