### PR TITLE
Fix a bug in the computation of Up and Down MVA shift

### DIFF
--- a/Systematics/plugins/PhotonMvaTransform.cc
+++ b/Systematics/plugins/PhotonMvaTransform.cc
@@ -92,7 +92,8 @@ namespace flashgg {
             for(auto keyval = beforeMap.begin(); keyval != beforeMap.end(); ++keyval) {
                 vtx = keyval->first;
                 mvaVal = keyval->second;
-                shift = shift_val + (mvaVal - corrections_[correctionIndex]->Eval(mvaVal))*abs(syst_shift);
+                //shift = shift_val + (mvaVal - corrections_[correctionIndex]->Eval(mvaVal))*abs(syst_shift); // AL Up/Down fix
+                shift = shift_val + (corrections_[correctionIndex]->Eval(mvaVal) - mvaVal )*abs(syst_shift);
                 y.shiftMvaValueBy(shift, vtx);
             }
             if ( debug_) {

--- a/Systematics/plugins/PhotonMvaTransform.cc
+++ b/Systematics/plugins/PhotonMvaTransform.cc
@@ -92,7 +92,6 @@ namespace flashgg {
             for(auto keyval = beforeMap.begin(); keyval != beforeMap.end(); ++keyval) {
                 vtx = keyval->first;
                 mvaVal = keyval->second;
-                //shift = shift_val + (mvaVal - corrections_[correctionIndex]->Eval(mvaVal))*abs(syst_shift); // AL Up/Down fix
                 shift = shift_val + (corrections_[correctionIndex]->Eval(mvaVal) - mvaVal )*abs(syst_shift);
                 y.shiftMvaValueBy(shift, vtx);
             }


### PR DESCRIPTION
Found a bug that causes the up and down shift of the phoID MVA syst unc to be flipped:

- The input to the shifts are graph that map the nominal_MVA to the shifted_MVA value.
- The correction was computed as nominal_MVA-shifted_MVA and this value is then add back to the original_MVA (this is also unnecessary in itself, should be investigated further).
- FIX: nominal-shifted replaced by shifted-nominal.