### PR TITLE
Topic trigger filter

### DIFF
--- a/MetaData/data/MetaConditions/Era2016_RR-17Jul2018_v1.json
+++ b/MetaData/data/MetaConditions/Era2016_RR-17Jul2018_v1.json
@@ -50,22 +50,34 @@
     "TriggerPaths" :
     {
         ".*DoubleEG.*" :
-        [
-            "HLT_Diphoton30_18_R9Id_OR_IsoCaloId_AND_HE_R9Id_Mass90*",
-            "HLT_Diphoton30PV_18PV_R9Id_AND_IsoCaloId_AND_HE_R9Id_DoublePixelVeto_Mass55*",
-            "HLT_Diphoton30EB_18EB_R9Id_OR_IsoCaloId_AND_HE_R9Id_DoublePixelVeto_Mass55*"
-        ],
+        {
+	    "mainAnalysis" :
+	    [
+		"HLT_Diphoton30_18_R9Id_OR_IsoCaloId_AND_HE_R9Id_Mass90*"
+	    ],
+	    "lowMassAnalysis" :
+	    [
+		"HLT_Diphoton30PV_18PV_R9Id_AND_IsoCaloId_AND_HE_R9Id_DoublePixelVeto_Mass55*",
+		"HLT_Diphoton30EB_18EB_R9Id_OR_IsoCaloId_AND_HE_R9Id_DoublePixelVeto_Mass55*"
+	    ]
+        },
         ".*SingleEle.*" :
-        [
-            "HLT_Ele27_WPTight_Gsf*"
-        ],
+        {
+	    "tagAndProbe" : 
+	    [
+		"HLT_Ele27_WPTight_Gsf*"
+	    ]
+        },
         ".*DoubleMuon.*" :
-        [
-            "HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_v*",
-            "HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_v*",
-            "HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_Mass3p8_v*",
-            "HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_Mass8_v*"
-        ]
+        {
+	    "ZmumuGamma" :
+	    [
+		"HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_v*",
+		"HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_v*",
+		"HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_Mass3p8_v*",
+		"HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_Mass8_v*"
+	    ]
+        }
     },
     
     "MUON_ID" : "Medium",

--- a/MetaData/data/MetaConditions/Era2017_RR-31Mar2018_v1.json
+++ b/MetaData/data/MetaConditions/Era2017_RR-31Mar2018_v1.json
@@ -49,27 +49,39 @@
     "TriggerPaths" :
     {
         ".*DoubleEG.*" :
-        [
-            "HLT_Diphoton30_22_R9Id_OR_IsoCaloId_AND_HE_R9Id_Mass90*",
-            "HLT_Diphoton30_22_R9Id_OR_IsoCaloId_AND_HE_R9Id_Mass95*",
-            "HLT_Diphoton30PV_18PV_R9Id_AND_IsoCaloId_AND_HE_R9Id_PixelVeto_Mass55*",
-            "HLT_Diphoton30PV_18PV_R9Id_AND_IsoCaloId_AND_HE_R9Id_NoPixelVeto_Mass55*",
-            "HLT_Diphoton30EB_18EB_R9Id_OR_IsoCaloId_AND_HE_R9Id_NoPixelVeto_Mass55*",
-            "HLT_Diphoton30EB_18EB_R9Id_OR_IsoCaloId_AND_HE_R9Id_PixelVeto_Mass55*",
-            "HLT_Diphoton30_18_PVrealAND_R9Id_AND_IsoCaloId_AND_HE_R9Id_PixelVeto_Mass55*",
-            "HLT_Diphoton30_18_PVrealAND_R9Id_AND_IsoCaloId_AND_HE_R9Id_NoPixelVeto_Mass55*"
-        ],
+        {
+	    "mainAnalysis" : 
+            [
+		"HLT_Diphoton30_22_R9Id_OR_IsoCaloId_AND_HE_R9Id_Mass90*",
+		"HLT_Diphoton30_22_R9Id_OR_IsoCaloId_AND_HE_R9Id_Mass95*"
+	    ],
+	    "lowMassAnalysis":
+	    [
+		"HLT_Diphoton30PV_18PV_R9Id_AND_IsoCaloId_AND_HE_R9Id_PixelVeto_Mass55*",
+		"HLT_Diphoton30PV_18PV_R9Id_AND_IsoCaloId_AND_HE_R9Id_NoPixelVeto_Mass55*",
+		"HLT_Diphoton30EB_18EB_R9Id_OR_IsoCaloId_AND_HE_R9Id_NoPixelVeto_Mass55*",
+		"HLT_Diphoton30EB_18EB_R9Id_OR_IsoCaloId_AND_HE_R9Id_PixelVeto_Mass55*",
+		"HLT_Diphoton30_18_PVrealAND_R9Id_AND_IsoCaloId_AND_HE_R9Id_PixelVeto_Mass55*",
+		"HLT_Diphoton30_18_PVrealAND_R9Id_AND_IsoCaloId_AND_HE_R9Id_NoPixelVeto_Mass55*"
+	    ]
+        },
         ".*SingleEle.*" :
-        [
-            "HLT_Ele32_WPTight_Gsf*"
-        ],
+        {
+	    "tagAndProbe" : 
+            [
+		"HLT_Ele32_WPTight_Gsf*"
+	    ]
+        },
         ".*DoubleMuon.*" :
-        [
-            "HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_v*",
-            "HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_v*",
-            "HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_Mass3p8_v*",
-            "HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_Mass8_v*"
-        ]
+        {
+	    "ZmumuGamma" :
+	    [
+		"HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_v*",
+		"HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_v*",
+		"HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_Mass3p8_v*",
+		"HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_Mass8_v*"
+	    ]
+        }
     },
 
     "flashggDiPhotonSystematics" : "flashggDiPhotonSystematics2017_cfi",

--- a/MetaData/data/MetaConditions/Era2018_RR-17Sep2018_v1.json
+++ b/MetaData/data/MetaConditions/Era2018_RR-17Sep2018_v1.json
@@ -49,20 +49,32 @@
     "TriggerPaths" :
     {
         ".*EGamma.*2018.*" :
-        [
-            "HLT_Diphoton30_22_R9Id_OR_IsoCaloId_AND_HE_R9Id_Mass90*",
-            "HLT_Diphoton30_22_R9Id_OR_IsoCaloId_AND_HE_R9Id_Mass95*",
-            "HLT_Diphoton30_18_R9IdL_AND_HE_AND_IsoCaloId_NoPixelVeto_Mass55*",
-            "HLT_Diphoton30_18_R9IdL_AND_HE_AND_IsoCaloId_NoPixelVeto*",
-            "HLT_Ele*_WPTight_Gsf_v*"
-        ],        
+        {
+	    "mainAnalysis" :
+	    [
+		"HLT_Diphoton30_22_R9Id_OR_IsoCaloId_AND_HE_R9Id_Mass90*",
+		"HLT_Diphoton30_22_R9Id_OR_IsoCaloId_AND_HE_R9Id_Mass95*"
+	    ],
+	    "lowMassAnalysis" :
+	    [
+		"HLT_Diphoton30_18_R9IdL_AND_HE_AND_IsoCaloId_NoPixelVeto_Mass55*",
+		"HLT_Diphoton30_18_R9IdL_AND_HE_AND_IsoCaloId_NoPixelVeto*"
+	    ],
+	    "tagAndProbe" :
+	    [
+		"HLT_Ele*_WPTight_Gsf_v*"
+	    ]
+        },        
         ".*DoubleMuon.*2018.*" :
-        [
-            "HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_v*",
-            "HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_v*",
-            "HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_Mass3p8_v*",
-            "HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_Mass8_v*"
-        ]
+        {
+	    "ZmumuGamma" :
+	    [
+		"HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_v*",
+		"HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_v*",
+		"HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_Mass3p8_v*",
+		"HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_Mass8_v*"
+	    ]
+        }
     },
     "flashggDiPhotonSystematics" : "flashggDiPhotonSystematics2018_cfi",
     

--- a/Systematics/python/SystematicsCustomize.py
+++ b/Systematics/python/SystematicsCustomize.py
@@ -352,4 +352,13 @@ def recalculatePDFWeights(process, options):
                                                 ) 
     process.p.insert(0, process.flashggPDFWeightObject)
 
-    
+def filterHLTrigger(process, options):
+
+    import re
+    from HLTrigger.HLTfilters.hltHighLevel_cfi import hltHighLevel
+    hlt_paths = []
+    for dset in options.metaConditions["TriggerPaths"]:
+        regDset = re.compile(dset)
+        if re.match(regDset, options.datasetName()):
+            hlt_paths.extend([str(x) for x in options.metaConditions["TriggerPaths"][dset][options.analysisType]])
+    process.hltHighLevel = hltHighLevel.clone(HLTPaths=cms.vstring(hlt_paths))

--- a/Systematics/test/workspaceStd.py
+++ b/Systematics/test/workspaceStd.py
@@ -143,6 +143,12 @@ customize.options.register('verboseSystDump',
                            VarParsing.VarParsing.varType.bool,
                            'verboseSystDump'
                            )
+customize.options.register('analysisType',
+                           'mainAnalysis',
+                           VarParsing.VarParsing.multiplicity.singleton,
+                           VarParsing.VarParsing.varType.string,
+                           'analysisType'
+                           )
 
 
 print "Printing defaults"
@@ -537,12 +543,7 @@ for tag in tagList:
                            )
 
 # Require standard diphoton trigger
-from HLTrigger.HLTfilters.hltHighLevel_cfi import hltHighLevel
-hlt_paths = []
-for dset in customize.metaConditions["TriggerPaths"]:
-    if dset in customize.datasetName():
-        hlt_paths.extend(customize.metaConditions["TriggerPaths"][dset])
-process.hltHighLevel= hltHighLevel.clone(HLTPaths = cms.vstring(hlt_paths))
+filterHLTrigger(process, customize)
 
 process.options = cms.untracked.PSet( wantSummary = cms.untracked.bool(True) )
 


### PR DESCRIPTION
The trigger filters were not correctly applied in workspaceStd.py. 
The effect should be zero for 2016 and 2017 since for the DoubleEG dataset the trigger selection is already applied during the microAOD production (although both low mass and main analysis triggered events are selected).
For 2018 the effect instead is relevant since in the EGamma dataset the SingleEle triggger used for Zee validation is included in the microAOD. Therefore workspaceStd was also running on SingleEle triggered events which were most likely rejected by the preselection (CS ele veto).