### PR TITLE
Fix THQ likelihood discrimitor class

### DIFF
--- a/DataFormats/interface/likelihood_thq.h
+++ b/DataFormats/interface/likelihood_thq.h
@@ -1,4 +1,7 @@
-﻿#include "TTree.h"
+﻿#ifndef FLASHgg_LikelihoodTHQ_h
+#define FLASHgg_LikelihoodTHQ_h
+
+#include "TTree.h"
 #include "TH1.h"
 #include "TFile.h"
 #include "TNtuple.h"
@@ -14,118 +17,101 @@
 #include <TChain.h>
 #include "TMath.h"
 #include "TGraphErrors.h"
+
+#define NVARS 14
+
 using namespace std;
 using namespace edm;
 
-namespace flashgg{
+namespace flashgg {
 class LikelihoodClass {
 public:
-//    LikelihoodClass();
-    ~LikelihoodClass();
-    double evaluate_likelihood(std::vector<double> inputvars , const char * likelihood_inputfile);
+LikelihoodClass(const char* likelihood_inputfile);
+~LikelihoodClass();
+    double evaluate_likelihood(const std::vector<double> &inputvars);
     const char * likelihood_inputfile_;
 //    TFile *file_inputdistributions;
 private:
-    TH1F * h_fstatekinematics_sig[14];
-    TH1F * h_fstatekinematics_bkg[14];
+    TH1F * h_fstatekinematics_sig[NVARS];
+    TH1F * h_fstatekinematics_bkg[NVARS];
     TFile * file_inputdistributions;
 //    const char * likelihood_inputfile_;
 };
 
-double LikelihoodClass::evaluate_likelihood(std::vector<double> inputvars, const char * likelihood_inputfile ) {
-    likelihood_inputfile_ = likelihood_inputfile;
-    file_inputdistributions=new TFile( likelihood_inputfile_ , "READ");
-    h_fstatekinematics_sig[0]= (TH1F*) file_inputdistributions->Get("thq_n_jets");
-    h_fstatekinematics_sig[1]= (TH1F*) file_inputdistributions->Get("thq_n_centraljets");
-    h_fstatekinematics_sig[2]= (TH1F*) file_inputdistributions->Get("thq_muon1_ch");
-    h_fstatekinematics_sig[3]= (TH1F*) file_inputdistributions->Get("thq_fwdjet1_eta");
-    h_fstatekinematics_sig[4]= (TH1F*) file_inputdistributions->Get("thq_deta_muonfwdjet");
-    h_fstatekinematics_sig[5]= (TH1F*) file_inputdistributions->Get("thq_dr_leadphofwdjet");
-    h_fstatekinematics_sig[6]= (TH1F*) file_inputdistributions->Get("thq_dr_subleadphofwdjet");
-    h_fstatekinematics_sig[7]= (TH1F*) file_inputdistributions->Get("thq_bjet1_pt");
-    h_fstatekinematics_sig[8]= (TH1F*) file_inputdistributions->Get("top_mt11_thq");
-    h_fstatekinematics_sig[9]= (TH1F*) file_inputdistributions->Get("thq_dipho_pt");
-    h_fstatekinematics_sig[10]= (TH1F*) file_inputdistributions->Get("thq_n_bjets");
-    h_fstatekinematics_sig[11]= (TH1F*) file_inputdistributions->Get("thq_dr_tHchainfwdjet");
-    h_fstatekinematics_sig[12]= (TH1F*) file_inputdistributions->Get("thq_dr_leptonbjet");
-    h_fstatekinematics_sig[13]= (TH1F*) file_inputdistributions->Get("thq_dr_leptonfwdjet");
-    
-	
-    h_fstatekinematics_bkg[0]= (TH1F*) file_inputdistributions->Get("tth_n_jets");
-    h_fstatekinematics_bkg[1]= (TH1F*) file_inputdistributions->Get("tth_n_centraljets");
-    h_fstatekinematics_bkg[2]= (TH1F*) file_inputdistributions->Get("tth_muon1_ch");
-    h_fstatekinematics_bkg[3]= (TH1F*) file_inputdistributions->Get("tth_fwdjet1_eta");
-    h_fstatekinematics_bkg[4]= (TH1F*) file_inputdistributions->Get("tth_deta_muonfwdjet");
-    h_fstatekinematics_bkg[5]= (TH1F*) file_inputdistributions->Get("tth_dr_leadphofwdjet");
-    h_fstatekinematics_bkg[6]= (TH1F*) file_inputdistributions->Get("tth_dr_subleadphofwdjet");
-    h_fstatekinematics_bkg[7]= (TH1F*) file_inputdistributions->Get("tth_bjet1_pt");
-    h_fstatekinematics_bkg[8]= (TH1F*) file_inputdistributions->Get("top_mt11_tth");
-    h_fstatekinematics_bkg[9]= (TH1F*) file_inputdistributions->Get("tth_dipho_pt");
-    h_fstatekinematics_bkg[10]= (TH1F*) file_inputdistributions->Get("tth_n_bjets");
-    h_fstatekinematics_bkg[11]= (TH1F*) file_inputdistributions->Get("tth_dr_tHchainfwdjet");
-    h_fstatekinematics_bkg[12]= (TH1F*) file_inputdistributions->Get("tth_dr_leptonbjet");
-    h_fstatekinematics_bkg[13]= (TH1F*) file_inputdistributions->Get("tth_dr_leptonfwdjet");
-    
+LikelihoodClass::LikelihoodClass(const char* likelihood_inputfile):
+likelihood_inputfile_(likelihood_inputfile)
+{
+  file_inputdistributions = new TFile( likelihood_inputfile_ , "READ");
+  h_fstatekinematics_sig[0]= (TH1F*) file_inputdistributions->Get("thq_n_jets");
+  h_fstatekinematics_sig[1]= (TH1F*) file_inputdistributions->Get("thq_n_centraljets");
+  h_fstatekinematics_sig[2]= (TH1F*) file_inputdistributions->Get("thq_muon1_ch");
+  h_fstatekinematics_sig[3]= (TH1F*) file_inputdistributions->Get("thq_fwdjet1_eta");
+  h_fstatekinematics_sig[4]= (TH1F*) file_inputdistributions->Get("thq_deta_muonfwdjet");
+  h_fstatekinematics_sig[5]= (TH1F*) file_inputdistributions->Get("thq_dr_leadphofwdjet");
+  h_fstatekinematics_sig[6]= (TH1F*) file_inputdistributions->Get("thq_dr_subleadphofwdjet");
+  h_fstatekinematics_sig[7]= (TH1F*) file_inputdistributions->Get("thq_bjet1_pt");
+  h_fstatekinematics_sig[8]= (TH1F*) file_inputdistributions->Get("top_mt11_thq");
+  h_fstatekinematics_sig[9]= (TH1F*) file_inputdistributions->Get("thq_dipho_pt");
+  h_fstatekinematics_sig[10]= (TH1F*) file_inputdistributions->Get("thq_n_bjets");
+  h_fstatekinematics_sig[11]= (TH1F*) file_inputdistributions->Get("thq_dr_tHchainfwdjet");
+  h_fstatekinematics_sig[12]= (TH1F*) file_inputdistributions->Get("thq_dr_leptonbjet");
+  h_fstatekinematics_sig[13]= (TH1F*) file_inputdistributions->Get("thq_dr_leptonfwdjet");
+  
+  h_fstatekinematics_bkg[0]= (TH1F*) file_inputdistributions->Get("tth_n_jets");
+  h_fstatekinematics_bkg[1]= (TH1F*) file_inputdistributions->Get("tth_n_centraljets");
+  h_fstatekinematics_bkg[2]= (TH1F*) file_inputdistributions->Get("tth_muon1_ch");
+  h_fstatekinematics_bkg[3]= (TH1F*) file_inputdistributions->Get("tth_fwdjet1_eta");
+  h_fstatekinematics_bkg[4]= (TH1F*) file_inputdistributions->Get("tth_deta_muonfwdjet");
+  h_fstatekinematics_bkg[5]= (TH1F*) file_inputdistributions->Get("tth_dr_leadphofwdjet");
+  h_fstatekinematics_bkg[6]= (TH1F*) file_inputdistributions->Get("tth_dr_subleadphofwdjet");
+  h_fstatekinematics_bkg[7]= (TH1F*) file_inputdistributions->Get("tth_bjet1_pt");
+  h_fstatekinematics_bkg[8]= (TH1F*) file_inputdistributions->Get("top_mt11_tth");
+  h_fstatekinematics_bkg[9]= (TH1F*) file_inputdistributions->Get("tth_dipho_pt");
+  h_fstatekinematics_bkg[10]= (TH1F*) file_inputdistributions->Get("tth_n_bjets");
+  h_fstatekinematics_bkg[11]= (TH1F*) file_inputdistributions->Get("tth_dr_tHchainfwdjet");
+  h_fstatekinematics_bkg[12]= (TH1F*) file_inputdistributions->Get("tth_dr_leptonbjet");
+  h_fstatekinematics_bkg[13]= (TH1F*) file_inputdistributions->Get("tth_dr_leptonfwdjet");
+  
+  for(int i_histo=0; i_histo<NVARS; ++i_histo) {
+    h_fstatekinematics_sig[i_histo] -> SetDirectory(0);
+    h_fstatekinematics_bkg[i_histo] -> SetDirectory(0);
+  }
 
-
-//    file_inputdistributions->Close();
-
-    if(inputvars.size()!=14) {
-        std::cout<<"<LikelihoodClass::evaluate_likelihood>: inputvars.size() is "<<inputvars.size()<< " and it is expected to be 8!"<<std::endl;
-        std::cout<<"<LikelihoodClass::evaluate_likelihood>: is returning a value of -10.!"<<std::endl;
-        return -10.;
-    }
-    double p_signal=1.;
-    double p_background=1.;
-    for(unsigned int ielement=0; ielement<inputvars.size(); ielement++) {
-        int bin_hsignal= (Int_t) h_fstatekinematics_sig[ielement]->FindBin(inputvars.at(ielement));
-        int bin_hbackground= (Int_t) h_fstatekinematics_bkg[ielement]->FindBin(inputvars[ielement]);
-        p_signal = (p_signal*h_fstatekinematics_sig[ielement]->GetBinContent(bin_hsignal));
-        p_background = (p_background*h_fstatekinematics_bkg[ielement]->GetBinContent(bin_hbackground));
-//    cout<<"inputvars.at(ielement)"<<inputvars.at(ielement)<<endl;
-        }
-	file_inputdistributions->Close();
-          double lhood_val_den = (p_signal+p_background);
-        return (lhood_val_den != 0. ? (p_signal/lhood_val_den) : -11.);
-//	file_inputdistributions->Close();
-                };
-
+  file_inputdistributions->Close();
+}
 
 LikelihoodClass::~LikelihoodClass() {
-//    file_inputdistributions->Close();
-    
-	delete h_fstatekinematics_sig[0];
-	delete h_fstatekinematics_sig[1];
-	delete h_fstatekinematics_sig[2];
-        delete h_fstatekinematics_sig[3];
-	delete h_fstatekinematics_sig[4];
-        delete h_fstatekinematics_sig[5];
-        delete h_fstatekinematics_sig[6];
-        delete h_fstatekinematics_sig[7];
-	delete h_fstatekinematics_sig[8];
-	delete h_fstatekinematics_sig[9];
-        delete h_fstatekinematics_sig[10];
-        delete h_fstatekinematics_sig[11];
-        delete h_fstatekinematics_sig[12];
-        delete h_fstatekinematics_sig[13];
+  for(int i_histo=0; i_histo<NVARS; ++i_histo) {
+    delete h_fstatekinematics_sig[i_histo];
+    delete h_fstatekinematics_bkg[i_histo];
+  }
+  
+}
 
+double LikelihoodClass::evaluate_likelihood(const std::vector<double> &inputvars) 
+{
+  if(inputvars.size()!=NVARS) {
+    std::cout<<"<LikelihoodClass::evaluate_likelihood>: inputvars.size() is "<<inputvars.size()<< " and it is expected to be "<<NVARS<<std::endl;
+    std::cout<<"<LikelihoodClass::evaluate_likelihood>: is returning a value of -10.!"<<std::endl;
+    return -10.;
+  }
 
-	delete h_fstatekinematics_bkg[0];
-        delete h_fstatekinematics_bkg[1];
-        delete h_fstatekinematics_bkg[2];
-        delete h_fstatekinematics_bkg[3];
-        delete h_fstatekinematics_bkg[4];
-        delete h_fstatekinematics_bkg[5];
-        delete h_fstatekinematics_bkg[6];
-        delete h_fstatekinematics_bkg[7];
-        delete h_fstatekinematics_bkg[8];
-        delete h_fstatekinematics_bkg[9];
-        delete h_fstatekinematics_bkg[10];
-        delete h_fstatekinematics_bkg[11];
-        delete h_fstatekinematics_bkg[12];
-        delete h_fstatekinematics_bkg[13];
+  double p_signal=1.;
+  double p_background=1.;
+  for(unsigned int ielement=0; ielement<inputvars.size(); ielement++) {
+    int bin_hsignal= (Int_t) h_fstatekinematics_sig[ielement]->FindBin(inputvars.at(ielement));
+    int bin_hbackground= (Int_t) h_fstatekinematics_bkg[ielement]->FindBin(inputvars[ielement]);
+    p_signal = (p_signal*h_fstatekinematics_sig[ielement]->GetBinContent(bin_hsignal));
+    p_background = (p_background*h_fstatekinematics_bkg[ielement]->GetBinContent(bin_hbackground));
+    //    cout<<"inputvars.at(ielement)"<<inputvars.at(ielement)<<endl;
+  }
+
+  double lhood_val_den = (p_signal+p_background);
+  return (lhood_val_den != 0. ? (p_signal/lhood_val_den) : -11.);
+
+}
 
 }
 
 
-}
+#endif

--- a/MetaData/data/cross_sections.json
+++ b/MetaData/data/cross_sections.json
@@ -143,6 +143,7 @@
         "ttHToGG_M125_13TeV_powheg_pythia8_v2"                                           : { "xs" : 0.5071,   "br" : 0.00227, "kf" : 1.06, "itype":-125300 },  
 	"ttHToGG_M125_13TeV_powheg_pythia8"                                              : { "xs" : 0.5071,   "br" : 0.00227, "kf" : 1.06, "itype":-125300 },
         "ttHJetToGG_M125_13TeV_amcatnloFXFX_madspin_pythia8"                             : { "xs" : 0.5071,   "br" : 0.00227, "kf" : 1.06, "itype":-125300 },
+        "ttHJetToGG_M125_13TeV_amcatnloFXFX_madspin_pythia8_PSWeights"                   : { "xs" : 0.5071,   "br" : 0.00227, "kf" : 1.06, "itype":-125300 },
         "ttHJetToGG_M125_13TeV_amcatnloFXFX_madspin_pythia8_v2"                          : { "xs" : 0.5071,   "br" : 0.00227, "kf" : 1.06, "itype":-125300 },
 
         "ttHJetToGG_M125_13TeV_amcatnloFXFX_madspin_pythia8_CUETP8M1Up"                          : { "xs" : 0.5071,   "br" : 0.00227, "kf" : 1.06, "itype":-125300 },

--- a/Taggers/interface/FoxWolfram.hpp
+++ b/Taggers/interface/FoxWolfram.hpp
@@ -59,9 +59,16 @@ class FoxWolfram
         
         double cosTheta(const TLorentzVector& v1, const TLorentzVector& v2)
         {
-	  //return std::cos(v1.getTheta())*std::cos(v2.getTheta())+std::sin(v1.getTheta())*std::sin(v2.getTheta())*std::cos(v1.getPhi()-v2.getPhi());
-	  double ret = (v1.X()*v2.X()+v1.Y()*v2.Y()+v1.Z()*v2.Z())/sqrt(v1.Vect().Mag2()*v2.Vect().Mag2());
-	  //cout << ret << endl;
+	  double ret = 0;
+	  if(v1.P()!=0 && v2.P()!=0)
+	    ret = (v1.Px()*v2.Px()+v1.Py()*v2.Py()+v1.Pz()*v2.Pz()) / (v1.P()*v2.P());
+
+	  if(ret>0.9999)
+	    ret = 0.9999;
+	  else
+	    if(ret<-0.9999)
+	      ret = -0.9999;
+
 	  return ret;
         }
        

--- a/Taggers/interface/THQLikelihoodComputer.h
+++ b/Taggers/interface/THQLikelihoodComputer.h
@@ -1,0 +1,30 @@
+﻿#ifndef flashgg_THQLikelihoodComputer_h
+#define flashgg_THQLikelihoodComputer_h
+
+#include "TH1.h"
+#include "TFile.h"
+#include "TLorentzVector.h"
+#include "TMath.h"
+
+#include <vector>
+#include <iostream>
+#include <map>
+#include <algorithm>
+
+#define NVARS 14
+
+namespace flashgg {
+  class THQLikelihoodComputer 
+  {
+  public:
+    THQLikelihoodComputer(const char* likelihood_inputfile);
+    ~THQLikelihoodComputer();
+    double evaluate_likelihood(const std::vector<double> &inputvars);
+  private:
+    TH1F * h_fstatekinematics_sig[NVARS];
+    TH1F * h_fstatekinematics_bkg[NVARS];
+    const char * likelihood_inputfile_;
+  };
+}
+
+#endif

--- a/Taggers/plugins/THQLeptonicTagProducer.cc
+++ b/Taggers/plugins/THQLeptonicTagProducer.cc
@@ -91,9 +91,9 @@ public:
     map< string , CTCVWeightedVariable* > CTCVWeightedVariables;
     THQLeptonicTagProducer( const ParameterSet & );
     ~THQLeptonicTagProducer();
-    LikelihoodClass *likelihood_tHq;
 
 private:
+    LikelihoodClass* likelihood_tHq_;
     std::string processId_;
     edm::EDGetTokenT< LHEEventProduct > token_lhe;
 //    int  chooseCategory( float, float);
@@ -444,11 +444,12 @@ THQLeptonicTagProducer::THQLeptonicTagProducer( const ParameterSet &iConfig ) :
     }
     produces<vector<THQLeptonicTag> >();
     produces<vector<THQLeptonicTagTruth> >();
-    likelihood_tHq = new LikelihoodClass();
+    std::string filename = likelihood_input_.fullPath();
+    likelihood_tHq_ = new LikelihoodClass(filename.c_str());
 }
 
 THQLeptonicTagProducer::~THQLeptonicTagProducer() {
-    delete likelihood_tHq;
+    delete likelihood_tHq_;
 }
 
 int THQLeptonicTagProducer::chooseCategory( float mvavalue )
@@ -1032,9 +1033,7 @@ void THQLeptonicTagProducer::produce( Event &evt, const EventSetup & )
         vec_lhood_calc.push_back( dRleptonbjet_ );
         vec_lhood_calc.push_back( dRleptonfwdjet_ );
 
-        std::string filename = likelihood_input_.fullPath();
-
-        double lhood_value= likelihood_tHq->evaluate_likelihood(vec_lhood_calc, filename.c_str() );
+        double lhood_value= likelihood_tHq_->evaluate_likelihood(vec_lhood_calc );
         thqLeptonicMvaResult_value_ = thqLeptonicMva_->EvaluateMVA( MVAMethod_.c_str() );
         thqltags_obj.setlikelihood ( lhood_value ) ;
 	thqltags_obj.setthq_mvaresult ( thqLeptonicMvaResult_value_ );

--- a/Taggers/plugins/THQLeptonicTagProducer.cc
+++ b/Taggers/plugins/THQLeptonicTagProducer.cc
@@ -33,7 +33,7 @@
 #include "flashgg/Taggers/interface/FoxWolfram.hpp"
 
 #include "flashgg/DataFormats/interface/PDFWeightObject.h"
-#include "flashgg/DataFormats/interface/likelihood_thq.h"
+#include "flashgg/Taggers/interface/THQLikelihoodComputer.h"
 
 #include <vector>
 #include <algorithm>
@@ -93,7 +93,7 @@ public:
     ~THQLeptonicTagProducer();
 
 private:
-    LikelihoodClass* likelihood_tHq_;
+    THQLikelihoodComputer* likelihood_tHq_;
     std::string processId_;
     edm::EDGetTokenT< LHEEventProduct > token_lhe;
 //    int  chooseCategory( float, float);
@@ -445,7 +445,7 @@ THQLeptonicTagProducer::THQLeptonicTagProducer( const ParameterSet &iConfig ) :
     produces<vector<THQLeptonicTag> >();
     produces<vector<THQLeptonicTagTruth> >();
     std::string filename = likelihood_input_.fullPath();
-    likelihood_tHq_ = new LikelihoodClass(filename.c_str());
+    likelihood_tHq_ = new THQLikelihoodComputer(filename.c_str());
 }
 
 THQLeptonicTagProducer::~THQLeptonicTagProducer() {
@@ -940,7 +940,7 @@ void THQLeptonicTagProducer::produce( Event &evt, const EventSetup & )
          continue; }	
 //------------------------------------Likelihood and MVA-----------------------------------------
 //---------------------------------------------------------------------------------------
-//        LikelihoodClass *likelihood_tHq = new LikelihoodClass();
+//        THQLikelihoodComputer *likelihood_tHq = new THQLikelihoodComputer();
         std::vector<double> vec_lhood_calc;
 
         fwdJet1 = SelJetVect_EtaSorted[0];

--- a/Taggers/src/THQLikelihoodComputer.cc
+++ b/Taggers/src/THQLikelihoodComputer.cc
@@ -1,47 +1,12 @@
-﻿#ifndef FLASHgg_LikelihoodTHQ_h
-#define FLASHgg_LikelihoodTHQ_h
+﻿#include "flashgg/Taggers/interface/THQLikelihoodComputer.h"
 
-#include "TTree.h"
-#include "TH1.h"
-#include "TFile.h"
-#include "TNtuple.h"
-#include "TLegend.h"
-#include "TCanvas.h"
-#include "TStyle.h"
-#include "TLorentzVector.h"
-
-#include <vector>
-#include <iostream>
-#include <map>
-#include <algorithm>
-#include <TChain.h>
-#include "TMath.h"
-#include "TGraphErrors.h"
-
-#define NVARS 14
-
+using namespace flashgg;
 using namespace std;
-using namespace edm;
 
-namespace flashgg {
-class LikelihoodClass {
-public:
-LikelihoodClass(const char* likelihood_inputfile);
-~LikelihoodClass();
-    double evaluate_likelihood(const std::vector<double> &inputvars);
-    const char * likelihood_inputfile_;
-//    TFile *file_inputdistributions;
-private:
-    TH1F * h_fstatekinematics_sig[NVARS];
-    TH1F * h_fstatekinematics_bkg[NVARS];
-    TFile * file_inputdistributions;
-//    const char * likelihood_inputfile_;
-};
-
-LikelihoodClass::LikelihoodClass(const char* likelihood_inputfile):
+THQLikelihoodComputer::THQLikelihoodComputer(const char* likelihood_inputfile):
 likelihood_inputfile_(likelihood_inputfile)
 {
-  file_inputdistributions = new TFile( likelihood_inputfile_ , "READ");
+  TFile* file_inputdistributions = new TFile( likelihood_inputfile_ , "READ");
   h_fstatekinematics_sig[0]= (TH1F*) file_inputdistributions->Get("thq_n_jets");
   h_fstatekinematics_sig[1]= (TH1F*) file_inputdistributions->Get("thq_n_centraljets");
   h_fstatekinematics_sig[2]= (TH1F*) file_inputdistributions->Get("thq_muon1_ch");
@@ -80,7 +45,7 @@ likelihood_inputfile_(likelihood_inputfile)
   file_inputdistributions->Close();
 }
 
-LikelihoodClass::~LikelihoodClass() {
+THQLikelihoodComputer::~THQLikelihoodComputer() {
   for(int i_histo=0; i_histo<NVARS; ++i_histo) {
     delete h_fstatekinematics_sig[i_histo];
     delete h_fstatekinematics_bkg[i_histo];
@@ -88,11 +53,11 @@ LikelihoodClass::~LikelihoodClass() {
   
 }
 
-double LikelihoodClass::evaluate_likelihood(const std::vector<double> &inputvars) 
+double THQLikelihoodComputer::evaluate_likelihood(const std::vector<double> &inputvars) 
 {
   if(inputvars.size()!=NVARS) {
-    std::cout<<"<LikelihoodClass::evaluate_likelihood>: inputvars.size() is "<<inputvars.size()<< " and it is expected to be "<<NVARS<<std::endl;
-    std::cout<<"<LikelihoodClass::evaluate_likelihood>: is returning a value of -10.!"<<std::endl;
+    std::cout<<"<THQLikelihoodComputer::evaluate_likelihood>: inputvars.size() is "<<inputvars.size()<< " and it is expected to be "<<NVARS<<std::endl;
+    std::cout<<"<THQLikelihoodComputer::evaluate_likelihood>: is returning a value of -10.!"<<std::endl;
     return -10.;
   }
 
@@ -111,7 +76,6 @@ double LikelihoodClass::evaluate_likelihood(const std::vector<double> &inputvars
 
 }
 
-}
 
 
-#endif
+


### PR DESCRIPTION
- Avoid costheta>1 in THQTag (probably due to roundoff).
- Load all histograms just once at the beginning of the job instead of at every event.
- Rename the LikelihoodClass and move it to Taggers instead of DataFormats