### PR TITLE
Malcles/fix pixel seed sf

### DIFF
--- a/MicroAOD/python/flashggDiPhotons_cfi.py
+++ b/MicroAOD/python/flashggDiPhotons_cfi.py
@@ -12,8 +12,8 @@ flashggDiPhotons = cms.EDProducer('FlashggDiPhotonProducer',
                                   GenParticleTag         = cms.InputTag( "flashggPrunedGenParticles" ),
 
                                   ##Parameters for Legacy Vertex Selector                                                
-                                  vertexIdMVAweightfile   = cms.FileInPath(""),
-                                  vertexProbMVAweightfile = cms.FileInPath(""),
+                                  vertexIdMVAweightfile   = cms.FileInPath("flashgg/MicroAOD/data/TMVAClassification_BDTVtxId_SL_2016.xml"),
+                                  vertexProbMVAweightfile = cms.FileInPath("flashgg/MicroAOD/data/TMVAClassification_BDTVtxProb_SL_2016.xml"),
 
                                   useSingleLeg            = cms.bool(True),
                                   useZerothVertexFromMicro = cms.bool(False),

--- a/MicroAOD/python/flashggDiPhotons_cfi.py
+++ b/MicroAOD/python/flashggDiPhotons_cfi.py
@@ -12,8 +12,8 @@ flashggDiPhotons = cms.EDProducer('FlashggDiPhotonProducer',
                                   GenParticleTag         = cms.InputTag( "flashggPrunedGenParticles" ),
 
                                   ##Parameters for Legacy Vertex Selector                                                
-                                  vertexIdMVAweightfile   = cms.FileInPath("flashgg/MicroAOD/data/TMVAClassification_BDTVtxId_SL_2016.xml"),
-                                  vertexProbMVAweightfile = cms.FileInPath("flashgg/MicroAOD/data/TMVAClassification_BDTVtxProb_SL_2016.xml"),
+                                  vertexIdMVAweightfile   = cms.FileInPath(""),
+                                  vertexProbMVAweightfile = cms.FileInPath(""),
 
                                   useSingleLeg            = cms.bool(True),
                                   useZerothVertexFromMicro = cms.bool(False),

--- a/Systematics/python/SystematicsCustomize.py
+++ b/Systematics/python/SystematicsCustomize.py
@@ -169,6 +169,12 @@ def allowLargettHMVAs(process):
     for tag in ["flashggTTHLeptonicTag", "flashggTTHHadronicTag"]:
         getattr(process, tag).UseLargeMVAs = cms.bool(True) # enable memory-intensive MVAs
 
+
+def customizeDiPhotonSystematicsForTTH(process, options):
+    process.load("flashgg.Systematics.flashggDiPhotonSystematics_cfi")
+    import flashgg.Systematics.flashggDiPhotonSystematics_cfi as diPhotons_syst
+    diPhotons_syst.addPixelSeedWeightToDiPhotonSystematics( process, options )
+
 def customizeSystematicsForMC(process):
     customizePhotonSystematicsForMC(process)
 

--- a/Systematics/python/flashggDiPhotonSystematics2016_cfi.py
+++ b/Systematics/python/flashggDiPhotonSystematics2016_cfi.py
@@ -33,6 +33,54 @@ electronVetoBins = cms.PSet(
         )
     )
 
+
+# JMalcles - based on JTao SF + ttH efficiencies. calculated to preserve nTot ttH.
+# Initial SF taken from: https://indico.cern.ch/event/850506/contributions/3606914/attachments/1927946/3192290/201910_Zmmg_RhoBugFixed.pdf
+
+leadPixelSeedBins = cms.PSet(
+    variables = cms.vstring("abs(superCluster.eta)","full5x5_r9", "hasPixelSeed"),
+    bins = cms.VPSet(
+    
+     # No Pixel Seed                                                                                                                                                                        
+        cms.PSet( lowBounds = cms.vdouble( 0.0, 0.85, -0.1 ) , upBounds = cms.vdouble( 1.5, 999. , 0.1) , values = cms.vdouble(0.989 ) , uncertainties = cms.vdouble( -0.007 )  ),
+        cms.PSet( lowBounds = cms.vdouble( 0.0, 0.00, -0.1 ) , upBounds = cms.vdouble( 1.5, 0.85 , 0.1) , values = cms.vdouble(1.007 ) , uncertainties = cms.vdouble( -0.007 )  ),
+        cms.PSet( lowBounds = cms.vdouble( 1.5, 0.90, -0.1 ) , upBounds = cms.vdouble( 6.0, 999.,  0.1) , values = cms.vdouble(0.966 ) , uncertainties = cms.vdouble( -0.01  )  ),
+        cms.PSet( lowBounds = cms.vdouble( 1.5, 0.00, -0.1 ) , upBounds = cms.vdouble( 6.0, 0.90 , 0.1) , values = cms.vdouble(0.979 ) , uncertainties = cms.vdouble( -0.03  )  ),
+        
+        # Yes Pixel Seed                                                                                                                                                                       
+        cms.PSet( lowBounds = cms.vdouble( 0.0, 0.85, 0.9 ) , upBounds = cms.vdouble( 1.5, 999., 1.1 ) , values = cms.vdouble( 1.434 ) , uncertainties = cms.vdouble( 0.20  )  ),
+        cms.PSet( lowBounds = cms.vdouble( 0.0, 0.00, 0.9 ) , upBounds = cms.vdouble( 1.5, 0.85, 1.1 ) , values = cms.vdouble( 0.979 ) , uncertainties = cms.vdouble( 0.02  )  ),   
+        cms.PSet( lowBounds = cms.vdouble( 1.5, 0.90, 0.9 ) , upBounds = cms.vdouble( 6.0, 999., 1.1 ) , values = cms.vdouble( 1.176 ) , uncertainties = cms.vdouble( 0.06  )  ),
+        cms.PSet( lowBounds = cms.vdouble( 1.5, 0.00, 0.9 ) , upBounds = cms.vdouble( 6.0, 0.90, 1.1 ) , values = cms.vdouble( 1.046 ) , uncertainties = cms.vdouble( 0.07  )  ) 
+        )
+    )
+
+subleadPixelSeedBins = cms.PSet(
+    variables = cms.vstring("abs(superCluster.eta)","full5x5_r9", "hasPixelSeed"),
+    bins = cms.VPSet(
+
+     # No Pixel Seed                                                                                                                                                                                
+        cms.PSet( lowBounds = cms.vdouble( 0.0, 0.85, -0.1 ) , upBounds = cms.vdouble( 1.5, 999. , 0.1) , values = cms.vdouble(0.989 ) , uncertainties = cms.vdouble( -0.007 )  ),
+        cms.PSet( lowBounds = cms.vdouble( 0.0, 0.00, -0.1 ) , upBounds = cms.vdouble( 1.5, 0.85 , 0.1) , values = cms.vdouble(1.007 ) , uncertainties = cms.vdouble( -0.007 )  ),
+        cms.PSet( lowBounds = cms.vdouble( 1.5, 0.90, -0.1 ) , upBounds = cms.vdouble( 6.0, 999.,  0.1) , values = cms.vdouble(0.966 ) , uncertainties = cms.vdouble( -0.01  )  ),
+        cms.PSet( lowBounds = cms.vdouble( 1.5, 0.00, -0.1 ) , upBounds = cms.vdouble( 6.0, 0.90 , 0.1) , values = cms.vdouble(0.979 ) , uncertainties = cms.vdouble( -0.03  )  ),
+
+        # Yes Pixel Seed                                                                                                                                                                            
+        cms.PSet( lowBounds = cms.vdouble( 0.0, 0.85, 0.9 ) , upBounds = cms.vdouble( 1.5, 999., 1.1 ) , values = cms.vdouble( 1.434 ) , uncertainties = cms.vdouble( 0.20  )  ),
+        cms.PSet( lowBounds = cms.vdouble( 0.0, 0.00, 0.9 ) , upBounds = cms.vdouble( 1.5, 0.85, 1.1 ) , values = cms.vdouble( 0.979 ) , uncertainties = cms.vdouble( 0.02  )  ),
+        cms.PSet( lowBounds = cms.vdouble( 1.5, 0.90, 0.9 ) , upBounds = cms.vdouble( 6.0, 999., 1.1 ) , values = cms.vdouble( 1.176 ) , uncertainties = cms.vdouble( 0.06  )  ),
+        cms.PSet( lowBounds = cms.vdouble( 1.5, 0.00, 0.9 ) , upBounds = cms.vdouble( 6.0, 0.90, 1.1 ) , values = cms.vdouble( 1.046 ) , uncertainties = cms.vdouble( 0.07  )  )
+        )
+    )
+
+
+
+
+
+
+
+
+
 FNUFBins = cms.PSet(
     variables = cms.vstring("abs(superCluster.eta)","full5x5_r9"),
     bins = cms.VPSet(

--- a/Systematics/python/flashggDiPhotonSystematics2016_cfi.py
+++ b/Systematics/python/flashggDiPhotonSystematics2016_cfi.py
@@ -41,13 +41,15 @@ leadPixelSeedBins = cms.PSet(
     variables = cms.vstring("abs(superCluster.eta)","full5x5_r9", "hasPixelSeed"),
     bins = cms.VPSet(
     
-     # No Pixel Seed                                                                                                                                                                        
+     # No Pixel Seed                                                                                                                                                          
+        
         cms.PSet( lowBounds = cms.vdouble( 0.0, 0.85, -0.1 ) , upBounds = cms.vdouble( 1.5, 999. , 0.1) , values = cms.vdouble(0.989 ) , uncertainties = cms.vdouble( -0.007 )  ),
         cms.PSet( lowBounds = cms.vdouble( 0.0, 0.00, -0.1 ) , upBounds = cms.vdouble( 1.5, 0.85 , 0.1) , values = cms.vdouble(1.007 ) , uncertainties = cms.vdouble( -0.007 )  ),
         cms.PSet( lowBounds = cms.vdouble( 1.5, 0.90, -0.1 ) , upBounds = cms.vdouble( 6.0, 999.,  0.1) , values = cms.vdouble(0.966 ) , uncertainties = cms.vdouble( -0.01  )  ),
         cms.PSet( lowBounds = cms.vdouble( 1.5, 0.00, -0.1 ) , upBounds = cms.vdouble( 6.0, 0.90 , 0.1) , values = cms.vdouble(0.979 ) , uncertainties = cms.vdouble( -0.03  )  ),
         
-        # Yes Pixel Seed                                                                                                                                                                       
+        # Yes Pixel Seed                                                                                                                                                     
+        
         cms.PSet( lowBounds = cms.vdouble( 0.0, 0.85, 0.9 ) , upBounds = cms.vdouble( 1.5, 999., 1.1 ) , values = cms.vdouble( 1.434 ) , uncertainties = cms.vdouble( 0.20  )  ),
         cms.PSet( lowBounds = cms.vdouble( 0.0, 0.00, 0.9 ) , upBounds = cms.vdouble( 1.5, 0.85, 1.1 ) , values = cms.vdouble( 0.979 ) , uncertainties = cms.vdouble( 0.02  )  ),   
         cms.PSet( lowBounds = cms.vdouble( 1.5, 0.90, 0.9 ) , upBounds = cms.vdouble( 6.0, 999., 1.1 ) , values = cms.vdouble( 1.176 ) , uncertainties = cms.vdouble( 0.06  )  ),
@@ -59,13 +61,15 @@ subleadPixelSeedBins = cms.PSet(
     variables = cms.vstring("abs(superCluster.eta)","full5x5_r9", "hasPixelSeed"),
     bins = cms.VPSet(
 
-     # No Pixel Seed                                                                                                                                                                                
+     # No Pixel Seed                                                                                                                                                        
+        
         cms.PSet( lowBounds = cms.vdouble( 0.0, 0.85, -0.1 ) , upBounds = cms.vdouble( 1.5, 999. , 0.1) , values = cms.vdouble(0.989 ) , uncertainties = cms.vdouble( -0.007 )  ),
         cms.PSet( lowBounds = cms.vdouble( 0.0, 0.00, -0.1 ) , upBounds = cms.vdouble( 1.5, 0.85 , 0.1) , values = cms.vdouble(1.007 ) , uncertainties = cms.vdouble( -0.007 )  ),
         cms.PSet( lowBounds = cms.vdouble( 1.5, 0.90, -0.1 ) , upBounds = cms.vdouble( 6.0, 999.,  0.1) , values = cms.vdouble(0.966 ) , uncertainties = cms.vdouble( -0.01  )  ),
         cms.PSet( lowBounds = cms.vdouble( 1.5, 0.00, -0.1 ) , upBounds = cms.vdouble( 6.0, 0.90 , 0.1) , values = cms.vdouble(0.979 ) , uncertainties = cms.vdouble( -0.03  )  ),
 
-        # Yes Pixel Seed                                                                                                                                                                            
+        # Yes Pixel Seed                                                                                                                                                      
+        
         cms.PSet( lowBounds = cms.vdouble( 0.0, 0.85, 0.9 ) , upBounds = cms.vdouble( 1.5, 999., 1.1 ) , values = cms.vdouble( 1.434 ) , uncertainties = cms.vdouble( 0.20  )  ),
         cms.PSet( lowBounds = cms.vdouble( 0.0, 0.00, 0.9 ) , upBounds = cms.vdouble( 1.5, 0.85, 1.1 ) , values = cms.vdouble( 0.979 ) , uncertainties = cms.vdouble( 0.02  )  ),
         cms.PSet( lowBounds = cms.vdouble( 1.5, 0.90, 0.9 ) , upBounds = cms.vdouble( 6.0, 999., 1.1 ) , values = cms.vdouble( 1.176 ) , uncertainties = cms.vdouble( 0.06  )  ),
@@ -657,6 +661,17 @@ electronVetoSF = cms.PSet( PhotonMethodName = cms.string("FlashggPhotonWeight"),
           NSigmas = cms.vint32(-1,1),
           OverallRange = cms.string("1"),
           BinList = electronVetoBins,
+          Debug = cms.untracked.bool(False),
+          ApplyCentralValue = cms.bool(True)
+          )
+
+PixelSeedWeight = cms.PSet( PhotonMethodName = cms.string("FlashggPhotonWeight"),
+          MethodName = cms.string("FlashggDiPhotonFromPhoton"),
+          Label = cms.string("PixelSeedWeight"),
+          NSigmas = cms.vint32(-1,1),
+          OverallRange = cms.string("pt<99999"),
+          BinList = leadPixelSeedBins,
+          BinList2 = subleadPixelSeedBins,
           Debug = cms.untracked.bool(False),
           ApplyCentralValue = cms.bool(True)
           )

--- a/Systematics/python/flashggDiPhotonSystematics2017_cfi.py
+++ b/Systematics/python/flashggDiPhotonSystematics2017_cfi.py
@@ -41,13 +41,15 @@ leadPixelSeedBins = cms.PSet(
     variables = cms.vstring("abs(superCluster.eta)","full5x5_r9", "hasPixelSeed"),
     bins = cms.VPSet(
     
-     # No Pixel Seed                                                                                                                                                                        
+     # No Pixel Seed  
+        
         cms.PSet( lowBounds = cms.vdouble( 0.0, 0.85, -0.1 ) , upBounds = cms.vdouble( 1.5, 999. , 0.1) , values = cms.vdouble(0.982 ) , uncertainties = cms.vdouble( -0.007 )  ),
         cms.PSet( lowBounds = cms.vdouble( 0.0, 0.00, -0.1 ) , upBounds = cms.vdouble( 1.5, 0.85 , 0.1) , values = cms.vdouble(0.975 ) , uncertainties = cms.vdouble( -0.007 )  ),
         cms.PSet( lowBounds = cms.vdouble( 1.5, 0.90, -0.1 ) , upBounds = cms.vdouble( 6.0, 999.,  0.1) , values = cms.vdouble(0.943 ) , uncertainties = cms.vdouble( -0.01  )  ),
         cms.PSet( lowBounds = cms.vdouble( 1.5, 0.00, -0.1 ) , upBounds = cms.vdouble( 6.0, 0.90 , 0.1) , values = cms.vdouble(0.912 ) , uncertainties = cms.vdouble( -0.04  )  ),
         
-        # Yes Pixel Seed                                                                                                                                                                    
+        # Yes Pixel Seed   
+        
         cms.PSet( lowBounds = cms.vdouble( 0.0, 0.85, 0.9 ) , upBounds = cms.vdouble( 1.5, 999., 1.1 ) , values = cms.vdouble( 1.622 ) , uncertainties = cms.vdouble( 0.25  )  ),
         cms.PSet( lowBounds = cms.vdouble( 0.0, 0.00, 0.9 ) , upBounds = cms.vdouble( 1.5, 0.85, 1.1 ) , values = cms.vdouble( 1.106 ) , uncertainties = cms.vdouble( 0.03  )  ),   
         cms.PSet( lowBounds = cms.vdouble( 1.5, 0.90, 0.9 ) , upBounds = cms.vdouble( 6.0, 999., 1.1 ) , values = cms.vdouble( 1.181 ) , uncertainties = cms.vdouble(  0.03 )  ),

--- a/Systematics/python/flashggDiPhotonSystematics2017_cfi.py
+++ b/Systematics/python/flashggDiPhotonSystematics2017_cfi.py
@@ -34,40 +34,47 @@ electronVetoBins = cms.PSet(
     )
 
 
-# JMalcles - based on JTao SF + ttH efficiencies. calculated to preserve nTot ttH. 
+# JMalcles - based on JTao SF + ttH efficiencies. calculated to preserve nTot ttH.
+# Initial SF taken from: https://indico.cern.ch/event/850506/contributions/3606914/attachments/1927946/3192290/201910_Zmmg_RhoBugFixed.pdf
 
 leadPixelSeedBins = cms.PSet(
     variables = cms.vstring("abs(superCluster.eta)","full5x5_r9", "hasPixelSeed"),
     bins = cms.VPSet(
-        # No Pixel Seed
-        cms.PSet( lowBounds = cms.vdouble( 0.0, 0.00, -0.1 ) , upBounds = cms.vdouble( 1.5, 0.85 , 0.1) , values = cms.vdouble(0.978 ) , uncertainties = cms.vdouble( -0.00401807 )  ) ,
-        cms.PSet( lowBounds = cms.vdouble( 0.0, 0.85, -0.1 ) , upBounds = cms.vdouble( 1.5, 999. , 0.1) , values = cms.vdouble(0.9824) , uncertainties = cms.vdouble( -0.00200421 )  ) ,
-        cms.PSet( lowBounds = cms.vdouble( 1.5, 0.00, -0.1 ) , upBounds = cms.vdouble( 6.0, 0.90 , 0.1) , values = cms.vdouble(0.9168 ) , uncertainties = cms.vdouble( -0.0224756 )  ) ,
-        cms.PSet( lowBounds = cms.vdouble( 1.5, 0.90 ,-0.1) , upBounds = cms.vdouble( 6.0, 999., 0.1) , values = cms.vdouble( 0.9403 ) , uncertainties = cms.vdouble(  -0.00631264  )  ),        
-        # Yes Pixel Seed
-        cms.PSet( lowBounds = cms.vdouble( 0.0, 0.00 ,0.9) , upBounds = cms.vdouble( 1.5, 0.85, 1.1 ) , values = cms.vdouble( 1.08876 ) , uncertainties = cms.vdouble( 0.0162106 )  ) ,
-        cms.PSet( lowBounds = cms.vdouble( 0.0, 0.85 ,0.9) , upBounds = cms.vdouble( 1.5, 999., 1.1 ) , values = cms.vdouble( 1.5961) , uncertainties = cms.vdouble( 0.0678807 )  ) ,
-        cms.PSet( lowBounds = cms.vdouble( 1.5, 0.00 ,0.9) , upBounds = cms.vdouble( 6.0, 0.90, 1.1 ) , values = cms.vdouble( 1.09763 ) , uncertainties = cms.vdouble( 0.0263745 )  ) ,
-        cms.PSet( lowBounds = cms.vdouble( 1.5, 0.90 ,0.9) , upBounds = cms.vdouble( 6.0, 999., 1.1 ) , values = cms.vdouble( 1.20264 ) , uncertainties = cms.vdouble(  0.0214274 )  )
+    
+     # No Pixel Seed                                                                                                                                                                        
+        cms.PSet( lowBounds = cms.vdouble( 0.0, 0.85, -0.1 ) , upBounds = cms.vdouble( 1.5, 999. , 0.1) , values = cms.vdouble(0.982 ) , uncertainties = cms.vdouble( -0.007 )  ),
+        cms.PSet( lowBounds = cms.vdouble( 0.0, 0.00, -0.1 ) , upBounds = cms.vdouble( 1.5, 0.85 , 0.1) , values = cms.vdouble(0.975 ) , uncertainties = cms.vdouble( -0.007 )  ),
+        cms.PSet( lowBounds = cms.vdouble( 1.5, 0.90, -0.1 ) , upBounds = cms.vdouble( 6.0, 999.,  0.1) , values = cms.vdouble(0.943 ) , uncertainties = cms.vdouble( -0.01  )  ),
+        cms.PSet( lowBounds = cms.vdouble( 1.5, 0.00, -0.1 ) , upBounds = cms.vdouble( 6.0, 0.90 , 0.1) , values = cms.vdouble(0.912 ) , uncertainties = cms.vdouble( -0.04  )  ),
+        
+        # Yes Pixel Seed                                                                                                                                                                    
+        cms.PSet( lowBounds = cms.vdouble( 0.0, 0.85, 0.9 ) , upBounds = cms.vdouble( 1.5, 999., 1.1 ) , values = cms.vdouble( 1.622 ) , uncertainties = cms.vdouble( 0.25  )  ),
+        cms.PSet( lowBounds = cms.vdouble( 0.0, 0.00, 0.9 ) , upBounds = cms.vdouble( 1.5, 0.85, 1.1 ) , values = cms.vdouble( 1.106 ) , uncertainties = cms.vdouble( 0.03  )  ),   
+        cms.PSet( lowBounds = cms.vdouble( 1.5, 0.90, 0.9 ) , upBounds = cms.vdouble( 6.0, 999., 1.1 ) , values = cms.vdouble( 1.181 ) , uncertainties = cms.vdouble(  0.03 )  ),
+        cms.PSet( lowBounds = cms.vdouble( 1.5, 0.00, 0.9 ) , upBounds = cms.vdouble( 6.0, 0.90, 1.1 ) , values = cms.vdouble( 1.081 ) , uncertainties = cms.vdouble( 0.03  )  ) 
         )
     )
-
 
 subleadPixelSeedBins = cms.PSet(
     variables = cms.vstring("abs(superCluster.eta)","full5x5_r9", "hasPixelSeed"),
     bins = cms.VPSet(
-        # No Pixel Seed
-        cms.PSet( lowBounds = cms.vdouble( 0.0, 0.00, -0.1 ) , upBounds = cms.vdouble( 1.5, 0.85 , 0.1) , values = cms.vdouble( 0.978  ) , uncertainties = cms.vdouble(  -0.00415083)  ) ,
-        cms.PSet( lowBounds = cms.vdouble( 0.0, 0.85, -0.1 ) , upBounds = cms.vdouble( 1.5, 999. , 0.1) , values = cms.vdouble( 0.9824 ) , uncertainties = cms.vdouble( -0.00280026 )  ) ,
-        cms.PSet( lowBounds = cms.vdouble( 1.5, 0.00, -0.1 ) , upBounds = cms.vdouble( 6.0, 0.90 , 0.1) , values = cms.vdouble( 0.9168 ) , uncertainties = cms.vdouble( -0.0225538  )  ) ,
-        cms.PSet( lowBounds = cms.vdouble( 1.5, 0.90 ,-0.1) , upBounds = cms.vdouble( 6.0, 999., 0.1) , values = cms.vdouble( 0.9403 ) , uncertainties = cms.vdouble( -0.00655045 )  ),        
-        # Yes Pixel Seed
-        cms.PSet( lowBounds = cms.vdouble( 0.0, 0.00 ,0.9) , upBounds = cms.vdouble( 1.5, 0.85, 1.1 ) , values = cms.vdouble( 1.13196) , uncertainties = cms.vdouble( 0.0248967 )  ) ,
-        cms.PSet( lowBounds = cms.vdouble( 0.0, 0.85 ,0.9) , upBounds = cms.vdouble( 1.5, 999., 1.1 ) , values = cms.vdouble( 1.61512 ) , uncertainties = cms.vdouble(  0.0978689 )  ) ,
-        cms.PSet( lowBounds = cms.vdouble( 1.5, 0.00 ,0.9) , upBounds = cms.vdouble( 6.0, 0.90, 1.1 ) , values = cms.vdouble( 1.10623 ) , uncertainties = cms.vdouble(  0.0287957 )  ) ,
-        cms.PSet( lowBounds = cms.vdouble( 1.5, 0.90 ,0.9) , upBounds = cms.vdouble( 6.0, 999., 1.1 ) , values = cms.vdouble( 1.20311 ) , uncertainties = cms.vdouble(  0.0222861 )  )
+        
+        # No Pixel Seed                                                                                                                                                                     
+        cms.PSet( lowBounds = cms.vdouble( 0.0, 0.85, -0.1 ) , upBounds = cms.vdouble( 1.5, 999. , 0.1) , values = cms.vdouble(0.982 ) , uncertainties = cms.vdouble( -0.007 )  ),
+        cms.PSet( lowBounds = cms.vdouble( 0.0, 0.00, -0.1 ) , upBounds = cms.vdouble( 1.5, 0.85 , 0.1) , values = cms.vdouble(0.975 ) , uncertainties = cms.vdouble( -0.007 )  ),
+        cms.PSet( lowBounds = cms.vdouble( 1.5, 0.90, -0.1 ) , upBounds = cms.vdouble( 6.0, 999.,  0.1) , values = cms.vdouble(0.943 ) , uncertainties = cms.vdouble( -0.01  )  ),
+        cms.PSet( lowBounds = cms.vdouble( 1.5, 0.00, -0.1 ) , upBounds = cms.vdouble( 6.0, 0.90 , 0.1) , values = cms.vdouble(0.912 ) , uncertainties = cms.vdouble( -0.04  )  ),
+        
+        # Yes Pixel Seed                                                                                                                                                                     
+        cms.PSet( lowBounds = cms.vdouble( 0.0, 0.85, 0.9 ) , upBounds = cms.vdouble( 1.5, 999., 1.1 ) , values = cms.vdouble( 1.622 ) , uncertainties = cms.vdouble( 0.25  )  ),
+        cms.PSet( lowBounds = cms.vdouble( 0.0, 0.00, 0.9 ) , upBounds = cms.vdouble( 1.5, 0.85, 1.1 ) , values = cms.vdouble( 1.106 ) , uncertainties = cms.vdouble( 0.03  )  ),   
+        cms.PSet( lowBounds = cms.vdouble( 1.5, 0.90, 0.9 ) , upBounds = cms.vdouble( 6.0, 999., 1.1 ) , values = cms.vdouble( 1.181 ) , uncertainties = cms.vdouble(  0.03 )  ),
+        cms.PSet( lowBounds = cms.vdouble( 1.5, 0.00, 0.9 ) , upBounds = cms.vdouble( 6.0, 0.90, 1.1 ) , values = cms.vdouble( 1.081 ) , uncertainties = cms.vdouble( 0.03  )  ) 
+
         )
     )
+
+
 
 FNUFBins = cms.PSet(
     variables = cms.vstring("abs(superCluster.eta)","full5x5_r9"),

--- a/Systematics/python/flashggDiPhotonSystematics2018_cfi.py
+++ b/Systematics/python/flashggDiPhotonSystematics2018_cfi.py
@@ -59,13 +59,15 @@ subleadPixelSeedBins = cms.PSet(
     variables = cms.vstring("abs(superCluster.eta)","full5x5_r9", "hasPixelSeed"),
     bins = cms.VPSet(
 
-     # No Pixel Seed                                                                                                                                                                                
+     # No Pixel Seed                                                                                                                                                         
+        
         cms.PSet( lowBounds = cms.vdouble( 0.0, 0.85, -0.1 ) , upBounds = cms.vdouble( 1.5, 999. , 0.1) , values = cms.vdouble(0.975 ) , uncertainties = cms.vdouble( -0.011 )  ),
         cms.PSet( lowBounds = cms.vdouble( 0.0, 0.00, -0.1 ) , upBounds = cms.vdouble( 1.5, 0.85 , 0.1) , values = cms.vdouble(0.989 ) , uncertainties = cms.vdouble( -0.006 )  ),
         cms.PSet( lowBounds = cms.vdouble( 1.5, 0.90, -0.1 ) , upBounds = cms.vdouble( 6.0, 999.,  0.1) , values = cms.vdouble(0.916 ) , uncertainties = cms.vdouble( -0.015  )  ),
         cms.PSet( lowBounds = cms.vdouble( 1.5, 0.00, -0.1 ) , upBounds = cms.vdouble( 6.0, 0.90 , 0.1) , values = cms.vdouble(0.897 ) , uncertainties = cms.vdouble( -0.041  )  ),
 
-        # Yes Pixel Seed                                                                                                                                                                            
+        # Yes Pixel Seed                                                                                                                                                      
+        
         cms.PSet( lowBounds = cms.vdouble( 0.0, 0.85, 0.9 ) , upBounds = cms.vdouble( 1.5, 999., 1.1 ) , values = cms.vdouble( 1.871 ) , uncertainties = cms.vdouble( 0.380  )  ),
         cms.PSet( lowBounds = cms.vdouble( 0.0, 0.00, 0.9 ) , upBounds = cms.vdouble( 1.5, 0.85, 1.1 ) , values = cms.vdouble( 1.047 ) , uncertainties = cms.vdouble( 0.037  )  ),
         cms.PSet( lowBounds = cms.vdouble( 1.5, 0.90, 0.9 ) , upBounds = cms.vdouble( 6.0, 999., 1.1 ) , values = cms.vdouble( 1.261 ) , uncertainties = cms.vdouble( 0.047  )  ),

--- a/Systematics/python/flashggDiPhotonSystematics2018_cfi.py
+++ b/Systematics/python/flashggDiPhotonSystematics2018_cfi.py
@@ -34,38 +34,42 @@ electronVetoBins = cms.PSet(
     )
 
 
-# JMalcles - based on JTao SF + ttH efficiencies. calculated to preserve nTot ttH. 
+# JMalcles - based on JTao SF + ttH efficiencies. calculated to preserve nTot ttH.
+# Initial SF taken from: https://indico.cern.ch/event/850506/contributions/3606914/attachments/1927946/3192290/201910_Zmmg_RhoBugFixed.pdf
 
 leadPixelSeedBins = cms.PSet(
     variables = cms.vstring("abs(superCluster.eta)","full5x5_r9", "hasPixelSeed"),
     bins = cms.VPSet(
-        # No Pixel Seed
-        cms.PSet( lowBounds = cms.vdouble( 0.0, 0.00, -0.1 ) , upBounds = cms.vdouble( 1.5, 0.85 , 0.1) , values = cms.vdouble(0.978 ) , uncertainties = cms.vdouble( -0.00401807 )  ) ,
-        cms.PSet( lowBounds = cms.vdouble( 0.0, 0.85, -0.1 ) , upBounds = cms.vdouble( 1.5, 999. , 0.1) , values = cms.vdouble(0.9824) , uncertainties = cms.vdouble( -0.00200421 )  ) ,
-        cms.PSet( lowBounds = cms.vdouble( 1.5, 0.00, -0.1 ) , upBounds = cms.vdouble( 6.0, 0.90 , 0.1) , values = cms.vdouble(0.9168 ) , uncertainties = cms.vdouble( -0.0224756 )  ) ,
-        cms.PSet( lowBounds = cms.vdouble( 1.5, 0.90 ,-0.1) , upBounds = cms.vdouble( 6.0, 999., 0.1) , values = cms.vdouble( 0.9403 ) , uncertainties = cms.vdouble(  -0.00631264  )  ),        
-        # Yes Pixel Seed
-        cms.PSet( lowBounds = cms.vdouble( 0.0, 0.00 ,0.9) , upBounds = cms.vdouble( 1.5, 0.85, 1.1 ) , values = cms.vdouble( 1.08876 ) , uncertainties = cms.vdouble( 0.0162106 )  ) ,
-        cms.PSet( lowBounds = cms.vdouble( 0.0, 0.85 ,0.9) , upBounds = cms.vdouble( 1.5, 999., 1.1 ) , values = cms.vdouble( 1.5961) , uncertainties = cms.vdouble( 0.0678807 )  ) ,
-        cms.PSet( lowBounds = cms.vdouble( 1.5, 0.00 ,0.9) , upBounds = cms.vdouble( 6.0, 0.90, 1.1 ) , values = cms.vdouble( 1.09763 ) , uncertainties = cms.vdouble( 0.0263745 )  ) ,
-        cms.PSet( lowBounds = cms.vdouble( 1.5, 0.90 ,0.9) , upBounds = cms.vdouble( 6.0, 999., 1.1 ) , values = cms.vdouble( 1.20264 ) , uncertainties = cms.vdouble(  0.0214274 )  )
+    
+     # No Pixel Seed                                                                                                                                                                        
+        cms.PSet( lowBounds = cms.vdouble( 0.0, 0.85, -0.1 ) , upBounds = cms.vdouble( 1.5, 999. , 0.1) , values = cms.vdouble(0.975 ) , uncertainties = cms.vdouble( -0.011 )  ),
+        cms.PSet( lowBounds = cms.vdouble( 0.0, 0.00, -0.1 ) , upBounds = cms.vdouble( 1.5, 0.85 , 0.1) , values = cms.vdouble(0.989 ) , uncertainties = cms.vdouble( -0.006 )  ),
+        cms.PSet( lowBounds = cms.vdouble( 1.5, 0.90, -0.1 ) , upBounds = cms.vdouble( 6.0, 999.,  0.1) , values = cms.vdouble(0.916 ) , uncertainties = cms.vdouble( -0.015  )  ),
+        cms.PSet( lowBounds = cms.vdouble( 1.5, 0.00, -0.1 ) , upBounds = cms.vdouble( 6.0, 0.90 , 0.1) , values = cms.vdouble(0.897 ) , uncertainties = cms.vdouble( -0.041  )  ),
+        
+        # Yes Pixel Seed                                                                                                                                                                       
+        cms.PSet( lowBounds = cms.vdouble( 0.0, 0.85, 0.9 ) , upBounds = cms.vdouble( 1.5, 999., 1.1 ) , values = cms.vdouble( 1.871 ) , uncertainties = cms.vdouble( 0.380  )  ),
+        cms.PSet( lowBounds = cms.vdouble( 0.0, 0.00, 0.9 ) , upBounds = cms.vdouble( 1.5, 0.85, 1.1 ) , values = cms.vdouble( 1.047 ) , uncertainties = cms.vdouble( 0.037  )  ),   
+        cms.PSet( lowBounds = cms.vdouble( 1.5, 0.90, 0.9 ) , upBounds = cms.vdouble( 6.0, 999., 1.1 ) , values = cms.vdouble( 1.261 ) , uncertainties = cms.vdouble( 0.047  )  ),
+        cms.PSet( lowBounds = cms.vdouble( 1.5, 0.00, 0.9 ) , upBounds = cms.vdouble( 6.0, 0.90, 1.1 ) , values = cms.vdouble( 1.095 ) , uncertainties = cms.vdouble( 0.038  )  ) 
         )
     )
-
 
 subleadPixelSeedBins = cms.PSet(
     variables = cms.vstring("abs(superCluster.eta)","full5x5_r9", "hasPixelSeed"),
     bins = cms.VPSet(
-        # No Pixel Seed
-        cms.PSet( lowBounds = cms.vdouble( 0.0, 0.00, -0.1 ) , upBounds = cms.vdouble( 1.5, 0.85 , 0.1) , values = cms.vdouble( 0.978  ) , uncertainties = cms.vdouble(  -0.00415083)  ) ,
-        cms.PSet( lowBounds = cms.vdouble( 0.0, 0.85, -0.1 ) , upBounds = cms.vdouble( 1.5, 999. , 0.1) , values = cms.vdouble( 0.9824 ) , uncertainties = cms.vdouble( -0.00280026 )  ) ,
-        cms.PSet( lowBounds = cms.vdouble( 1.5, 0.00, -0.1 ) , upBounds = cms.vdouble( 6.0, 0.90 , 0.1) , values = cms.vdouble( 0.9168 ) , uncertainties = cms.vdouble( -0.0225538  )  ) ,
-        cms.PSet( lowBounds = cms.vdouble( 1.5, 0.90 ,-0.1) , upBounds = cms.vdouble( 6.0, 999., 0.1) , values = cms.vdouble( 0.9403 ) , uncertainties = cms.vdouble( -0.00655045 )  ),        
-        # Yes Pixel Seed
-        cms.PSet( lowBounds = cms.vdouble( 0.0, 0.00 ,0.9) , upBounds = cms.vdouble( 1.5, 0.85, 1.1 ) , values = cms.vdouble( 1.13196) , uncertainties = cms.vdouble( 0.0248967 )  ) ,
-        cms.PSet( lowBounds = cms.vdouble( 0.0, 0.85 ,0.9) , upBounds = cms.vdouble( 1.5, 999., 1.1 ) , values = cms.vdouble( 1.61512 ) , uncertainties = cms.vdouble(  0.0978689 )  ) ,
-        cms.PSet( lowBounds = cms.vdouble( 1.5, 0.00 ,0.9) , upBounds = cms.vdouble( 6.0, 0.90, 1.1 ) , values = cms.vdouble( 1.10623 ) , uncertainties = cms.vdouble(  0.0287957 )  ) ,
-        cms.PSet( lowBounds = cms.vdouble( 1.5, 0.90 ,0.9) , upBounds = cms.vdouble( 6.0, 999., 1.1 ) , values = cms.vdouble( 1.20311 ) , uncertainties = cms.vdouble(  0.0222861 )  )
+
+     # No Pixel Seed                                                                                                                                                                                
+        cms.PSet( lowBounds = cms.vdouble( 0.0, 0.85, -0.1 ) , upBounds = cms.vdouble( 1.5, 999. , 0.1) , values = cms.vdouble(0.975 ) , uncertainties = cms.vdouble( -0.011 )  ),
+        cms.PSet( lowBounds = cms.vdouble( 0.0, 0.00, -0.1 ) , upBounds = cms.vdouble( 1.5, 0.85 , 0.1) , values = cms.vdouble(0.989 ) , uncertainties = cms.vdouble( -0.006 )  ),
+        cms.PSet( lowBounds = cms.vdouble( 1.5, 0.90, -0.1 ) , upBounds = cms.vdouble( 6.0, 999.,  0.1) , values = cms.vdouble(0.916 ) , uncertainties = cms.vdouble( -0.015  )  ),
+        cms.PSet( lowBounds = cms.vdouble( 1.5, 0.00, -0.1 ) , upBounds = cms.vdouble( 6.0, 0.90 , 0.1) , values = cms.vdouble(0.897 ) , uncertainties = cms.vdouble( -0.041  )  ),
+
+        # Yes Pixel Seed                                                                                                                                                                            
+        cms.PSet( lowBounds = cms.vdouble( 0.0, 0.85, 0.9 ) , upBounds = cms.vdouble( 1.5, 999., 1.1 ) , values = cms.vdouble( 1.871 ) , uncertainties = cms.vdouble( 0.380  )  ),
+        cms.PSet( lowBounds = cms.vdouble( 0.0, 0.00, 0.9 ) , upBounds = cms.vdouble( 1.5, 0.85, 1.1 ) , values = cms.vdouble( 1.047 ) , uncertainties = cms.vdouble( 0.037  )  ),
+        cms.PSet( lowBounds = cms.vdouble( 1.5, 0.90, 0.9 ) , upBounds = cms.vdouble( 6.0, 999., 1.1 ) , values = cms.vdouble( 1.261 ) , uncertainties = cms.vdouble( 0.047  )  ),
+        cms.PSet( lowBounds = cms.vdouble( 1.5, 0.00, 0.9 ) , upBounds = cms.vdouble( 6.0, 0.90, 1.1 ) , values = cms.vdouble( 1.095 ) , uncertainties = cms.vdouble( 0.038  )  )
         )
     )
 

--- a/Systematics/python/flashggDiPhotonSystematics_cfi.py
+++ b/Systematics/python/flashggDiPhotonSystematics_cfi.py
@@ -39,3 +39,10 @@ def setupDiPhotonSystematics( process, options ):
    flashggDiPhotonSystematics.SystMethods.append(sysmodule.SigmaEOverESmearing)
    flashggDiPhotonSystematics.SystMethods.append(sysmodule.FracRVWeight)
    flashggDiPhotonSystematics.SystMethods.append(sysmodule.FracRVNvtxWeight)
+
+
+def addPixelSeedWeightToDiPhotonSystematics( process, options ):
+   process.load("flashgg.Systematics."+options.metaConditions["flashggDiPhotonSystematics"])
+   sysmodule = importlib.import_module("flashgg.Systematics."+options.metaConditions["flashggDiPhotonSystematics"])
+   flashggDiPhotonSystematics.SystMethods.append(sysmodule.PixelSeedWeight)
+

--- a/Systematics/test/workspaceStd.py
+++ b/Systematics/test/workspaceStd.py
@@ -266,15 +266,15 @@ if customize.tthTagsOnly:
 
     print "customize.processId:",customize.processId
 
-    print "Removing FracRVNvtxWeight from syst and adding  PixelSeed"
+    print "Removing FracRV and adding PixelSeed"
     
+    addPixelSeed=customizeDiPhotonSystematicsForTTH(process,customize)
+
     newvpset = cms.VPSet()
     for pset in process.flashggDiPhotonSystematics.SystMethods:
-        if not pset.Label.value().count("FracRVNvtxWeight") :
+        if not pset.Label.value().count("FracRV") :
             print  pset.Label.value()
             newvpset += [pset]
-    #from flashgg.Systematics.flashggDiPhotonSystematics_cfi import PixelSeedWeight #FIXME: this does not currently work, so comment it out for now
-    #newvpset += [ PixelSeedWeight ]
     
     process.flashggDiPhotonSystematics.SystMethods = newvpset
    


### PR DESCRIPTION
Here are the new pixel seed SF. I will now try to add them to the workspaceStd and check it works but numbers at least are available here. 
They are based on Junquan SF from z->mumugamma:
 https://indico.cern.ch/event/850506/contributions/3606914/attachments/1927946/3192290/201910_Zmmg_RhoBugFixed.pdf
Plus ttH pixel seed efficiencies (after PU reweighting) to make them for both passing and non passing events while preserving total number of events (it was checked that eff are very similar also for ggH). These are to be used only for tags using hasPixelSeed info.