### PR TITLE
Fix extraction of [secondary]Dataset files from DAS in JobConfig

### DIFF
--- a/MetaData/python/JobConfig.py
+++ b/MetaData/python/JobConfig.py
@@ -381,18 +381,18 @@ class JobConfig(object):
                 process.source.lumisToProcess = target.getVLuminosityBlockRange()
 
                 print process.source.lumisToProcess
-            
+
         flist = []
         sflist = []
-        
+
         # get the runs and lumis contained in each file of the secondary dataset
         if self.options.secondaryDataset:
             secondary_files = [fdata['file'][0]['name'] for fdata in das_query("file dataset=%s instance=prod/phys03" % self.options.secondaryDataset, 
                                                                                cmd='dasgoclient --dasmaps=./')['data']]
             runs_and_lumis = {}
             for s in secondary_files:
-                runs_and_lumis[str(s)] = {lumi['run_number'] : lumi['lumi_section_num'] for lumi in das_query("lumi file=%s instance=prod/phys03" % s,
-                                                                                                              cmd='dasgoclient --dasmaps=./')['data'][0]['lumi']}
+                runs_and_lumis[str(s)] = {data['lumi'][0]['run_number'] : data['lumi'][0]['lumi_section_num']
+                                          for data in das_query("lumi file=%s instance=prod/phys03" % s, cmd='dasgoclient --dasmaps=./')['data']}
 
         for f in files:
             if len(f.split(":",1))>1:
@@ -407,14 +407,14 @@ class JobConfig(object):
                     sflist.append('root://cms-xrd-global.cern.ch/'+parent_f_name if 'root://' not in parent_f_name else parent_f_name)
             elif self.options.secondaryDataset != "":
                 # match primary file to the corresponding secondary file(s)
-                f_runs_and_lumis = {lumi['run_number'] : lumi['lumi_section_num'] for lumi in das_query("lumi file=%s instance=prod/phys03" % f,
-                                                                                                        cmd='dasgoclient --dasmaps=./')['data'][0]['lumi']}
+                f_runs_and_lumis = {data['lumi'][0]['run_number'] : data['lumi'][0]['lumi_section_num']
+                                    for data in das_query("lumi file=%s instance=prod/phys03" % f, cmd='dasgoclient --dasmaps=./')['data']}
                 for s_name, s_runs_and_lumis in runs_and_lumis.items():
                     matched_runs = set(f_runs_and_lumis.keys()).intersection(s_runs_and_lumis.keys())
-                    for run in matched_runs:                        
+                    for run in matched_runs:
                         if any(lumi in f_runs_and_lumis[run] for lumi in s_runs_and_lumis[run]):
                             sflist.append(s_name)
-                
+
         if len(flist) > 0:
             ## fwlite
             if isFwlite:


### PR DESCRIPTION
In extraction of secondaryDataset files in `MetaData/python/JobConfig.py`, `runs_and_lumis[str(s)]` was only extracting the first run in each file `s` from the DAS query,

`{ ... for lumi in das_query(...)['data'][0]['lumi']}`

but `len(das_query(...)['data'])` == number of runs contained in file `s`, leading to missing files when running with a secondary dataset. This has been fixed to extract all runs in the file,

`{ ... for data in das_query(...)['data']}`

and similarly for the extraction of primary dataset files in `f_runs_and_lumis`.