### PR TITLE
RunII legacy production: missing lowmass signal samples

### DIFF
--- a/MetaData/data/Era2016_RR-17Jul2018_v2/datasets_9.json
+++ b/MetaData/data/Era2016_RR-17Jul2018_v2/datasets_9.json
@@ -1591,6 +1591,117 @@
         "parent_n_units": 1000000, 
         "vetted": true
     }, 
+    "/VBFHToGG_M105_13TeV_amcatnlo_pythia8/spigazzi-Era2016_RR-17Jul2018_v2-legacyRun2FullV1-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2-d737d9b3bcefc7687f6dac8b97dc98e5/USER": {
+        "dset_type": "mc", 
+        "files": [
+            {
+                "bad": false, 
+                "events": 24810, 
+                "name": "/store/user/spigazzi/flashgg/Era2016_RR-17Jul2018_v2/legacyRun2FullV1/VBFHToGG_M105_13TeV_amcatnlo_pythia8/Era2016_RR-17Jul2018_v2-legacyRun2FullV1-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2/200104_120958/0000/myMicroAODOutputFile_5.root", 
+                "nevents": 24810, 
+                "totEvents": 24810, 
+                "weights": 115076.6953125
+            }, 
+            {
+                "bad": false, 
+                "events": 25116, 
+                "name": "/store/user/spigazzi/flashgg/Era2016_RR-17Jul2018_v2/legacyRun2FullV1/VBFHToGG_M105_13TeV_amcatnlo_pythia8/Era2016_RR-17Jul2018_v2-legacyRun2FullV1-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2/200104_120958/0000/myMicroAODOutputFile_12.root", 
+                "nevents": 25116, 
+                "totEvents": 25116, 
+                "weights": 112776.203125
+            }, 
+            {
+                "bad": false, 
+                "events": 24963, 
+                "name": "/store/user/spigazzi/flashgg/Era2016_RR-17Jul2018_v2/legacyRun2FullV1/VBFHToGG_M105_13TeV_amcatnlo_pythia8/Era2016_RR-17Jul2018_v2-legacyRun2FullV1-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2/200104_120958/0000/myMicroAODOutputFile_11.root", 
+                "nevents": 24963, 
+                "totEvents": 24963, 
+                "weights": 113656.578125
+            }, 
+            {
+                "bad": false, 
+                "events": 24351, 
+                "name": "/store/user/spigazzi/flashgg/Era2016_RR-17Jul2018_v2/legacyRun2FullV1/VBFHToGG_M105_13TeV_amcatnlo_pythia8/Era2016_RR-17Jul2018_v2-legacyRun2FullV1-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2/200104_120958/0000/myMicroAODOutputFile_8.root", 
+                "nevents": 24351, 
+                "totEvents": 24351, 
+                "weights": 112904.5546875
+            }, 
+            {
+                "bad": false, 
+                "events": 25116, 
+                "name": "/store/user/spigazzi/flashgg/Era2016_RR-17Jul2018_v2/legacyRun2FullV1/VBFHToGG_M105_13TeV_amcatnlo_pythia8/Era2016_RR-17Jul2018_v2-legacyRun2FullV1-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2/200104_120958/0000/myMicroAODOutputFile_6.root", 
+                "nevents": 25116, 
+                "totEvents": 25116, 
+                "weights": 116071.015625
+            }, 
+            {
+                "bad": false, 
+                "events": 24810, 
+                "name": "/store/user/spigazzi/flashgg/Era2016_RR-17Jul2018_v2/legacyRun2FullV1/VBFHToGG_M105_13TeV_amcatnlo_pythia8/Era2016_RR-17Jul2018_v2-legacyRun2FullV1-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2/200104_120958/0000/myMicroAODOutputFile_3.root", 
+                "nevents": 24810, 
+                "totEvents": 24810, 
+                "weights": 116192.2265625
+            }, 
+            {
+                "bad": false, 
+                "events": 24963, 
+                "name": "/store/user/spigazzi/flashgg/Era2016_RR-17Jul2018_v2/legacyRun2FullV1/VBFHToGG_M105_13TeV_amcatnlo_pythia8/Era2016_RR-17Jul2018_v2-legacyRun2FullV1-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2/200104_120958/0000/myMicroAODOutputFile_2.root", 
+                "nevents": 24963, 
+                "totEvents": 24963, 
+                "weights": 109683.7109375
+            }, 
+            {
+                "bad": false, 
+                "events": 24657, 
+                "name": "/store/user/spigazzi/flashgg/Era2016_RR-17Jul2018_v2/legacyRun2FullV1/VBFHToGG_M105_13TeV_amcatnlo_pythia8/Era2016_RR-17Jul2018_v2-legacyRun2FullV1-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2/200104_120958/0000/myMicroAODOutputFile_7.root", 
+                "nevents": 24657, 
+                "totEvents": 24657, 
+                "weights": 113694.953125
+            }, 
+            {
+                "bad": false, 
+                "events": 25116, 
+                "name": "/store/user/spigazzi/flashgg/Era2016_RR-17Jul2018_v2/legacyRun2FullV1/VBFHToGG_M105_13TeV_amcatnlo_pythia8/Era2016_RR-17Jul2018_v2-legacyRun2FullV1-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2/200104_120958/0000/myMicroAODOutputFile_10.root", 
+                "nevents": 25116, 
+                "totEvents": 25116, 
+                "weights": 114138.6015625
+            }, 
+            {
+                "bad": false, 
+                "events": 24810, 
+                "name": "/store/user/spigazzi/flashgg/Era2016_RR-17Jul2018_v2/legacyRun2FullV1/VBFHToGG_M105_13TeV_amcatnlo_pythia8/Era2016_RR-17Jul2018_v2-legacyRun2FullV1-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2/200104_120958/0000/myMicroAODOutputFile_9.root", 
+                "nevents": 24810, 
+                "totEvents": 24810, 
+                "weights": 110780.328125
+            }, 
+            {
+                "bad": false, 
+                "events": 447, 
+                "name": "/store/user/spigazzi/flashgg/Era2016_RR-17Jul2018_v2/legacyRun2FullV1/VBFHToGG_M105_13TeV_amcatnlo_pythia8/Era2016_RR-17Jul2018_v2-legacyRun2FullV1-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2/200104_120958/0000/myMicroAODOutputFile_13.root", 
+                "nevents": 447, 
+                "totEvents": 447, 
+                "weights": 1624.4454345703125
+            }, 
+            {
+                "bad": false, 
+                "events": 24963, 
+                "name": "/store/user/spigazzi/flashgg/Era2016_RR-17Jul2018_v2/legacyRun2FullV1/VBFHToGG_M105_13TeV_amcatnlo_pythia8/Era2016_RR-17Jul2018_v2-legacyRun2FullV1-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2/200104_120958/0000/myMicroAODOutputFile_1.root", 
+                "nevents": 24963, 
+                "totEvents": 24963, 
+                "weights": 114251.8828125
+            }, 
+            {
+                "bad": false, 
+                "events": 25078, 
+                "name": "/store/user/spigazzi/flashgg/Era2016_RR-17Jul2018_v2/legacyRun2FullV1/VBFHToGG_M105_13TeV_amcatnlo_pythia8/Era2016_RR-17Jul2018_v2-legacyRun2FullV1-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2/200104_120958/0000/myMicroAODOutputFile_4.root", 
+                "nevents": 25078, 
+                "totEvents": 25078, 
+                "weights": 110483.125
+            }
+        ], 
+        "parent_n_units": 299200, 
+        "vetted": true
+    }, 
     "/VBFHToGG_M120_13TeV_amcatnlo_pythia8/spigazzi-Era2016_RR-17Jul2018_v2-legacyRun2FullV1-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2-42666aea495bdc3a36d796ff9c4bc819/USER": {
         "dset_type": "mc", 
         "files": [
@@ -3751,6 +3862,196 @@
         "parent_n_units": 183341, 
         "vetted": true
     }, 
+    "/VHToGG_M70_13TeV_amcatnloFXFX_madspin_pythia8/spigazzi-Era2016_RR-17Jul2018_v2-legacyRun2FullV1-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3_ext1-v1-fb658acde5f31c48e0d1d7af8abc107a/USER": {
+        "dset_type": "mc", 
+        "files": [
+            {
+                "bad": false, 
+                "events": 24850, 
+                "name": "/store/user/spigazzi/flashgg/Era2016_RR-17Jul2018_v2/legacyRun2FullV1/VHToGG_M70_13TeV_amcatnloFXFX_madspin_pythia8/Era2016_RR-17Jul2018_v2-legacyRun2FullV1-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3_ext1-v1/200104_111146/0000/myMicroAODOutputFile_2.root", 
+                "nevents": 24850, 
+                "totEvents": 24850, 
+                "weights": 851781.75
+            }, 
+            {
+                "bad": false, 
+                "events": 25074, 
+                "name": "/store/user/spigazzi/flashgg/Era2016_RR-17Jul2018_v2/legacyRun2FullV1/VHToGG_M70_13TeV_amcatnloFXFX_madspin_pythia8/Era2016_RR-17Jul2018_v2-legacyRun2FullV1-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3_ext1-v1/200104_111146/0000/myMicroAODOutputFile_1.root", 
+                "nevents": 25074, 
+                "totEvents": 25074, 
+                "weights": 857972.4375
+            }, 
+            {
+                "bad": false, 
+                "events": 423, 
+                "name": "/store/user/spigazzi/flashgg/Era2016_RR-17Jul2018_v2/legacyRun2FullV1/VHToGG_M70_13TeV_amcatnloFXFX_madspin_pythia8/Era2016_RR-17Jul2018_v2-legacyRun2FullV1-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3_ext1-v1/200104_111146/0000/myMicroAODOutputFile_3.root", 
+                "nevents": 423, 
+                "totEvents": 423, 
+                "weights": 15363.1376953125
+            }
+        ], 
+        "parent_n_units": 50347, 
+        "vetted": true
+    }, 
+    "/VHToGG_M75_13TeV_amcatnloFXFX_madspin_pythia8/spigazzi-Era2016_RR-17Jul2018_v2-legacyRun2FullV1-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2-fb658acde5f31c48e0d1d7af8abc107a/USER": {
+        "dset_type": "mc", 
+        "files": [
+            {
+                "bad": false, 
+                "events": 24992, 
+                "name": "/store/user/spigazzi/flashgg/Era2016_RR-17Jul2018_v2/legacyRun2FullV1/VHToGG_M75_13TeV_amcatnloFXFX_madspin_pythia8/Era2016_RR-17Jul2018_v2-legacyRun2FullV1-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2/200104_121314/0000/myMicroAODOutputFile_14.root", 
+                "nevents": 24992, 
+                "totEvents": 24992, 
+                "weights": 705953.3125
+            }, 
+            {
+                "bad": false, 
+                "events": 24965, 
+                "name": "/store/user/spigazzi/flashgg/Era2016_RR-17Jul2018_v2/legacyRun2FullV1/VHToGG_M75_13TeV_amcatnloFXFX_madspin_pythia8/Era2016_RR-17Jul2018_v2-legacyRun2FullV1-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2/200104_121314/0000/myMicroAODOutputFile_17.root", 
+                "nevents": 24965, 
+                "totEvents": 24965, 
+                "weights": 710462.6875
+            }, 
+            {
+                "bad": false, 
+                "events": 24784, 
+                "name": "/store/user/spigazzi/flashgg/Era2016_RR-17Jul2018_v2/legacyRun2FullV1/VHToGG_M75_13TeV_amcatnloFXFX_madspin_pythia8/Era2016_RR-17Jul2018_v2-legacyRun2FullV1-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2/200104_121314/0000/myMicroAODOutputFile_4.root", 
+                "nevents": 24784, 
+                "totEvents": 24784, 
+                "weights": 705465.8125
+            }, 
+            {
+                "bad": false, 
+                "events": 12558, 
+                "name": "/store/user/spigazzi/flashgg/Era2016_RR-17Jul2018_v2/legacyRun2FullV1/VHToGG_M75_13TeV_amcatnloFXFX_madspin_pythia8/Era2016_RR-17Jul2018_v2-legacyRun2FullV1-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2/200104_121314/0000/myMicroAODOutputFile_19.root", 
+                "nevents": 12558, 
+                "totEvents": 12558, 
+                "weights": 352800.09375
+            }, 
+            {
+                "bad": false, 
+                "events": 24868, 
+                "name": "/store/user/spigazzi/flashgg/Era2016_RR-17Jul2018_v2/legacyRun2FullV1/VHToGG_M75_13TeV_amcatnloFXFX_madspin_pythia8/Era2016_RR-17Jul2018_v2-legacyRun2FullV1-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2/200104_121314/0000/myMicroAODOutputFile_15.root", 
+                "nevents": 24868, 
+                "totEvents": 24868, 
+                "weights": 704239.75
+            }, 
+            {
+                "bad": false, 
+                "events": 25078, 
+                "name": "/store/user/spigazzi/flashgg/Era2016_RR-17Jul2018_v2/legacyRun2FullV1/VHToGG_M75_13TeV_amcatnloFXFX_madspin_pythia8/Era2016_RR-17Jul2018_v2-legacyRun2FullV1-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2/200104_121314/0000/myMicroAODOutputFile_2.root", 
+                "nevents": 25078, 
+                "totEvents": 25078, 
+                "weights": 710449.5
+            }, 
+            {
+                "bad": false, 
+                "events": 25277, 
+                "name": "/store/user/spigazzi/flashgg/Era2016_RR-17Jul2018_v2/legacyRun2FullV1/VHToGG_M75_13TeV_amcatnloFXFX_madspin_pythia8/Era2016_RR-17Jul2018_v2-legacyRun2FullV1-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2/200104_121314/0000/myMicroAODOutputFile_10.root", 
+                "nevents": 25277, 
+                "totEvents": 25277, 
+                "weights": 711621.25
+            }, 
+            {
+                "bad": false, 
+                "events": 24828, 
+                "name": "/store/user/spigazzi/flashgg/Era2016_RR-17Jul2018_v2/legacyRun2FullV1/VHToGG_M75_13TeV_amcatnloFXFX_madspin_pythia8/Era2016_RR-17Jul2018_v2-legacyRun2FullV1-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2/200104_121314/0000/myMicroAODOutputFile_7.root", 
+                "nevents": 24828, 
+                "totEvents": 24828, 
+                "weights": 704475.1875
+            }, 
+            {
+                "bad": false, 
+                "events": 25010, 
+                "name": "/store/user/spigazzi/flashgg/Era2016_RR-17Jul2018_v2/legacyRun2FullV1/VHToGG_M75_13TeV_amcatnloFXFX_madspin_pythia8/Era2016_RR-17Jul2018_v2-legacyRun2FullV1-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2/200104_121314/0000/myMicroAODOutputFile_6.root", 
+                "nevents": 25010, 
+                "totEvents": 25010, 
+                "weights": 712377.125
+            }, 
+            {
+                "bad": false, 
+                "events": 24774, 
+                "name": "/store/user/spigazzi/flashgg/Era2016_RR-17Jul2018_v2/legacyRun2FullV1/VHToGG_M75_13TeV_amcatnloFXFX_madspin_pythia8/Era2016_RR-17Jul2018_v2-legacyRun2FullV1-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2/200104_121314/0000/myMicroAODOutputFile_8.root", 
+                "nevents": 24774, 
+                "totEvents": 24774, 
+                "weights": 710941.625
+            }, 
+            {
+                "bad": false, 
+                "events": 25037, 
+                "name": "/store/user/spigazzi/flashgg/Era2016_RR-17Jul2018_v2/legacyRun2FullV1/VHToGG_M75_13TeV_amcatnloFXFX_madspin_pythia8/Era2016_RR-17Jul2018_v2-legacyRun2FullV1-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2/200104_121314/0000/myMicroAODOutputFile_12.root", 
+                "nevents": 25037, 
+                "totEvents": 25037, 
+                "weights": 708982.6875
+            }, 
+            {
+                "bad": false, 
+                "events": 24719, 
+                "name": "/store/user/spigazzi/flashgg/Era2016_RR-17Jul2018_v2/legacyRun2FullV1/VHToGG_M75_13TeV_amcatnloFXFX_madspin_pythia8/Era2016_RR-17Jul2018_v2-legacyRun2FullV1-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2/200104_121314/0000/myMicroAODOutputFile_11.root", 
+                "nevents": 24719, 
+                "totEvents": 24719, 
+                "weights": 699301.875
+            }, 
+            {
+                "bad": false, 
+                "events": 24937, 
+                "name": "/store/user/spigazzi/flashgg/Era2016_RR-17Jul2018_v2/legacyRun2FullV1/VHToGG_M75_13TeV_amcatnloFXFX_madspin_pythia8/Era2016_RR-17Jul2018_v2-legacyRun2FullV1-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2/200104_121314/0000/myMicroAODOutputFile_3.root", 
+                "nevents": 24937, 
+                "totEvents": 24937, 
+                "weights": 712975.25
+            }, 
+            {
+                "bad": false, 
+                "events": 24803, 
+                "name": "/store/user/spigazzi/flashgg/Era2016_RR-17Jul2018_v2/legacyRun2FullV1/VHToGG_M75_13TeV_amcatnloFXFX_madspin_pythia8/Era2016_RR-17Jul2018_v2-legacyRun2FullV1-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2/200104_121314/0000/myMicroAODOutputFile_5.root", 
+                "nevents": 24803, 
+                "totEvents": 24803, 
+                "weights": 692188.4375
+            }, 
+            {
+                "bad": false, 
+                "events": 24801, 
+                "name": "/store/user/spigazzi/flashgg/Era2016_RR-17Jul2018_v2/legacyRun2FullV1/VHToGG_M75_13TeV_amcatnloFXFX_madspin_pythia8/Era2016_RR-17Jul2018_v2-legacyRun2FullV1-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2/200104_121314/0000/myMicroAODOutputFile_1.root", 
+                "nevents": 24801, 
+                "totEvents": 24801, 
+                "weights": 707096.875
+            }, 
+            {
+                "bad": false, 
+                "events": 24890, 
+                "name": "/store/user/spigazzi/flashgg/Era2016_RR-17Jul2018_v2/legacyRun2FullV1/VHToGG_M75_13TeV_amcatnloFXFX_madspin_pythia8/Era2016_RR-17Jul2018_v2-legacyRun2FullV1-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2/200104_121314/0000/myMicroAODOutputFile_16.root", 
+                "nevents": 24890, 
+                "totEvents": 24890, 
+                "weights": 703970.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25030, 
+                "name": "/store/user/spigazzi/flashgg/Era2016_RR-17Jul2018_v2/legacyRun2FullV1/VHToGG_M75_13TeV_amcatnloFXFX_madspin_pythia8/Era2016_RR-17Jul2018_v2-legacyRun2FullV1-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2/200104_121314/0000/myMicroAODOutputFile_13.root", 
+                "nevents": 25030, 
+                "totEvents": 25030, 
+                "weights": 713340.625
+            }, 
+            {
+                "bad": false, 
+                "events": 25095, 
+                "name": "/store/user/spigazzi/flashgg/Era2016_RR-17Jul2018_v2/legacyRun2FullV1/VHToGG_M75_13TeV_amcatnloFXFX_madspin_pythia8/Era2016_RR-17Jul2018_v2-legacyRun2FullV1-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2/200104_121314/0000/myMicroAODOutputFile_18.root", 
+                "nevents": 25095, 
+                "totEvents": 25095, 
+                "weights": 712766.25
+            }, 
+            {
+                "bad": false, 
+                "events": 25138, 
+                "name": "/store/user/spigazzi/flashgg/Era2016_RR-17Jul2018_v2/legacyRun2FullV1/VHToGG_M75_13TeV_amcatnloFXFX_madspin_pythia8/Era2016_RR-17Jul2018_v2-legacyRun2FullV1-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2/200104_121314/0000/myMicroAODOutputFile_9.root", 
+                "nevents": 25138, 
+                "totEvents": 25138, 
+                "weights": 708069.375
+            }
+        ], 
+        "parent_n_units": 461584, 
+        "vetted": true
+    }, 
     "/VHToGG_M95_13TeV_amcatnloFXFX_madspin_pythia8/spigazzi-Era2016_RR-17Jul2018_v2-legacyRun2FullV1-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2-b8a5b6287120fce79bb02069cbed82a0/USER": {
         "dset_type": "mc", 
         "files": [
@@ -4662,6 +4963,538 @@
             }
         ], 
         "parent_n_units": 685453, 
+        "vetted": true
+    }, 
+    "/ttHJetToGG_M75_13TeV_amcatnloFXFX_madspin_pythia8/spigazzi-Era2016_RR-17Jul2018_v2-legacyRun2FullV1-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2-1ba48e602bb4b02d368894d3decf1523/USER": {
+        "dset_type": "mc", 
+        "files": [
+            {
+                "bad": false, 
+                "events": 25244, 
+                "name": "/store/user/spigazzi/flashgg/Era2016_RR-17Jul2018_v2/legacyRun2FullV1/ttHJetToGG_M75_13TeV_amcatnloFXFX_madspin_pythia8/Era2016_RR-17Jul2018_v2-legacyRun2FullV1-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2/200104_111927/0000/myMicroAODOutputFile_12.root", 
+                "nevents": 25244, 
+                "totEvents": 25244, 
+                "weights": 90045.1875
+            }, 
+            {
+                "bad": false, 
+                "events": 24742, 
+                "name": "/store/user/spigazzi/flashgg/Era2016_RR-17Jul2018_v2/legacyRun2FullV1/ttHJetToGG_M75_13TeV_amcatnloFXFX_madspin_pythia8/Era2016_RR-17Jul2018_v2-legacyRun2FullV1-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2/200104_111927/0000/myMicroAODOutputFile_13.root", 
+                "nevents": 24742, 
+                "totEvents": 24742, 
+                "weights": 90537.5859375
+            }, 
+            {
+                "bad": false, 
+                "events": 24858, 
+                "name": "/store/user/spigazzi/flashgg/Era2016_RR-17Jul2018_v2/legacyRun2FullV1/ttHJetToGG_M75_13TeV_amcatnloFXFX_madspin_pythia8/Era2016_RR-17Jul2018_v2-legacyRun2FullV1-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2/200104_111927/0000/myMicroAODOutputFile_8.root", 
+                "nevents": 24858, 
+                "totEvents": 24858, 
+                "weights": 88769.9140625
+            }, 
+            {
+                "bad": false, 
+                "events": 24990, 
+                "name": "/store/user/spigazzi/flashgg/Era2016_RR-17Jul2018_v2/legacyRun2FullV1/ttHJetToGG_M75_13TeV_amcatnloFXFX_madspin_pythia8/Era2016_RR-17Jul2018_v2-legacyRun2FullV1-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2/200104_111927/0000/myMicroAODOutputFile_6.root", 
+                "nevents": 24990, 
+                "totEvents": 24990, 
+                "weights": 86689.7109375
+            }, 
+            {
+                "bad": false, 
+                "events": 24874, 
+                "name": "/store/user/spigazzi/flashgg/Era2016_RR-17Jul2018_v2/legacyRun2FullV1/ttHJetToGG_M75_13TeV_amcatnloFXFX_madspin_pythia8/Era2016_RR-17Jul2018_v2-legacyRun2FullV1-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2/200104_111927/0000/myMicroAODOutputFile_11.root", 
+                "nevents": 24874, 
+                "totEvents": 24874, 
+                "weights": 87982.703125
+            }, 
+            {
+                "bad": false, 
+                "events": 24773, 
+                "name": "/store/user/spigazzi/flashgg/Era2016_RR-17Jul2018_v2/legacyRun2FullV1/ttHJetToGG_M75_13TeV_amcatnloFXFX_madspin_pythia8/Era2016_RR-17Jul2018_v2-legacyRun2FullV1-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2/200104_111927/0000/myMicroAODOutputFile_9.root", 
+                "nevents": 24773, 
+                "totEvents": 24773, 
+                "weights": 89320.78125
+            }, 
+            {
+                "bad": false, 
+                "events": 25066, 
+                "name": "/store/user/spigazzi/flashgg/Era2016_RR-17Jul2018_v2/legacyRun2FullV1/ttHJetToGG_M75_13TeV_amcatnloFXFX_madspin_pythia8/Era2016_RR-17Jul2018_v2-legacyRun2FullV1-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2/200104_111927/0000/myMicroAODOutputFile_14.root", 
+                "nevents": 25066, 
+                "totEvents": 25066, 
+                "weights": 88522.953125
+            }, 
+            {
+                "bad": false, 
+                "events": 24838, 
+                "name": "/store/user/spigazzi/flashgg/Era2016_RR-17Jul2018_v2/legacyRun2FullV1/ttHJetToGG_M75_13TeV_amcatnloFXFX_madspin_pythia8/Era2016_RR-17Jul2018_v2-legacyRun2FullV1-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2/200104_111927/0000/myMicroAODOutputFile_4.root", 
+                "nevents": 24838, 
+                "totEvents": 24838, 
+                "weights": 90032.65625
+            }, 
+            {
+                "bad": false, 
+                "events": 24915, 
+                "name": "/store/user/spigazzi/flashgg/Era2016_RR-17Jul2018_v2/legacyRun2FullV1/ttHJetToGG_M75_13TeV_amcatnloFXFX_madspin_pythia8/Era2016_RR-17Jul2018_v2-legacyRun2FullV1-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2/200104_111927/0000/myMicroAODOutputFile_5.root", 
+                "nevents": 24915, 
+                "totEvents": 24915, 
+                "weights": 89740.671875
+            }, 
+            {
+                "bad": false, 
+                "events": 24756, 
+                "name": "/store/user/spigazzi/flashgg/Era2016_RR-17Jul2018_v2/legacyRun2FullV1/ttHJetToGG_M75_13TeV_amcatnloFXFX_madspin_pythia8/Era2016_RR-17Jul2018_v2-legacyRun2FullV1-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2/200104_111927/0000/myMicroAODOutputFile_10.root", 
+                "nevents": 24756, 
+                "totEvents": 24756, 
+                "weights": 87179.2578125
+            }, 
+            {
+                "bad": false, 
+                "events": 19212, 
+                "name": "/store/user/spigazzi/flashgg/Era2016_RR-17Jul2018_v2/legacyRun2FullV1/ttHJetToGG_M75_13TeV_amcatnloFXFX_madspin_pythia8/Era2016_RR-17Jul2018_v2-legacyRun2FullV1-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2/200104_111927/0000/myMicroAODOutputFile_15.root", 
+                "nevents": 19212, 
+                "totEvents": 19212, 
+                "weights": 67156.8984375
+            }, 
+            {
+                "bad": false, 
+                "events": 25060, 
+                "name": "/store/user/spigazzi/flashgg/Era2016_RR-17Jul2018_v2/legacyRun2FullV1/ttHJetToGG_M75_13TeV_amcatnloFXFX_madspin_pythia8/Era2016_RR-17Jul2018_v2-legacyRun2FullV1-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2/200104_111927/0000/myMicroAODOutputFile_7.root", 
+                "nevents": 25060, 
+                "totEvents": 25060, 
+                "weights": 88914.7109375
+            }, 
+            {
+                "bad": false, 
+                "events": 24841, 
+                "name": "/store/user/spigazzi/flashgg/Era2016_RR-17Jul2018_v2/legacyRun2FullV1/ttHJetToGG_M75_13TeV_amcatnloFXFX_madspin_pythia8/Era2016_RR-17Jul2018_v2-legacyRun2FullV1-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2/200104_111927/0000/myMicroAODOutputFile_2.root", 
+                "nevents": 24841, 
+                "totEvents": 24841, 
+                "weights": 85817.203125
+            }, 
+            {
+                "bad": false, 
+                "events": 24715, 
+                "name": "/store/user/spigazzi/flashgg/Era2016_RR-17Jul2018_v2/legacyRun2FullV1/ttHJetToGG_M75_13TeV_amcatnloFXFX_madspin_pythia8/Era2016_RR-17Jul2018_v2-legacyRun2FullV1-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2/200104_111927/0000/myMicroAODOutputFile_1.root", 
+                "nevents": 24715, 
+                "totEvents": 24715, 
+                "weights": 86787.7265625
+            }, 
+            {
+                "bad": false, 
+                "events": 24974, 
+                "name": "/store/user/spigazzi/flashgg/Era2016_RR-17Jul2018_v2/legacyRun2FullV1/ttHJetToGG_M75_13TeV_amcatnloFXFX_madspin_pythia8/Era2016_RR-17Jul2018_v2-legacyRun2FullV1-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2/200104_111927/0000/myMicroAODOutputFile_3.root", 
+                "nevents": 24974, 
+                "totEvents": 24974, 
+                "weights": 87092.84375
+            }
+        ], 
+        "parent_n_units": 367858, 
+        "vetted": true
+    }, 
+    "/ttHJetToGG_M80_13TeV_amcatnloFXFX_madspin_pythia8/spigazzi-Era2016_RR-17Jul2018_v2-legacyRun2FullV1-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2-1ba48e602bb4b02d368894d3decf1523/USER": {
+        "dset_type": "mc", 
+        "files": [
+            {
+                "bad": false, 
+                "events": 24893, 
+                "name": "/store/user/spigazzi/flashgg/Era2016_RR-17Jul2018_v2/legacyRun2FullV1/ttHJetToGG_M80_13TeV_amcatnloFXFX_madspin_pythia8/Era2016_RR-17Jul2018_v2-legacyRun2FullV1-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2/200104_121644/0000/myMicroAODOutputFile_9.root", 
+                "nevents": 24893, 
+                "totEvents": 24893, 
+                "weights": 77617.953125
+            }, 
+            {
+                "bad": false, 
+                "events": 24958, 
+                "name": "/store/user/spigazzi/flashgg/Era2016_RR-17Jul2018_v2/legacyRun2FullV1/ttHJetToGG_M80_13TeV_amcatnloFXFX_madspin_pythia8/Era2016_RR-17Jul2018_v2-legacyRun2FullV1-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2/200104_121644/0000/myMicroAODOutputFile_18.root", 
+                "nevents": 24958, 
+                "totEvents": 24958, 
+                "weights": 75364.7265625
+            }, 
+            {
+                "bad": false, 
+                "events": 24938, 
+                "name": "/store/user/spigazzi/flashgg/Era2016_RR-17Jul2018_v2/legacyRun2FullV1/ttHJetToGG_M80_13TeV_amcatnloFXFX_madspin_pythia8/Era2016_RR-17Jul2018_v2-legacyRun2FullV1-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2/200104_121644/0000/myMicroAODOutputFile_7.root", 
+                "nevents": 24938, 
+                "totEvents": 24938, 
+                "weights": 76600.890625
+            }, 
+            {
+                "bad": false, 
+                "events": 24704, 
+                "name": "/store/user/spigazzi/flashgg/Era2016_RR-17Jul2018_v2/legacyRun2FullV1/ttHJetToGG_M80_13TeV_amcatnloFXFX_madspin_pythia8/Era2016_RR-17Jul2018_v2-legacyRun2FullV1-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2/200104_121644/0000/myMicroAODOutputFile_17.root", 
+                "nevents": 24704, 
+                "totEvents": 24704, 
+                "weights": 77055.796875
+            }, 
+            {
+                "bad": false, 
+                "events": 24845, 
+                "name": "/store/user/spigazzi/flashgg/Era2016_RR-17Jul2018_v2/legacyRun2FullV1/ttHJetToGG_M80_13TeV_amcatnloFXFX_madspin_pythia8/Era2016_RR-17Jul2018_v2-legacyRun2FullV1-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2/200104_121644/0000/myMicroAODOutputFile_6.root", 
+                "nevents": 24845, 
+                "totEvents": 24845, 
+                "weights": 77028.640625
+            }, 
+            {
+                "bad": false, 
+                "events": 24916, 
+                "name": "/store/user/spigazzi/flashgg/Era2016_RR-17Jul2018_v2/legacyRun2FullV1/ttHJetToGG_M80_13TeV_amcatnloFXFX_madspin_pythia8/Era2016_RR-17Jul2018_v2-legacyRun2FullV1-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2/200104_121644/0000/myMicroAODOutputFile_11.root", 
+                "nevents": 24916, 
+                "totEvents": 24916, 
+                "weights": 75802.171875
+            }, 
+            {
+                "bad": false, 
+                "events": 24717, 
+                "name": "/store/user/spigazzi/flashgg/Era2016_RR-17Jul2018_v2/legacyRun2FullV1/ttHJetToGG_M80_13TeV_amcatnloFXFX_madspin_pythia8/Era2016_RR-17Jul2018_v2-legacyRun2FullV1-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2/200104_121644/0000/myMicroAODOutputFile_12.root", 
+                "nevents": 24717, 
+                "totEvents": 24717, 
+                "weights": 77723.78125
+            }, 
+            {
+                "bad": false, 
+                "events": 24785, 
+                "name": "/store/user/spigazzi/flashgg/Era2016_RR-17Jul2018_v2/legacyRun2FullV1/ttHJetToGG_M80_13TeV_amcatnloFXFX_madspin_pythia8/Era2016_RR-17Jul2018_v2-legacyRun2FullV1-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2/200104_121644/0000/myMicroAODOutputFile_4.root", 
+                "nevents": 24785, 
+                "totEvents": 24785, 
+                "weights": 76905.1484375
+            }, 
+            {
+                "bad": false, 
+                "events": 15031, 
+                "name": "/store/user/spigazzi/flashgg/Era2016_RR-17Jul2018_v2/legacyRun2FullV1/ttHJetToGG_M80_13TeV_amcatnloFXFX_madspin_pythia8/Era2016_RR-17Jul2018_v2-legacyRun2FullV1-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2/200104_121644/0000/myMicroAODOutputFile_19.root", 
+                "nevents": 15031, 
+                "totEvents": 15031, 
+                "weights": 45436.60546875
+            }, 
+            {
+                "bad": false, 
+                "events": 25119, 
+                "name": "/store/user/spigazzi/flashgg/Era2016_RR-17Jul2018_v2/legacyRun2FullV1/ttHJetToGG_M80_13TeV_amcatnloFXFX_madspin_pythia8/Era2016_RR-17Jul2018_v2-legacyRun2FullV1-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2/200104_121644/0000/myMicroAODOutputFile_15.root", 
+                "nevents": 25119, 
+                "totEvents": 25119, 
+                "weights": 78404.2421875
+            }, 
+            {
+                "bad": false, 
+                "events": 24866, 
+                "name": "/store/user/spigazzi/flashgg/Era2016_RR-17Jul2018_v2/legacyRun2FullV1/ttHJetToGG_M80_13TeV_amcatnloFXFX_madspin_pythia8/Era2016_RR-17Jul2018_v2-legacyRun2FullV1-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2/200104_121644/0000/myMicroAODOutputFile_5.root", 
+                "nevents": 24866, 
+                "totEvents": 24866, 
+                "weights": 77258.8046875
+            }, 
+            {
+                "bad": false, 
+                "events": 25168, 
+                "name": "/store/user/spigazzi/flashgg/Era2016_RR-17Jul2018_v2/legacyRun2FullV1/ttHJetToGG_M80_13TeV_amcatnloFXFX_madspin_pythia8/Era2016_RR-17Jul2018_v2-legacyRun2FullV1-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2/200104_121644/0000/myMicroAODOutputFile_16.root", 
+                "nevents": 25168, 
+                "totEvents": 25168, 
+                "weights": 79033.15625
+            }, 
+            {
+                "bad": false, 
+                "events": 24823, 
+                "name": "/store/user/spigazzi/flashgg/Era2016_RR-17Jul2018_v2/legacyRun2FullV1/ttHJetToGG_M80_13TeV_amcatnloFXFX_madspin_pythia8/Era2016_RR-17Jul2018_v2-legacyRun2FullV1-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2/200104_121644/0000/myMicroAODOutputFile_14.root", 
+                "nevents": 24823, 
+                "totEvents": 24823, 
+                "weights": 76500.828125
+            }, 
+            {
+                "bad": false, 
+                "events": 24616, 
+                "name": "/store/user/spigazzi/flashgg/Era2016_RR-17Jul2018_v2/legacyRun2FullV1/ttHJetToGG_M80_13TeV_amcatnloFXFX_madspin_pythia8/Era2016_RR-17Jul2018_v2-legacyRun2FullV1-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2/200104_121644/0000/myMicroAODOutputFile_1.root", 
+                "nevents": 24616, 
+                "totEvents": 24616, 
+                "weights": 75924.25
+            }, 
+            {
+                "bad": false, 
+                "events": 24896, 
+                "name": "/store/user/spigazzi/flashgg/Era2016_RR-17Jul2018_v2/legacyRun2FullV1/ttHJetToGG_M80_13TeV_amcatnloFXFX_madspin_pythia8/Era2016_RR-17Jul2018_v2-legacyRun2FullV1-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2/200104_121644/0000/myMicroAODOutputFile_2.root", 
+                "nevents": 24896, 
+                "totEvents": 24896, 
+                "weights": 75068.5546875
+            }, 
+            {
+                "bad": false, 
+                "events": 24902, 
+                "name": "/store/user/spigazzi/flashgg/Era2016_RR-17Jul2018_v2/legacyRun2FullV1/ttHJetToGG_M80_13TeV_amcatnloFXFX_madspin_pythia8/Era2016_RR-17Jul2018_v2-legacyRun2FullV1-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2/200104_121644/0000/myMicroAODOutputFile_3.root", 
+                "nevents": 24902, 
+                "totEvents": 24902, 
+                "weights": 76013.3984375
+            }, 
+            {
+                "bad": false, 
+                "events": 24861, 
+                "name": "/store/user/spigazzi/flashgg/Era2016_RR-17Jul2018_v2/legacyRun2FullV1/ttHJetToGG_M80_13TeV_amcatnloFXFX_madspin_pythia8/Era2016_RR-17Jul2018_v2-legacyRun2FullV1-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2/200104_121644/0000/myMicroAODOutputFile_10.root", 
+                "nevents": 24861, 
+                "totEvents": 24861, 
+                "weights": 77813.296875
+            }, 
+            {
+                "bad": false, 
+                "events": 24752, 
+                "name": "/store/user/spigazzi/flashgg/Era2016_RR-17Jul2018_v2/legacyRun2FullV1/ttHJetToGG_M80_13TeV_amcatnloFXFX_madspin_pythia8/Era2016_RR-17Jul2018_v2-legacyRun2FullV1-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2/200104_121644/0000/myMicroAODOutputFile_8.root", 
+                "nevents": 24752, 
+                "totEvents": 24752, 
+                "weights": 76356.5859375
+            }
+        ], 
+        "parent_n_units": 462486, 
+        "vetted": true
+    }, 
+    "/ttHJetToGG_M85_13TeV_amcatnloFXFX_madspin_pythia8/spigazzi-Era2016_RR-17Jul2018_v2-legacyRun2FullV1-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2-1ba48e602bb4b02d368894d3decf1523/USER": {
+        "dset_type": "mc", 
+        "files": [
+            {
+                "bad": false, 
+                "events": 24634, 
+                "name": "/store/user/spigazzi/flashgg/Era2016_RR-17Jul2018_v2/legacyRun2FullV1/ttHJetToGG_M85_13TeV_amcatnloFXFX_madspin_pythia8/Era2016_RR-17Jul2018_v2-legacyRun2FullV1-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2/200104_121947/0000/myMicroAODOutputFile_9.root", 
+                "nevents": 24634, 
+                "totEvents": 24634, 
+                "weights": 64567.84765625
+            }, 
+            {
+                "bad": false, 
+                "events": 24650, 
+                "name": "/store/user/spigazzi/flashgg/Era2016_RR-17Jul2018_v2/legacyRun2FullV1/ttHJetToGG_M85_13TeV_amcatnloFXFX_madspin_pythia8/Era2016_RR-17Jul2018_v2-legacyRun2FullV1-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2/200104_121947/0000/myMicroAODOutputFile_4.root", 
+                "nevents": 24650, 
+                "totEvents": 24650, 
+                "weights": 66133.515625
+            }, 
+            {
+                "bad": false, 
+                "events": 25151, 
+                "name": "/store/user/spigazzi/flashgg/Era2016_RR-17Jul2018_v2/legacyRun2FullV1/ttHJetToGG_M85_13TeV_amcatnloFXFX_madspin_pythia8/Era2016_RR-17Jul2018_v2-legacyRun2FullV1-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2/200104_121947/0000/myMicroAODOutputFile_12.root", 
+                "nevents": 25151, 
+                "totEvents": 25151, 
+                "weights": 67096.25
+            }, 
+            {
+                "bad": false, 
+                "events": 24821, 
+                "name": "/store/user/spigazzi/flashgg/Era2016_RR-17Jul2018_v2/legacyRun2FullV1/ttHJetToGG_M85_13TeV_amcatnloFXFX_madspin_pythia8/Era2016_RR-17Jul2018_v2-legacyRun2FullV1-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2/200104_121947/0000/myMicroAODOutputFile_11.root", 
+                "nevents": 24821, 
+                "totEvents": 24821, 
+                "weights": 66457.8828125
+            }, 
+            {
+                "bad": false, 
+                "events": 24995, 
+                "name": "/store/user/spigazzi/flashgg/Era2016_RR-17Jul2018_v2/legacyRun2FullV1/ttHJetToGG_M85_13TeV_amcatnloFXFX_madspin_pythia8/Era2016_RR-17Jul2018_v2-legacyRun2FullV1-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2/200104_121947/0000/myMicroAODOutputFile_14.root", 
+                "nevents": 24995, 
+                "totEvents": 24995, 
+                "weights": 66044.625
+            }, 
+            {
+                "bad": false, 
+                "events": 25625, 
+                "name": "/store/user/spigazzi/flashgg/Era2016_RR-17Jul2018_v2/legacyRun2FullV1/ttHJetToGG_M85_13TeV_amcatnloFXFX_madspin_pythia8/Era2016_RR-17Jul2018_v2-legacyRun2FullV1-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2/200104_121947/0000/myMicroAODOutputFile_1.root", 
+                "nevents": 25625, 
+                "totEvents": 25625, 
+                "weights": 66166.9140625
+            }, 
+            {
+                "bad": false, 
+                "events": 25348, 
+                "name": "/store/user/spigazzi/flashgg/Era2016_RR-17Jul2018_v2/legacyRun2FullV1/ttHJetToGG_M85_13TeV_amcatnloFXFX_madspin_pythia8/Era2016_RR-17Jul2018_v2-legacyRun2FullV1-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2/200104_121947/0000/myMicroAODOutputFile_5.root", 
+                "nevents": 25348, 
+                "totEvents": 25348, 
+                "weights": 65962.2578125
+            }, 
+            {
+                "bad": false, 
+                "events": 24923, 
+                "name": "/store/user/spigazzi/flashgg/Era2016_RR-17Jul2018_v2/legacyRun2FullV1/ttHJetToGG_M85_13TeV_amcatnloFXFX_madspin_pythia8/Era2016_RR-17Jul2018_v2-legacyRun2FullV1-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2/200104_121947/0000/myMicroAODOutputFile_7.root", 
+                "nevents": 24923, 
+                "totEvents": 24923, 
+                "weights": 67376.3671875
+            }, 
+            {
+                "bad": false, 
+                "events": 24878, 
+                "name": "/store/user/spigazzi/flashgg/Era2016_RR-17Jul2018_v2/legacyRun2FullV1/ttHJetToGG_M85_13TeV_amcatnloFXFX_madspin_pythia8/Era2016_RR-17Jul2018_v2-legacyRun2FullV1-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2/200104_121947/0000/myMicroAODOutputFile_13.root", 
+                "nevents": 24878, 
+                "totEvents": 24878, 
+                "weights": 64159.9921875
+            }, 
+            {
+                "bad": false, 
+                "events": 25047, 
+                "name": "/store/user/spigazzi/flashgg/Era2016_RR-17Jul2018_v2/legacyRun2FullV1/ttHJetToGG_M85_13TeV_amcatnloFXFX_madspin_pythia8/Era2016_RR-17Jul2018_v2-legacyRun2FullV1-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2/200104_121947/0000/myMicroAODOutputFile_2.root", 
+                "nevents": 25047, 
+                "totEvents": 25047, 
+                "weights": 64247.6640625
+            }, 
+            {
+                "bad": false, 
+                "events": 24798, 
+                "name": "/store/user/spigazzi/flashgg/Era2016_RR-17Jul2018_v2/legacyRun2FullV1/ttHJetToGG_M85_13TeV_amcatnloFXFX_madspin_pythia8/Era2016_RR-17Jul2018_v2-legacyRun2FullV1-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2/200104_121947/0000/myMicroAODOutputFile_6.root", 
+                "nevents": 24798, 
+                "totEvents": 24798, 
+                "weights": 66401.21875
+            }, 
+            {
+                "bad": false, 
+                "events": 20159, 
+                "name": "/store/user/spigazzi/flashgg/Era2016_RR-17Jul2018_v2/legacyRun2FullV1/ttHJetToGG_M85_13TeV_amcatnloFXFX_madspin_pythia8/Era2016_RR-17Jul2018_v2-legacyRun2FullV1-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2/200104_121947/0000/myMicroAODOutputFile_15.root", 
+                "nevents": 20159, 
+                "totEvents": 20159, 
+                "weights": 52203.734375
+            }, 
+            {
+                "bad": false, 
+                "events": 24796, 
+                "name": "/store/user/spigazzi/flashgg/Era2016_RR-17Jul2018_v2/legacyRun2FullV1/ttHJetToGG_M85_13TeV_amcatnloFXFX_madspin_pythia8/Era2016_RR-17Jul2018_v2-legacyRun2FullV1-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2/200104_121947/0000/myMicroAODOutputFile_10.root", 
+                "nevents": 24796, 
+                "totEvents": 24796, 
+                "weights": 66763.515625
+            }, 
+            {
+                "bad": false, 
+                "events": 24271, 
+                "name": "/store/user/spigazzi/flashgg/Era2016_RR-17Jul2018_v2/legacyRun2FullV1/ttHJetToGG_M85_13TeV_amcatnloFXFX_madspin_pythia8/Era2016_RR-17Jul2018_v2-legacyRun2FullV1-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2/200104_121947/0000/myMicroAODOutputFile_3.root", 
+                "nevents": 24271, 
+                "totEvents": 24271, 
+                "weights": 64363.97265625
+            }, 
+            {
+                "bad": false, 
+                "events": 25323, 
+                "name": "/store/user/spigazzi/flashgg/Era2016_RR-17Jul2018_v2/legacyRun2FullV1/ttHJetToGG_M85_13TeV_amcatnloFXFX_madspin_pythia8/Era2016_RR-17Jul2018_v2-legacyRun2FullV1-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2/200104_121947/0000/myMicroAODOutputFile_8.root", 
+                "nevents": 25323, 
+                "totEvents": 25323, 
+                "weights": 67832.03125
+            }
+        ], 
+        "parent_n_units": 369419, 
+        "vetted": true
+    }, 
+    "/ttHJetToGG_M95_13TeV_amcatnloFXFX_madspin_pythia8/spigazzi-Era2016_RR-17Jul2018_v2-legacyRun2FullV1-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2-1ba48e602bb4b02d368894d3decf1523/USER": {
+        "dset_type": "mc", 
+        "files": [
+            {
+                "bad": false, 
+                "events": 24776, 
+                "name": "/store/user/spigazzi/flashgg/Era2016_RR-17Jul2018_v2/legacyRun2FullV1/ttHJetToGG_M95_13TeV_amcatnloFXFX_madspin_pythia8/Era2016_RR-17Jul2018_v2-legacyRun2FullV1-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2/200104_122259/0000/myMicroAODOutputFile_7.root", 
+                "nevents": 24776, 
+                "totEvents": 24776, 
+                "weights": 50208.796875
+            }, 
+            {
+                "bad": false, 
+                "events": 25029, 
+                "name": "/store/user/spigazzi/flashgg/Era2016_RR-17Jul2018_v2/legacyRun2FullV1/ttHJetToGG_M95_13TeV_amcatnloFXFX_madspin_pythia8/Era2016_RR-17Jul2018_v2-legacyRun2FullV1-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2/200104_122259/0000/myMicroAODOutputFile_14.root", 
+                "nevents": 25029, 
+                "totEvents": 25029, 
+                "weights": 50796.08984375
+            }, 
+            {
+                "bad": false, 
+                "events": 24768, 
+                "name": "/store/user/spigazzi/flashgg/Era2016_RR-17Jul2018_v2/legacyRun2FullV1/ttHJetToGG_M95_13TeV_amcatnloFXFX_madspin_pythia8/Era2016_RR-17Jul2018_v2-legacyRun2FullV1-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2/200104_122259/0000/myMicroAODOutputFile_10.root", 
+                "nevents": 24768, 
+                "totEvents": 24768, 
+                "weights": 50542.69921875
+            }, 
+            {
+                "bad": false, 
+                "events": 25228, 
+                "name": "/store/user/spigazzi/flashgg/Era2016_RR-17Jul2018_v2/legacyRun2FullV1/ttHJetToGG_M95_13TeV_amcatnloFXFX_madspin_pythia8/Era2016_RR-17Jul2018_v2-legacyRun2FullV1-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2/200104_122259/0000/myMicroAODOutputFile_12.root", 
+                "nevents": 25228, 
+                "totEvents": 25228, 
+                "weights": 49388.06640625
+            }, 
+            {
+                "bad": false, 
+                "events": 24944, 
+                "name": "/store/user/spigazzi/flashgg/Era2016_RR-17Jul2018_v2/legacyRun2FullV1/ttHJetToGG_M95_13TeV_amcatnloFXFX_madspin_pythia8/Era2016_RR-17Jul2018_v2-legacyRun2FullV1-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2/200104_122259/0000/myMicroAODOutputFile_2.root", 
+                "nevents": 24944, 
+                "totEvents": 24944, 
+                "weights": 50333.828125
+            }, 
+            {
+                "bad": false, 
+                "events": 25237, 
+                "name": "/store/user/spigazzi/flashgg/Era2016_RR-17Jul2018_v2/legacyRun2FullV1/ttHJetToGG_M95_13TeV_amcatnloFXFX_madspin_pythia8/Era2016_RR-17Jul2018_v2-legacyRun2FullV1-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2/200104_122259/0000/myMicroAODOutputFile_9.root", 
+                "nevents": 25237, 
+                "totEvents": 25237, 
+                "weights": 50329.80859375
+            }, 
+            {
+                "bad": false, 
+                "events": 24367, 
+                "name": "/store/user/spigazzi/flashgg/Era2016_RR-17Jul2018_v2/legacyRun2FullV1/ttHJetToGG_M95_13TeV_amcatnloFXFX_madspin_pythia8/Era2016_RR-17Jul2018_v2-legacyRun2FullV1-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2/200104_122259/0000/myMicroAODOutputFile_13.root", 
+                "nevents": 24367, 
+                "totEvents": 24367, 
+                "weights": 48972.296875
+            }, 
+            {
+                "bad": false, 
+                "events": 21307, 
+                "name": "/store/user/spigazzi/flashgg/Era2016_RR-17Jul2018_v2/legacyRun2FullV1/ttHJetToGG_M95_13TeV_amcatnloFXFX_madspin_pythia8/Era2016_RR-17Jul2018_v2-legacyRun2FullV1-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2/200104_122259/0000/myMicroAODOutputFile_15.root", 
+                "nevents": 21307, 
+                "totEvents": 21307, 
+                "weights": 43163.52734375
+            }, 
+            {
+                "bad": false, 
+                "events": 25134, 
+                "name": "/store/user/spigazzi/flashgg/Era2016_RR-17Jul2018_v2/legacyRun2FullV1/ttHJetToGG_M95_13TeV_amcatnloFXFX_madspin_pythia8/Era2016_RR-17Jul2018_v2-legacyRun2FullV1-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2/200104_122259/0000/myMicroAODOutputFile_1.root", 
+                "nevents": 25134, 
+                "totEvents": 25134, 
+                "weights": 49304.4453125
+            }, 
+            {
+                "bad": false, 
+                "events": 24717, 
+                "name": "/store/user/spigazzi/flashgg/Era2016_RR-17Jul2018_v2/legacyRun2FullV1/ttHJetToGG_M95_13TeV_amcatnloFXFX_madspin_pythia8/Era2016_RR-17Jul2018_v2-legacyRun2FullV1-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2/200104_122259/0000/myMicroAODOutputFile_6.root", 
+                "nevents": 24717, 
+                "totEvents": 24717, 
+                "weights": 49349.171875
+            }, 
+            {
+                "bad": false, 
+                "events": 24988, 
+                "name": "/store/user/spigazzi/flashgg/Era2016_RR-17Jul2018_v2/legacyRun2FullV1/ttHJetToGG_M95_13TeV_amcatnloFXFX_madspin_pythia8/Era2016_RR-17Jul2018_v2-legacyRun2FullV1-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2/200104_122259/0000/myMicroAODOutputFile_3.root", 
+                "nevents": 24988, 
+                "totEvents": 24988, 
+                "weights": 51180.11328125
+            }, 
+            {
+                "bad": false, 
+                "events": 24773, 
+                "name": "/store/user/spigazzi/flashgg/Era2016_RR-17Jul2018_v2/legacyRun2FullV1/ttHJetToGG_M95_13TeV_amcatnloFXFX_madspin_pythia8/Era2016_RR-17Jul2018_v2-legacyRun2FullV1-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2/200104_122259/0000/myMicroAODOutputFile_4.root", 
+                "nevents": 24773, 
+                "totEvents": 24773, 
+                "weights": 49291.70703125
+            }, 
+            {
+                "bad": false, 
+                "events": 25202, 
+                "name": "/store/user/spigazzi/flashgg/Era2016_RR-17Jul2018_v2/legacyRun2FullV1/ttHJetToGG_M95_13TeV_amcatnloFXFX_madspin_pythia8/Era2016_RR-17Jul2018_v2-legacyRun2FullV1-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2/200104_122259/0000/myMicroAODOutputFile_11.root", 
+                "nevents": 25202, 
+                "totEvents": 25202, 
+                "weights": 49152.1015625
+            }, 
+            {
+                "bad": false, 
+                "events": 25100, 
+                "name": "/store/user/spigazzi/flashgg/Era2016_RR-17Jul2018_v2/legacyRun2FullV1/ttHJetToGG_M95_13TeV_amcatnloFXFX_madspin_pythia8/Era2016_RR-17Jul2018_v2-legacyRun2FullV1-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2/200104_122259/0000/myMicroAODOutputFile_8.root", 
+                "nevents": 25100, 
+                "totEvents": 25100, 
+                "weights": 51180.5390625
+            }, 
+            {
+                "bad": false, 
+                "events": 25421, 
+                "name": "/store/user/spigazzi/flashgg/Era2016_RR-17Jul2018_v2/legacyRun2FullV1/ttHJetToGG_M95_13TeV_amcatnloFXFX_madspin_pythia8/Era2016_RR-17Jul2018_v2-legacyRun2FullV1-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2/200104_122259/0000/myMicroAODOutputFile_5.root", 
+                "nevents": 25421, 
+                "totEvents": 25421, 
+                "weights": 51486.3984375
+            }
+        ], 
+        "parent_n_units": 370991, 
         "vetted": true
     }
 }

--- a/MetaData/data/Era2017_RR-31Mar2018_v2/datasets_9.json
+++ b/MetaData/data/Era2017_RR-31Mar2018_v2/datasets_9.json
@@ -1246,6 +1246,211 @@
         "parent_n_units": 3911968, 
         "vetted": true
     }, 
+    "/GluGluHToGG_M80_13TeV_amcatnloFXFX_pythia8/spigazzi-Era2017_RR-31Mar2018_v2-legacyRun2FullV1-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1-8c6318498cd00f339849a28190567b7a/USER": {
+        "dset_type": "mc", 
+        "files": [
+            {
+                "bad": false, 
+                "events": 24911, 
+                "name": "/store/user/spigazzi/flashgg/Era2017_RR-31Mar2018_v2/legacyRun2FullV1/GluGluHToGG_M80_13TeV_amcatnloFXFX_pythia8/Era2017_RR-31Mar2018_v2-legacyRun2FullV1-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/200104_103524/0000/myMicroAODOutputFile_2.root", 
+                "nevents": 24911, 
+                "totEvents": 24911, 
+                "weights": 6322061.0
+            }, 
+            {
+                "bad": false, 
+                "events": 1020, 
+                "name": "/store/user/spigazzi/flashgg/Era2017_RR-31Mar2018_v2/legacyRun2FullV1/GluGluHToGG_M80_13TeV_amcatnloFXFX_pythia8/Era2017_RR-31Mar2018_v2-legacyRun2FullV1-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/200104_103524/0000/myMicroAODOutputFile_13.root", 
+                "nevents": 1020, 
+                "totEvents": 1020, 
+                "weights": 267228.40625
+            }, 
+            {
+                "bad": false, 
+                "events": 24649, 
+                "name": "/store/user/spigazzi/flashgg/Era2017_RR-31Mar2018_v2/legacyRun2FullV1/GluGluHToGG_M80_13TeV_amcatnloFXFX_pythia8/Era2017_RR-31Mar2018_v2-legacyRun2FullV1-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/200104_103524/0000/myMicroAODOutputFile_11.root", 
+                "nevents": 24649, 
+                "totEvents": 24649, 
+                "weights": 6212025.5
+            }, 
+            {
+                "bad": false, 
+                "events": 24539, 
+                "name": "/store/user/spigazzi/flashgg/Era2017_RR-31Mar2018_v2/legacyRun2FullV1/GluGluHToGG_M80_13TeV_amcatnloFXFX_pythia8/Era2017_RR-31Mar2018_v2-legacyRun2FullV1-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/200104_103524/0000/myMicroAODOutputFile_3.root", 
+                "nevents": 24539, 
+                "totEvents": 24539, 
+                "weights": 6360946.0
+            }, 
+            {
+                "bad": false, 
+                "events": 23269, 
+                "name": "/store/user/spigazzi/flashgg/Era2017_RR-31Mar2018_v2/legacyRun2FullV1/GluGluHToGG_M80_13TeV_amcatnloFXFX_pythia8/Era2017_RR-31Mar2018_v2-legacyRun2FullV1-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/200104_103524/0000/myMicroAODOutputFile_9.root", 
+                "nevents": 23269, 
+                "totEvents": 23269, 
+                "weights": 5948934.5
+            }, 
+            {
+                "bad": false, 
+                "events": 24642, 
+                "name": "/store/user/spigazzi/flashgg/Era2017_RR-31Mar2018_v2/legacyRun2FullV1/GluGluHToGG_M80_13TeV_amcatnloFXFX_pythia8/Era2017_RR-31Mar2018_v2-legacyRun2FullV1-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/200104_103524/0000/myMicroAODOutputFile_1.root", 
+                "nevents": 24642, 
+                "totEvents": 24642, 
+                "weights": 6180174.0
+            }, 
+            {
+                "bad": false, 
+                "events": 23865, 
+                "name": "/store/user/spigazzi/flashgg/Era2017_RR-31Mar2018_v2/legacyRun2FullV1/GluGluHToGG_M80_13TeV_amcatnloFXFX_pythia8/Era2017_RR-31Mar2018_v2-legacyRun2FullV1-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/200104_103524/0000/myMicroAODOutputFile_4.root", 
+                "nevents": 23865, 
+                "totEvents": 23865, 
+                "weights": 5972927.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25292, 
+                "name": "/store/user/spigazzi/flashgg/Era2017_RR-31Mar2018_v2/legacyRun2FullV1/GluGluHToGG_M80_13TeV_amcatnloFXFX_pythia8/Era2017_RR-31Mar2018_v2-legacyRun2FullV1-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/200104_103524/0000/myMicroAODOutputFile_5.root", 
+                "nevents": 25292, 
+                "totEvents": 25292, 
+                "weights": 6477187.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24933, 
+                "name": "/store/user/spigazzi/flashgg/Era2017_RR-31Mar2018_v2/legacyRun2FullV1/GluGluHToGG_M80_13TeV_amcatnloFXFX_pythia8/Era2017_RR-31Mar2018_v2-legacyRun2FullV1-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/200104_103524/0000/myMicroAODOutputFile_10.root", 
+                "nevents": 24933, 
+                "totEvents": 24933, 
+                "weights": 6478427.5
+            }, 
+            {
+                "bad": false, 
+                "events": 25626, 
+                "name": "/store/user/spigazzi/flashgg/Era2017_RR-31Mar2018_v2/legacyRun2FullV1/GluGluHToGG_M80_13TeV_amcatnloFXFX_pythia8/Era2017_RR-31Mar2018_v2-legacyRun2FullV1-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/200104_103524/0000/myMicroAODOutputFile_8.root", 
+                "nevents": 25626, 
+                "totEvents": 25626, 
+                "weights": 6601286.5
+            }, 
+            {
+                "bad": false, 
+                "events": 23841, 
+                "name": "/store/user/spigazzi/flashgg/Era2017_RR-31Mar2018_v2/legacyRun2FullV1/GluGluHToGG_M80_13TeV_amcatnloFXFX_pythia8/Era2017_RR-31Mar2018_v2-legacyRun2FullV1-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/200104_103524/0000/myMicroAODOutputFile_6.root", 
+                "nevents": 23841, 
+                "totEvents": 23841, 
+                "weights": 6064760.5
+            }, 
+            {
+                "bad": false, 
+                "events": 24691, 
+                "name": "/store/user/spigazzi/flashgg/Era2017_RR-31Mar2018_v2/legacyRun2FullV1/GluGluHToGG_M80_13TeV_amcatnloFXFX_pythia8/Era2017_RR-31Mar2018_v2-legacyRun2FullV1-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/200104_103524/0000/myMicroAODOutputFile_12.root", 
+                "nevents": 24691, 
+                "totEvents": 24691, 
+                "weights": 6292277.5
+            }, 
+            {
+                "bad": false, 
+                "events": 24829, 
+                "name": "/store/user/spigazzi/flashgg/Era2017_RR-31Mar2018_v2/legacyRun2FullV1/GluGluHToGG_M80_13TeV_amcatnloFXFX_pythia8/Era2017_RR-31Mar2018_v2-legacyRun2FullV1-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/200104_103524/0000/myMicroAODOutputFile_7.root", 
+                "nevents": 24829, 
+                "totEvents": 24829, 
+                "weights": 6286485.5
+            }
+        ], 
+        "parent_n_units": 296107, 
+        "vetted": true
+    }, 
+    "/GluGluHToGG_M85_13TeV_amcatnloFXFX_pythia8/spigazzi-Era2017_RR-31Mar2018_v2-legacyRun2FullV1-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1-8c6318498cd00f339849a28190567b7a/USER": {
+        "dset_type": "mc", 
+        "files": [
+            {
+                "bad": false, 
+                "events": 24660, 
+                "name": "/store/user/spigazzi/flashgg/Era2017_RR-31Mar2018_v2/legacyRun2FullV1/GluGluHToGG_M85_13TeV_amcatnloFXFX_pythia8/Era2017_RR-31Mar2018_v2-legacyRun2FullV1-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/200106_092135/0000/myMicroAODOutputFile_3.root", 
+                "nevents": 24660, 
+                "totEvents": 24660, 
+                "weights": 5668232.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24603, 
+                "name": "/store/user/spigazzi/flashgg/Era2017_RR-31Mar2018_v2/legacyRun2FullV1/GluGluHToGG_M85_13TeV_amcatnloFXFX_pythia8/Era2017_RR-31Mar2018_v2-legacyRun2FullV1-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/200106_092135/0000/myMicroAODOutputFile_1.root", 
+                "nevents": 24603, 
+                "totEvents": 24603, 
+                "weights": 5607134.5
+            }, 
+            {
+                "bad": false, 
+                "events": 20230, 
+                "name": "/store/user/spigazzi/flashgg/Era2017_RR-31Mar2018_v2/legacyRun2FullV1/GluGluHToGG_M85_13TeV_amcatnloFXFX_pythia8/Era2017_RR-31Mar2018_v2-legacyRun2FullV1-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/200106_092135/0000/myMicroAODOutputFile_5.root", 
+                "nevents": 20230, 
+                "totEvents": 20230, 
+                "weights": 4644936.5
+            }, 
+            {
+                "bad": false, 
+                "events": 24658, 
+                "name": "/store/user/spigazzi/flashgg/Era2017_RR-31Mar2018_v2/legacyRun2FullV1/GluGluHToGG_M85_13TeV_amcatnloFXFX_pythia8/Era2017_RR-31Mar2018_v2-legacyRun2FullV1-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/200106_092135/0000/myMicroAODOutputFile_2.root", 
+                "nevents": 24658, 
+                "totEvents": 24658, 
+                "weights": 5625501.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24554, 
+                "name": "/store/user/spigazzi/flashgg/Era2017_RR-31Mar2018_v2/legacyRun2FullV1/GluGluHToGG_M85_13TeV_amcatnloFXFX_pythia8/Era2017_RR-31Mar2018_v2-legacyRun2FullV1-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/200106_092135/0000/myMicroAODOutputFile_4.root", 
+                "nevents": 24554, 
+                "totEvents": 24554, 
+                "weights": 5647241.0
+            }
+        ], 
+        "parent_n_units": 118705, 
+        "vetted": true
+    }, 
+    "/VBFHToGG_M90_13TeV_amcatnlo_pythia8/spigazzi-Era2017_RR-31Mar2018_v2-legacyRun2FullV1-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1-6c894bdf3f1f10979f737dbd06b2913c/USER": {
+        "dset_type": "mc", 
+        "files": [
+            {
+                "bad": false, 
+                "events": 24530, 
+                "name": "/store/user/spigazzi/flashgg/Era2017_RR-31Mar2018_v2/legacyRun2FullV1/VBFHToGG_M90_13TeV_amcatnlo_pythia8/Era2017_RR-31Mar2018_v2-legacyRun2FullV1-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/200106_092433/0000/myMicroAODOutputFile_4.root", 
+                "nevents": 24530, 
+                "totEvents": 24530, 
+                "weights": 130646.203125
+            }, 
+            {
+                "bad": false, 
+                "events": 24624, 
+                "name": "/store/user/spigazzi/flashgg/Era2017_RR-31Mar2018_v2/legacyRun2FullV1/VBFHToGG_M90_13TeV_amcatnlo_pythia8/Era2017_RR-31Mar2018_v2-legacyRun2FullV1-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/200106_092433/0000/myMicroAODOutputFile_1.root", 
+                "nevents": 24624, 
+                "totEvents": 24624, 
+                "weights": 130504.4609375
+            }, 
+            {
+                "bad": false, 
+                "events": 1504, 
+                "name": "/store/user/spigazzi/flashgg/Era2017_RR-31Mar2018_v2/legacyRun2FullV1/VBFHToGG_M90_13TeV_amcatnlo_pythia8/Era2017_RR-31Mar2018_v2-legacyRun2FullV1-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/200106_092433/0000/myMicroAODOutputFile_5.root", 
+                "nevents": 1504, 
+                "totEvents": 1504, 
+                "weights": 7972.7138671875
+            }, 
+            {
+                "bad": false, 
+                "events": 24624, 
+                "name": "/store/user/spigazzi/flashgg/Era2017_RR-31Mar2018_v2/legacyRun2FullV1/VBFHToGG_M90_13TeV_amcatnlo_pythia8/Era2017_RR-31Mar2018_v2-legacyRun2FullV1-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/200106_092433/0000/myMicroAODOutputFile_3.root", 
+                "nevents": 24624, 
+                "totEvents": 24624, 
+                "weights": 129547.734375
+            }, 
+            {
+                "bad": false, 
+                "events": 24718, 
+                "name": "/store/user/spigazzi/flashgg/Era2017_RR-31Mar2018_v2/legacyRun2FullV1/VBFHToGG_M90_13TeV_amcatnlo_pythia8/Era2017_RR-31Mar2018_v2-legacyRun2FullV1-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/200106_092433/0000/myMicroAODOutputFile_2.root", 
+                "nevents": 24718, 
+                "totEvents": 24718, 
+                "weights": 136776.359375
+            }
+        ], 
+        "parent_n_units": 100000, 
+        "vetted": true
+    }, 
     "/VBFHiggs0L1ZgToGG_M125_13TeV_JHUGenV7011_pythia8/spigazzi-Era2017_RR-31Mar2018_v2-legacyRun2FullV1-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1-74a2d034c64a1ac58313a5e6f31a092a/USER": {
         "dset_type": "mc", 
         "files": [
@@ -2734,6 +2939,205 @@
             }
         ], 
         "parent_n_units": 750000, 
+        "vetted": true
+    }, 
+    "/VHToGG_M105_13TeV_amcatnloFXFX_madspin_pythia8/spigazzi-Era2017_RR-31Mar2018_v2-legacyRun2FullV1-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1-3dc2898cd0915d8451093b62835d3c63/USER": {
+        "dset_type": "mc", 
+        "files": [
+            {
+                "bad": false, 
+                "events": 23283, 
+                "name": "/store/user/spigazzi/flashgg/Era2017_RR-31Mar2018_v2/legacyRun2FullV1/VHToGG_M105_13TeV_amcatnloFXFX_madspin_pythia8/Era2017_RR-31Mar2018_v2-legacyRun2FullV1-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/200106_092727/0000/myMicroAODOutputFile_5.root", 
+                "nevents": 23283, 
+                "totEvents": 23283, 
+                "weights": 291015.84375
+            }, 
+            {
+                "bad": false, 
+                "events": 24232, 
+                "name": "/store/user/spigazzi/flashgg/Era2017_RR-31Mar2018_v2/legacyRun2FullV1/VHToGG_M105_13TeV_amcatnloFXFX_madspin_pythia8/Era2017_RR-31Mar2018_v2-legacyRun2FullV1-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/200106_092727/0000/myMicroAODOutputFile_12.root", 
+                "nevents": 24232, 
+                "totEvents": 24232, 
+                "weights": 301959.34375
+            }, 
+            {
+                "bad": false, 
+                "events": 24743, 
+                "name": "/store/user/spigazzi/flashgg/Era2017_RR-31Mar2018_v2/legacyRun2FullV1/VHToGG_M105_13TeV_amcatnloFXFX_madspin_pythia8/Era2017_RR-31Mar2018_v2-legacyRun2FullV1-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/200106_092727/0000/myMicroAODOutputFile_6.root", 
+                "nevents": 24743, 
+                "totEvents": 24743, 
+                "weights": 307561.53125
+            }, 
+            {
+                "bad": false, 
+                "events": 24990, 
+                "name": "/store/user/spigazzi/flashgg/Era2017_RR-31Mar2018_v2/legacyRun2FullV1/VHToGG_M105_13TeV_amcatnloFXFX_madspin_pythia8/Era2017_RR-31Mar2018_v2-legacyRun2FullV1-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/200106_092727/0000/myMicroAODOutputFile_17.root", 
+                "nevents": 24990, 
+                "totEvents": 24990, 
+                "weights": 316296.28125
+            }, 
+            {
+                "bad": false, 
+                "events": 24081, 
+                "name": "/store/user/spigazzi/flashgg/Era2017_RR-31Mar2018_v2/legacyRun2FullV1/VHToGG_M105_13TeV_amcatnloFXFX_madspin_pythia8/Era2017_RR-31Mar2018_v2-legacyRun2FullV1-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/200106_092727/0000/myMicroAODOutputFile_10.root", 
+                "nevents": 24081, 
+                "totEvents": 24081, 
+                "weights": 296517.71875
+            }, 
+            {
+                "bad": false, 
+                "events": 24696, 
+                "name": "/store/user/spigazzi/flashgg/Era2017_RR-31Mar2018_v2/legacyRun2FullV1/VHToGG_M105_13TeV_amcatnloFXFX_madspin_pythia8/Era2017_RR-31Mar2018_v2-legacyRun2FullV1-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/200106_092727/0000/myMicroAODOutputFile_16.root", 
+                "nevents": 24696, 
+                "totEvents": 24696, 
+                "weights": 304127.96875
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/spigazzi/flashgg/Era2017_RR-31Mar2018_v2/legacyRun2FullV1/VHToGG_M105_13TeV_amcatnloFXFX_madspin_pythia8/Era2017_RR-31Mar2018_v2-legacyRun2FullV1-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/200106_092727/0000/myMicroAODOutputFile_7.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 306336.71875
+            }, 
+            {
+                "bad": false, 
+                "events": 24881, 
+                "name": "/store/user/spigazzi/flashgg/Era2017_RR-31Mar2018_v2/legacyRun2FullV1/VHToGG_M105_13TeV_amcatnloFXFX_madspin_pythia8/Era2017_RR-31Mar2018_v2-legacyRun2FullV1-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/200106_092727/0000/myMicroAODOutputFile_19.root", 
+                "nevents": 24881, 
+                "totEvents": 24881, 
+                "weights": 307963.15625
+            }, 
+            {
+                "bad": false, 
+                "events": 25709, 
+                "name": "/store/user/spigazzi/flashgg/Era2017_RR-31Mar2018_v2/legacyRun2FullV1/VHToGG_M105_13TeV_amcatnloFXFX_madspin_pythia8/Era2017_RR-31Mar2018_v2-legacyRun2FullV1-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/200106_092727/0000/myMicroAODOutputFile_21.root", 
+                "nevents": 25709, 
+                "totEvents": 25709, 
+                "weights": 314750.125
+            }, 
+            {
+                "bad": false, 
+                "events": 24882, 
+                "name": "/store/user/spigazzi/flashgg/Era2017_RR-31Mar2018_v2/legacyRun2FullV1/VHToGG_M105_13TeV_amcatnloFXFX_madspin_pythia8/Era2017_RR-31Mar2018_v2-legacyRun2FullV1-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/200106_092727/0000/myMicroAODOutputFile_11.root", 
+                "nevents": 24882, 
+                "totEvents": 24882, 
+                "weights": 308344.65625
+            }, 
+            {
+                "bad": false, 
+                "events": 7566, 
+                "name": "/store/user/spigazzi/flashgg/Era2017_RR-31Mar2018_v2/legacyRun2FullV1/VHToGG_M105_13TeV_amcatnloFXFX_madspin_pythia8/Era2017_RR-31Mar2018_v2-legacyRun2FullV1-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/200106_092727/0000/myMicroAODOutputFile_24.root", 
+                "nevents": 7566, 
+                "totEvents": 7566, 
+                "weights": 94374.828125
+            }, 
+            {
+                "bad": false, 
+                "events": 23831, 
+                "name": "/store/user/spigazzi/flashgg/Era2017_RR-31Mar2018_v2/legacyRun2FullV1/VHToGG_M105_13TeV_amcatnloFXFX_madspin_pythia8/Era2017_RR-31Mar2018_v2-legacyRun2FullV1-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/200106_092727/0000/myMicroAODOutputFile_23.root", 
+                "nevents": 23831, 
+                "totEvents": 23831, 
+                "weights": 292983.65625
+            }, 
+            {
+                "bad": false, 
+                "events": 24985, 
+                "name": "/store/user/spigazzi/flashgg/Era2017_RR-31Mar2018_v2/legacyRun2FullV1/VHToGG_M105_13TeV_amcatnloFXFX_madspin_pythia8/Era2017_RR-31Mar2018_v2-legacyRun2FullV1-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/200106_092727/0000/myMicroAODOutputFile_1.root", 
+                "nevents": 24985, 
+                "totEvents": 24985, 
+                "weights": 306276.5
+            }, 
+            {
+                "bad": false, 
+                "events": 23940, 
+                "name": "/store/user/spigazzi/flashgg/Era2017_RR-31Mar2018_v2/legacyRun2FullV1/VHToGG_M105_13TeV_amcatnloFXFX_madspin_pythia8/Era2017_RR-31Mar2018_v2-legacyRun2FullV1-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/200106_092727/0000/myMicroAODOutputFile_4.root", 
+                "nevents": 23940, 
+                "totEvents": 23940, 
+                "weights": 300232.46875
+            }, 
+            {
+                "bad": false, 
+                "events": 24702, 
+                "name": "/store/user/spigazzi/flashgg/Era2017_RR-31Mar2018_v2/legacyRun2FullV1/VHToGG_M105_13TeV_amcatnloFXFX_madspin_pythia8/Era2017_RR-31Mar2018_v2-legacyRun2FullV1-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/200106_092727/0000/myMicroAODOutputFile_15.root", 
+                "nevents": 24702, 
+                "totEvents": 24702, 
+                "weights": 307300.53125
+            }, 
+            {
+                "bad": false, 
+                "events": 23369, 
+                "name": "/store/user/spigazzi/flashgg/Era2017_RR-31Mar2018_v2/legacyRun2FullV1/VHToGG_M105_13TeV_amcatnloFXFX_madspin_pythia8/Era2017_RR-31Mar2018_v2-legacyRun2FullV1-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/200106_092727/0000/myMicroAODOutputFile_14.root", 
+                "nevents": 23369, 
+                "totEvents": 23369, 
+                "weights": 285554.15625
+            }, 
+            {
+                "bad": false, 
+                "events": 24052, 
+                "name": "/store/user/spigazzi/flashgg/Era2017_RR-31Mar2018_v2/legacyRun2FullV1/VHToGG_M105_13TeV_amcatnloFXFX_madspin_pythia8/Era2017_RR-31Mar2018_v2-legacyRun2FullV1-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/200106_092727/0000/myMicroAODOutputFile_20.root", 
+                "nevents": 24052, 
+                "totEvents": 24052, 
+                "weights": 293566.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24153, 
+                "name": "/store/user/spigazzi/flashgg/Era2017_RR-31Mar2018_v2/legacyRun2FullV1/VHToGG_M105_13TeV_amcatnloFXFX_madspin_pythia8/Era2017_RR-31Mar2018_v2-legacyRun2FullV1-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/200106_092727/0000/myMicroAODOutputFile_9.root", 
+                "nevents": 24153, 
+                "totEvents": 24153, 
+                "weights": 298445.34375
+            }, 
+            {
+                "bad": false, 
+                "events": 24128, 
+                "name": "/store/user/spigazzi/flashgg/Era2017_RR-31Mar2018_v2/legacyRun2FullV1/VHToGG_M105_13TeV_amcatnloFXFX_madspin_pythia8/Era2017_RR-31Mar2018_v2-legacyRun2FullV1-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/200106_092727/0000/myMicroAODOutputFile_22.root", 
+                "nevents": 24128, 
+                "totEvents": 24128, 
+                "weights": 300393.09375
+            }, 
+            {
+                "bad": false, 
+                "events": 25162, 
+                "name": "/store/user/spigazzi/flashgg/Era2017_RR-31Mar2018_v2/legacyRun2FullV1/VHToGG_M105_13TeV_amcatnloFXFX_madspin_pythia8/Era2017_RR-31Mar2018_v2-legacyRun2FullV1-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/200106_092727/0000/myMicroAODOutputFile_2.root", 
+                "nevents": 25162, 
+                "totEvents": 25162, 
+                "weights": 311276.375
+            }, 
+            {
+                "bad": false, 
+                "events": 25106, 
+                "name": "/store/user/spigazzi/flashgg/Era2017_RR-31Mar2018_v2/legacyRun2FullV1/VHToGG_M105_13TeV_amcatnloFXFX_madspin_pythia8/Era2017_RR-31Mar2018_v2-legacyRun2FullV1-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/200106_092727/0000/myMicroAODOutputFile_8.root", 
+                "nevents": 25106, 
+                "totEvents": 25106, 
+                "weights": 307661.9375
+            }, 
+            {
+                "bad": false, 
+                "events": 24732, 
+                "name": "/store/user/spigazzi/flashgg/Era2017_RR-31Mar2018_v2/legacyRun2FullV1/VHToGG_M105_13TeV_amcatnloFXFX_madspin_pythia8/Era2017_RR-31Mar2018_v2-legacyRun2FullV1-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/200106_092727/0000/myMicroAODOutputFile_13.root", 
+                "nevents": 24732, 
+                "totEvents": 24732, 
+                "weights": 311396.8125
+            }, 
+            {
+                "bad": false, 
+                "events": 25008, 
+                "name": "/store/user/spigazzi/flashgg/Era2017_RR-31Mar2018_v2/legacyRun2FullV1/VHToGG_M105_13TeV_amcatnloFXFX_madspin_pythia8/Era2017_RR-31Mar2018_v2-legacyRun2FullV1-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/200106_092727/0000/myMicroAODOutputFile_3.root", 
+                "nevents": 25008, 
+                "totEvents": 25008, 
+                "weights": 311878.6875
+            }, 
+            {
+                "bad": false, 
+                "events": 24004, 
+                "name": "/store/user/spigazzi/flashgg/Era2017_RR-31Mar2018_v2/legacyRun2FullV1/VHToGG_M105_13TeV_amcatnloFXFX_madspin_pythia8/Era2017_RR-31Mar2018_v2-legacyRun2FullV1-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/200106_092727/0000/myMicroAODOutputFile_18.root", 
+                "nevents": 24004, 
+                "totEvents": 24004, 
+                "weights": 298304.8125
+            }
+        ], 
+        "parent_n_units": 571235, 
         "vetted": true
     }, 
     "/WHiggs0L1ToGG_M125_13TeV_JHUGenV7011_pythia8/spigazzi-Era2017_RR-31Mar2018_v2-legacyRun2FullV1-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1-3da075b92990944976687db6a045f405/USER": {
@@ -5897,6 +6301,268 @@
             }
         ], 
         "parent_n_units": 740304, 
+        "vetted": true
+    }, 
+    "/ttHJetToGG_M65_13TeV_amcatnloFXFX_madspin_pythia8/spigazzi-Era2017_RR-31Mar2018_v2-legacyRun2FullV1-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1-700b9fc72bd1fceec96100a69dfab19d/USER": {
+        "dset_type": "mc", 
+        "files": [
+            {
+                "bad": false, 
+                "events": 26002, 
+                "name": "/store/user/spigazzi/flashgg/Era2017_RR-31Mar2018_v2/legacyRun2FullV1/ttHJetToGG_M65_13TeV_amcatnloFXFX_madspin_pythia8/Era2017_RR-31Mar2018_v2-legacyRun2FullV1-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/200106_093024/0000/myMicroAODOutputFile_6.root", 
+                "nevents": 26002, 
+                "totEvents": 26002, 
+                "weights": 123561.4921875
+            }, 
+            {
+                "bad": false, 
+                "events": 24893, 
+                "name": "/store/user/spigazzi/flashgg/Era2017_RR-31Mar2018_v2/legacyRun2FullV1/ttHJetToGG_M65_13TeV_amcatnloFXFX_madspin_pythia8/Era2017_RR-31Mar2018_v2-legacyRun2FullV1-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/200106_093024/0000/myMicroAODOutputFile_11.root", 
+                "nevents": 24893, 
+                "totEvents": 24893, 
+                "weights": 123602.5859375
+            }, 
+            {
+                "bad": false, 
+                "events": 25383, 
+                "name": "/store/user/spigazzi/flashgg/Era2017_RR-31Mar2018_v2/legacyRun2FullV1/ttHJetToGG_M65_13TeV_amcatnloFXFX_madspin_pythia8/Era2017_RR-31Mar2018_v2-legacyRun2FullV1-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/200106_093024/0000/myMicroAODOutputFile_14.root", 
+                "nevents": 25383, 
+                "totEvents": 25383, 
+                "weights": 124560.859375
+            }, 
+            {
+                "bad": false, 
+                "events": 23844, 
+                "name": "/store/user/spigazzi/flashgg/Era2017_RR-31Mar2018_v2/legacyRun2FullV1/ttHJetToGG_M65_13TeV_amcatnloFXFX_madspin_pythia8/Era2017_RR-31Mar2018_v2-legacyRun2FullV1-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/200106_093024/0000/myMicroAODOutputFile_7.root", 
+                "nevents": 23844, 
+                "totEvents": 23844, 
+                "weights": 115539.453125
+            }, 
+            {
+                "bad": false, 
+                "events": 24542, 
+                "name": "/store/user/spigazzi/flashgg/Era2017_RR-31Mar2018_v2/legacyRun2FullV1/ttHJetToGG_M65_13TeV_amcatnloFXFX_madspin_pythia8/Era2017_RR-31Mar2018_v2-legacyRun2FullV1-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/200106_093024/0000/myMicroAODOutputFile_15.root", 
+                "nevents": 24542, 
+                "totEvents": 24542, 
+                "weights": 121453.34375
+            }, 
+            {
+                "bad": false, 
+                "events": 12338, 
+                "name": "/store/user/spigazzi/flashgg/Era2017_RR-31Mar2018_v2/legacyRun2FullV1/ttHJetToGG_M65_13TeV_amcatnloFXFX_madspin_pythia8/Era2017_RR-31Mar2018_v2-legacyRun2FullV1-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/200106_093024/0000/myMicroAODOutputFile_17.root", 
+                "nevents": 12338, 
+                "totEvents": 12338, 
+                "weights": 57961.3828125
+            }, 
+            {
+                "bad": false, 
+                "events": 24402, 
+                "name": "/store/user/spigazzi/flashgg/Era2017_RR-31Mar2018_v2/legacyRun2FullV1/ttHJetToGG_M65_13TeV_amcatnloFXFX_madspin_pythia8/Era2017_RR-31Mar2018_v2-legacyRun2FullV1-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/200106_093024/0000/myMicroAODOutputFile_3.root", 
+                "nevents": 24402, 
+                "totEvents": 24402, 
+                "weights": 117127.46875
+            }, 
+            {
+                "bad": false, 
+                "events": 24469, 
+                "name": "/store/user/spigazzi/flashgg/Era2017_RR-31Mar2018_v2/legacyRun2FullV1/ttHJetToGG_M65_13TeV_amcatnloFXFX_madspin_pythia8/Era2017_RR-31Mar2018_v2-legacyRun2FullV1-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/200106_093024/0000/myMicroAODOutputFile_9.root", 
+                "nevents": 24469, 
+                "totEvents": 24469, 
+                "weights": 118619.59375
+            }, 
+            {
+                "bad": false, 
+                "events": 24630, 
+                "name": "/store/user/spigazzi/flashgg/Era2017_RR-31Mar2018_v2/legacyRun2FullV1/ttHJetToGG_M65_13TeV_amcatnloFXFX_madspin_pythia8/Era2017_RR-31Mar2018_v2-legacyRun2FullV1-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/200106_093024/0000/myMicroAODOutputFile_10.root", 
+                "nevents": 24630, 
+                "totEvents": 24630, 
+                "weights": 123479.375
+            }, 
+            {
+                "bad": false, 
+                "events": 25300, 
+                "name": "/store/user/spigazzi/flashgg/Era2017_RR-31Mar2018_v2/legacyRun2FullV1/ttHJetToGG_M65_13TeV_amcatnloFXFX_madspin_pythia8/Era2017_RR-31Mar2018_v2-legacyRun2FullV1-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/200106_093024/0000/myMicroAODOutputFile_2.root", 
+                "nevents": 25300, 
+                "totEvents": 25300, 
+                "weights": 126217.28125
+            }, 
+            {
+                "bad": false, 
+                "events": 22090, 
+                "name": "/store/user/spigazzi/flashgg/Era2017_RR-31Mar2018_v2/legacyRun2FullV1/ttHJetToGG_M65_13TeV_amcatnloFXFX_madspin_pythia8/Era2017_RR-31Mar2018_v2-legacyRun2FullV1-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/200106_093024/0000/myMicroAODOutputFile_5.root", 
+                "nevents": 22090, 
+                "totEvents": 22090, 
+                "weights": 109242.2890625
+            }, 
+            {
+                "bad": false, 
+                "events": 25935, 
+                "name": "/store/user/spigazzi/flashgg/Era2017_RR-31Mar2018_v2/legacyRun2FullV1/ttHJetToGG_M65_13TeV_amcatnloFXFX_madspin_pythia8/Era2017_RR-31Mar2018_v2-legacyRun2FullV1-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/200106_093024/0000/myMicroAODOutputFile_4.root", 
+                "nevents": 25935, 
+                "totEvents": 25935, 
+                "weights": 125929.796875
+            }, 
+            {
+                "bad": false, 
+                "events": 26669, 
+                "name": "/store/user/spigazzi/flashgg/Era2017_RR-31Mar2018_v2/legacyRun2FullV1/ttHJetToGG_M65_13TeV_amcatnloFXFX_madspin_pythia8/Era2017_RR-31Mar2018_v2-legacyRun2FullV1-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/200106_093024/0000/myMicroAODOutputFile_8.root", 
+                "nevents": 26669, 
+                "totEvents": 26669, 
+                "weights": 127736.8125
+            }, 
+            {
+                "bad": false, 
+                "events": 24690, 
+                "name": "/store/user/spigazzi/flashgg/Era2017_RR-31Mar2018_v2/legacyRun2FullV1/ttHJetToGG_M65_13TeV_amcatnloFXFX_madspin_pythia8/Era2017_RR-31Mar2018_v2-legacyRun2FullV1-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/200106_093024/0000/myMicroAODOutputFile_1.root", 
+                "nevents": 24690, 
+                "totEvents": 24690, 
+                "weights": 118879.7109375
+            }
+        ], 
+        "parent_n_units": 407477, 
+        "vetted": true
+    }, 
+    "/ttHJetToGG_M85_13TeV_amcatnloFXFX_madspin_pythia8/spigazzi-Era2017_RR-31Mar2018_v2-legacyRun2FullV1-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1-700b9fc72bd1fceec96100a69dfab19d/USER": {
+        "dset_type": "mc", 
+        "files": [
+            {
+                "bad": false, 
+                "events": 24590, 
+                "name": "/store/user/spigazzi/flashgg/Era2017_RR-31Mar2018_v2/legacyRun2FullV1/ttHJetToGG_M85_13TeV_amcatnloFXFX_madspin_pythia8/Era2017_RR-31Mar2018_v2-legacyRun2FullV1-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/200106_093321/0000/myMicroAODOutputFile_13.root", 
+                "nevents": 24590, 
+                "totEvents": 24590, 
+                "weights": 65034.4140625
+            }, 
+            {
+                "bad": false, 
+                "events": 24266, 
+                "name": "/store/user/spigazzi/flashgg/Era2017_RR-31Mar2018_v2/legacyRun2FullV1/ttHJetToGG_M85_13TeV_amcatnloFXFX_madspin_pythia8/Era2017_RR-31Mar2018_v2-legacyRun2FullV1-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/200106_093321/0000/myMicroAODOutputFile_6.root", 
+                "nevents": 24266, 
+                "totEvents": 24266, 
+                "weights": 65249.61328125
+            }, 
+            {
+                "bad": false, 
+                "events": 24674, 
+                "name": "/store/user/spigazzi/flashgg/Era2017_RR-31Mar2018_v2/legacyRun2FullV1/ttHJetToGG_M85_13TeV_amcatnloFXFX_madspin_pythia8/Era2017_RR-31Mar2018_v2-legacyRun2FullV1-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/200106_093321/0000/myMicroAODOutputFile_5.root", 
+                "nevents": 24674, 
+                "totEvents": 24674, 
+                "weights": 67001.8984375
+            }, 
+            {
+                "bad": false, 
+                "events": 24554, 
+                "name": "/store/user/spigazzi/flashgg/Era2017_RR-31Mar2018_v2/legacyRun2FullV1/ttHJetToGG_M85_13TeV_amcatnloFXFX_madspin_pythia8/Era2017_RR-31Mar2018_v2-legacyRun2FullV1-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/200106_093321/0000/myMicroAODOutputFile_11.root", 
+                "nevents": 24554, 
+                "totEvents": 24554, 
+                "weights": 64619.40625
+            }, 
+            {
+                "bad": false, 
+                "events": 24756, 
+                "name": "/store/user/spigazzi/flashgg/Era2017_RR-31Mar2018_v2/legacyRun2FullV1/ttHJetToGG_M85_13TeV_amcatnloFXFX_madspin_pythia8/Era2017_RR-31Mar2018_v2-legacyRun2FullV1-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/200106_093321/0000/myMicroAODOutputFile_9.root", 
+                "nevents": 24756, 
+                "totEvents": 24756, 
+                "weights": 66986.53125
+            }, 
+            {
+                "bad": false, 
+                "events": 24388, 
+                "name": "/store/user/spigazzi/flashgg/Era2017_RR-31Mar2018_v2/legacyRun2FullV1/ttHJetToGG_M85_13TeV_amcatnloFXFX_madspin_pythia8/Era2017_RR-31Mar2018_v2-legacyRun2FullV1-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/200106_093321/0000/myMicroAODOutputFile_3.root", 
+                "nevents": 24388, 
+                "totEvents": 24388, 
+                "weights": 65019.0546875
+            }, 
+            {
+                "bad": false, 
+                "events": 24157, 
+                "name": "/store/user/spigazzi/flashgg/Era2017_RR-31Mar2018_v2/legacyRun2FullV1/ttHJetToGG_M85_13TeV_amcatnloFXFX_madspin_pythia8/Era2017_RR-31Mar2018_v2-legacyRun2FullV1-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/200106_093321/0000/myMicroAODOutputFile_16.root", 
+                "nevents": 24157, 
+                "totEvents": 24157, 
+                "weights": 66256.4140625
+            }, 
+            {
+                "bad": false, 
+                "events": 24429, 
+                "name": "/store/user/spigazzi/flashgg/Era2017_RR-31Mar2018_v2/legacyRun2FullV1/ttHJetToGG_M85_13TeV_amcatnloFXFX_madspin_pythia8/Era2017_RR-31Mar2018_v2-legacyRun2FullV1-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/200106_093321/0000/myMicroAODOutputFile_1.root", 
+                "nevents": 24429, 
+                "totEvents": 24429, 
+                "weights": 65334.15625
+            }, 
+            {
+                "bad": false, 
+                "events": 24737, 
+                "name": "/store/user/spigazzi/flashgg/Era2017_RR-31Mar2018_v2/legacyRun2FullV1/ttHJetToGG_M85_13TeV_amcatnloFXFX_madspin_pythia8/Era2017_RR-31Mar2018_v2-legacyRun2FullV1-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/200106_093321/0000/myMicroAODOutputFile_8.root", 
+                "nevents": 24737, 
+                "totEvents": 24737, 
+                "weights": 66410.1171875
+            }, 
+            {
+                "bad": false, 
+                "events": 24793, 
+                "name": "/store/user/spigazzi/flashgg/Era2017_RR-31Mar2018_v2/legacyRun2FullV1/ttHJetToGG_M85_13TeV_amcatnloFXFX_madspin_pythia8/Era2017_RR-31Mar2018_v2-legacyRun2FullV1-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/200106_093321/0000/myMicroAODOutputFile_14.root", 
+                "nevents": 24793, 
+                "totEvents": 24793, 
+                "weights": 67409.2265625
+            }, 
+            {
+                "bad": false, 
+                "events": 24735, 
+                "name": "/store/user/spigazzi/flashgg/Era2017_RR-31Mar2018_v2/legacyRun2FullV1/ttHJetToGG_M85_13TeV_amcatnloFXFX_madspin_pythia8/Era2017_RR-31Mar2018_v2-legacyRun2FullV1-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/200106_093321/0000/myMicroAODOutputFile_15.root", 
+                "nevents": 24735, 
+                "totEvents": 24735, 
+                "weights": 68316.109375
+            }, 
+            {
+                "bad": false, 
+                "events": 24745, 
+                "name": "/store/user/spigazzi/flashgg/Era2017_RR-31Mar2018_v2/legacyRun2FullV1/ttHJetToGG_M85_13TeV_amcatnloFXFX_madspin_pythia8/Era2017_RR-31Mar2018_v2-legacyRun2FullV1-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/200106_093321/0000/myMicroAODOutputFile_10.root", 
+                "nevents": 24745, 
+                "totEvents": 24745, 
+                "weights": 65380.265625
+            }, 
+            {
+                "bad": false, 
+                "events": 24842, 
+                "name": "/store/user/spigazzi/flashgg/Era2017_RR-31Mar2018_v2/legacyRun2FullV1/ttHJetToGG_M85_13TeV_amcatnloFXFX_madspin_pythia8/Era2017_RR-31Mar2018_v2-legacyRun2FullV1-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/200106_093321/0000/myMicroAODOutputFile_12.root", 
+                "nevents": 24842, 
+                "totEvents": 24842, 
+                "weights": 67785.8125
+            }, 
+            {
+                "bad": false, 
+                "events": 24777, 
+                "name": "/store/user/spigazzi/flashgg/Era2017_RR-31Mar2018_v2/legacyRun2FullV1/ttHJetToGG_M85_13TeV_amcatnloFXFX_madspin_pythia8/Era2017_RR-31Mar2018_v2-legacyRun2FullV1-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/200106_093321/0000/myMicroAODOutputFile_2.root", 
+                "nevents": 24777, 
+                "totEvents": 24777, 
+                "weights": 67931.8359375
+            }, 
+            {
+                "bad": false, 
+                "events": 24402, 
+                "name": "/store/user/spigazzi/flashgg/Era2017_RR-31Mar2018_v2/legacyRun2FullV1/ttHJetToGG_M85_13TeV_amcatnloFXFX_madspin_pythia8/Era2017_RR-31Mar2018_v2-legacyRun2FullV1-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/200106_093321/0000/myMicroAODOutputFile_7.root", 
+                "nevents": 24402, 
+                "totEvents": 24402, 
+                "weights": 65895.1953125
+            }, 
+            {
+                "bad": false, 
+                "events": 15946, 
+                "name": "/store/user/spigazzi/flashgg/Era2017_RR-31Mar2018_v2/legacyRun2FullV1/ttHJetToGG_M85_13TeV_amcatnloFXFX_madspin_pythia8/Era2017_RR-31Mar2018_v2-legacyRun2FullV1-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/200106_093321/0000/myMicroAODOutputFile_17.root", 
+                "nevents": 15946, 
+                "totEvents": 15946, 
+                "weights": 42208.58203125
+            }, 
+            {
+                "bad": false, 
+                "events": 25071, 
+                "name": "/store/user/spigazzi/flashgg/Era2017_RR-31Mar2018_v2/legacyRun2FullV1/ttHJetToGG_M85_13TeV_amcatnloFXFX_madspin_pythia8/Era2017_RR-31Mar2018_v2-legacyRun2FullV1-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/200106_093321/0000/myMicroAODOutputFile_4.root", 
+                "nevents": 25071, 
+                "totEvents": 25071, 
+                "weights": 67732.015625
+            }
+        ], 
+        "parent_n_units": 409862, 
         "vetted": true
     }, 
     "/ttHiggs0MToGG_M125_13TeV_JHUGenV7011_pythia8/spigazzi-Era2017_RR-31Mar2018_v2-legacyRun2FullV1-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1-851cfecc9715c3596b595bc9640e0673/USER": {

--- a/MetaData/data/Era2018_RR-17Sep2018_v2/datasets_22.json
+++ b/MetaData/data/Era2018_RR-17Sep2018_v2/datasets_22.json
@@ -7798,6 +7798,181 @@
         "parent_n_units": 10205533, 
         "vetted": true
     }, 
+    "/VHToGG_M105_13TeV_amcatnloFXFX_madspin_pythia8/spigazzi-Era2018_RR-17Sep2018_v2-legacyRun2FullV2-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1-998bdfa01158ca6a61927c704048cd6b/USER": {
+        "dset_type": "mc", 
+        "files": [
+            {
+                "bad": false, 
+                "events": 24230, 
+                "name": "/store/user/spigazzi/flashgg/Era2018_RR-17Sep2018_v2/legacyRun2FullV2/VHToGG_M105_13TeV_amcatnloFXFX_madspin_pythia8/Era2018_RR-17Sep2018_v2-legacyRun2FullV2-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/200104_102635/0000/myMicroAODOutputFile_19.root", 
+                "nevents": 24230, 
+                "totEvents": 24230, 
+                "weights": 296653.6875
+            }, 
+            {
+                "bad": false, 
+                "events": 24076, 
+                "name": "/store/user/spigazzi/flashgg/Era2018_RR-17Sep2018_v2/legacyRun2FullV2/VHToGG_M105_13TeV_amcatnloFXFX_madspin_pythia8/Era2018_RR-17Sep2018_v2-legacyRun2FullV2-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/200104_102635/0000/myMicroAODOutputFile_6.root", 
+                "nevents": 24076, 
+                "totEvents": 24076, 
+                "weights": 296132.21875
+            }, 
+            {
+                "bad": false, 
+                "events": 24171, 
+                "name": "/store/user/spigazzi/flashgg/Era2018_RR-17Sep2018_v2/legacyRun2FullV2/VHToGG_M105_13TeV_amcatnloFXFX_madspin_pythia8/Era2018_RR-17Sep2018_v2-legacyRun2FullV2-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/200104_102635/0000/myMicroAODOutputFile_7.root", 
+                "nevents": 24171, 
+                "totEvents": 24171, 
+                "weights": 296884.28125
+            }, 
+            {
+                "bad": false, 
+                "events": 24206, 
+                "name": "/store/user/spigazzi/flashgg/Era2018_RR-17Sep2018_v2/legacyRun2FullV2/VHToGG_M105_13TeV_amcatnloFXFX_madspin_pythia8/Era2018_RR-17Sep2018_v2-legacyRun2FullV2-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/200104_102635/0000/myMicroAODOutputFile_2.root", 
+                "nevents": 24206, 
+                "totEvents": 24206, 
+                "weights": 299021.65625
+            }, 
+            {
+                "bad": false, 
+                "events": 24315, 
+                "name": "/store/user/spigazzi/flashgg/Era2018_RR-17Sep2018_v2/legacyRun2FullV2/VHToGG_M105_13TeV_amcatnloFXFX_madspin_pythia8/Era2018_RR-17Sep2018_v2-legacyRun2FullV2-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/200104_102635/0000/myMicroAODOutputFile_11.root", 
+                "nevents": 24315, 
+                "totEvents": 24315, 
+                "weights": 300010.625
+            }, 
+            {
+                "bad": false, 
+                "events": 24031, 
+                "name": "/store/user/spigazzi/flashgg/Era2018_RR-17Sep2018_v2/legacyRun2FullV2/VHToGG_M105_13TeV_amcatnloFXFX_madspin_pythia8/Era2018_RR-17Sep2018_v2-legacyRun2FullV2-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/200104_102635/0000/myMicroAODOutputFile_4.root", 
+                "nevents": 24031, 
+                "totEvents": 24031, 
+                "weights": 295924.59375
+            }, 
+            {
+                "bad": false, 
+                "events": 24366, 
+                "name": "/store/user/spigazzi/flashgg/Era2018_RR-17Sep2018_v2/legacyRun2FullV2/VHToGG_M105_13TeV_amcatnloFXFX_madspin_pythia8/Era2018_RR-17Sep2018_v2-legacyRun2FullV2-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/200104_102635/0000/myMicroAODOutputFile_8.root", 
+                "nevents": 24366, 
+                "totEvents": 24366, 
+                "weights": 305041.78125
+            }, 
+            {
+                "bad": false, 
+                "events": 23899, 
+                "name": "/store/user/spigazzi/flashgg/Era2018_RR-17Sep2018_v2/legacyRun2FullV2/VHToGG_M105_13TeV_amcatnloFXFX_madspin_pythia8/Era2018_RR-17Sep2018_v2-legacyRun2FullV2-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/200104_102635/0000/myMicroAODOutputFile_3.root", 
+                "nevents": 23899, 
+                "totEvents": 23899, 
+                "weights": 292139.34375
+            }, 
+            {
+                "bad": false, 
+                "events": 24136, 
+                "name": "/store/user/spigazzi/flashgg/Era2018_RR-17Sep2018_v2/legacyRun2FullV2/VHToGG_M105_13TeV_amcatnloFXFX_madspin_pythia8/Era2018_RR-17Sep2018_v2-legacyRun2FullV2-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/200104_102635/0000/myMicroAODOutputFile_17.root", 
+                "nevents": 24136, 
+                "totEvents": 24136, 
+                "weights": 295415.15625
+            }, 
+            {
+                "bad": false, 
+                "events": 24174, 
+                "name": "/store/user/spigazzi/flashgg/Era2018_RR-17Sep2018_v2/legacyRun2FullV2/VHToGG_M105_13TeV_amcatnloFXFX_madspin_pythia8/Era2018_RR-17Sep2018_v2-legacyRun2FullV2-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/200104_102635/0000/myMicroAODOutputFile_14.root", 
+                "nevents": 24174, 
+                "totEvents": 24174, 
+                "weights": 298518.3125
+            }, 
+            {
+                "bad": false, 
+                "events": 24142, 
+                "name": "/store/user/spigazzi/flashgg/Era2018_RR-17Sep2018_v2/legacyRun2FullV2/VHToGG_M105_13TeV_amcatnloFXFX_madspin_pythia8/Era2018_RR-17Sep2018_v2-legacyRun2FullV2-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/200104_102635/0000/myMicroAODOutputFile_13.root", 
+                "nevents": 24142, 
+                "totEvents": 24142, 
+                "weights": 296939.40625
+            }, 
+            {
+                "bad": false, 
+                "events": 24103, 
+                "name": "/store/user/spigazzi/flashgg/Era2018_RR-17Sep2018_v2/legacyRun2FullV2/VHToGG_M105_13TeV_amcatnloFXFX_madspin_pythia8/Era2018_RR-17Sep2018_v2-legacyRun2FullV2-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/200104_102635/0000/myMicroAODOutputFile_5.root", 
+                "nevents": 24103, 
+                "totEvents": 24103, 
+                "weights": 300394.71875
+            }, 
+            {
+                "bad": false, 
+                "events": 24203, 
+                "name": "/store/user/spigazzi/flashgg/Era2018_RR-17Sep2018_v2/legacyRun2FullV2/VHToGG_M105_13TeV_amcatnloFXFX_madspin_pythia8/Era2018_RR-17Sep2018_v2-legacyRun2FullV2-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/200104_102635/0000/myMicroAODOutputFile_18.root", 
+                "nevents": 24203, 
+                "totEvents": 24203, 
+                "weights": 296479.1875
+            }, 
+            {
+                "bad": false, 
+                "events": 24180, 
+                "name": "/store/user/spigazzi/flashgg/Era2018_RR-17Sep2018_v2/legacyRun2FullV2/VHToGG_M105_13TeV_amcatnloFXFX_madspin_pythia8/Era2018_RR-17Sep2018_v2-legacyRun2FullV2-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/200104_102635/0000/myMicroAODOutputFile_12.root", 
+                "nevents": 24180, 
+                "totEvents": 24180, 
+                "weights": 299901.78125
+            }, 
+            {
+                "bad": false, 
+                "events": 24383, 
+                "name": "/store/user/spigazzi/flashgg/Era2018_RR-17Sep2018_v2/legacyRun2FullV2/VHToGG_M105_13TeV_amcatnloFXFX_madspin_pythia8/Era2018_RR-17Sep2018_v2-legacyRun2FullV2-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/200104_102635/0000/myMicroAODOutputFile_16.root", 
+                "nevents": 24383, 
+                "totEvents": 24383, 
+                "weights": 302300.09375
+            }, 
+            {
+                "bad": false, 
+                "events": 24088, 
+                "name": "/store/user/spigazzi/flashgg/Era2018_RR-17Sep2018_v2/legacyRun2FullV2/VHToGG_M105_13TeV_amcatnloFXFX_madspin_pythia8/Era2018_RR-17Sep2018_v2-legacyRun2FullV2-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/200104_102635/0000/myMicroAODOutputFile_20.root", 
+                "nevents": 24088, 
+                "totEvents": 24088, 
+                "weights": 299904.78125
+            }, 
+            {
+                "bad": false, 
+                "events": 23994, 
+                "name": "/store/user/spigazzi/flashgg/Era2018_RR-17Sep2018_v2/legacyRun2FullV2/VHToGG_M105_13TeV_amcatnloFXFX_madspin_pythia8/Era2018_RR-17Sep2018_v2-legacyRun2FullV2-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/200104_102635/0000/myMicroAODOutputFile_9.root", 
+                "nevents": 23994, 
+                "totEvents": 23994, 
+                "weights": 295810.53125
+            }, 
+            {
+                "bad": false, 
+                "events": 24073, 
+                "name": "/store/user/spigazzi/flashgg/Era2018_RR-17Sep2018_v2/legacyRun2FullV2/VHToGG_M105_13TeV_amcatnloFXFX_madspin_pythia8/Era2018_RR-17Sep2018_v2-legacyRun2FullV2-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/200104_102635/0000/myMicroAODOutputFile_10.root", 
+                "nevents": 24073, 
+                "totEvents": 24073, 
+                "weights": 302252.15625
+            }, 
+            {
+                "bad": false, 
+                "events": 24327, 
+                "name": "/store/user/spigazzi/flashgg/Era2018_RR-17Sep2018_v2/legacyRun2FullV2/VHToGG_M105_13TeV_amcatnloFXFX_madspin_pythia8/Era2018_RR-17Sep2018_v2-legacyRun2FullV2-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/200104_102635/0000/myMicroAODOutputFile_15.root", 
+                "nevents": 24327, 
+                "totEvents": 24327, 
+                "weights": 302342.46875
+            }, 
+            {
+                "bad": false, 
+                "events": 24182, 
+                "name": "/store/user/spigazzi/flashgg/Era2018_RR-17Sep2018_v2/legacyRun2FullV2/VHToGG_M105_13TeV_amcatnloFXFX_madspin_pythia8/Era2018_RR-17Sep2018_v2-legacyRun2FullV2-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/200104_102635/0000/myMicroAODOutputFile_1.root", 
+                "nevents": 24182, 
+                "totEvents": 24182, 
+                "weights": 299668.25
+            }, 
+            {
+                "bad": false, 
+                "events": 3460, 
+                "name": "/store/user/spigazzi/flashgg/Era2018_RR-17Sep2018_v2/legacyRun2FullV2/VHToGG_M105_13TeV_amcatnloFXFX_madspin_pythia8/Era2018_RR-17Sep2018_v2-legacyRun2FullV2-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/200104_102635/0000/myMicroAODOutputFile_21.root", 
+                "nevents": 3460, 
+                "totEvents": 3460, 
+                "weights": 43438.328125
+            }
+        ], 
+        "parent_n_units": 486739, 
+        "vetted": true
+    }, 
     "/ttHiggs0MToGG_M125_13TeV_JHUGenV7011_pythia8/spigazzi-Era2018_RR-17Sep2018_v2-legacyRun2FullV2-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1-f92c9f599a06a0b9ad7359dd0fdbd5d1/USER": {
         "dset_type": "mc", 
         "files": [

--- a/MetaData/data/Era2018_RR-17Sep2018_v2/datasets_23.json
+++ b/MetaData/data/Era2018_RR-17Sep2018_v2/datasets_23.json
@@ -4172,5 +4172,783 @@
         ], 
         "parent_n_units": 1960300, 
         "vetted": true
+    }, 
+    "/ttHJetToGG_M100_13TeV_amcatnloFXFX_madspin_pythia8/spigazzi-Era2018_RR-17Sep2018_v2-legacyRun2FullV2-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1-7145f61eea1f4686ab4f2077a024bf4a/USER": {
+        "dset_type": "mc", 
+        "files": [
+            {
+                "bad": false, 
+                "events": 24959, 
+                "name": "/store/user/spigazzi/flashgg/Era2018_RR-17Sep2018_v2/legacyRun2FullV2/ttHJetToGG_M100_13TeV_amcatnloFXFX_madspin_pythia8/Era2018_RR-17Sep2018_v2-legacyRun2FullV2-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/200106_090956/0000/myMicroAODOutputFile_11.root", 
+                "nevents": 24959, 
+                "totEvents": 24959, 
+                "weights": 45132.33203125
+            }, 
+            {
+                "bad": false, 
+                "events": 24966, 
+                "name": "/store/user/spigazzi/flashgg/Era2018_RR-17Sep2018_v2/legacyRun2FullV2/ttHJetToGG_M100_13TeV_amcatnloFXFX_madspin_pythia8/Era2018_RR-17Sep2018_v2-legacyRun2FullV2-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/200106_090956/0000/myMicroAODOutputFile_16.root", 
+                "nevents": 24966, 
+                "totEvents": 24966, 
+                "weights": 46167.04296875
+            }, 
+            {
+                "bad": false, 
+                "events": 24124, 
+                "name": "/store/user/spigazzi/flashgg/Era2018_RR-17Sep2018_v2/legacyRun2FullV2/ttHJetToGG_M100_13TeV_amcatnloFXFX_madspin_pythia8/Era2018_RR-17Sep2018_v2-legacyRun2FullV2-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/200106_090956/0000/myMicroAODOutputFile_6.root", 
+                "nevents": 24124, 
+                "totEvents": 24124, 
+                "weights": 43629.4609375
+            }, 
+            {
+                "bad": false, 
+                "events": 24879, 
+                "name": "/store/user/spigazzi/flashgg/Era2018_RR-17Sep2018_v2/legacyRun2FullV2/ttHJetToGG_M100_13TeV_amcatnloFXFX_madspin_pythia8/Era2018_RR-17Sep2018_v2-legacyRun2FullV2-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/200106_090956/0000/myMicroAODOutputFile_10.root", 
+                "nevents": 24879, 
+                "totEvents": 24879, 
+                "weights": 43933.6953125
+            }, 
+            {
+                "bad": false, 
+                "events": 24813, 
+                "name": "/store/user/spigazzi/flashgg/Era2018_RR-17Sep2018_v2/legacyRun2FullV2/ttHJetToGG_M100_13TeV_amcatnloFXFX_madspin_pythia8/Era2018_RR-17Sep2018_v2-legacyRun2FullV2-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/200106_090956/0000/myMicroAODOutputFile_2.root", 
+                "nevents": 24813, 
+                "totEvents": 24813, 
+                "weights": 45244.60546875
+            }, 
+            {
+                "bad": false, 
+                "events": 18678, 
+                "name": "/store/user/spigazzi/flashgg/Era2018_RR-17Sep2018_v2/legacyRun2FullV2/ttHJetToGG_M100_13TeV_amcatnloFXFX_madspin_pythia8/Era2018_RR-17Sep2018_v2-legacyRun2FullV2-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/200106_090956/0000/myMicroAODOutputFile_17.root", 
+                "nevents": 18678, 
+                "totEvents": 18678, 
+                "weights": 34188.85546875
+            }, 
+            {
+                "bad": false, 
+                "events": 24729, 
+                "name": "/store/user/spigazzi/flashgg/Era2018_RR-17Sep2018_v2/legacyRun2FullV2/ttHJetToGG_M100_13TeV_amcatnloFXFX_madspin_pythia8/Era2018_RR-17Sep2018_v2-legacyRun2FullV2-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/200106_090956/0000/myMicroAODOutputFile_3.root", 
+                "nevents": 24729, 
+                "totEvents": 24729, 
+                "weights": 45048.5
+            }, 
+            {
+                "bad": false, 
+                "events": 24866, 
+                "name": "/store/user/spigazzi/flashgg/Era2018_RR-17Sep2018_v2/legacyRun2FullV2/ttHJetToGG_M100_13TeV_amcatnloFXFX_madspin_pythia8/Era2018_RR-17Sep2018_v2-legacyRun2FullV2-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/200106_090956/0000/myMicroAODOutputFile_13.root", 
+                "nevents": 24866, 
+                "totEvents": 24866, 
+                "weights": 45544.94921875
+            }, 
+            {
+                "bad": false, 
+                "events": 24635, 
+                "name": "/store/user/spigazzi/flashgg/Era2018_RR-17Sep2018_v2/legacyRun2FullV2/ttHJetToGG_M100_13TeV_amcatnloFXFX_madspin_pythia8/Era2018_RR-17Sep2018_v2-legacyRun2FullV2-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/200106_090956/0000/myMicroAODOutputFile_9.root", 
+                "nevents": 24635, 
+                "totEvents": 24635, 
+                "weights": 44609.02734375
+            }, 
+            {
+                "bad": false, 
+                "events": 24749, 
+                "name": "/store/user/spigazzi/flashgg/Era2018_RR-17Sep2018_v2/legacyRun2FullV2/ttHJetToGG_M100_13TeV_amcatnloFXFX_madspin_pythia8/Era2018_RR-17Sep2018_v2-legacyRun2FullV2-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/200106_090956/0000/myMicroAODOutputFile_5.root", 
+                "nevents": 24749, 
+                "totEvents": 24749, 
+                "weights": 45932.1015625
+            }, 
+            {
+                "bad": false, 
+                "events": 24977, 
+                "name": "/store/user/spigazzi/flashgg/Era2018_RR-17Sep2018_v2/legacyRun2FullV2/ttHJetToGG_M100_13TeV_amcatnloFXFX_madspin_pythia8/Era2018_RR-17Sep2018_v2-legacyRun2FullV2-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/200106_090956/0000/myMicroAODOutputFile_8.root", 
+                "nevents": 24977, 
+                "totEvents": 24977, 
+                "weights": 45557.71484375
+            }, 
+            {
+                "bad": false, 
+                "events": 23934, 
+                "name": "/store/user/spigazzi/flashgg/Era2018_RR-17Sep2018_v2/legacyRun2FullV2/ttHJetToGG_M100_13TeV_amcatnloFXFX_madspin_pythia8/Era2018_RR-17Sep2018_v2-legacyRun2FullV2-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/200106_090956/0000/myMicroAODOutputFile_7.root", 
+                "nevents": 23934, 
+                "totEvents": 23934, 
+                "weights": 44228.6796875
+            }, 
+            {
+                "bad": false, 
+                "events": 24869, 
+                "name": "/store/user/spigazzi/flashgg/Era2018_RR-17Sep2018_v2/legacyRun2FullV2/ttHJetToGG_M100_13TeV_amcatnloFXFX_madspin_pythia8/Era2018_RR-17Sep2018_v2-legacyRun2FullV2-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/200106_090956/0000/myMicroAODOutputFile_1.root", 
+                "nevents": 24869, 
+                "totEvents": 24869, 
+                "weights": 44705.60546875
+            }, 
+            {
+                "bad": false, 
+                "events": 24775, 
+                "name": "/store/user/spigazzi/flashgg/Era2018_RR-17Sep2018_v2/legacyRun2FullV2/ttHJetToGG_M100_13TeV_amcatnloFXFX_madspin_pythia8/Era2018_RR-17Sep2018_v2-legacyRun2FullV2-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/200106_090956/0000/myMicroAODOutputFile_15.root", 
+                "nevents": 24775, 
+                "totEvents": 24775, 
+                "weights": 45008.58984375
+            }, 
+            {
+                "bad": false, 
+                "events": 24913, 
+                "name": "/store/user/spigazzi/flashgg/Era2018_RR-17Sep2018_v2/legacyRun2FullV2/ttHJetToGG_M100_13TeV_amcatnloFXFX_madspin_pythia8/Era2018_RR-17Sep2018_v2-legacyRun2FullV2-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/200106_090956/0000/myMicroAODOutputFile_12.root", 
+                "nevents": 24913, 
+                "totEvents": 24913, 
+                "weights": 44641.05078125
+            }, 
+            {
+                "bad": false, 
+                "events": 24911, 
+                "name": "/store/user/spigazzi/flashgg/Era2018_RR-17Sep2018_v2/legacyRun2FullV2/ttHJetToGG_M100_13TeV_amcatnloFXFX_madspin_pythia8/Era2018_RR-17Sep2018_v2-legacyRun2FullV2-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/200106_090956/0000/myMicroAODOutputFile_4.root", 
+                "nevents": 24911, 
+                "totEvents": 24911, 
+                "weights": 46634.93359375
+            }, 
+            {
+                "bad": false, 
+                "events": 24741, 
+                "name": "/store/user/spigazzi/flashgg/Era2018_RR-17Sep2018_v2/legacyRun2FullV2/ttHJetToGG_M100_13TeV_amcatnloFXFX_madspin_pythia8/Era2018_RR-17Sep2018_v2-legacyRun2FullV2-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/200106_090956/0000/myMicroAODOutputFile_14.root", 
+                "nevents": 24741, 
+                "totEvents": 24741, 
+                "weights": 45179.47265625
+            }
+        ], 
+        "parent_n_units": 395904, 
+        "vetted": true
+    }, 
+    "/ttHJetToGG_M105_13TeV_amcatnloFXFX_madspin_pythia8/spigazzi-Era2018_RR-17Sep2018_v2-legacyRun2FullV2-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1-7145f61eea1f4686ab4f2077a024bf4a/USER": {
+        "dset_type": "mc", 
+        "files": [
+            {
+                "bad": false, 
+                "events": 24815, 
+                "name": "/store/user/spigazzi/flashgg/Era2018_RR-17Sep2018_v2/legacyRun2FullV2/ttHJetToGG_M105_13TeV_amcatnloFXFX_madspin_pythia8/Era2018_RR-17Sep2018_v2-legacyRun2FullV2-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/200104_100633/0000/myMicroAODOutputFile_1.root", 
+                "nevents": 24815, 
+                "totEvents": 24815, 
+                "weights": 41200.12109375
+            }, 
+            {
+                "bad": false, 
+                "events": 24973, 
+                "name": "/store/user/spigazzi/flashgg/Era2018_RR-17Sep2018_v2/legacyRun2FullV2/ttHJetToGG_M105_13TeV_amcatnloFXFX_madspin_pythia8/Era2018_RR-17Sep2018_v2-legacyRun2FullV2-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/200104_100633/0000/myMicroAODOutputFile_13.root", 
+                "nevents": 24973, 
+                "totEvents": 24973, 
+                "weights": 39285.99609375
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/spigazzi/flashgg/Era2018_RR-17Sep2018_v2/legacyRun2FullV2/ttHJetToGG_M105_13TeV_amcatnloFXFX_madspin_pythia8/Era2018_RR-17Sep2018_v2-legacyRun2FullV2-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/200104_100633/0000/myMicroAODOutputFile_11.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 39956.3984375
+            }, 
+            {
+                "bad": false, 
+                "events": 25015, 
+                "name": "/store/user/spigazzi/flashgg/Era2018_RR-17Sep2018_v2/legacyRun2FullV2/ttHJetToGG_M105_13TeV_amcatnloFXFX_madspin_pythia8/Era2018_RR-17Sep2018_v2-legacyRun2FullV2-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/200104_100633/0000/myMicroAODOutputFile_15.root", 
+                "nevents": 25015, 
+                "totEvents": 25015, 
+                "weights": 39634.484375
+            }, 
+            {
+                "bad": false, 
+                "events": 24843, 
+                "name": "/store/user/spigazzi/flashgg/Era2018_RR-17Sep2018_v2/legacyRun2FullV2/ttHJetToGG_M105_13TeV_amcatnloFXFX_madspin_pythia8/Era2018_RR-17Sep2018_v2-legacyRun2FullV2-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/200104_100633/0000/myMicroAODOutputFile_14.root", 
+                "nevents": 24843, 
+                "totEvents": 24843, 
+                "weights": 40831.375
+            }, 
+            {
+                "bad": false, 
+                "events": 24710, 
+                "name": "/store/user/spigazzi/flashgg/Era2018_RR-17Sep2018_v2/legacyRun2FullV2/ttHJetToGG_M105_13TeV_amcatnloFXFX_madspin_pythia8/Era2018_RR-17Sep2018_v2-legacyRun2FullV2-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/200104_100633/0000/myMicroAODOutputFile_12.root", 
+                "nevents": 24710, 
+                "totEvents": 24710, 
+                "weights": 39327.73828125
+            }, 
+            {
+                "bad": false, 
+                "events": 24798, 
+                "name": "/store/user/spigazzi/flashgg/Era2018_RR-17Sep2018_v2/legacyRun2FullV2/ttHJetToGG_M105_13TeV_amcatnloFXFX_madspin_pythia8/Era2018_RR-17Sep2018_v2-legacyRun2FullV2-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/200104_100633/0000/myMicroAODOutputFile_3.root", 
+                "nevents": 24798, 
+                "totEvents": 24798, 
+                "weights": 39560.58203125
+            }, 
+            {
+                "bad": false, 
+                "events": 24780, 
+                "name": "/store/user/spigazzi/flashgg/Era2018_RR-17Sep2018_v2/legacyRun2FullV2/ttHJetToGG_M105_13TeV_amcatnloFXFX_madspin_pythia8/Era2018_RR-17Sep2018_v2-legacyRun2FullV2-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/200104_100633/0000/myMicroAODOutputFile_9.root", 
+                "nevents": 24780, 
+                "totEvents": 24780, 
+                "weights": 39681.41015625
+            }, 
+            {
+                "bad": false, 
+                "events": 24819, 
+                "name": "/store/user/spigazzi/flashgg/Era2018_RR-17Sep2018_v2/legacyRun2FullV2/ttHJetToGG_M105_13TeV_amcatnloFXFX_madspin_pythia8/Era2018_RR-17Sep2018_v2-legacyRun2FullV2-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/200104_100633/0000/myMicroAODOutputFile_7.root", 
+                "nevents": 24819, 
+                "totEvents": 24819, 
+                "weights": 40713.40234375
+            }, 
+            {
+                "bad": false, 
+                "events": 24906, 
+                "name": "/store/user/spigazzi/flashgg/Era2018_RR-17Sep2018_v2/legacyRun2FullV2/ttHJetToGG_M105_13TeV_amcatnloFXFX_madspin_pythia8/Era2018_RR-17Sep2018_v2-legacyRun2FullV2-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/200104_100633/0000/myMicroAODOutputFile_4.root", 
+                "nevents": 24906, 
+                "totEvents": 24906, 
+                "weights": 39718.9609375
+            }, 
+            {
+                "bad": false, 
+                "events": 24877, 
+                "name": "/store/user/spigazzi/flashgg/Era2018_RR-17Sep2018_v2/legacyRun2FullV2/ttHJetToGG_M105_13TeV_amcatnloFXFX_madspin_pythia8/Era2018_RR-17Sep2018_v2-legacyRun2FullV2-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/200104_100633/0000/myMicroAODOutputFile_8.root", 
+                "nevents": 24877, 
+                "totEvents": 24877, 
+                "weights": 40538.8125
+            }, 
+            {
+                "bad": false, 
+                "events": 24800, 
+                "name": "/store/user/spigazzi/flashgg/Era2018_RR-17Sep2018_v2/legacyRun2FullV2/ttHJetToGG_M105_13TeV_amcatnloFXFX_madspin_pythia8/Era2018_RR-17Sep2018_v2-legacyRun2FullV2-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/200104_100633/0000/myMicroAODOutputFile_5.root", 
+                "nevents": 24800, 
+                "totEvents": 24800, 
+                "weights": 40096.58203125
+            }, 
+            {
+                "bad": false, 
+                "events": 24988, 
+                "name": "/store/user/spigazzi/flashgg/Era2018_RR-17Sep2018_v2/legacyRun2FullV2/ttHJetToGG_M105_13TeV_amcatnloFXFX_madspin_pythia8/Era2018_RR-17Sep2018_v2-legacyRun2FullV2-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/200104_100633/0000/myMicroAODOutputFile_6.root", 
+                "nevents": 24988, 
+                "totEvents": 24988, 
+                "weights": 38769.62890625
+            }, 
+            {
+                "bad": false, 
+                "events": 8289, 
+                "name": "/store/user/spigazzi/flashgg/Era2018_RR-17Sep2018_v2/legacyRun2FullV2/ttHJetToGG_M105_13TeV_amcatnloFXFX_madspin_pythia8/Era2018_RR-17Sep2018_v2-legacyRun2FullV2-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/200104_100633/0000/myMicroAODOutputFile_16.root", 
+                "nevents": 8289, 
+                "totEvents": 8289, 
+                "weights": 13153.6005859375
+            }, 
+            {
+                "bad": false, 
+                "events": 24908, 
+                "name": "/store/user/spigazzi/flashgg/Era2018_RR-17Sep2018_v2/legacyRun2FullV2/ttHJetToGG_M105_13TeV_amcatnloFXFX_madspin_pythia8/Era2018_RR-17Sep2018_v2-legacyRun2FullV2-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/200104_100633/0000/myMicroAODOutputFile_10.root", 
+                "nevents": 24908, 
+                "totEvents": 24908, 
+                "weights": 40481.6015625
+            }, 
+            {
+                "bad": false, 
+                "events": 24739, 
+                "name": "/store/user/spigazzi/flashgg/Era2018_RR-17Sep2018_v2/legacyRun2FullV2/ttHJetToGG_M105_13TeV_amcatnloFXFX_madspin_pythia8/Era2018_RR-17Sep2018_v2-legacyRun2FullV2-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/200104_100633/0000/myMicroAODOutputFile_2.root", 
+                "nevents": 24739, 
+                "totEvents": 24739, 
+                "weights": 38481.015625
+            }
+        ], 
+        "parent_n_units": 381260, 
+        "vetted": true
+    }, 
+    "/ttHJetToGG_M115_TuneCP5_13TeV-amcatnloFXFX-madspin-pythia8/spigazzi-Era2018_RR-17Sep2018_v2-legacyRun2FullV2-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1-7145f61eea1f4686ab4f2077a024bf4a/USER": {
+        "dset_type": "mc", 
+        "files": [
+            {
+                "bad": false, 
+                "events": 24946, 
+                "name": "/store/user/spigazzi/flashgg/Era2018_RR-17Sep2018_v2/legacyRun2FullV2/ttHJetToGG_M115_TuneCP5_13TeV-amcatnloFXFX-madspin-pythia8/Era2018_RR-17Sep2018_v2-legacyRun2FullV2-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/200104_100928/0000/myMicroAODOutputFile_9.root", 
+                "nevents": 24946, 
+                "totEvents": 24946, 
+                "weights": 30661.775390625
+            }, 
+            {
+                "bad": false, 
+                "events": 25099, 
+                "name": "/store/user/spigazzi/flashgg/Era2018_RR-17Sep2018_v2/legacyRun2FullV2/ttHJetToGG_M115_TuneCP5_13TeV-amcatnloFXFX-madspin-pythia8/Era2018_RR-17Sep2018_v2-legacyRun2FullV2-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/200104_100928/0000/myMicroAODOutputFile_12.root", 
+                "nevents": 25099, 
+                "totEvents": 25099, 
+                "weights": 32148.5625
+            }, 
+            {
+                "bad": false, 
+                "events": 25008, 
+                "name": "/store/user/spigazzi/flashgg/Era2018_RR-17Sep2018_v2/legacyRun2FullV2/ttHJetToGG_M115_TuneCP5_13TeV-amcatnloFXFX-madspin-pythia8/Era2018_RR-17Sep2018_v2-legacyRun2FullV2-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/200104_100928/0000/myMicroAODOutputFile_7.root", 
+                "nevents": 25008, 
+                "totEvents": 25008, 
+                "weights": 31942.3671875
+            }, 
+            {
+                "bad": false, 
+                "events": 24966, 
+                "name": "/store/user/spigazzi/flashgg/Era2018_RR-17Sep2018_v2/legacyRun2FullV2/ttHJetToGG_M115_TuneCP5_13TeV-amcatnloFXFX-madspin-pythia8/Era2018_RR-17Sep2018_v2-legacyRun2FullV2-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/200104_100928/0000/myMicroAODOutputFile_3.root", 
+                "nevents": 24966, 
+                "totEvents": 24966, 
+                "weights": 32137.703125
+            }, 
+            {
+                "bad": false, 
+                "events": 25067, 
+                "name": "/store/user/spigazzi/flashgg/Era2018_RR-17Sep2018_v2/legacyRun2FullV2/ttHJetToGG_M115_TuneCP5_13TeV-amcatnloFXFX-madspin-pythia8/Era2018_RR-17Sep2018_v2-legacyRun2FullV2-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/200104_100928/0000/myMicroAODOutputFile_10.root", 
+                "nevents": 25067, 
+                "totEvents": 25067, 
+                "weights": 31258.662109375
+            }, 
+            {
+                "bad": false, 
+                "events": 24898, 
+                "name": "/store/user/spigazzi/flashgg/Era2018_RR-17Sep2018_v2/legacyRun2FullV2/ttHJetToGG_M115_TuneCP5_13TeV-amcatnloFXFX-madspin-pythia8/Era2018_RR-17Sep2018_v2-legacyRun2FullV2-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/200104_100928/0000/myMicroAODOutputFile_16.root", 
+                "nevents": 24898, 
+                "totEvents": 24898, 
+                "weights": 31848.31640625
+            }, 
+            {
+                "bad": false, 
+                "events": 25007, 
+                "name": "/store/user/spigazzi/flashgg/Era2018_RR-17Sep2018_v2/legacyRun2FullV2/ttHJetToGG_M115_TuneCP5_13TeV-amcatnloFXFX-madspin-pythia8/Era2018_RR-17Sep2018_v2-legacyRun2FullV2-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/200104_100928/0000/myMicroAODOutputFile_1.root", 
+                "nevents": 25007, 
+                "totEvents": 25007, 
+                "weights": 32228.14453125
+            }, 
+            {
+                "bad": false, 
+                "events": 24922, 
+                "name": "/store/user/spigazzi/flashgg/Era2018_RR-17Sep2018_v2/legacyRun2FullV2/ttHJetToGG_M115_TuneCP5_13TeV-amcatnloFXFX-madspin-pythia8/Era2018_RR-17Sep2018_v2-legacyRun2FullV2-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/200104_100928/0000/myMicroAODOutputFile_14.root", 
+                "nevents": 24922, 
+                "totEvents": 24922, 
+                "weights": 30792.00390625
+            }, 
+            {
+                "bad": false, 
+                "events": 24982, 
+                "name": "/store/user/spigazzi/flashgg/Era2018_RR-17Sep2018_v2/legacyRun2FullV2/ttHJetToGG_M115_TuneCP5_13TeV-amcatnloFXFX-madspin-pythia8/Era2018_RR-17Sep2018_v2-legacyRun2FullV2-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/200104_100928/0000/myMicroAODOutputFile_4.root", 
+                "nevents": 24982, 
+                "totEvents": 24982, 
+                "weights": 31370.806640625
+            }, 
+            {
+                "bad": false, 
+                "events": 24914, 
+                "name": "/store/user/spigazzi/flashgg/Era2018_RR-17Sep2018_v2/legacyRun2FullV2/ttHJetToGG_M115_TuneCP5_13TeV-amcatnloFXFX-madspin-pythia8/Era2018_RR-17Sep2018_v2-legacyRun2FullV2-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/200104_100928/0000/myMicroAODOutputFile_11.root", 
+                "nevents": 24914, 
+                "totEvents": 24914, 
+                "weights": 30951.1875
+            }, 
+            {
+                "bad": false, 
+                "events": 25024, 
+                "name": "/store/user/spigazzi/flashgg/Era2018_RR-17Sep2018_v2/legacyRun2FullV2/ttHJetToGG_M115_TuneCP5_13TeV-amcatnloFXFX-madspin-pythia8/Era2018_RR-17Sep2018_v2-legacyRun2FullV2-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/200104_100928/0000/myMicroAODOutputFile_2.root", 
+                "nevents": 25024, 
+                "totEvents": 25024, 
+                "weights": 31725.318359375
+            }, 
+            {
+                "bad": false, 
+                "events": 11834, 
+                "name": "/store/user/spigazzi/flashgg/Era2018_RR-17Sep2018_v2/legacyRun2FullV2/ttHJetToGG_M115_TuneCP5_13TeV-amcatnloFXFX-madspin-pythia8/Era2018_RR-17Sep2018_v2-legacyRun2FullV2-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/200104_100928/0000/myMicroAODOutputFile_17.root", 
+                "nevents": 11834, 
+                "totEvents": 11834, 
+                "weights": 14882.31640625
+            }, 
+            {
+                "bad": false, 
+                "events": 25003, 
+                "name": "/store/user/spigazzi/flashgg/Era2018_RR-17Sep2018_v2/legacyRun2FullV2/ttHJetToGG_M115_TuneCP5_13TeV-amcatnloFXFX-madspin-pythia8/Era2018_RR-17Sep2018_v2-legacyRun2FullV2-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/200104_100928/0000/myMicroAODOutputFile_5.root", 
+                "nevents": 25003, 
+                "totEvents": 25003, 
+                "weights": 30954.78515625
+            }, 
+            {
+                "bad": false, 
+                "events": 24975, 
+                "name": "/store/user/spigazzi/flashgg/Era2018_RR-17Sep2018_v2/legacyRun2FullV2/ttHJetToGG_M115_TuneCP5_13TeV-amcatnloFXFX-madspin-pythia8/Era2018_RR-17Sep2018_v2-legacyRun2FullV2-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/200104_100928/0000/myMicroAODOutputFile_8.root", 
+                "nevents": 24975, 
+                "totEvents": 24975, 
+                "weights": 32170.279296875
+            }, 
+            {
+                "bad": false, 
+                "events": 25105, 
+                "name": "/store/user/spigazzi/flashgg/Era2018_RR-17Sep2018_v2/legacyRun2FullV2/ttHJetToGG_M115_TuneCP5_13TeV-amcatnloFXFX-madspin-pythia8/Era2018_RR-17Sep2018_v2-legacyRun2FullV2-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/200104_100928/0000/myMicroAODOutputFile_6.root", 
+                "nevents": 25105, 
+                "totEvents": 25105, 
+                "weights": 31280.36328125
+            }, 
+            {
+                "bad": false, 
+                "events": 24914, 
+                "name": "/store/user/spigazzi/flashgg/Era2018_RR-17Sep2018_v2/legacyRun2FullV2/ttHJetToGG_M115_TuneCP5_13TeV-amcatnloFXFX-madspin-pythia8/Era2018_RR-17Sep2018_v2-legacyRun2FullV2-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/200104_100928/0000/myMicroAODOutputFile_13.root", 
+                "nevents": 24914, 
+                "totEvents": 24914, 
+                "weights": 30813.7109375
+            }
+        ], 
+        "parent_n_units": 409764, 
+        "vetted": true
+    }, 
+    "/ttHJetToGG_M70_13TeV_amcatnloFXFX_madspin_pythia8/spigazzi-Era2018_RR-17Sep2018_v2-legacyRun2FullV2-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1-7145f61eea1f4686ab4f2077a024bf4a/USER": {
+        "dset_type": "mc", 
+        "files": [
+            {
+                "bad": false, 
+                "events": 24744, 
+                "name": "/store/user/spigazzi/flashgg/Era2018_RR-17Sep2018_v2/legacyRun2FullV2/ttHJetToGG_M70_13TeV_amcatnloFXFX_madspin_pythia8/Era2018_RR-17Sep2018_v2-legacyRun2FullV2-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/200104_101230/0000/myMicroAODOutputFile_4.root", 
+                "nevents": 24744, 
+                "totEvents": 24744, 
+                "weights": 104729.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24581, 
+                "name": "/store/user/spigazzi/flashgg/Era2018_RR-17Sep2018_v2/legacyRun2FullV2/ttHJetToGG_M70_13TeV_amcatnloFXFX_madspin_pythia8/Era2018_RR-17Sep2018_v2-legacyRun2FullV2-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/200104_101230/0000/myMicroAODOutputFile_5.root", 
+                "nevents": 24581, 
+                "totEvents": 24581, 
+                "weights": 105590.2421875
+            }, 
+            {
+                "bad": false, 
+                "events": 24701, 
+                "name": "/store/user/spigazzi/flashgg/Era2018_RR-17Sep2018_v2/legacyRun2FullV2/ttHJetToGG_M70_13TeV_amcatnloFXFX_madspin_pythia8/Era2018_RR-17Sep2018_v2-legacyRun2FullV2-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/200104_101230/0000/myMicroAODOutputFile_7.root", 
+                "nevents": 24701, 
+                "totEvents": 24701, 
+                "weights": 100467.5
+            }, 
+            {
+                "bad": false, 
+                "events": 24620, 
+                "name": "/store/user/spigazzi/flashgg/Era2018_RR-17Sep2018_v2/legacyRun2FullV2/ttHJetToGG_M70_13TeV_amcatnloFXFX_madspin_pythia8/Era2018_RR-17Sep2018_v2-legacyRun2FullV2-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/200104_101230/0000/myMicroAODOutputFile_6.root", 
+                "nevents": 24620, 
+                "totEvents": 24620, 
+                "weights": 100717.8671875
+            }, 
+            {
+                "bad": false, 
+                "events": 24667, 
+                "name": "/store/user/spigazzi/flashgg/Era2018_RR-17Sep2018_v2/legacyRun2FullV2/ttHJetToGG_M70_13TeV_amcatnloFXFX_madspin_pythia8/Era2018_RR-17Sep2018_v2-legacyRun2FullV2-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/200104_101230/0000/myMicroAODOutputFile_1.root", 
+                "nevents": 24667, 
+                "totEvents": 24667, 
+                "weights": 103326.5546875
+            }, 
+            {
+                "bad": false, 
+                "events": 24884, 
+                "name": "/store/user/spigazzi/flashgg/Era2018_RR-17Sep2018_v2/legacyRun2FullV2/ttHJetToGG_M70_13TeV_amcatnloFXFX_madspin_pythia8/Era2018_RR-17Sep2018_v2-legacyRun2FullV2-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/200104_101230/0000/myMicroAODOutputFile_2.root", 
+                "nevents": 24884, 
+                "totEvents": 24884, 
+                "weights": 102172.90625
+            }, 
+            {
+                "bad": false, 
+                "events": 22421, 
+                "name": "/store/user/spigazzi/flashgg/Era2018_RR-17Sep2018_v2/legacyRun2FullV2/ttHJetToGG_M70_13TeV_amcatnloFXFX_madspin_pythia8/Era2018_RR-17Sep2018_v2-legacyRun2FullV2-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/200104_101230/0000/myMicroAODOutputFile_8.root", 
+                "nevents": 22421, 
+                "totEvents": 22421, 
+                "weights": 96843.90625
+            }, 
+            {
+                "bad": false, 
+                "events": 24879, 
+                "name": "/store/user/spigazzi/flashgg/Era2018_RR-17Sep2018_v2/legacyRun2FullV2/ttHJetToGG_M70_13TeV_amcatnloFXFX_madspin_pythia8/Era2018_RR-17Sep2018_v2-legacyRun2FullV2-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/200104_101230/0000/myMicroAODOutputFile_3.root", 
+                "nevents": 24879, 
+                "totEvents": 24879, 
+                "weights": 105023.84375
+            }
+        ], 
+        "parent_n_units": 195497, 
+        "vetted": true
+    }, 
+    "/ttHJetToGG_M75_13TeV_amcatnloFXFX_madspin_pythia8/spigazzi-Era2018_RR-17Sep2018_v2-legacyRun2FullV2-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1-7145f61eea1f4686ab4f2077a024bf4a/USER": {
+        "dset_type": "mc", 
+        "files": [
+            {
+                "bad": false, 
+                "events": 24835, 
+                "name": "/store/user/spigazzi/flashgg/Era2018_RR-17Sep2018_v2/legacyRun2FullV2/ttHJetToGG_M75_13TeV_amcatnloFXFX_madspin_pythia8/Era2018_RR-17Sep2018_v2-legacyRun2FullV2-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/200104_101530/0000/myMicroAODOutputFile_5.root", 
+                "nevents": 24835, 
+                "totEvents": 24835, 
+                "weights": 90579.53125
+            }, 
+            {
+                "bad": false, 
+                "events": 24597, 
+                "name": "/store/user/spigazzi/flashgg/Era2018_RR-17Sep2018_v2/legacyRun2FullV2/ttHJetToGG_M75_13TeV_amcatnloFXFX_madspin_pythia8/Era2018_RR-17Sep2018_v2-legacyRun2FullV2-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/200104_101530/0000/myMicroAODOutputFile_12.root", 
+                "nevents": 24597, 
+                "totEvents": 24597, 
+                "weights": 86552.375
+            }, 
+            {
+                "bad": false, 
+                "events": 24636, 
+                "name": "/store/user/spigazzi/flashgg/Era2018_RR-17Sep2018_v2/legacyRun2FullV2/ttHJetToGG_M75_13TeV_amcatnloFXFX_madspin_pythia8/Era2018_RR-17Sep2018_v2-legacyRun2FullV2-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/200104_101530/0000/myMicroAODOutputFile_10.root", 
+                "nevents": 24636, 
+                "totEvents": 24636, 
+                "weights": 89445.5859375
+            }, 
+            {
+                "bad": false, 
+                "events": 24851, 
+                "name": "/store/user/spigazzi/flashgg/Era2018_RR-17Sep2018_v2/legacyRun2FullV2/ttHJetToGG_M75_13TeV_amcatnloFXFX_madspin_pythia8/Era2018_RR-17Sep2018_v2-legacyRun2FullV2-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/200104_101530/0000/myMicroAODOutputFile_2.root", 
+                "nevents": 24851, 
+                "totEvents": 24851, 
+                "weights": 87178.4375
+            }, 
+            {
+                "bad": false, 
+                "events": 24790, 
+                "name": "/store/user/spigazzi/flashgg/Era2018_RR-17Sep2018_v2/legacyRun2FullV2/ttHJetToGG_M75_13TeV_amcatnloFXFX_madspin_pythia8/Era2018_RR-17Sep2018_v2-legacyRun2FullV2-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/200104_101530/0000/myMicroAODOutputFile_9.root", 
+                "nevents": 24790, 
+                "totEvents": 24790, 
+                "weights": 89853.328125
+            }, 
+            {
+                "bad": false, 
+                "events": 24415, 
+                "name": "/store/user/spigazzi/flashgg/Era2018_RR-17Sep2018_v2/legacyRun2FullV2/ttHJetToGG_M75_13TeV_amcatnloFXFX_madspin_pythia8/Era2018_RR-17Sep2018_v2-legacyRun2FullV2-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/200104_101530/0000/myMicroAODOutputFile_8.root", 
+                "nevents": 24415, 
+                "totEvents": 24415, 
+                "weights": 88397.6953125
+            }, 
+            {
+                "bad": false, 
+                "events": 24673, 
+                "name": "/store/user/spigazzi/flashgg/Era2018_RR-17Sep2018_v2/legacyRun2FullV2/ttHJetToGG_M75_13TeV_amcatnloFXFX_madspin_pythia8/Era2018_RR-17Sep2018_v2-legacyRun2FullV2-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/200104_101530/0000/myMicroAODOutputFile_14.root", 
+                "nevents": 24673, 
+                "totEvents": 24673, 
+                "weights": 89264.125
+            }, 
+            {
+                "bad": false, 
+                "events": 24747, 
+                "name": "/store/user/spigazzi/flashgg/Era2018_RR-17Sep2018_v2/legacyRun2FullV2/ttHJetToGG_M75_13TeV_amcatnloFXFX_madspin_pythia8/Era2018_RR-17Sep2018_v2-legacyRun2FullV2-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/200104_101530/0000/myMicroAODOutputFile_15.root", 
+                "nevents": 24747, 
+                "totEvents": 24747, 
+                "weights": 86192.4375
+            }, 
+            {
+                "bad": false, 
+                "events": 24675, 
+                "name": "/store/user/spigazzi/flashgg/Era2018_RR-17Sep2018_v2/legacyRun2FullV2/ttHJetToGG_M75_13TeV_amcatnloFXFX_madspin_pythia8/Era2018_RR-17Sep2018_v2-legacyRun2FullV2-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/200104_101530/0000/myMicroAODOutputFile_4.root", 
+                "nevents": 24675, 
+                "totEvents": 24675, 
+                "weights": 86900.1328125
+            }, 
+            {
+                "bad": false, 
+                "events": 23647, 
+                "name": "/store/user/spigazzi/flashgg/Era2018_RR-17Sep2018_v2/legacyRun2FullV2/ttHJetToGG_M75_13TeV_amcatnloFXFX_madspin_pythia8/Era2018_RR-17Sep2018_v2-legacyRun2FullV2-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/200104_101530/0000/myMicroAODOutputFile_16.root", 
+                "nevents": 23647, 
+                "totEvents": 23647, 
+                "weights": 84863.5859375
+            }, 
+            {
+                "bad": false, 
+                "events": 24581, 
+                "name": "/store/user/spigazzi/flashgg/Era2018_RR-17Sep2018_v2/legacyRun2FullV2/ttHJetToGG_M75_13TeV_amcatnloFXFX_madspin_pythia8/Era2018_RR-17Sep2018_v2-legacyRun2FullV2-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/200104_101530/0000/myMicroAODOutputFile_13.root", 
+                "nevents": 24581, 
+                "totEvents": 24581, 
+                "weights": 88996.4765625
+            }, 
+            {
+                "bad": false, 
+                "events": 24697, 
+                "name": "/store/user/spigazzi/flashgg/Era2018_RR-17Sep2018_v2/legacyRun2FullV2/ttHJetToGG_M75_13TeV_amcatnloFXFX_madspin_pythia8/Era2018_RR-17Sep2018_v2-legacyRun2FullV2-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/200104_101530/0000/myMicroAODOutputFile_11.root", 
+                "nevents": 24697, 
+                "totEvents": 24697, 
+                "weights": 88545.359375
+            }, 
+            {
+                "bad": false, 
+                "events": 24678, 
+                "name": "/store/user/spigazzi/flashgg/Era2018_RR-17Sep2018_v2/legacyRun2FullV2/ttHJetToGG_M75_13TeV_amcatnloFXFX_madspin_pythia8/Era2018_RR-17Sep2018_v2-legacyRun2FullV2-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/200104_101530/0000/myMicroAODOutputFile_1.root", 
+                "nevents": 24678, 
+                "totEvents": 24678, 
+                "weights": 87729.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24667, 
+                "name": "/store/user/spigazzi/flashgg/Era2018_RR-17Sep2018_v2/legacyRun2FullV2/ttHJetToGG_M75_13TeV_amcatnloFXFX_madspin_pythia8/Era2018_RR-17Sep2018_v2-legacyRun2FullV2-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/200104_101530/0000/myMicroAODOutputFile_3.root", 
+                "nevents": 24667, 
+                "totEvents": 24667, 
+                "weights": 89519.578125
+            }, 
+            {
+                "bad": false, 
+                "events": 24918, 
+                "name": "/store/user/spigazzi/flashgg/Era2018_RR-17Sep2018_v2/legacyRun2FullV2/ttHJetToGG_M75_13TeV_amcatnloFXFX_madspin_pythia8/Era2018_RR-17Sep2018_v2-legacyRun2FullV2-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/200104_101530/0000/myMicroAODOutputFile_7.root", 
+                "nevents": 24918, 
+                "totEvents": 24918, 
+                "weights": 91924.7578125
+            }, 
+            {
+                "bad": false, 
+                "events": 24721, 
+                "name": "/store/user/spigazzi/flashgg/Era2018_RR-17Sep2018_v2/legacyRun2FullV2/ttHJetToGG_M75_13TeV_amcatnloFXFX_madspin_pythia8/Era2018_RR-17Sep2018_v2-legacyRun2FullV2-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/200104_101530/0000/myMicroAODOutputFile_6.root", 
+                "nevents": 24721, 
+                "totEvents": 24721, 
+                "weights": 89998.5
+            }
+        ], 
+        "parent_n_units": 394128, 
+        "vetted": true
+    }, 
+    "/ttHJetToGG_M80_13TeV_amcatnloFXFX_madspin_pythia8/spigazzi-Era2018_RR-17Sep2018_v2-legacyRun2FullV2-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1-7145f61eea1f4686ab4f2077a024bf4a/USER": {
+        "dset_type": "mc", 
+        "files": [
+            {
+                "bad": false, 
+                "events": 2081, 
+                "name": "/store/user/spigazzi/flashgg/Era2018_RR-17Sep2018_v2/legacyRun2FullV2/ttHJetToGG_M80_13TeV_amcatnloFXFX_madspin_pythia8/Era2018_RR-17Sep2018_v2-legacyRun2FullV2-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/200104_101831/0000/myMicroAODOutputFile_19.root", 
+                "nevents": 2081, 
+                "totEvents": 2081, 
+                "weights": 6837.580078125
+            }, 
+            {
+                "bad": false, 
+                "events": 24745, 
+                "name": "/store/user/spigazzi/flashgg/Era2018_RR-17Sep2018_v2/legacyRun2FullV2/ttHJetToGG_M80_13TeV_amcatnloFXFX_madspin_pythia8/Era2018_RR-17Sep2018_v2-legacyRun2FullV2-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/200104_101831/0000/myMicroAODOutputFile_16.root", 
+                "nevents": 24745, 
+                "totEvents": 24745, 
+                "weights": 77243.15625
+            }, 
+            {
+                "bad": false, 
+                "events": 24694, 
+                "name": "/store/user/spigazzi/flashgg/Era2018_RR-17Sep2018_v2/legacyRun2FullV2/ttHJetToGG_M80_13TeV_amcatnloFXFX_madspin_pythia8/Era2018_RR-17Sep2018_v2-legacyRun2FullV2-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/200104_101831/0000/myMicroAODOutputFile_13.root", 
+                "nevents": 24694, 
+                "totEvents": 24694, 
+                "weights": 76834.484375
+            }, 
+            {
+                "bad": false, 
+                "events": 24750, 
+                "name": "/store/user/spigazzi/flashgg/Era2018_RR-17Sep2018_v2/legacyRun2FullV2/ttHJetToGG_M80_13TeV_amcatnloFXFX_madspin_pythia8/Era2018_RR-17Sep2018_v2-legacyRun2FullV2-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/200104_101831/0000/myMicroAODOutputFile_2.root", 
+                "nevents": 24750, 
+                "totEvents": 24750, 
+                "weights": 77786.7109375
+            }, 
+            {
+                "bad": false, 
+                "events": 24785, 
+                "name": "/store/user/spigazzi/flashgg/Era2018_RR-17Sep2018_v2/legacyRun2FullV2/ttHJetToGG_M80_13TeV_amcatnloFXFX_madspin_pythia8/Era2018_RR-17Sep2018_v2-legacyRun2FullV2-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/200104_101831/0000/myMicroAODOutputFile_9.root", 
+                "nevents": 24785, 
+                "totEvents": 24785, 
+                "weights": 74937.0390625
+            }, 
+            {
+                "bad": false, 
+                "events": 24611, 
+                "name": "/store/user/spigazzi/flashgg/Era2018_RR-17Sep2018_v2/legacyRun2FullV2/ttHJetToGG_M80_13TeV_amcatnloFXFX_madspin_pythia8/Era2018_RR-17Sep2018_v2-legacyRun2FullV2-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/200104_101831/0000/myMicroAODOutputFile_5.root", 
+                "nevents": 24611, 
+                "totEvents": 24611, 
+                "weights": 79177.9921875
+            }, 
+            {
+                "bad": false, 
+                "events": 24758, 
+                "name": "/store/user/spigazzi/flashgg/Era2018_RR-17Sep2018_v2/legacyRun2FullV2/ttHJetToGG_M80_13TeV_amcatnloFXFX_madspin_pythia8/Era2018_RR-17Sep2018_v2-legacyRun2FullV2-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/200104_101831/0000/myMicroAODOutputFile_4.root", 
+                "nevents": 24758, 
+                "totEvents": 24758, 
+                "weights": 75705.9453125
+            }, 
+            {
+                "bad": false, 
+                "events": 24704, 
+                "name": "/store/user/spigazzi/flashgg/Era2018_RR-17Sep2018_v2/legacyRun2FullV2/ttHJetToGG_M80_13TeV_amcatnloFXFX_madspin_pythia8/Era2018_RR-17Sep2018_v2-legacyRun2FullV2-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/200104_101831/0000/myMicroAODOutputFile_1.root", 
+                "nevents": 24704, 
+                "totEvents": 24704, 
+                "weights": 77167.375
+            }, 
+            {
+                "bad": false, 
+                "events": 24780, 
+                "name": "/store/user/spigazzi/flashgg/Era2018_RR-17Sep2018_v2/legacyRun2FullV2/ttHJetToGG_M80_13TeV_amcatnloFXFX_madspin_pythia8/Era2018_RR-17Sep2018_v2-legacyRun2FullV2-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/200104_101831/0000/myMicroAODOutputFile_7.root", 
+                "nevents": 24780, 
+                "totEvents": 24780, 
+                "weights": 78231.4453125
+            }, 
+            {
+                "bad": false, 
+                "events": 24796, 
+                "name": "/store/user/spigazzi/flashgg/Era2018_RR-17Sep2018_v2/legacyRun2FullV2/ttHJetToGG_M80_13TeV_amcatnloFXFX_madspin_pythia8/Era2018_RR-17Sep2018_v2-legacyRun2FullV2-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/200104_101831/0000/myMicroAODOutputFile_3.root", 
+                "nevents": 24796, 
+                "totEvents": 24796, 
+                "weights": 78348.828125
+            }, 
+            {
+                "bad": false, 
+                "events": 24676, 
+                "name": "/store/user/spigazzi/flashgg/Era2018_RR-17Sep2018_v2/legacyRun2FullV2/ttHJetToGG_M80_13TeV_amcatnloFXFX_madspin_pythia8/Era2018_RR-17Sep2018_v2-legacyRun2FullV2-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/200104_101831/0000/myMicroAODOutputFile_10.root", 
+                "nevents": 24676, 
+                "totEvents": 24676, 
+                "weights": 81019.84375
+            }, 
+            {
+                "bad": false, 
+                "events": 24703, 
+                "name": "/store/user/spigazzi/flashgg/Era2018_RR-17Sep2018_v2/legacyRun2FullV2/ttHJetToGG_M80_13TeV_amcatnloFXFX_madspin_pythia8/Era2018_RR-17Sep2018_v2-legacyRun2FullV2-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/200104_101831/0000/myMicroAODOutputFile_8.root", 
+                "nevents": 24703, 
+                "totEvents": 24703, 
+                "weights": 77284.5546875
+            }, 
+            {
+                "bad": false, 
+                "events": 24780, 
+                "name": "/store/user/spigazzi/flashgg/Era2018_RR-17Sep2018_v2/legacyRun2FullV2/ttHJetToGG_M80_13TeV_amcatnloFXFX_madspin_pythia8/Era2018_RR-17Sep2018_v2-legacyRun2FullV2-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/200104_101831/0000/myMicroAODOutputFile_17.root", 
+                "nevents": 24780, 
+                "totEvents": 24780, 
+                "weights": 77846.046875
+            }, 
+            {
+                "bad": false, 
+                "events": 24860, 
+                "name": "/store/user/spigazzi/flashgg/Era2018_RR-17Sep2018_v2/legacyRun2FullV2/ttHJetToGG_M80_13TeV_amcatnloFXFX_madspin_pythia8/Era2018_RR-17Sep2018_v2-legacyRun2FullV2-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/200104_101831/0000/myMicroAODOutputFile_15.root", 
+                "nevents": 24860, 
+                "totEvents": 24860, 
+                "weights": 75372.9609375
+            }, 
+            {
+                "bad": false, 
+                "events": 24701, 
+                "name": "/store/user/spigazzi/flashgg/Era2018_RR-17Sep2018_v2/legacyRun2FullV2/ttHJetToGG_M80_13TeV_amcatnloFXFX_madspin_pythia8/Era2018_RR-17Sep2018_v2-legacyRun2FullV2-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/200104_101831/0000/myMicroAODOutputFile_18.root", 
+                "nevents": 24701, 
+                "totEvents": 24701, 
+                "weights": 76542.2265625
+            }, 
+            {
+                "bad": false, 
+                "events": 24964, 
+                "name": "/store/user/spigazzi/flashgg/Era2018_RR-17Sep2018_v2/legacyRun2FullV2/ttHJetToGG_M80_13TeV_amcatnloFXFX_madspin_pythia8/Era2018_RR-17Sep2018_v2-legacyRun2FullV2-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/200104_101831/0000/myMicroAODOutputFile_12.root", 
+                "nevents": 24964, 
+                "totEvents": 24964, 
+                "weights": 78673.5625
+            }, 
+            {
+                "bad": false, 
+                "events": 24961, 
+                "name": "/store/user/spigazzi/flashgg/Era2018_RR-17Sep2018_v2/legacyRun2FullV2/ttHJetToGG_M80_13TeV_amcatnloFXFX_madspin_pythia8/Era2018_RR-17Sep2018_v2-legacyRun2FullV2-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/200104_101831/0000/myMicroAODOutputFile_14.root", 
+                "nevents": 24961, 
+                "totEvents": 24961, 
+                "weights": 76925.9765625
+            }, 
+            {
+                "bad": false, 
+                "events": 24727, 
+                "name": "/store/user/spigazzi/flashgg/Era2018_RR-17Sep2018_v2/legacyRun2FullV2/ttHJetToGG_M80_13TeV_amcatnloFXFX_madspin_pythia8/Era2018_RR-17Sep2018_v2-legacyRun2FullV2-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/200104_101831/0000/myMicroAODOutputFile_6.root", 
+                "nevents": 24727, 
+                "totEvents": 24727, 
+                "weights": 77916.859375
+            }, 
+            {
+                "bad": false, 
+                "events": 23944, 
+                "name": "/store/user/spigazzi/flashgg/Era2018_RR-17Sep2018_v2/legacyRun2FullV2/ttHJetToGG_M80_13TeV_amcatnloFXFX_madspin_pythia8/Era2018_RR-17Sep2018_v2-legacyRun2FullV2-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/200104_101831/0000/myMicroAODOutputFile_11.root", 
+                "nevents": 23944, 
+                "totEvents": 23944, 
+                "weights": 74707.6328125
+            }
+        ], 
+        "parent_n_units": 447020, 
+        "vetted": true
     }
 }

--- a/MetaData/work/campaigns/Era2016_RR-17Jul2018_v2_p7.json
+++ b/MetaData/work/campaigns/Era2016_RR-17Jul2018_v2_p7.json
@@ -1,0 +1,8 @@
+{
+    "data" : [],
+    "sig" : [],
+    "bkg" : 
+    [
+        "/QCD_Pt-30to40_DoubleEMEnriched_MGG-80toInf_TuneCUETP8M1_13TeV_Pythia8/RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2/MINIAODSIM"
+    ]
+}

--- a/MetaData/work/campaigns/Era2016_RR-17Jul2018_v2_p8.json
+++ b/MetaData/work/campaigns/Era2016_RR-17Jul2018_v2_p8.json
@@ -1,0 +1,20 @@
+{
+    "data" : [],
+    "sig" : [
+        "/GluGluHToGG_M-120_13TeV_powheg_pythia8/RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2/MINIAODSIM",
+        "/GluGluHToGG_M-125_13TeV_powheg_pythia8/RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/MINIAODSIM",
+        "/WplusH_HToGG_WToAll_M120_13TeV_powheg_pythia8/RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2/MINIAODSIM",
+        "/WplusH_HToGG_WToAll_M125_13TeV_powheg_pythia8/RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/MINIAODSIM",
+        "/ZH_HToGG_ZToAll_M125_13TeV_powheg_pythia8/RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/MINIAODSIM",
+        "/GluGluHToGG_M124_13TeV_amcatnloFXFX_pythia8/RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/MINIAODSIM",
+        "/VBFHToGG_M-125_13TeV_powheg_pythia8/RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/MINIAODSIM",
+        "/VBFHToGG_M125_13TeV_amcatnlo_pythia8_CUETP8M1Up/RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3_ext1-v2/MINIAODSIM",
+        "/VBFHToGG_M125_13TeV_amcatnlo_pythia8_UpPS/RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2/MINIAODSIM",
+        "/VHToGG_M125_13TeV_amcatnloFXFX_madspin_pythia8_DownPS/RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2/MINIAODSIM",
+        "/ttHJetToGG_M125_13TeV_amcatnloFXFX_madspin_pythia8_CUETP8M1Up/RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2/MINIAODSIM",
+        "/ttHJetToGG_M125_13TeV_amcatnloFXFX_madspin_pythia8_DownPS/RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2/MINIAODSIM",
+        "/ttHJetToGG_M125_13TeV_amcatnloFXFX_madspin_pythia8_UpPS/RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2/MINIAODSIM"
+    ],
+    "bkg" :
+    []
+}

--- a/MetaData/work/campaigns/Era2016_RR-17Jul2018_v2_p9.json
+++ b/MetaData/work/campaigns/Era2016_RR-17Jul2018_v2_p9.json
@@ -1,0 +1,13 @@
+{
+    "data" : [],
+    "bkg" : [],
+    "sig" : [
+        "/VBFHToGG_M105_13TeV_amcatnlo_pythia8/RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2/MINIAODSIM",
+        "/VHToGG_M70_13TeV_amcatnloFXFX_madspin_pythia8/RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3_ext1-v1/MINIAODSIM",
+        "/VHToGG_M75_13TeV_amcatnloFXFX_madspin_pythia8/RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2/MINIAODSIM",
+        "/ttHJetToGG_M75_13TeV_amcatnloFXFX_madspin_pythia8/RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2/MINIAODSIM",
+        "/ttHJetToGG_M80_13TeV_amcatnloFXFX_madspin_pythia8/RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2/MINIAODSIM",
+        "/ttHJetToGG_M85_13TeV_amcatnloFXFX_madspin_pythia8/RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2/MINIAODSIM",
+        "/ttHJetToGG_M95_13TeV_amcatnloFXFX_madspin_pythia8/RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2/MINIAODSIM"
+    ]
+}

--- a/MetaData/work/campaigns/Era2017_RR-31Mar2018_v2_p7.json
+++ b/MetaData/work/campaigns/Era2017_RR-31Mar2018_v2_p7.json
@@ -1,0 +1,8 @@
+{
+    "data" : [],
+    "sig" : [],
+    "bkg" :
+    [
+        "/DiPhotonJetsBox_M40_80-Sherpa/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/MINIAODSIM"
+    ]
+}

--- a/MetaData/work/campaigns/Era2017_RR-31Mar2018_v2_p8.json
+++ b/MetaData/work/campaigns/Era2017_RR-31Mar2018_v2_p8.json
@@ -1,0 +1,12 @@
+{
+    "data" : [],
+    "bkg" : [],
+    "sig" : [
+        "/GluGluHToGG_M80_13TeV_amcatnloFXFX_pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM",
+        "/GluGluHToGG_M85_13TeV_amcatnloFXFX_pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM",
+        "/VBFHToGG_M90_13TeV_amcatnlo_pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM",
+        "/VHToGG_M105_13TeV_amcatnloFXFX_madspin_pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM",
+        "/ttHJetToGG_M65_13TeV_amcatnloFXFX_madspin_pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM",
+        "/ttHJetToGG_M85_13TeV_amcatnloFXFX_madspin_pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM"
+    ]
+}

--- a/MetaData/work/campaigns/Era2018_RR-17Sep2018_v2_p7.json
+++ b/MetaData/work/campaigns/Era2018_RR-17Sep2018_v2_p7.json
@@ -1,0 +1,8 @@
+{
+    "data" : [],
+    "sig" : [],
+    "bkg" : [
+        "/QCD_Pt-30toInf_DoubleEMEnriched_MGG-40to80_TuneCP5_13TeV_Pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/MINIAODSIM"
+    ]
+}
+    

--- a/MetaData/work/campaigns/Era2018_RR-17Sep2018_v2_p8.json
+++ b/MetaData/work/campaigns/Era2018_RR-17Sep2018_v2_p8.json
@@ -1,0 +1,11 @@
+{
+    "data" : [],
+    "sig" : [
+        "/THQ_ctcvcp_HToGG_M123_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/MINIAODSIM",
+        "/THQ_ctcvcp_HToGG_M124_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/MINIAODSIM",
+        "/THQ_ctcvcp_HToGG_M125_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/MINIAODSIM",
+        "/THQ_ctcvcp_HToGG_M126_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/MINIAODSIM",
+        "/THQ_ctcvcp_HToGG_M127_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/MINIAODSIM"
+    ],
+    "bkg" : []
+}

--- a/MetaData/work/campaigns/Era2018_RR-17Sep2018_v2_p9.json
+++ b/MetaData/work/campaigns/Era2018_RR-17Sep2018_v2_p9.json
@@ -1,0 +1,13 @@
+{
+    "data" : [],
+    "bkg" : [],
+    "sig" : [
+            "/ttHJetToGG_M70_13TeV_amcatnloFXFX_madspin_pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/MINIAODSIM",
+            "/ttHJetToGG_M75_13TeV_amcatnloFXFX_madspin_pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/MINIAODSIM",
+            "/ttHJetToGG_M80_13TeV_amcatnloFXFX_madspin_pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/MINIAODSIM",
+            "/ttHJetToGG_M100_13TeV_amcatnloFXFX_madspin_pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/MINIAODSIM",
+            "/ttHJetToGG_M105_13TeV_amcatnloFXFX_madspin_pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/MINIAODSIM",
+            "/ttHJetToGG_M115_TuneCP5_13TeV-amcatnloFXFX-madspin-pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/MINIAODSIM",
+            "/VHToGG_M105_13TeV_amcatnloFXFX_madspin_pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/MINIAODSIM"
+    ]
+}


### PR DESCRIPTION
2016 p9, 2017 p8 and 2018 p9 production jsons.