### PR TITLE
updating 2018 GTs from PPD latest recommendations

### DIFF
--- a/MetaData/data/MetaConditions/Era2018_Prompt_v1.json
+++ b/MetaData/data/MetaConditions/Era2018_Prompt_v1.json
@@ -1,8 +1,8 @@
 {
     "globalTags" :
     {
-        "data" : "102X_dataRun2_Prompt_v11",
-        "MC" : "102X_upgrade2018_realistic_v12"
+        "data" : "102X_dataRun2_Prompt_v15",
+        "MC" : "102X_upgrade2018_realistic_v19"
     },
 
     "flashggMETsFunction" : "runMETs2016",

--- a/MetaData/data/MetaConditions/Era2018_RR-17Sep2018_v1.json
+++ b/MetaData/data/MetaConditions/Era2018_RR-17Sep2018_v1.json
@@ -1,8 +1,8 @@
 {
     "globalTags" :
     {
-        "data" : "102X_dataRun2_v10",
-        "MC" : "102X_upgrade2018_realistic_v18"
+        "data" : "102X_dataRun2_v12",
+        "MC" : "102X_upgrade2018_realistic_v19"
     },
 
     "flashggMETsFunction" : "runMETs2016",


### PR DESCRIPTION
Dear Simone,

I am making this PR to update the 2018 GTs according to the latest PPD recommendation. But before you merge I need to clear a few points.
1. For 2018 Data, GTs work perfectly.
2. For 2018 MC, the v20 2018 shows the error [1] when I try to run on 2018 mircoAODs so, for now, I have kept it v19 (from link [2], it shows that only uncertainty changes between v19 and v20 mc tag, central values are same). 

The problem with v20 also was reported at [3] in December so I preferred to stick with v19. If you find that v19 is good then GTs are correct but if we need to go with v20 then could you please help me fix the error?

Thanks,
Lata

[1] Begin processing the 1st record. Run 1, Event 604005, LumiSection 605 on stream 0 at 15-Feb-2020 09:08:22.547 CET
----- Begin Fatal Exception 15-Feb-2020 09:09:08 CET-----------------------
An exception of category 'NotFound' occurred while
   [0] Processing  Event run: 1 lumi: 605 event: 604005 stream: 0
   [1] Running path 'p'
   [2] Calling method for module FlashggJetSystematicProducer/'flashggJetSystematics0'
Exception Message:
JER parametrisation depends on 'JetPt' but no value for this parameter has been specified. Please call the appropriate 'set' function of the JME::JetParameters object 
----- End Fatal Exception -------------------------------------------------

[2] https://hypernews.cern.ch/HyperNews/CMS/get/jes/898.html

[3] https://hypernews.cern.ch/HyperNews/CMS/get/jes/933.html
