### PR TITLE
2 categories VBFHH training

### DIFF
--- a/MetaData/data/MetaConditions/Era2016_RR-17Jul2018_v1.json
+++ b/MetaData/data/MetaConditions/Era2016_RR-17Jul2018_v1.json
@@ -259,11 +259,27 @@
         "jetID" : "Loose",
         "weightsFile" : {
                 "with_Mjj" : "flashgg/Taggers/data/HHTagger/training_30_04_2020_vbfHHbbgg_C2V0_2016.weights.xml",
-                "wo_Mjj" : "flashgg/Taggers/data/HHTagger/training_with_2016_new_vbfhh_signal_07_05_2020.weights.xml"
+                "wo_Mjj" : "flashgg/Taggers/data/HHTagger/training_30_04_2020_vbfHHbbgg_C2V0_2016.weights.xml"
         },
         "MVAFlatteningFileName" : {
                 "with_Mjj" : "flashgg/Taggers/data/HHTagger/cumulativeTrans_30_04_2020_vbfHHbbgg_C2V0_training_2016.root",
-                "wo_Mjj" : "flashgg/Taggers/data/HHTagger/cumulativeTransformation_2016_new_vbfhh_signal_07_05_2020.root"
+                "wo_Mjj" : "flashgg/Taggers/data/HHTagger/cumulativeTrans_30_04_2020_vbfHHbbgg_C2V0_training_2016.root"
+        },
+        "weightsFileCAT0" : {
+                "with_Mjj" : "flashgg/Taggers/data/HHTagger/training_with_2016_single_qqHHcat_14_5_2020.weights.xml",
+                "wo_Mjj" : "flashgg/Taggers/data/HHTagger/training_with_2016_single_qqHHcat_14_5_2020.weights.xml"
+        },
+        "MVAFlatteningFileNameCAT0" : {
+                "with_Mjj" : "flashgg/Taggers/data/HHTagger/cumulativeTransformation_qqHH_single_2016_cat_14_5_2020.root",
+                "wo_Mjj" : "flashgg/Taggers/data/HHTagger/cumulativeTransformation_qqHH_single_2016_cat_14_5_2020.root"
+        },
+        "weightsFileCAT1" : {
+                "with_Mjj" : "flashgg/Taggers/data/HHTagger/training_with_2016_double_qqHHcat_MX_lt_500GeV_28_5_2020_withSM.weights.xml",
+                "wo_Mjj" : "flashgg/Taggers/data/HHTagger/training_with_2016_double_qqHHcat_MX_lt_500GeV_28_5_2020_withSM.weights.xml"
+        },
+        "MVAFlatteningFileNameCAT1" : {
+                "with_Mjj" : "flashgg/Taggers/data/HHTagger/cumulativeTransformation_SMqqHH_28_05_2020_MX_lt_500_2016.root",
+                "wo_Mjj" : "flashgg/Taggers/data/HHTagger/cumulativeTransformation_SMqqHH_28_05_2020_MX_lt_500_2016.root"
         },
         "MVAscalingValue" : 1.0,
         "ttHWeightfile" : "flashgg/Taggers/data/ttHKiller/Keras2017_converted_allnode.pb",

--- a/MetaData/data/MetaConditions/Era2016_RR-17Jul2018_v1.json
+++ b/MetaData/data/MetaConditions/Era2016_RR-17Jul2018_v1.json
@@ -107,6 +107,7 @@
 
     "flashggJetSystematics" : 
     {  
+        "doHEMuncertainty" : false,
         "textFileName" : "flashgg/Systematics/data/JEC/Regrouped_Summer16_07Aug2017_V11_MC_UncertaintySources_AK4PFchs.txt",
         "listOfSources" : [
                            "Absolute",

--- a/MetaData/data/MetaConditions/Era2016_RR-17Jul2018_v1.json
+++ b/MetaData/data/MetaConditions/Era2016_RR-17Jul2018_v1.json
@@ -266,20 +266,20 @@
                 "wo_Mjj" : "flashgg/Taggers/data/HHTagger/cumulativeTrans_30_04_2020_vbfHHbbgg_C2V0_training_2016.root"
         },
         "weightsFileCAT0" : {
-                "with_Mjj" : "flashgg/Taggers/data/HHTagger/training_with_2016_single_qqHHcat_14_5_2020.weights.xml",
-                "wo_Mjj" : "flashgg/Taggers/data/HHTagger/training_with_2016_single_qqHHcat_14_5_2020.weights.xml"
+                "with_Mjj" : "flashgg/Taggers/data/HHTagger/training_with_2016_12_06_2020_mixed_signal_MX_gt_500.weights.xml",
+                "wo_Mjj" : "flashgg/Taggers/data/HHTagger/training_with_2016_12_06_2020_mixed_signal_MX_gt_500.weights.xml"
         },
         "MVAFlatteningFileNameCAT0" : {
-                "with_Mjj" : "flashgg/Taggers/data/HHTagger/cumulativeTransformation_qqHH_single_2016_cat_14_5_2020.root",
-                "wo_Mjj" : "flashgg/Taggers/data/HHTagger/cumulativeTransformation_qqHH_single_2016_cat_14_5_2020.root"
+                "with_Mjj" : "flashgg/Taggers/data/HHTagger/cumulativeTransformation_Total_preselection_diffNaming_2016_12_06_2020_MX_gt_500.root",
+                "wo_Mjj" : "flashgg/Taggers/data/HHTagger/cumulativeTransformation_Total_preselection_diffNaming_2016_12_06_2020_MX_gt_500.root"
         },
         "weightsFileCAT1" : {
-                "with_Mjj" : "flashgg/Taggers/data/HHTagger/training_with_2016_double_qqHHcat_MX_lt_500GeV_28_5_2020_withSM.weights.xml",
-                "wo_Mjj" : "flashgg/Taggers/data/HHTagger/training_with_2016_double_qqHHcat_MX_lt_500GeV_28_5_2020_withSM.weights.xml"
+                "with_Mjj" : "flashgg/Taggers/data/HHTagger/training_with_2016_12_06_2020_mixed_signal_MX_lt_500.weights.xml",
+                "wo_Mjj" : "flashgg/Taggers/data/HHTagger/training_with_2016_12_06_2020_mixed_signal_MX_lt_500.weights.xml"
         },
         "MVAFlatteningFileNameCAT1" : {
-                "with_Mjj" : "flashgg/Taggers/data/HHTagger/cumulativeTransformation_SMqqHH_28_05_2020_MX_lt_500_2016.root",
-                "wo_Mjj" : "flashgg/Taggers/data/HHTagger/cumulativeTransformation_SMqqHH_28_05_2020_MX_lt_500_2016.root"
+                "with_Mjj" : "flashgg/Taggers/data/HHTagger/cumulativeTransformation_Total_preselection_diffNaming_2016_12_06_2020_MX_lt_500.root",
+                "wo_Mjj" : "flashgg/Taggers/data/HHTagger/cumulativeTransformation_Total_preselection_diffNaming_2016_12_06_2020_MX_lt_500.root"
         },
         "MVAscalingValue" : 1.0,
         "ttHWeightfile" : "flashgg/Taggers/data/ttHKiller/Keras2017_converted_allnode.pb",

--- a/MetaData/data/MetaConditions/Era2017_RR-31Mar2018_v1.json
+++ b/MetaData/data/MetaConditions/Era2017_RR-31Mar2018_v1.json
@@ -103,6 +103,7 @@
 
     "flashggJetSystematics" : 
     {  
+        "doHEMuncertainty" : false,
         "textFileName" : "flashgg/Systematics/data/JEC/Regrouped_Fall17_17Nov2017_V32_MC_UncertaintySources_AK4PFchs.txt",
         "listOfSources" : [
                            "Absolute",

--- a/MetaData/data/MetaConditions/Era2017_RR-31Mar2018_v1.json
+++ b/MetaData/data/MetaConditions/Era2017_RR-31Mar2018_v1.json
@@ -269,7 +269,6 @@
     "VBFdoubleHTag":
     {
         "jetID" : "Tight2017",
-        "MVAscalingValue" : 1.0,
         "weightsFile" : {
                 "with_Mjj" : "flashgg/Taggers/data/HHTagger/training_30_04_2020_vbfHHbbgg_C2V0_2017.weights.xml",
                 "wo_Mjj" : "flashgg/Taggers/data/HHTagger/training_30_04_2020_vbfHHbbgg_C2V0_2017.weights.xml"
@@ -278,6 +277,23 @@
                 "with_Mjj" : "flashgg/Taggers/data/HHTagger/cumulativeTrans_30_04_2020_vbfHHbbgg_C2V0_training_2017.root",
                 "wo_Mjj" : "flashgg/Taggers/data/HHTagger/cumulativeTrans_30_04_2020_vbfHHbbgg_C2V0_training_2017.root"
         },
+        "weightsFileCAT0" : {
+                "with_Mjj" : "flashgg/Taggers/data/HHTagger/training_with_2017_single_qqHHcat_14_5_2020.weights.xml",
+                "wo_Mjj" : "flashgg/Taggers/data/HHTagger/training_with_2017_single_qqHHcat_14_5_2020.weights.xml"
+        },
+        "MVAFlatteningFileNameCAT0" : {
+                "with_Mjj" : "flashgg/Taggers/data/HHTagger/cumulativeTransformation_qqHH_single_2017_cat_14_5_2020.root",
+                "wo_Mjj" : "flashgg/Taggers/data/HHTagger/cumulativeTransformation_qqHH_single_2017_cat_14_5_2020.root"
+        },
+        "weightsFileCAT1" : {
+                "with_Mjj" : "flashgg/Taggers/data/HHTagger/training_with_2017_double_qqHHcat_MX_lt_500GeV_28_5_2020_withSM.weights.xml",
+                "wo_Mjj" : "flashgg/Taggers/data/HHTagger/training_with_2017_double_qqHHcat_MX_lt_500GeV_28_5_2020_withSM.weights.xml"
+        },
+        "MVAFlatteningFileNameCAT1" : {
+                "with_Mjj" : "flashgg/Taggers/data/HHTagger/cumulativeTransformation_SMqqHH_28_05_2020_MX_lt_500_2017.root",
+                "wo_Mjj" : "flashgg/Taggers/data/HHTagger/cumulativeTransformation_SMqqHH_28_05_2020_MX_lt_500_2017.root"
+        },
+        "MVAscalingValue" : 1.0,
         "ttHWeightfile" : "flashgg/Taggers/data/ttHKiller/Keras2017_converted_allnode.pb",
         "ttHKiller_mean" : [  3.22491144e+02,   7.22919780e+01,   1.49387571e-01,   4.94052483e-03,
                               5.10246425e-04,   1.38947662e+00,   5.31453078e+00,   7.45455854e+00,

--- a/MetaData/data/MetaConditions/Era2017_RR-31Mar2018_v1.json
+++ b/MetaData/data/MetaConditions/Era2017_RR-31Mar2018_v1.json
@@ -278,20 +278,20 @@
                 "wo_Mjj" : "flashgg/Taggers/data/HHTagger/cumulativeTrans_30_04_2020_vbfHHbbgg_C2V0_training_2017.root"
         },
         "weightsFileCAT0" : {
-                "with_Mjj" : "flashgg/Taggers/data/HHTagger/training_with_2017_single_qqHHcat_14_5_2020.weights.xml",
-                "wo_Mjj" : "flashgg/Taggers/data/HHTagger/training_with_2017_single_qqHHcat_14_5_2020.weights.xml"
+                "with_Mjj" : "flashgg/Taggers/data/HHTagger/training_with_2017_12_06_2020_mixed_signal_MX_gt_500.weights.xml",
+                "wo_Mjj" : "flashgg/Taggers/data/HHTagger/training_with_2017_12_06_2020_mixed_signal_MX_gt_500.weights.xml"
         },
         "MVAFlatteningFileNameCAT0" : {
-                "with_Mjj" : "flashgg/Taggers/data/HHTagger/cumulativeTransformation_qqHH_single_2017_cat_14_5_2020.root",
-                "wo_Mjj" : "flashgg/Taggers/data/HHTagger/cumulativeTransformation_qqHH_single_2017_cat_14_5_2020.root"
+                "with_Mjj" : "flashgg/Taggers/data/HHTagger/cumulativeTransformation_Total_preselection_diffNaming_2017_12_06_2020_MX_gt_500.root",
+                "wo_Mjj" : "flashgg/Taggers/data/HHTagger/cumulativeTransformation_Total_preselection_diffNaming_2017_12_06_2020_MX_gt_500.root"
         },
         "weightsFileCAT1" : {
-                "with_Mjj" : "flashgg/Taggers/data/HHTagger/training_with_2017_double_qqHHcat_MX_lt_500GeV_28_5_2020_withSM.weights.xml",
-                "wo_Mjj" : "flashgg/Taggers/data/HHTagger/training_with_2017_double_qqHHcat_MX_lt_500GeV_28_5_2020_withSM.weights.xml"
+                "with_Mjj" : "flashgg/Taggers/data/HHTagger/training_with_2017_12_06_2020_mixed_signal_MX_lt_500.weights.xml",
+                "wo_Mjj" : "flashgg/Taggers/data/HHTagger/training_with_2017_12_06_2020_mixed_signal_MX_lt_500.weights.xml"
         },
         "MVAFlatteningFileNameCAT1" : {
-                "with_Mjj" : "flashgg/Taggers/data/HHTagger/cumulativeTransformation_SMqqHH_28_05_2020_MX_lt_500_2017.root",
-                "wo_Mjj" : "flashgg/Taggers/data/HHTagger/cumulativeTransformation_SMqqHH_28_05_2020_MX_lt_500_2017.root"
+                "with_Mjj" : "flashgg/Taggers/data/HHTagger/cumulativeTransformation_Total_preselection_diffNaming_2017_12_06_2020_MX_lt_500.root",
+                "wo_Mjj" : "flashgg/Taggers/data/HHTagger/cumulativeTransformation_Total_preselection_diffNaming_2017_12_06_2020_MX_lt_500.root"
         },
         "MVAscalingValue" : 1.0,
         "ttHWeightfile" : "flashgg/Taggers/data/ttHKiller/Keras2017_converted_allnode.pb",

--- a/MetaData/data/MetaConditions/Era2018_RR-17Sep2018_v1.json
+++ b/MetaData/data/MetaConditions/Era2018_RR-17Sep2018_v1.json
@@ -255,7 +255,6 @@
     "VBFdoubleHTag":
     {
         "jetID" : "Tight2018",
-        "MVAscalingValue" : 1.0,
         "weightsFile" : {
             "with_Mjj" : "flashgg/Taggers/data/HHTagger/training_30_04_2020_vbfHHbbgg_C2V0_2018.weights.xml",
             "wo_Mjj" : "flashgg/Taggers/data/HHTagger/training_30_04_2020_vbfHHbbgg_C2V0_2018.weights.xml"
@@ -264,6 +263,23 @@
             "with_Mjj" : "flashgg/Taggers/data/HHTagger/cumulativeTrans_30_04_2020_vbfHHbbgg_C2V0_training_2018.root",
             "wo_Mjj" : "flashgg/Taggers/data/HHTagger/cumulativeTrans_30_04_2020_vbfHHbbgg_C2V0_training_2018.root"
         },
+        "weightsFileCAT0" : {
+                "with_Mjj" : "flashgg/Taggers/data/HHTagger/training_with_2018_single_qqHHcat_14_5_2020.weights.xml",
+                "wo_Mjj" : "flashgg/Taggers/data/HHTagger/training_with_2018_single_qqHHcat_14_5_2020.weights.xml"
+        },
+        "MVAFlatteningFileNameCAT0" : {
+                "with_Mjj" : "flashgg/Taggers/data/HHTagger/cumulativeTransformation_qqHH_single_2018_cat_14_5_2020.root",
+                "wo_Mjj" : "flashgg/Taggers/data/HHTagger/cumulativeTransformation_qqHH_single_2018_cat_14_5_2020.root"
+        },
+        "weightsFileCAT1" : {
+                "with_Mjj" : "flashgg/Taggers/data/HHTagger/training_with_2018_double_qqHHcat_MX_lt_500GeV_28_5_2020_withSM.weights.xml",
+                "wo_Mjj" : "flashgg/Taggers/data/HHTagger/training_with_2018_double_qqHHcat_MX_lt_500GeV_28_5_2020_withSM.weights.xml"
+        },
+        "MVAFlatteningFileNameCAT1" : {
+                "with_Mjj" : "flashgg/Taggers/data/HHTagger/cumulativeTransformation_SMqqHH_28_05_2020_MX_lt_500_2018.root",
+                "wo_Mjj" : "flashgg/Taggers/data/HHTagger/cumulativeTransformation_SMqqHH_28_05_2020_MX_lt_500_2018.root"
+        },
+        "MVAscalingValue" : 1.0,
         "ttHWeightfile" : "flashgg/Taggers/data/ttHKiller/Keras2017_converted_allnode.pb",
         "ttHKiller_mean" : [  3.22491144e+02,   7.22919780e+01,   1.49387571e-01,   4.94052483e-03,
                               5.10246425e-04,   1.38947662e+00,   5.31453078e+00,   7.45455854e+00,

--- a/MetaData/data/MetaConditions/Era2018_RR-17Sep2018_v1.json
+++ b/MetaData/data/MetaConditions/Era2018_RR-17Sep2018_v1.json
@@ -264,20 +264,20 @@
             "wo_Mjj" : "flashgg/Taggers/data/HHTagger/cumulativeTrans_30_04_2020_vbfHHbbgg_C2V0_training_2018.root"
         },
         "weightsFileCAT0" : {
-                "with_Mjj" : "flashgg/Taggers/data/HHTagger/training_with_2018_single_qqHHcat_14_5_2020.weights.xml",
-                "wo_Mjj" : "flashgg/Taggers/data/HHTagger/training_with_2018_single_qqHHcat_14_5_2020.weights.xml"
+                "with_Mjj" : "flashgg/Taggers/data/HHTagger/training_with_2018_12_06_2020_mixed_signal_MX_gt_500.weights.xml",
+                "wo_Mjj" : "flashgg/Taggers/data/HHTagger/training_with_2018_12_06_2020_mixed_signal_MX_gt_500.weights.xml"
         },
         "MVAFlatteningFileNameCAT0" : {
-                "with_Mjj" : "flashgg/Taggers/data/HHTagger/cumulativeTransformation_qqHH_single_2018_cat_14_5_2020.root",
-                "wo_Mjj" : "flashgg/Taggers/data/HHTagger/cumulativeTransformation_qqHH_single_2018_cat_14_5_2020.root"
+                "with_Mjj" : "flashgg/Taggers/data/HHTagger/cumulativeTransformation_Total_preselection_diffNaming_2018_12_06_2020_MX_gt_500.root",
+                "wo_Mjj" : "flashgg/Taggers/data/HHTagger/cumulativeTransformation_Total_preselection_diffNaming_2018_12_06_2020_MX_gt_500.root"
         },
         "weightsFileCAT1" : {
-                "with_Mjj" : "flashgg/Taggers/data/HHTagger/training_with_2018_double_qqHHcat_MX_lt_500GeV_28_5_2020_withSM.weights.xml",
-                "wo_Mjj" : "flashgg/Taggers/data/HHTagger/training_with_2018_double_qqHHcat_MX_lt_500GeV_28_5_2020_withSM.weights.xml"
+                "with_Mjj" : "flashgg/Taggers/data/HHTagger/training_with_2018_12_06_2020_mixed_signal_MX_lt_500.weights.xml",
+                "wo_Mjj" : "flashgg/Taggers/data/HHTagger/training_with_2018_12_06_2020_mixed_signal_MX_lt_500.weights.xml"
         },
         "MVAFlatteningFileNameCAT1" : {
-                "with_Mjj" : "flashgg/Taggers/data/HHTagger/cumulativeTransformation_SMqqHH_28_05_2020_MX_lt_500_2018.root",
-                "wo_Mjj" : "flashgg/Taggers/data/HHTagger/cumulativeTransformation_SMqqHH_28_05_2020_MX_lt_500_2018.root"
+                "with_Mjj" : "flashgg/Taggers/data/HHTagger/cumulativeTransformation_Total_preselection_diffNaming_2018_12_06_2020_MX_lt_500.root",
+                "wo_Mjj" : "flashgg/Taggers/data/HHTagger/cumulativeTransformation_Total_preselection_diffNaming_2018_12_06_2020_MX_lt_500.root"
         },
         "MVAscalingValue" : 1.0,
         "ttHWeightfile" : "flashgg/Taggers/data/ttHKiller/Keras2017_converted_allnode.pb",

--- a/MetaData/data/MetaConditions/Era2018_RR-17Sep2018_v1.json
+++ b/MetaData/data/MetaConditions/Era2018_RR-17Sep2018_v1.json
@@ -89,6 +89,7 @@
 
     "flashggJetSystematics" : 
     {  
+        "doHEMuncertainty" : true,
         "textFileName" : "flashgg/Systematics/data/JEC/Regrouped_Autumn18_V19_MC_UncertaintySources_AK4PFchs.txt",
         "listOfSources" : [
                            "Absolute",

--- a/MetaData/data/cross_sections.json
+++ b/MetaData/data/cross_sections.json
@@ -328,7 +328,7 @@
     "ZNuNuGJets_MonoPhoton_PtG-130_TuneCP5_13TeV-madgraph"                 : { "xs" : 0.2052 },
     "ZNuNuGJets_MonoPhoton_PtG-40to130_TuneCP5_13TeV-madgraph-pythia8"     : { "xs" : 2.996  },
     "ZNuNuGJets_MonoPhoton_PtG-130_TuneCP5_13TeV-madgraph-pythia8"         : { "xs" : 0.1921 },
-    "WW_TuneCUETP8M1_13TeV-pythia8"                                        : { "xs" : 64.3,  },
+    "WW_TuneCUETP8M1_13TeV-pythia8"                                        : { "xs" : 64.3  },
     "WZ_TuneCUETP8M1_13TeV-pythia8"                                        : { "xs" : 23.43  },
     "ZZ_TuneCUETP8M1_13TeV-pythia8"                                        : { "xs" : 10.16  },
     "WW_TuneCP5_13TeV-pythia8"                                             : { "xs" : 75.8   },

--- a/Systematics/plugins/JetHEMCorrector.cc
+++ b/Systematics/plugins/JetHEMCorrector.cc
@@ -1,0 +1,83 @@
+#include "flashgg/Systematics/interface/ObjectSystMethodBinnedByFunctor.h"
+#include "DataFormats/Common/interface/Handle.h"
+#include "DataFormats/Common/interface/PtrVector.h"
+#include "flashgg/DataFormats/interface/Jet.h"
+#include "CommonTools/Utils/interface/StringCutObjectSelector.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+
+
+namespace flashgg {
+
+    class JetHEMCorrector: public BaseSystMethod<flashgg::Jet, int>
+    {
+
+    public:
+        typedef StringCutObjectSelector<Jet, true> selector_type;
+
+        JetHEMCorrector( const edm::ParameterSet &conf, edm::ConsumesCollector && iC, const GlobalVariablesComputer * gv );
+        void applyCorrection( flashgg::Jet &y, int syst_shift ) override;
+        std::string shiftLabel( int ) const override;
+        void eventInitialize( const edm::Event &iEvent, const edm::EventSetup & iSetup ) override;
+
+    private:
+        selector_type overall_range_;
+        bool debug_;
+    };
+
+
+    JetHEMCorrector::JetHEMCorrector( const edm::ParameterSet &conf, edm::ConsumesCollector && iC, const GlobalVariablesComputer * gv ) :
+        BaseSystMethod( conf, std::forward<edm::ConsumesCollector>(iC)  ),
+        overall_range_( conf.getParameter<std::string>( "OverallRange" ) ),
+        debug_( conf.getUntrackedParameter<bool>( "Debug", false ) )
+    {
+    }
+
+    void JetHEMCorrector::eventInitialize( const edm::Event &iEvent, const edm::EventSetup & iSetup ) {
+    }
+
+    std::string JetHEMCorrector::shiftLabel( int syst_value ) const
+    {
+        std::string result;
+        if( syst_value == 0 ) {
+            result = Form( "%sCentral", label().c_str() );
+        } else if( syst_value > 0 ) {
+            result = Form( "%sUp%.2dsigma", label().c_str(), syst_value );
+        } else {
+            result = Form( "%sDown%.2dsigma", label().c_str(), -1 * syst_value );
+        }
+        return result;
+    }
+
+    void JetHEMCorrector::applyCorrection( flashgg::Jet &y, int syst_shift )
+    {
+        if( overall_range_( y ) ) {
+            float unc = 0.;
+            if( y.phi() > -1.57 && y.phi() < -0.87 ) {
+                if( y.eta() > -2.5 && y.eta() < -1.3 ) {
+                    unc = 0.2;
+                }
+                else if( y.eta() > -3.0 && y.eta() < -2.5 ) {
+                    unc = 0.35;
+                }
+            }
+            float scale = 1. + syst_shift*unc;
+            if( debug_ ) {
+                std::cout << "  " << shiftLabel( syst_shift ) << ": Jet has pt= " << y.pt() << " eta=" << y.eta()
+                          << " and we apply a multiplicative correction of " << scale << std::endl;
+            }
+            y.setP4( scale * y.p4() );
+        }
+    }
+}
+
+DEFINE_EDM_PLUGIN( FlashggSystematicJetMethodsFactory,
+                   flashgg::JetHEMCorrector,
+                   "FlashggJetHEMCorrector" );
+// Local Variables:
+// mode:c++
+// indent-tabs-mode:nil
+// tab-width:4
+// c-basic-offset:4
+// End:
+// vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4
+

--- a/Systematics/python/doubleHCustomize.py
+++ b/Systematics/python/doubleHCustomize.py
@@ -276,7 +276,7 @@ class DoubleHCustomize():
             #self.process.flashggVBFDoubleHTag.ttHScoreThreshold = cms.double(0.26)
             self.process.flashggVBFDoubleHTag.MVAConfigCAT0.variables.pop(0)
             self.process.flashggVBFDoubleHTag.MVAConfigCAT1.variables.pop(0)
-            self.process.flashggVBFDoubleHTag.MVABoundaries = cms.vdouble(0.61,0.87) #CAT0 MX > 500, CAT1 :MX <=500
+            self.process.flashggVBFDoubleHTag.MVABoundaries = cms.vdouble(0.52,0.86) #CAT0 MX > 500, CAT1 :MX <=500
             self.process.flashggVBFDoubleHTag.MXBoundaries = cms.vdouble(0.,500.)
             self.process.flashggVBFDoubleHTag.nMX = cms.uint32(2)
             self.process.flashggVBFDoubleHTag.ttHScoreThreshold = cms.double(0.26)

--- a/Systematics/python/doubleHCustomize.py
+++ b/Systematics/python/doubleHCustomize.py
@@ -11,7 +11,7 @@ class DoubleHCustomize():
         self.customize = customize
         self.metaConditions = metaConditions
         if customize.addVBFDoubleHTag:
-            self.tagList = [ ["VBFDoubleHTag",1], ["DoubleHTag",12] ]
+            self.tagList = [ ["VBFDoubleHTag",2], ["DoubleHTag",12] ]
         else:
             self.tagList = [ ["DoubleHTag",12] ]
         self.customizeTagSequence()
@@ -202,7 +202,6 @@ class DoubleHCustomize():
                "ttHScore := ttHScore()",
              ]
 
-       # return var_workspace ##Only temp fix 
         if self.customize.doubleHTagDumpMinVariables or self.customize.dumpWorkspace :
             return var_workspace
         else :
@@ -260,14 +259,26 @@ class DoubleHCustomize():
         # customizing training file (with/wo Mjj) 
         training_type = 'with_Mjj' if self.customize.doubleHTagsUseMjj else 'wo_Mjj'
 
-        self.process.flashggVBFDoubleHTag.MVAConfig.weights=cms.FileInPath(str(self.metaConditions["VBFdoubleHTag"]["weightsFile"][training_type]))
-        self.process.flashggVBFDoubleHTag.MVAFlatteningFileName = cms.untracked.FileInPath(str(self.metaConditions["VBFdoubleHTag"]["MVAFlatteningFileName"][training_type]))
+        #self.process.flashggVBFDoubleHTag.MVAConfig.weights=cms.FileInPath(str(self.metaConditions["VBFdoubleHTag"]["weightsFile"][training_type]))
+        #self.process.flashggVBFDoubleHTag.MVAFlatteningFileName = cms.untracked.FileInPath(str(self.metaConditions["VBFdoubleHTag"]["MVAFlatteningFileName"][training_type]))
+        self.process.flashggVBFDoubleHTag.MVAConfigCAT0.weights=cms.FileInPath(str(self.metaConditions["VBFdoubleHTag"]["weightsFileCAT0"][training_type]))
+        self.process.flashggVBFDoubleHTag.MVAFlatteningFileNameCAT0 = cms.untracked.FileInPath(str(self.metaConditions["VBFdoubleHTag"]["MVAFlatteningFileNameCAT0"][training_type]))
+        self.process.flashggVBFDoubleHTag.MVAConfigCAT1.weights=cms.FileInPath(str(self.metaConditions["VBFdoubleHTag"]["weightsFileCAT1"][training_type]))
+        self.process.flashggVBFDoubleHTag.MVAFlatteningFileNameCAT1 = cms.untracked.FileInPath(str(self.metaConditions["VBFdoubleHTag"]["MVAFlatteningFileNameCAT1"][training_type]))
+
+
         if training_type == 'with_Mjj' :
             self.process.flashggVBFDoubleHTag.MVABoundaries = cms.vdouble(0.95)
             self.process.flashggVBFDoubleHTag.ttHScoreThreshold = cms.double(0)
         elif training_type == 'wo_Mjj' :
-            self.process.flashggVBFDoubleHTag.MVAConfig.variables.pop(0)
-            self.process.flashggVBFDoubleHTag.MVABoundaries = cms.vdouble(0.70)
+            #self.process.flashggVBFDoubleHTag.MVAConfig.variables.pop(0)
+            #self.process.flashggVBFDoubleHTag.MVABoundaries = cms.vdouble(0.70)
+            #self.process.flashggVBFDoubleHTag.ttHScoreThreshold = cms.double(0.26)
+            self.process.flashggVBFDoubleHTag.MVAConfigCAT0.variables.pop(0)
+            self.process.flashggVBFDoubleHTag.MVAConfigCAT1.variables.pop(0)
+            self.process.flashggVBFDoubleHTag.MVABoundaries = cms.vdouble(0.61,0.87) #CAT0 MX > 500, CAT1 :MX <=500
+            self.process.flashggVBFDoubleHTag.MXBoundaries = cms.vdouble(0.,500.)
+            self.process.flashggVBFDoubleHTag.nMX = cms.uint32(2)
             self.process.flashggVBFDoubleHTag.ttHScoreThreshold = cms.double(0.26)
 
         ## customize meta conditions

--- a/Systematics/python/flashggJetSystematics_cfi.py
+++ b/Systematics/python/flashggJetSystematics_cfi.py
@@ -247,6 +247,16 @@ class jetSystematicsCustomize:
                                                     JetCorrectorTag = cms.InputTag("ak4PFCHSL1FastL2L3Corrector")
                                                   ) 
                                         )
+
+      if self.metaConditions['flashggJetSystematics']['doHEMuncertainty'] and self.options.doSystematics:
+          allJetUncerts += cms.VPSet( cms.PSet( MethodName = cms.string("FlashggJetHEMCorrector"),
+                                                Label = cms.string("JetHEM"),
+                                                NSigmas = cms.vint32(-1,1),
+                                                OverallRange = cms.string("abs(eta)<5.0"),
+                                                Debug = cms.untracked.bool(False),
+                                                ApplyCentralValue = cms.bool(False)
+                                              ) 
+                                    )
           
       setattr(self.process, newName,
               cms.EDProducer('FlashggJetSystematicProducer',

--- a/Systematics/test/workspaceStd.py
+++ b/Systematics/test/workspaceStd.py
@@ -335,7 +335,7 @@ if is_signal:
             if customize.doGranularJEC:
                 for sourceName in customize.metaConditions['flashggJetSystematics']['listOfSources']:
                     jetsystlabels.append("JEC%s%s01sigma" % (str(sourceName),direction))
-            if customize.metaConditions['flashggJetSystematics']['doHEMuncertianty']:
+            if customize.metaConditions['flashggJetSystematics']['doHEMuncertainty']:
                 jetsystlabels.append("JetHEM%s01sigma" % direction)
             metsystlabels.append("metJecUncertainty%s01sigma" % direction)
             metsystlabels.append("metJerUncertainty%s01sigma" % direction)

--- a/Systematics/test/workspaceStd.py
+++ b/Systematics/test/workspaceStd.py
@@ -507,7 +507,7 @@ for tag in tagList:
               currentVariables = []
       isBinnedOnly = (systlabel !=  "")
       is_signal = reduce(lambda y,z: y or z, map(lambda x: customize.processId.count(x), signal_processes))
-      if ( customize.doPdfWeights or customize.doSystematics ) and ( (customize.datasetName() and customize.datasetName().count("HToGG")) or customize.processId.count("h_") or customize.processId.count("vbf_") or is_signal ) and (systlabel ==  "") and not (customize.processId == "th_125" or customize.processId == "bbh_125"):
+      if ( customize.doPdfWeights and customize.doSystematics ) and ( (customize.datasetName() and customize.datasetName().count("HToGG")) or customize.processId.count("h_") or customize.processId.count("vbf_") or is_signal ) and (systlabel ==  "") and not (customize.processId == "th_125" or customize.processId == "bbh_125"):
           #print "Signal MC central value, so dumping PDF weights"
           dumpPdfWeights = True
           nPdfWeights = 60

--- a/Systematics/test/workspaceStd.py
+++ b/Systematics/test/workspaceStd.py
@@ -335,6 +335,8 @@ if is_signal:
             if customize.doGranularJEC:
                 for sourceName in customize.metaConditions['flashggJetSystematics']['listOfSources']:
                     jetsystlabels.append("JEC%s%s01sigma" % (str(sourceName),direction))
+            if customize.metaConditions['flashggJetSystematics']['doHEMuncertianty']:
+                jetsystlabels.append("JetHEM%s01sigma" % direction)
             metsystlabels.append("metJecUncertainty%s01sigma" % direction)
             metsystlabels.append("metJerUncertainty%s01sigma" % direction)
             metsystlabels.append("metPhoUncertainty%s01sigma" % direction)

--- a/Taggers/python/flashggVBFDoubleHTag_cfi.py
+++ b/Taggers/python/flashggVBFDoubleHTag_cfi.py
@@ -31,8 +31,8 @@ flashggVBFDoubleHTag = cms.EDProducer("FlashggVBFDoubleHTagProducer",
                                    JetsCollSize = cms.uint32(maxJetCollections), #
                                    JetsSuffixes = cms.vstring(''), #nominal and systematic variations 
                                    GenParticleTag = cms.InputTag( "flashggPrunedGenParticles" ), # to compute MC-truth info
-
-                                   VBFJetsInputTag= UnpackedJetCollectionVInputTag, 
+                                   
+                                   VBFJetsInputTag= UnpackedJetCollectionVInputTag,
                                    VBFJetsSystematicsName=cms.string('flashggJetSystematics'),
                                    VBFJetsCollSize = cms.uint32(maxJetCollections), #
 
@@ -59,30 +59,30 @@ flashggVBFDoubleHTag = cms.EDProducer("FlashggVBFDoubleHTagProducer",
                                    VBFJetEta = cms.double(4.7),
                                    VBFleadJetPt  = cms.double(40.0),
                                    VBFsubleadJetPt = cms.double(30.0),
-
-                                   #MVABoundaries  = cms.vdouble(0.29,0.441, 0.724), # category boundaries for MVA w/o Mjj
-                                   #MXBoundaries   = cms.vdouble(250., 354., 478., 560.), # .. and MX w/o Mjj
-                                   #MJJBoundariesLower = cms.vdouble(98.0,95.0,97.0,96.0,95.0,95.0,95.0,95.0,95.0,95.0,95.0,95.0),#for each category following the convention cat0=MX0 MVA0, cat1=MX1 MVA0, cat2=MX2 MVA0....
-                                   #MJJBoundariesUpper = cms.vdouble(150.0,150.0,143.0,150.0,150.0,150.0,150.0,145.0,155.0,142.0,146.0,152.0),#for each category following the convention cat0=MX0 MVA0, cat1=MX1 MVA0, cat2=MX2 MVA0....
-                                   #MVABoundaries  = cms.vdouble(0.23,0.455, 0.709), # category boundaries for MVA with Mjj
-                                   #MXBoundaries   = cms.vdouble(250., 336., 411., 556.), # .. and MX for MVA with Mjj
                                    MVABoundaries  = cms.vdouble(0.87), # category boundaries for MVA with Mjj
-                                   MXBoundaries   = cms.vdouble(250., 370.,480.,585.,250.,335.,380.,545.,250.,330.,360.,530.), # .. and MX for MVA with Mjj
-                                   nMX   = cms.uint32(4), # number of MX categories
+                                   MXBoundaries   = cms.vdouble(0,500), 
+                                   nMX   = cms.uint32(2), # number of MX categories
                                    MJJBoundariesLower = cms.vdouble(70.0,70.0,70.0,70.0,70.0,70.0,70.0,70.0,70.0,70.0,70.0,70.0),#for each category following the convention cat0=MX0 MVA0, cat1=MX1 MVA0, cat2=MX2 MVA0....
                                    MJJBoundariesUpper = cms.vdouble(190.0,190.0,190.0,190.0,190.0,190.0,190.0,190.0,190.0,190.0,190.0,190.0),#for each category following the convention cat0=MX0 MVA0, cat1=MX1 MVA0, cat2=MX2 MVA0....
-                                   MVAConfig = cms.PSet(variables=cms.VPSet(), # variables are added below
+                                   MVAConfigCAT0 = cms.PSet(variables=cms.VPSet(), # variables are added below
                                                         classifier=cms.string("BDT::bdt"), # classifier name
                                                         weights=cms.FileInPath("%s"%weightsFile), 
                                                         regression=cms.bool(False), # this is not a regression
                                                         multiclass=cms.bool(True), # this is multiclass 
                                                         multiclassSignalIdx=cms.int32(2), # this is multiclass index for Signal
                                                         ),
-
+                                   MVAConfigCAT1 = cms.PSet(variables=cms.VPSet(), # variables are added below
+                                                        classifier=cms.string("BDT::bdt"), # classifier name
+                                                        weights=cms.FileInPath("%s"%weightsFile), 
+                                                        regression=cms.bool(False), # this is not a regression
+                                                        multiclass=cms.bool(True), # this is multiclass 
+                                                        multiclassSignalIdx=cms.int32(2), # this is multiclass index for Signal
+                                                        ),
                                    doMVAFlattening=cms.bool(True),#do transformation of cumulative to make it flat
                                    MVAscaling=cms.double(MVAscalingValue),
                                       doCategorization=cms.bool(True),#do categorization based on MVA x MX or only fill first tree with all events
-                                   MVAFlatteningFileName=cms.untracked.FileInPath("%s"%MVAFlatteningFileName),#FIXME, this should be optional, is it?
+                                   MVAFlatteningFileNameCAT0=cms.untracked.FileInPath("%s"%MVAFlatteningFileName),#FIXME, this should be optional, is it?
+                                   MVAFlatteningFileNameCAT1=cms.untracked.FileInPath("%s"%MVAFlatteningFileName),#FIXME, this should be optional, is it?
                                    globalVariables=globalVariables,
                                    doReweight = flashggDoubleHReweight.doReweight,
                                    reweight_producer = cms.string(reweight_settings.reweight_producer),
@@ -113,10 +113,9 @@ flashggVBFDoubleHTag = cms.EDProducer("FlashggVBFDoubleHTagProducer",
                                    ttHKiller_liststd = ttHKiller_liststd 
                                   ) 
 
-cfgTools.addVariables(flashggVBFDoubleHTag.MVAConfig.variables,
+MVAvariables =                       [
                       # here the syntax is VarNameInTMVA := expression
                       #### With or without Mjj is customized inside python doubleHCustomize and using options UseMjj
-                      [
                        "Mjj := dijet().M()",
                        "leadingJet_DeepFlavour := leadJet().bDiscriminator('mini_pfDeepFlavourJetTags:probb')+leadJet().bDiscriminator('mini_pfDeepFlavourJetTags:probbb')+leadJet().bDiscriminator('mini_pfDeepFlavourJetTags:problepb')",
                        "subleadingJet_DeepFlavour := subleadJet().bDiscriminator('mini_pfDeepFlavourJetTags:probb')+subleadJet().bDiscriminator('mini_pfDeepFlavourJetTags:probbb')+subleadJet().bDiscriminator('mini_pfDeepFlavourJetTags:problepb')",
@@ -156,4 +155,5 @@ cfgTools.addVariables(flashggVBFDoubleHTag.MVAConfig.variables,
                        "diHiggs_pt := getdiHiggsP4().pt()",
                        "MX := MX()"
                        ]
-                      )
+cfgTools.addVariables(flashggVBFDoubleHTag.MVAConfigCAT0.variables,MVAvariables)
+cfgTools.addVariables(flashggVBFDoubleHTag.MVAConfigCAT1.variables,MVAvariables)


### PR DESCRIPTION
 - VBFHH with 2 categories in sync with current flashgg master. "Green" strategy for VBFHH as agreed on 18.06.2020 at Hgg working meeting. BDT is trained using a mix of SM and C2V=0 signals in 2 MX regions </>500 GeV. 1 MVA category is optimized in each MX region.

 - Pdf systematics are now propagated if the PdfWeight is ON. Before it was ON even if PdfWeights are off, but doSystematics are on, which of course did not make any sense. 

 - HEM systematic for 2018 is cherry-picked from the STXS PR #1218. I can revert it back if requested, for now I put it in, to share the latest final PR for ttH+HH combination