### PR TITLE
Add option nCondorCpu to fggRunJobs

### DIFF
--- a/MetaData/python/jobs_utils.py
+++ b/MetaData/python/jobs_utils.py
@@ -93,6 +93,7 @@ class JobsManager(object):
                             help="default: %default"),
                 make_option("-m","--max-resubmissions",dest="maxResub", type="int",default=2),
                 make_option("-N","--ncpu",dest="ncpu", type="int",default=cpu_count()),
+                make_option("--nCondorCpu",dest="ncondorcpu", type="int",default=1),
                 make_option("-H","--hadd",dest="hadd",default=False, action="store_true",
                             help="hadd output files when all jobs are finished."
                             ),
@@ -150,11 +151,11 @@ class JobsManager(object):
         if self.options.summary:
             self.options.dry_run = True
             self.options.cont = True
-            
+  
         self.jobFactory = WorkNodeJobFactory(self.options.stageTo,self.options.stageCmd,job_outdir=self.options.outputDir,
                                             batchSystem=self.options.batchSystem,copy_proxy=self.options.copy_proxy)
         self.parallel = Parallel(self.options.ncpu,lsfQueue=self.options.queue,lsfJobName="%s/runJobs" % self.options.outputDir,
-                                 asyncLsf=self.options.asyncLsf,jobDriver=self.jobFactory,batchSystem=self.options.batchSystem)
+                                 asyncLsf=self.options.asyncLsf,jobDriver=self.jobFactory,batchSystem=self.options.batchSystem,ncondorcpu=self.options.ncondorcpu)
         
         self.jobs = None
         self.failedJobIds = {}

--- a/MetaData/python/parallel.py
+++ b/MetaData/python/parallel.py
@@ -370,7 +370,7 @@ class HTCondorJob(object):
     """ a thread to run condor_submit and wait until it completes """
 
     #----------------------------------------
-    def __init__(self, htcondorQueue, jobName="", async=True, replacesJob=None, copy_proxy=False):
+    def __init__(self, htcondorQueue, jobName="", async=True, replacesJob=None, copy_proxy=False, ncondorcpu=1):
         """ 
         @param cmd is the command to be executed inside the bsub script. Some CMSSW specific wrapper
         code will be added
@@ -386,6 +386,7 @@ class HTCondorJob(object):
         self.cmd = None
         self.replacesJob = replacesJob
         self.copy_proxy = copy_proxy
+        self.ncondorcpu = ncondorcpu
 
         if async != True:
             print "HTCondorJob: synchronous job processing is not supported by for HTCondor jobs ... running async jobs instead"
@@ -435,7 +436,8 @@ class HTCondorJob(object):
             fout.write('output        = '+self.jobName+'_$(ClusterId).$(ProcId).out\n')
             fout.write('error         = '+self.jobName+'_$(ClusterId).$(ProcId).err\n')
             fout.write('log           = '+self.jobName+'_$(ClusterId).$(ProcId)_htc.log\n\n')
-            fout.write('max_retries   = 1\n')
+            fout.write('RequestCpus   = {}\n'.format(self.ncondorcpu))
+            fout.write('max_retries   = 2\n')
             fout.write('queue '+str(njobs)+' \n')
             fout.close()        
 
@@ -1212,7 +1214,7 @@ class Wrap:
     
 # -----------------------------------------------------------------------------------------------------
 class Parallel:
-    def __init__(self,ncpu,lsfQueue=None,lsfJobName="job",asyncLsf=False,maxThreads=500,jobDriver=None,batchSystem="auto"):
+    def __init__(self,ncpu,lsfQueue=None,lsfJobName="job",asyncLsf=False,maxThreads=500,jobDriver=None,batchSystem="auto",ncondorcpu=1):
         self.returned = Queue()
 	self.njobs = 0
         self.JobDriver=jobDriver
@@ -1224,6 +1226,9 @@ class Parallel:
         self.maxThreads = maxThreads
         self.asyncLsf = asyncLsf
         self.batchSystem = batchSystem
+        
+        if BatchRegistry.getBatchSystem() == 'htcondor':
+            self.ncondorcpu = ncondorcpu
 
         if self.lsfQueue:
             self.running = Queue()
@@ -1266,8 +1271,11 @@ class Parallel:
     def addJob(self,cmd,args,batchId,jobName=None):
         if not self.asyncLsf:
             return
-        
-        job = self.JobDriver(self.lsfQueue,jobName,async=True)
+
+        if BatchRegistry.getBatchSystem() == 'htcondor':
+            job = self.JobDriver(self.lsfQueue,jobName,async=True,ncondorcpu=self.ncondorcpu)
+        else:
+            job = self.JobDriver(self.lsfQueue,jobName,async=True)
 
         job.setJobId(batchId)
         job.cmd = " ".join([cmd]+args)
@@ -1304,7 +1312,10 @@ class Parallel:
             if self.lsfQueue and not interactive:
                 if not jobName:
                     jobName = "%s%d" % (self.lsfJobName,self.getJobId())
-                cmd = self.JobDriver(self.lsfQueue,jobName,async=self.asyncLsf,replacesJob=replacesJob)
+                if BatchRegistry.getBatchSystem() == 'htcondor':
+                    cmd = self.JobDriver(self.lsfQueue,jobName,async=self.asyncLsf,replacesJob=replacesJob, ncondorcpu=self.ncondorcpu)
+                else:
+                    cmd = self.JobDriver(self.lsfQueue,jobName,async=self.asyncLsf,replacesJob=replacesJob)
             else:
                 cmd = commands.getstatusoutput
 


### PR DESCRIPTION
Allow user to specify number of cores used by each condor job. 
Given that condor allocates virtual memory proportionally to the number of cores used by the job this can be used effectively to increase the virtual memory allocated to the job on the worker node.