### PR TITLE
Add option for recalculating PDF weights on-the-fly

### DIFF
--- a/MetaData/data/MetaConditions/Era2017_RR-31Mar2018_v1.json
+++ b/MetaData/data/MetaConditions/Era2017_RR-31Mar2018_v1.json
@@ -107,6 +107,8 @@
 	"eta" : 2.5
     },
 
+    "mc2hessianCSV" : "PhysicsTools/HepMCCandAlgos/data/NNPDF30_lo_as_0130_hessian_60.csv",
+
     "bRegression" :
     {
         "weightFile" : "/src/flashgg/Taggers/data/DNN_models/breg_training_2017_JECv32.pb",

--- a/MetaData/data/MetaConditions/Era2018_RR-17Sep2018_v1.json
+++ b/MetaData/data/MetaConditions/Era2018_RR-17Sep2018_v1.json
@@ -92,6 +92,8 @@
 	"eta" : 2.5
     },
 
+    "mc2hessianCSV" : "PhysicsTools/HepMCCandAlgos/data/NNPDF30_lo_as_0130_hessian_60.csv",
+
     "bRegression" :
     {
         "weightFile" : "/src/flashgg/Taggers/data/DNN_models/breg_training_2018_v8.pb",

--- a/MetaData/python/JobConfig.py
+++ b/MetaData/python/JobConfig.py
@@ -70,6 +70,11 @@ class JobConfig(object):
                                VarParsing.VarParsing.multiplicity.singleton, # singleton or list
                                VarParsing.VarParsing.varType.bool,          # string, int, or float
                                "useParentDataset")
+        self.options.register ('recalculatePDFWeights',
+                               False, # default value
+                               VarParsing.VarParsing.multiplicity.singleton, # singleton or list
+                               VarParsing.VarParsing.varType.bool,          # string, int, or float
+                               "recalculatePDFWeights")
         self.options.register ('secondaryDataset',
                                "", # default value
                                VarParsing.VarParsing.multiplicity.singleton, # singleton or list

--- a/Systematics/python/SystematicsCustomize.py
+++ b/Systematics/python/SystematicsCustomize.py
@@ -301,3 +301,26 @@ def runRivetSequence(process, options):
                                          signalParticlePdgIds = cms.vint32(25), ## for the Higgs analysis
                                      )
     process.p.insert(0, process.mergedGenParticles*process.myGenerator*process.rivetProducerHTXS)
+
+def recalculatePDFWeights(process, options):
+    print "Recalculating PDF weights"
+    process.load("flashgg/MicroAOD/flashggPDFWeightObject_cfi")
+    process.flashggPDFWeightObject = cms.EDProducer('FlashggPDFWeightProducer',
+                                                    LHEEventTag = cms.InputTag('externalLHEProducer'),
+                                                    GenTag      = cms.InputTag('generator'),
+                                                    tag = cms.untracked.string("initrwgt"),
+                                                    doScaleWeights  = cms.untracked.bool(True),
+                                                    nPdfEigWeights = cms.uint32(60),
+                                                    mc2hessianCSV = cms.untracked.string(""),
+                                                    LHERunLabel = cms.string("externalLHEProducer"),
+                                                    Debug = cms.bool(False),
+                                                    PDFmap = cms.PSet(#see here https://lhapdf.hepforge.org/pdfsets.html to update the map if needed
+                                                        NNPDF30_lo_as_0130_nf_4 = cms.untracked.uint32(263400),
+                                                        NNPDF31_nnlo_as_0118_nf_4 = cms.untracked.uint32(320900)
+                                                    )
+                                                ) 
+    setattr(process.flashggPDFWeightObject, "mc2hessianCSV", "PhysicsTools/HepMCCandAlgos/data/NNPDF30_lo_as_0130_hessian_60.csv")
+    #process.p *= process.flashggPDFWeightObject
+    process.p.insert(0, process.flashggPDFWeightObject)
+
+    

--- a/Systematics/python/SystematicsCustomize.py
+++ b/Systematics/python/SystematicsCustomize.py
@@ -311,7 +311,7 @@ def recalculatePDFWeights(process, options):
                                                     tag = cms.untracked.string("initrwgt"),
                                                     doScaleWeights  = cms.untracked.bool(True),
                                                     nPdfEigWeights = cms.uint32(60),
-                                                    mc2hessianCSV = cms.untracked.string(""),
+                                                    mc2hessianCSV = cms.untracked.string(options["mc2hessianCSV"].encode("ascii")),
                                                     LHERunLabel = cms.string("externalLHEProducer"),
                                                     Debug = cms.bool(False),
                                                     PDFmap = cms.PSet(#see here https://lhapdf.hepforge.org/pdfsets.html to update the map if needed
@@ -319,8 +319,6 @@ def recalculatePDFWeights(process, options):
                                                         NNPDF31_nnlo_as_0118_nf_4 = cms.untracked.uint32(320900)
                                                     )
                                                 ) 
-    setattr(process.flashggPDFWeightObject, "mc2hessianCSV", "PhysicsTools/HepMCCandAlgos/data/NNPDF30_lo_as_0130_hessian_60.csv")
-    #process.p *= process.flashggPDFWeightObject
     process.p.insert(0, process.flashggPDFWeightObject)
 
     

--- a/Systematics/test/workspaceStd.py
+++ b/Systematics/test/workspaceStd.py
@@ -689,10 +689,9 @@ process.flashggTagSorter.BlindedSelectionPrintout = True
 
 ### Rerun microAOD sequence on top of microAODs using the parent dataset
 if customize.useParentDataset:
-    if is_signal:
-        recalculatePDFWeights(process, customize.metaConditions)
     runRivetSequence(process, customize.metaConditions)
-
+    if customize.recalculatePDFWeights and is_signal and not customize.processId.count("bbh"):
+        recalculatePDFWeights(process, customize.metaConditions)
 
 #### BELOW HERE IS MOSTLY DEBUGGING STUFF
 

--- a/Systematics/test/workspaceStd.py
+++ b/Systematics/test/workspaceStd.py
@@ -689,6 +689,8 @@ process.flashggTagSorter.BlindedSelectionPrintout = True
 
 ### Rerun microAOD sequence on top of microAODs using the parent dataset
 if customize.useParentDataset:
+    if is_signal:
+        recalculatePDFWeights(process, customize.metaConditions)
     runRivetSequence(process, customize.metaConditions)
 
 


### PR DESCRIPTION
Adding the `mc2hessianCSV` file and rerunning the `flashggPDFWeightObject` fixes the issue of missing PDF weights in the `Era2017_RR-31Mar2018_v2` and `Era2018_RR-17Sep2018_v2` microAOD campaigns.