### PR TITLE
udpating 2018 MC and Data GT; also fixing JER SF calcuation

### DIFF
--- a/MetaData/data/MetaConditions/Era2018_Prompt_v1.json
+++ b/MetaData/data/MetaConditions/Era2018_Prompt_v1.json
@@ -1,8 +1,8 @@
 {
     "globalTags" :
     {
-        "data" : "102X_dataRun2_Prompt_v15",
-        "MC" : "102X_upgrade2018_realistic_v19"
+        "data" : "102X_dataRun2_Prompt_v16",
+        "MC" : "102X_upgrade2018_realistic_v21"
     },
 
     "flashggMETsFunction" : "runMETs2016",

--- a/MetaData/data/MetaConditions/Era2018_RR-17Sep2018_v1.json
+++ b/MetaData/data/MetaConditions/Era2018_RR-17Sep2018_v1.json
@@ -1,8 +1,8 @@
 {
     "globalTags" :
     {
-        "data" : "102X_dataRun2_v12",
-        "MC" : "102X_upgrade2018_realistic_v19"
+        "data" : "102X_dataRun2_v13",
+        "MC" : "102X_upgrade2018_realistic_v21"
     },
 
     "flashggMETsFunction" : "runMETs2016",

--- a/Systematics/plugins/JetSmear.cc
+++ b/Systematics/plugins/JetSmear.cc
@@ -101,11 +101,11 @@ namespace flashgg {
             }
             float scale_factor;
             if (syst_shift == 0) {
-                scale_factor = res_sf.getScaleFactor({{JME::Binning::JetEta, y.eta()}});
+                scale_factor = res_sf.getScaleFactor({{JME::Binning::JetPt, y.pt()}, {JME::Binning::JetEta, y.eta()}});
             } else if (syst_shift == 1) {
-                scale_factor = res_sf.getScaleFactor({{JME::Binning::JetEta, y.eta()}}, Variation::UP);
+                scale_factor = res_sf.getScaleFactor({{JME::Binning::JetPt, y.pt()}, {JME::Binning::JetEta, y.eta()}}, Variation::UP);
             } else if (syst_shift == -1) {
-                scale_factor = res_sf.getScaleFactor({{JME::Binning::JetEta, y.eta()}}, Variation::DOWN);
+                scale_factor = res_sf.getScaleFactor({{JME::Binning::JetPt, y.pt()}, {JME::Binning::JetEta, y.eta()}}, Variation::DOWN);
             } else {
                 throw cms::Exception("UnsupportedJERShift") << " syst_shift=" << syst_shift << " is not supported";
             }


### PR DESCRIPTION
- updating 2018 SF for MC and Data where bug related to JER SF has been fixed
slide 6 https://indico.cern.ch/event/920726/contributions/3868370/attachments/2055396/3446379/20-06-11_News_PPD.pdf

- Fixing the JER SF calculation as recommend by JME converens in the HN post [1] to make it pt dependent.
https://hypernews.cern.ch/HyperNews/CMS/get/jes/1006/1/1/1.html

Tested setup with 2018 GTs and new updates in the smearing sf calculation. works fine

For more deatils of pt related SF, this TWiki can be read https://twiki.cern.ch/twiki/bin/viewauth/CMS/JetResolution#Smearing_procedures