### PR TITLE
This is currecntly for discussion ONLY

### DIFF
--- a/MetaData/data/MetaConditions/Era2016_RR-17Jul2018_v1.json
+++ b/MetaData/data/MetaConditions/Era2016_RR-17Jul2018_v1.json
@@ -81,6 +81,22 @@
     },
     
     "MUON_ID" : "Medium",
+
+    "flashggTTHLeptonicTag" :
+    {
+     "MUON_ID" : "Medium"
+     },
+
+    "flashggWHLeptonicTag" :
+    {
+     "MUON_ID" : "Tight"
+     },
+
+    "flashggZHLeptonicTag" :
+    { 
+     "MUON_ID" : "Tight"
+     },
+
     "MUON_ISO" : "LooseRel",
     "MUON_ID_JSON_FileName" : "flashgg/Systematics/data/Muon2016_RunBCDEFGH_SF_ID.json",
     "MUON_ID_JSON_FileName_LowPt" : "",

--- a/MetaData/data/MetaConditions/Era2016_RR-17Jul2018_v1.json
+++ b/MetaData/data/MetaConditions/Era2016_RR-17Jul2018_v1.json
@@ -80,22 +80,22 @@
         }
     },
     
-    "MUON_ID" : "Medium",
 
-    "flashggTTHLeptonicTag" :
+    "Default":
     {
-     "MUON_ID" : "Medium"
-     },
+        "MUON_ID" : "Medium"
+    },
 
-    "flashggWHLeptonicTag" :
+    "TTHLep" :
     {
-     "MUON_ID" : "Tight"
+        "MUON_ID" : "Medium"
      },
 
-    "flashggZHLeptonicTag" :
-    { 
-     "MUON_ID" : "Tight"
+    "VHLep" :
+    {
+        "MUON_ID" : "Tight"
      },
+
 
     "MUON_ISO" : "LooseRel",
     "MUON_ID_JSON_FileName" : "flashgg/Systematics/data/Muon2016_RunBCDEFGH_SF_ID.json",

--- a/MetaData/data/MetaConditions/Era2017_RR-31Mar2018_v1.json
+++ b/MetaData/data/MetaConditions/Era2017_RR-31Mar2018_v1.json
@@ -139,22 +139,22 @@
         "MC" : "JetCorrectorParametersCollection_Fall17_17Nov2017_V32_102X_MC_AK4PFchs"
     },
 
-    "MUON_ID" : "Medium",
 
-    "flashggTTHLeptonicTag" :
+    "Default":
     {
-     "MUON_ID" : "Medium"
+        "MUON_ID" : "Medium"
+    },
+
+    "TTHLep" :
+    {
+        "MUON_ID" : "Medium"
      },
 
-    "flashggWHLeptonicTag" :
+    "VHLep" :
     {
-     "MUON_ID" : "Tight"
+        "MUON_ID" : "Tight"
      },
 
-    "flashggZHLeptonicTag" :
-    {
-     "MUON_ID" : "Tight"
-     },
 
     "MUON_ISO" : "LooseRel",
 

--- a/MetaData/data/MetaConditions/Era2017_RR-31Mar2018_v1.json
+++ b/MetaData/data/MetaConditions/Era2017_RR-31Mar2018_v1.json
@@ -140,6 +140,22 @@
     },
 
     "MUON_ID" : "Medium",
+
+    "flashggTTHLeptonicTag" :
+    {
+     "MUON_ID" : "Medium"
+     },
+
+    "flashggWHLeptonicTag" :
+    {
+     "MUON_ID" : "Tight"
+     },
+
+    "flashggZHLeptonicTag" :
+    {
+     "MUON_ID" : "Tight"
+     },
+
     "MUON_ISO" : "LooseRel",
 
     "MUON_ID_JSON_FileName" : "flashgg/Systematics/data/Muon2017_RunBCDEF_SF_ID.json",

--- a/MetaData/data/MetaConditions/Era2018_Prompt_v1.json
+++ b/MetaData/data/MetaConditions/Era2018_Prompt_v1.json
@@ -66,6 +66,22 @@
     },
     
     "MUON_ID" : "Medium",
+
+    "flashggTTHLeptonicTag" :
+    {
+     "MUON_ID" : "Medium"
+     },
+
+    "flashggWHLeptonicTag" :
+    {
+     "MUON_ID" : "Tight"
+     },
+
+    "flashggZHLeptonicTag" :
+    {
+     "MUON_ID" : "Tight"
+     },
+
     "MUON_ISO" : "LooseRel",
 
     "Ele_ID_eff_bin" : "binInfo2018",

--- a/MetaData/data/MetaConditions/Era2018_RR-17Sep2018_v1.json
+++ b/MetaData/data/MetaConditions/Era2018_RR-17Sep2018_v1.json
@@ -127,6 +127,22 @@
 
     
     "MUON_ID" : "Medium",
+
+    "flashggTTHLeptonicTag" :
+    {
+     "MUON_ID" : "Medium"
+     },
+
+    "flashggWHLeptonicTag" :
+    {
+     "MUON_ID" : "Tight"
+     },
+
+    "flashggZHLeptonicTag" :
+    {
+     "MUON_ID" : "Tight"
+     },
+
     "MUON_ISO" : "LooseRel",
 
     "MUON_ID_JSON_FileName" : "flashgg/Systematics/data/Muon2018_RunABCD_SF_ID.json",

--- a/MetaData/data/MetaConditions/Era2018_RR-17Sep2018_v1.json
+++ b/MetaData/data/MetaConditions/Era2018_RR-17Sep2018_v1.json
@@ -125,22 +125,21 @@
                            ]
     },
 
-    
-    "MUON_ID" : "Medium",
+  
 
-    "flashggTTHLeptonicTag" :
+    "Default":
+    {  
+    	"MUON_ID" : "Medium"
+    },
+
+    "TTHLep" :
     {
-     "MUON_ID" : "Medium"
+     	"MUON_ID" : "Medium"
      },
 
-    "flashggWHLeptonicTag" :
+    "VHLep" :
     {
-     "MUON_ID" : "Tight"
-     },
-
-    "flashggZHLeptonicTag" :
-    {
-     "MUON_ID" : "Tight"
+     	"MUON_ID" : "Tight"
      },
 
     "MUON_ISO" : "LooseRel",

--- a/Systematics/python/SystematicsCustomize.py
+++ b/Systematics/python/SystematicsCustomize.py
@@ -70,6 +70,8 @@ def createStandardSystematicsProducers(process, options):
     process.load("flashgg.Systematics.flashggElectronSystematics_cfi")
     process.load("flashgg.Systematics.flashggMetSystematics_cfi")
 
+    LepIDs = ["Default", "VHLep", "TTHLep"]
+
     from flashgg.Taggers.flashggTagSequence_cfi import *
     process.flashggTagSequence = flashggPrepareTagSequence(process, options.metaConditions)
     
@@ -77,7 +79,8 @@ def createStandardSystematicsProducers(process, options):
     diPhotons_syst.setupDiPhotonSystematics( process, options )
 
     import flashgg.Systematics.flashggMuonSystematics_cfi as muon_sf
-    muon_sf.SetupMuonScaleFactors( process ,  options.metaConditions["MUON_ID_JSON_FileName"],  options.metaConditions["MUON_ID_JSON_FileName_LowPt"], options.metaConditions["MUON_ISO_JSON_FileName"], options.metaConditions["MUON_ID"], options.metaConditions["MUON_ISO"], options.metaConditions["MUON_ID_RefTracks"],options.metaConditions["MUON_ID_RefTracks_LowPt"] )
+    for i in range(len(LepIDs)):
+	muon_sf.SetupMuonScaleFactors( process ,  options.metaConditions["MUON_ID_JSON_FileName"],  options.metaConditions["MUON_ID_JSON_FileName_LowPt"], options.metaConditions["MUON_ISO_JSON_FileName"], options.metaConditions[LepIDs[i]]["MUON_ID"], options.metaConditions["MUON_ISO"], options.metaConditions["MUON_ID_RefTracks"],options.metaConditions["MUON_ID_RefTracks_LowPt"], i )
    
     #scale factors for electron ID
     from   flashgg.Systematics.flashggElectronSystematics_cfi import EleSF_JSONReader
@@ -101,6 +104,9 @@ def modifyTagSequenceForSystematics(process,jetSystematicsInputTags,ZPlusJetMode
     massSearchReplaceAnyInputTag(process.flashggTagSequence,cms.InputTag("flashggDifferentialPhoIdInputsCorrection"),cms.InputTag("flashggDiPhotonSystematics"))
     massSearchReplaceAnyInputTag(process.flashggTagSequence,cms.InputTag("flashggSelectedElectrons"),cms.InputTag("flashggElectronSystematics"))
     massSearchReplaceAnyInputTag(process.flashggTagSequence,cms.InputTag("flashggSelectedMuons"),cms.InputTag("flashggMuonSystematics"))
+    process.flashggWHLeptonicTag.MuonTag = cms.InputTag("flashggMuonSystematicsVH")
+    process.flashggZHLeptonicTag.MuonTag = cms.InputTag("flashggMuonSystematicsVH")
+    process.flashggTTHLeptonicTag.MuonTag = cms.InputTag("flashggMuonSystematicsTTH")
     massSearchReplaceAnyInputTag(process.flashggTagSequence,cms.InputTag("flashggMets"),cms.InputTag("flashggMetSystematics"))
     from flashgg.Taggers.flashggTags_cff import UnpackedJetCollectionVInputTag
     for i in range(len(jetSystematicsInputTags)):
@@ -172,6 +178,10 @@ def cloneTagSequenceForEachSystematic(process,systlabels=[],phosystlabels=[],met
             process.flashggSystTagMerger.src.append(cms.InputTag("flashggZPlusJetTag" + systlabel))
         else:
             process.flashggSystTagMerger.src.append(cms.InputTag("flashggTagSorter" + systlabel))
+
+
+
+#def modifySystematicsWorkflowForVHLep(process, systlabels, phosystlabels, metsystlabels, jetsystlabels):
 
 # ttH tags use large BDTs and DNNs that take up lots of memory and cause crashes with normal workflow
 # This function modifies the workflow so that systematic variations are evaluated in a single instance of the tagger, rather than individual instances for each variation

--- a/Systematics/python/flashggMuonSystematics_cfi.py
+++ b/Systematics/python/flashggMuonSystematics_cfi.py
@@ -192,9 +192,14 @@ flashggMuonSystematics = cms.EDProducer('FlashggMuonEffSystematicProducer',
 					SystMethods2D = cms.VPSet(),
 					SystMethods = cms.VPSet()
                                         )
+flashggMuonSystematicsVH = flashggMuonSystematics.clone()
+flashggMuonSystematicsTTH = flashggMuonSystematics.clone()
+
+
+
 
 import exceptions
-def SetupMuonScaleFactors( process , id_file_name, id_lowpt_file_name, iso_file_name, id_name , iso_name , id_ref_tracks, id_lowpt_ref_tracks):
+def SetupMuonScaleFactors( process , id_file_name, id_lowpt_file_name, iso_file_name, id_name , iso_name , id_ref_tracks, id_lowpt_ref_tracks, code=0):
 
     minAnaPt = 5
     extendPtValID = 0
@@ -211,7 +216,14 @@ def SetupMuonScaleFactors( process , id_file_name, id_lowpt_file_name, iso_file_
         MUON_ISO_ScaleFactors[ iso ] = MuonSF_JSONReader( iso_file_name , "NUM_" + iso , "", "", extendPtValISO)
 
     if id_name in MUON_ID_ScaleFactors.keys():
-        process.flashggMuonSystematics.SystMethods.append( MUON_ID_ScaleFactors[id_name].GetPSet(str("Muon" + id_name + "IDWeight")) )
+	if (code == 0):
+        	process.flashggMuonSystematics.SystMethods.append( MUON_ID_ScaleFactors[id_name].GetPSet(str("Muon" + id_name + "IDWeight")) )
+	elif (code == 1):
+		process.flashggMuonSystematicsVH.SystMethods.append( MUON_ID_ScaleFactors[id_name].GetPSet(str("Muon" + id_name + "IDWeight")) )
+	elif (code == 2):
+		process.flashggMuonSystematicsTTH.SystMethods.append( MUON_ID_ScaleFactors[id_name].GetPSet(str("Muon" + id_name + "IDWeight")) )
+	else:
+		raise NameError("%s Is NOT a valid code[HARDCODED]. 0 : Default; 1 : VH; 2 : TTH" % code )
     else :
         raise NameError("%s id for muon is not valid" % id_name )
 

--- a/Systematics/test/workspaceStd.py
+++ b/Systematics/test/workspaceStd.py
@@ -378,7 +378,7 @@ if is_signal:
             variablesToUse.append("TriggerWeight%s01sigma[1,-999999.,999999.] := weight(\"TriggerWeight%s01sigma\")" % (direction,direction))
             variablesToUse.append("FracRVWeight%s01sigma[1,-999999.,999999.] := weight(\"FracRVWeight%s01sigma\")" % (direction,direction))
             variablesToUse.append("FracRVNvtxWeight%s01sigma[1,-999999.,999999.] := weight(\"FracRVNvtxWeight%s01sigma\")" % (direction,direction))
-            variablesToUse.append("MuonIDWeight%s01sigma[1,-999999.,999999.] := weight(\"Muon%sIDWeight%s01sigma\")" % (direction,str(customize.metaConditions["MUON_ID"]),direction))
+            variablesToUse.append("MuonIDWeight%s01sigma[1,-999999.,999999.] := weight(\"Muon%sIDWeight%s01sigma\")" % (direction,str(customize.metaConditions["Default"]["MUON_ID"]),direction))
             variablesToUse.append("ElectronIDWeight%s01sigma[1,-999999.,999999.] := weight(\"ElectronIDWeight%s01sigma\")" % (direction,direction))
             variablesToUse.append("ElectronRecoWeight%s01sigma[1,-999999.,999999.] := weight(\"ElectronRecoWeight%s01sigma\")" % (direction,direction))
             variablesToUse.append("MuonIsoWeight%s01sigma[1,-999999.,999999.] := weight(\"Muon%sISOWeight%s01sigma\")" % (direction,str(customize.metaConditions['MUON_ISO']),direction))
@@ -645,13 +645,14 @@ if customize.tthTagsOnly:
     modifySystematicsWorkflowForttH(process, systlabels, phosystlabels, metsystlabels, jetsystlabels)
 
 else :
+    process.TestMuonSyst = process.flashggMuonSystematics.clone()
     process.p = cms.Path(process.dataRequirements*
                          process.flashggMetFilters*
                          process.genFilter*
-                         process.flashggDifferentialPhoIdInputsCorrection*
-                         process.flashggDiPhotonSystematics*
-                         process.flashggMetSystematics*
-                         process.flashggMuonSystematics*process.flashggElectronSystematics*
+                        process.flashggDifferentialPhoIdInputsCorrection*
+                        process.flashggDiPhotonSystematics*
+                        process.flashggMetSystematics*
+                        process.flashggMuonSystematics*process.flashggElectronSystematics*
                          (process.flashggUnpackedJets*process.jetSystematicsSequence)*
                          (process.flashggTagSequence*process.systematicsTagSequences)*
                          process.flashggSystTagMerger*


### PR DESCRIPTION
Need to disambiguate the different lep. ID choices for electrons and muons between the TTHLep and VHLep tags.
For now put in a proposed fix for muons only. The implementation is clumsy, since this is currently very entangled in a few places. Hence looking for suggestions for alternatives. Even with the current implementation need to review if [1] and the corresponding variable for electrons is later used in the final fits, in which case these need disambiguation as well.

Tests done: 1) explicitly checks that the relevant tags are picking up the desired IDs 
                  2) Ran on a single file and that works too



[1]: https://github.com/rchatter/flashgg/blob/Rajdeep_Working/Systematics/test/workspaceStd.py#L381