### PR TITLE
Add option copyInputMicroAOD

### DIFF
--- a/MetaData/python/JobConfig.py
+++ b/MetaData/python/JobConfig.py
@@ -424,10 +424,10 @@ class JobConfig(object):
 
         ## mitigate server glitches by copying the input files (microAOD) on the worker node
         if self.copyInputMicroAOD and not self.dryRun:
+            commands.getstatusoutput('mkdir -p input_files/')
             for i,f in enumerate(flist):
-                print f
-                commands.getstatusoutput('mkdir -p input_files/')
-                commands.getstatusoutput('xrdcp %s ./input_files/'%f)
+                status, out = commands.getstatusoutput('xrdcp %s ./input_files/'%f)
+                print(out)
                 flocal = 'file:./input_files/'+f.split('/')[-1]
                 flist[i] = flocal
 


### PR DESCRIPTION
Allow copy of input microAOD files from the storage element to the local working node.
The option should serve as a workaround for the observed connection glitches of T2_CH_CSCS which cause jobs to fail randomly.

The input file are copied by JobConfig at the beginning of the job and the input file list is
modified accordingly.