### PR TITLE
Use RECO triggerCollection for data, PAT triggerCollection for MC

### DIFF
--- a/Systematics/python/flashggMetFilters_cfi.py
+++ b/Systematics/python/flashggMetFilters_cfi.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
 flashggMetFilters = cms.EDFilter("flashggMetFilters",
-                                 filtersInputTag = cms.InputTag("TriggerResults", "", "RECO"),
+                                 filtersInputTag = cms.InputTag("TriggerResults", "", ""),
                                  requiredFilterNames = cms.untracked.vstring(),
 )

--- a/Systematics/test/workspaceStd.py
+++ b/Systematics/test/workspaceStd.py
@@ -621,10 +621,13 @@ process.load('flashgg/Systematics/flashggMetFilters_cfi')
 
 if customize.processId == "Data":
     metFilterSelector = "data"
+    filtersInputTag = cms.InputTag("TriggerResults", "", "RECO")
 else:
     metFilterSelector = "mc"
+    filtersInputTag = cms.InputTag("TriggerResults", "", "PAT")
 
 process.flashggMetFilters.requiredFilterNames = cms.untracked.vstring([filter.encode("ascii") for filter in customize.metaConditions["flashggMetFilters"][metFilterSelector]])
+process.flashggMetFilters.filtersInputTag = filtersInputTag
 
 if customize.tthTagsOnly:
     process.p = cms.Path(process.dataRequirements*


### PR DESCRIPTION
In MC microAOD, there are both "PAT" and "RECO" collections. The "PAT" collection contains the relevant filters [1], while the "RECO" collection contains only these filters [2] which are unimportant for our purposes. For reference, I am talking about this microAOD file [3].

However, in data microAOD files, the "PAT" collection is not always there (I find it in some 2017 files, but not all, and not in 2016 or 2018 data files), but the "RECO" collection is always there. For data, the "RECO" collection contains the relevant filters [4]. Again for reference, here's the file [5]. For a given microAOD, you can check which TriggerResults collections are present with e.g. [6].

The "PAT" collection has the filter results we need for MC files, while the "RECO" collection has the filter results we need for data files, so we toggle between the two depending on the input file.

[1] 
Flag_HBHENoiseFilter
Flag_HBHENoiseIsoFilter
Flag_CSCTightHaloFilter
Flag_CSCTightHaloTrkMuUnvetoFilter
Flag_CSCTightHalo2015Filter
Flag_globalTightHalo2016Filter
Flag_globalSuperTightHalo2016Filter
Flag_HcalStripHaloFilter
Flag_hcalLaserEventFilter
Flag_EcalDeadCellTriggerPrimitiveFilter
Flag_EcalDeadCellBoundaryEnergyFilter
Flag_ecalBadCalibFilter
Flag_goodVertices
Flag_eeBadScFilter
Flag_ecalLaserCorrFilter
Flag_trkPOGFilters
Flag_chargedHadronTrackResolutionFilter
Flag_muonBadTrackFilter
Flag_BadChargedCandidateFilter
Flag_BadPFMuonFilter
Flag_BadChargedCandidateSummer16Filter
Flag_BadPFMuonSummer16Filter
Flag_trkPOG_manystripclus53X
Flag_trkPOG_toomanystripclus53X
Flag_trkPOG_logErrorTooManyClusters
Flag_METFilters

[2]
raw2digi_step
reconstruction_step
recosim_step
eventinterpretaion_step

[3] root://cms-xrd-global.cern.ch//store/user/spigazzi/flashgg/Era2017_RR-31Mar2018_v2/legacyRun2FullV1/ttHJetToGG_M125_13TeV_amcatnloFXFX_madspin_pythia8/Era2017_RR-31Mar2018_v2-legacyRun2FullV1-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/190703_133141/0000/myMicroAODOutputFile_8.root

[4] 
raw2digi_step
L1Reco_step
reconstruction_step
EXOMONOPOLEPath
ZElectronPathGsf
pathALCARECOEcalESAlign
pathALCARECOEcalUncalWElectron
pathALCARECOHcalCalIsoTrkFilter
pathALCARECOHcalCalIterativePhiSym
pathALCARECOEcalUncalZElectron
pathALCARECOEcalUncalZSCElectron
eventinterpretaion_step
Flag_HBHENoiseFilter
Flag_HBHENoiseIsoFilter
Flag_CSCTightHaloFilter
Flag_CSCTightHaloTrkMuUnvetoFilter
Flag_CSCTightHalo2015Filter
Flag_globalTightHalo2016Filter
Flag_globalSuperTightHalo2016Filter
Flag_HcalStripHaloFilter
Flag_hcalLaserEventFilter
Flag_EcalDeadCellTriggerPrimitiveFilter
Flag_EcalDeadCellBoundaryEnergyFilter
Flag_ecalBadCalibFilter
Flag_goodVertices
Flag_eeBadScFilter
Flag_ecalLaserCorrFilter
Flag_trkPOGFilters
Flag_chargedHadronTrackResolutionFilter
Flag_muonBadTrackFilter
Flag_BadChargedCandidateFilter
Flag_BadPFMuonFilter
Flag_BadChargedCandidateSummer16Filter
Flag_BadPFMuonSummer16Filter
Flag_trkPOG_manystripclus53X
Flag_trkPOG_toomanystripclus53X
Flag_trkPOG_logErrorTooManyClusters
Flag_METFilters

[5] root://cms-xrd-global.cern.ch//store/user/spigazzi/flashgg/Era2018_RR-17Sep2018_v2/legacyRun2FullV2/EGamma/Era2018_RR-17Sep2018_v2-legacyRun2FullV2-v0-Run2018A-17Sep2018-v2/190610_103420/0001/myMicroAODOutputFile_1527.root

[6] edmDumpEventContent root://cms-xrd-global.cern.ch//store/user/spigazzi/flashgg/Era2018_RR-17Sep2018_v2/legacyRun2FullV2/EGamma/Era2018_RR-17Sep2018_v2-legacyRun2FullV2-v0-Run2018A-17Sep2018-v2/190610_103420/0001/myMicroAODOutputFile_1527.root | grep "TriggerResults"