### PR TITLE
Fix fatal ROOT error on lxbatch nodes in CMSSW_10_6_X

### DIFF
--- a/MetaData/python/parallel.py
+++ b/MetaData/python/parallel.py
@@ -431,6 +431,7 @@ class HTCondorJob(object):
             fout.write('+JobFlavour   = "'+self.htcondorQueue+'"\n\n')
             fout.write('+OnExitHold   = ExitStatus != 0 \n\n')
             fout.write('periodic_release =  (NumJobStarts < 4) && ((CurrentTime - EnteredCurrentStatus) > 60) \n\n')
+            fout.write('getenv        = True \n')
             fout.write('input         = %s/.dasmaps/das_maps_dbs_prod.js \n' % os.environ['HOME'])
             fout.write('executable    = '+self.execName+'\n')
             fout.write('arguments     = $(ProcId)\n')


### PR DESCRIPTION
The following error appeared after moving to CMSSW_10_6_1 while running on lxbatch.

[a] Fatal Root Error: @SUB=TSystem::ExpandFileName
input: $HOME/.root.mimes, output: $HOME/.root.mimes

The root cause is probably the use of some interactive-like features of ROOT.

The fix make sure that the local user environment is copied to the worker node by using the `getenv`
option available in condor.