### PR TITLE
Update UL 17 ingredients

### DIFF
--- a/MetaData/data/MetaConditions/Era2017_legacy_v1.json
+++ b/MetaData/data/MetaConditions/Era2017_legacy_v1.json
@@ -34,8 +34,8 @@
 
     "flashggPhotons" :
     {
-        "photonIdMVAweightfile_EB" : "flashgg/MicroAOD/data/HggPhoId_94X_barrel_BDT_v2.weights.xml",
-        "photonIdMVAweightfile_EE" : "flashgg/MicroAOD/data/HggPhoId_94X_endcap_BDT_v2.weights.xml",
+        "photonIdMVAweightfile_EB" : "flashgg/MicroAOD/data/PhoID_barrel_UL2017_GJetMC_SATrain_nTree2k_LR_0p1_13052020_BDTG.weights.xml",
+        "photonIdMVAweightfile_EE" : "flashgg/MicroAOD/data/PhoID_endcap_UL2017_GJetMC_SATrain_nTree2k_LR_0p1_13052020_BDTG.weights.xml",
         "effAreasConfigFile" : "RecoEgamma/PhotonIdentification/data/Fall17/effAreaPhotons_cone03_pfPhotons_90percentBased_TrueVtx.txt",
         "is2017" : true
     },

--- a/MetaData/data/MetaConditions/Era2017_legacy_v1.json
+++ b/MetaData/data/MetaConditions/Era2017_legacy_v1.json
@@ -96,6 +96,16 @@
         "MC" : "JetCorrectorParametersCollection_Summer19UL17_V5_MC_AK4PFchs",
         "MC_db" : "flashgg/Systematics/data/JEC/Summer19UL17_V5_MC.db"
     },
+
+    "JetResolutionParametersCollection_version" :
+    {
+        "data_res" : "JR_Summer19UL17_JRV2_DATA_PtResolution_AK4PFchs",
+        "data_sf" : "JR_Summer19UL17_JRV2_DATA_SF_AK4PFchs",
+        "data_db" : "flashgg/Systematics/data/JER/Summer19UL17_JRV2_DATA.db",
+        "MC_res" : "JR_Summer19UL17_JRV2_MC_PtResolution_AK4PFchs",
+        "MC_sf" : "JR_Summer19UL17_JRV2_MC_SF_AK4PFchs",
+        "MC_db" : "flashgg/Systematics/data/JER/Summer19UL17_JRV2_MC.db"
+    },
 	
     "flashggDiPhotonMVA" : 
     {  

--- a/MetaData/data/MetaConditions/Era2017_legacy_v1.json
+++ b/MetaData/data/MetaConditions/Era2017_legacy_v1.json
@@ -91,8 +91,10 @@
 
     "JetCorrectorParametersCollection_version" :
     {
-        "data" : "JetCorrectorParametersCollection_Fall17_17Nov2017_V32_102X_DATA_AK4PFchs",
-        "MC" : "JetCorrectorParametersCollection_Fall17_17Nov2017_V32_102X_MC_AK4PFchs"
+        "data" : "JetCorrectorParametersCollection_Summer19UL17_RunBCDEF_V5_DATA_AK4PFchs",
+        "data_db" : "flashgg/Systematics/data/JEC/Summer19UL17_RunBCDEF_V5_DATA.db",
+        "MC" : "JetCorrectorParametersCollection_Summer19UL17_V5_MC_AK4PFchs",
+        "MC_db" : "flashgg/Systematics/data/JEC/Summer19UL17_V5_MC.db"
     },
 	
     "flashggDiPhotonMVA" : 

--- a/MetaData/data/MetaConditions/Era2017_legacy_v1.json
+++ b/MetaData/data/MetaConditions/Era2017_legacy_v1.json
@@ -200,9 +200,9 @@
     "MUON_ID" : "Medium",
     "MUON_ISO" : "LooseRel",
 
-    "MUON_ID_JSON_FileName" : "flashgg/Systematics/data/Muon2017_RunBCDEF_SF_ID.json",
-    "MUON_ID_JSON_FileName_LowPt" : "flashgg/Systematics/data/Muon2017_RunBCDEF_SF_ID_lowPt.json",
-    "MUON_ISO_JSON_FileName" : "flashgg/Systematics/data/Muon2017_RunBCDEF_SF_ISO.json",
+    "MUON_ID_JSON_FileName" : "flashgg/Systematics/data/Muon_UL2017_RunBCDEF_SF_ID.json",
+    "MUON_ID_JSON_FileName_LowPt" : "flashgg/Systematics/data/Muon_UL2017_RunBCDEF_SF_ID_lowPt.json",
+    "MUON_ISO_JSON_FileName" : "flashgg/Systematics/data/Muon_UL2017_RunBCDEF_SF_ISO.json",
 
     "MUON_ID_RefTracks" :  "genTracks",
     "MUON_ID_RefTracks_LowPt" : "genTracks",
@@ -219,13 +219,13 @@
 
 	"bTagger" : "pfDeepJet",
 
-	"bDiscriminatorValue_pfDeepCSV" : 0.4941,
-	"bTagCalibrationFile_Reshape_pfDeepCSV" : "flashgg/Systematics/data/DeepCSV_94XSF_V4_B_F.csv",
-	"bTagCalibrationFile_WPCut_pfDeepCSV" : "flashgg/Systematics/data/DeepCSV_94XSF_WP_V4_B_F.csv",
+	"bDiscriminatorValue_pfDeepCSV" : 0.4506,
+	"bTagCalibrationFile_Reshape_pfDeepCSV" : "flashgg/Systematics/data/DeepCSV_106XUL17SF.csv",
+	"bTagCalibrationFile_WPCut_pfDeepCSV" : "flashgg/Systematics/data/DeepCSV_106XUL17SF_WPonly.csv",
 
-	"bDiscriminatorValue_pfDeepJet" : 0.3033,
-	"bTagCalibrationFile_Reshape_pfDeepJet" : "flashgg/Systematics/data/DeepFlavour_94XSF_V2_B_F.csv",
-	"bTagCalibrationFile_WPCut_pfDeepJet" : "flashgg/Systematics/data/DeepFlavour_94XSF_WP_V2_B_F.csv",
+	"bDiscriminatorValue_pfDeepJet" : 0.3040,
+	"bTagCalibrationFile_Reshape_pfDeepJet" : "flashgg/Systematics/data/DeepJet_106XUL17SF.csv",
+	"bTagCalibrationFile_WPCut_pfDeepJet" : "flashgg/Systematics/data/DeepJet_106XUL17SF_WPonly.csv",
 
 	"eta" : 2.5
     },

--- a/MetaData/data/MetaConditions/Era2017_legacy_v1.json
+++ b/MetaData/data/MetaConditions/Era2017_legacy_v1.json
@@ -201,11 +201,11 @@
     "MUON_ID" : "Medium",
     "MUON_ISO" : "LooseRel",
 
-    "MUON_ID_JSON_FileName" : "flashgg/Systematics/data/Muon2017_RunBCDEF_SF_ID.json",
-    "MUON_ID_JSON_FileName_LowPt" : "flashgg/Systematics/data/Muon2017_RunBCDEF_SF_ID_lowPt.json",
-    "MUON_ISO_JSON_FileName" : "flashgg/Systematics/data/Muon2017_RunBCDEF_SF_ISO.json",
+    "MUON_ID_JSON_FileName" : "flashgg/Systematics/data/Muon_UL2017_RunBCDEF_SF_ID.json",
+    "MUON_ID_JSON_FileName_LowPt" : "flashgg/Systematics/data/Muon_UL2017_RunBCDEF_SF_ID_lowPt.json",
+    "MUON_ISO_JSON_FileName" : "flashgg/Systematics/data/Muon_UL2017_RunBCDEF_SF_ISO.json",
 
-    "MUON_ID_RefTracks" :  "genTracks",
+    "MUON_ID_RefTracks" :  "TrackerMuons",
     "MUON_ID_RefTracks_LowPt" : "genTracks",
 
     "Ele_ID_SF_FileName" : "flashgg/Systematics/data/combined_MVA_eleIDSFs_UL_2017.json",

--- a/MetaData/data/MetaConditions/Era2017_legacy_v1.json
+++ b/MetaData/data/MetaConditions/Era2017_legacy_v1.json
@@ -84,7 +84,7 @@
         }
     },
 
-    "flashggDiPhotonSystematics" : "flashggDiPhotonSystematics2017_cfi",
+    "flashggDiPhotonSystematics" : "flashggDiPhotonSystematics2017_Legacy_cfi",
 
 
     "sigmaM_M_decorr" : "flashgg/Taggers/data/diphoMVA_sigmaMoMdecorr_split_2017_Mgg100to180.root",

--- a/MetaData/data/MetaConditions/Era2017_legacy_v1.json
+++ b/MetaData/data/MetaConditions/Era2017_legacy_v1.json
@@ -208,10 +208,10 @@
     "MUON_ID_RefTracks" :  "genTracks",
     "MUON_ID_RefTracks_LowPt" : "genTracks",
 
-    "Ele_ID_SF_FileName" : "flashgg/Systematics/data/combined_eleIDSFs_2017.json",
+    "Ele_ID_SF_FileName" : "flashgg/Systematics/data/combined_MVA_eleIDSFs_UL_2017.json",
     "Ele_ID_version" : "mvaEleID-Fall17-iso-V2-wp90",
 
-    "Ele_reco_SF_FileName" : "flashgg/Systematics/data/2017_reco-eff.json",
+    "Ele_reco_SF_FileName" : "flashgg/Systematics/data/2017_UL_reco-eff.json",
 
     "bTagSystematics" :
     {

--- a/MetaData/data/MetaConditions/Era2017_legacy_v1.json
+++ b/MetaData/data/MetaConditions/Era2017_legacy_v1.json
@@ -316,7 +316,7 @@
 
    "PhoIdInputCorrections":
     {
-	"corrections_summary" : "flashgg/Taggers/data/PhoIdInputsCorrections/corrections_summary_2017.json",
+	"corrections_summary" : "flashgg/Taggers/data/PhoIdInputsCorrections/corrections_summary_2017_Legacy.json",
 	"SS_variables" :   ["f0 := pt",
                             "f1 := superCluster.eta",
                             "f2 := phi",

--- a/MetaData/data/MetaConditions/Era2017_legacy_v1.json
+++ b/MetaData/data/MetaConditions/Era2017_legacy_v1.json
@@ -114,7 +114,8 @@
     },
 
     "flashggJetSystematics" : 
-    {  
+    { 
+	"doHEMuncertainty" : false, 
         "textFileName" : "flashgg/Systematics/data/JEC/Regrouped_Fall17_17Nov2017_V32_MC_UncertaintySources_AK4PFchs.txt",
         "listOfSources" : [
                            "Absolute",
@@ -200,9 +201,9 @@
     "MUON_ID" : "Medium",
     "MUON_ISO" : "LooseRel",
 
-    "MUON_ID_JSON_FileName" : "flashgg/Systematics/data/Muon_UL2017_RunBCDEF_SF_ID.json",
-    "MUON_ID_JSON_FileName_LowPt" : "flashgg/Systematics/data/Muon_UL2017_RunBCDEF_SF_ID_lowPt.json",
-    "MUON_ISO_JSON_FileName" : "flashgg/Systematics/data/Muon_UL2017_RunBCDEF_SF_ISO.json",
+    "MUON_ID_JSON_FileName" : "flashgg/Systematics/data/Muon2017_RunBCDEF_SF_ID.json",
+    "MUON_ID_JSON_FileName_LowPt" : "flashgg/Systematics/data/Muon2017_RunBCDEF_SF_ID_lowPt.json",
+    "MUON_ISO_JSON_FileName" : "flashgg/Systematics/data/Muon2017_RunBCDEF_SF_ISO.json",
 
     "MUON_ID_RefTracks" :  "genTracks",
     "MUON_ID_RefTracks_LowPt" : "genTracks",

--- a/Systematics/python/flashggJetSystematics_cfi.py
+++ b/Systematics/python/flashggJetSystematics_cfi.py
@@ -277,8 +277,8 @@ class jetSystematicsCustomize:
          module,tag = self.createJetSystematicsForTag(jetInputTag)
          self.process.jetSystematicsSequence += module
          systematicsInputList.append(tag)
-         self.createJECESource()  
-         #  createJERESource(self.process)  
+         self.createJECESource()
+         #createJERESource(self.process)
       return systematicsInputList
 
    def createJECESource(self):
@@ -288,19 +288,32 @@ class jetSystematicsCustomize:
       # self.process.load("CondCore.DBCommon.CondDBCommon_cfi")
       # self.process.load("CondCore.DBCommon.CondDBSetup_cfi")
       self.process.load("CondCore.CondDB.CondDB_cfi")
-      self.process.jec = cms.ESSource("PoolDBESSource",
-                                      DBParameters = cms.PSet(
-                                         messageLevel = cms.untracked.int32(0)
-                                      ),
-                                      timetype = cms.string('runnumber'),
-                                      toGet = cms.VPSet(cms.PSet(
-                                         record = cms.string('JetCorrectionsRecord'),
-                                         tag    = cms.string(
-                                            str(self.metaConditions['JetCorrectorParametersCollection_version']["data" if self.options.processType=="data" else "MC"])),   
-                                         label  = cms.untracked.string("AK4PFchs")
-                                      )),
-                                      connect = cms.string('frontier://FrontierProd/CMS_CONDITIONS')
-                                   )                               
+      if 'data_db' in self.metaConditions['JetCorrectorParametersCollection_version'].keys():
+          CondDBJECFile = self.process.CondDB.clone(connect = cms.string('sqlite_fip:%s'%str(self.metaConditions['JetCorrectorParametersCollection_version']["data_db" if self.options.processType=="data" else "MC_db"])))
+          self.process.jec = cms.ESSource("PoolDBESSource",
+                                          CondDBJECFile,
+                                          timetype = cms.string('runnumber'),
+                                          toGet = cms.VPSet(cms.PSet(
+                                             record = cms.string('JetCorrectionsRecord'),
+                                             tag    = cms.string(
+                                                str(self.metaConditions['JetCorrectorParametersCollection_version']["data" if self.options.processType=="data" else "MC"])),   
+                                             label  = cms.untracked.string("AK4PFchs")
+                                          ))
+                                       )                               
+      else:
+          self.process.jec = cms.ESSource("PoolDBESSource",
+                                          DBParameters = cms.PSet(
+                                             messageLevel = cms.untracked.int32(0)
+                                          ),
+                                          timetype = cms.string('runnumber'),
+                                          toGet = cms.VPSet(cms.PSet(
+                                             record = cms.string('JetCorrectionsRecord'),
+                                             tag    = cms.string(
+                                                str(self.metaConditions['JetCorrectorParametersCollection_version']["data" if self.options.processType=="data" else "MC"])),   
+                                             label  = cms.untracked.string("AK4PFchs")
+                                          )),
+                                          connect = cms.string('frontier://FrontierProd/CMS_CONDITIONS')
+                                          )
       self.process.es_prefer_jec = cms.ESPrefer('PoolDBESSource', 'jec')
 
    def createJERESource(self):

--- a/Systematics/python/flashggJetSystematics_cfi.py
+++ b/Systematics/python/flashggJetSystematics_cfi.py
@@ -318,7 +318,6 @@ class jetSystematicsCustomize:
       if 'JetResolutionParametersCollection_version' not in self.metaConditions.keys():
          return
       
-      self.process.load('Configuration.StandardSequences.Services_cff')
       self.process.load("JetMETCorrections.Modules.JetResolutionESProducer_cfi")
       self.process.load("CondCore.CondDB.CondDB_cfi")
 

--- a/Systematics/python/flashggJetSystematics_cfi.py
+++ b/Systematics/python/flashggJetSystematics_cfi.py
@@ -278,15 +278,13 @@ class jetSystematicsCustomize:
          self.process.jetSystematicsSequence += module
          systematicsInputList.append(tag)
          self.createJECESource()
-         #createJERESource(self.process)
+         self.createJERESource()
       return systematicsInputList
 
    def createJECESource(self):
       if 'JetCorrectorParametersCollection_version' not in self.metaConditions.keys():
          return
-      
-      # self.process.load("CondCore.DBCommon.CondDBCommon_cfi")
-      # self.process.load("CondCore.DBCommon.CondDBSetup_cfi")
+
       self.process.load("CondCore.CondDB.CondDB_cfi")
       if 'data_db' in self.metaConditions['JetCorrectorParametersCollection_version'].keys():
           CondDBJECFile = self.process.CondDB.clone(connect = cms.string('sqlite_fip:%s'%str(self.metaConditions['JetCorrectorParametersCollection_version']["data_db" if self.options.processType=="data" else "MC_db"])))
@@ -298,8 +296,8 @@ class jetSystematicsCustomize:
                                              tag    = cms.string(
                                                 str(self.metaConditions['JetCorrectorParametersCollection_version']["data" if self.options.processType=="data" else "MC"])),   
                                              label  = cms.untracked.string("AK4PFchs")
-                                          ))
-                                       )                               
+                                             ))
+                                         )                               
       else:
           self.process.jec = cms.ESSource("PoolDBESSource",
                                           DBParameters = cms.PSet(
@@ -317,32 +315,32 @@ class jetSystematicsCustomize:
       self.process.es_prefer_jec = cms.ESPrefer('PoolDBESSource', 'jec')
 
    def createJERESource(self):
-      if 'JR_PtResolution_version' not in self.metaConditions.keys() or 'JR_SF_version' not in self.metaConditions.keys():
+      if 'JetResolutionParametersCollection_version' not in self.metaConditions.keys():
          return
       
       self.process.load('Configuration.StandardSequences.Services_cff')
       self.process.load("JetMETCorrections.Modules.JetResolutionESProducer_cfi")
-      # from CondCore.DBCommon.CondDBSetup_cfi import CondDBSetup
-      from CondCore.CondDB.CondDB_cfi import CondDBSetup
+      self.process.load("CondCore.CondDB.CondDB_cfi")
+
+      CondDBJERFile = self.process.CondDB.clone(connect = cms.string('sqlite_fip:%s'%str(self.metaConditions['JetResolutionParametersCollection_version']["data_db" if self.options.processType=="data" else "MC_db"])))
          
       self.process.jer = cms.ESSource("PoolDBESSource",
-                                      CondDBSetup,
+                                      CondDBJERFile,
                                       toGet = cms.VPSet(
                                          # Resolution
                                          cms.PSet(
                                             record = cms.string('JetResolutionRcd'),
-                                            tag    = cms.string(str(self.metaConditions['JR_PtResolution_version'])),       
+                                            tag    = cms.string(str(self.metaConditions['JetResolutionParametersCollection_version']["data_res" if self.options.processType=="data" else "MC_res"])),       
                                             label  = cms.untracked.string('AK4PFchs_pt')
                                          ),                                  
                                          # Scale factors
                                          cms.PSet(
                                             record = cms.string('JetResolutionScaleFactorRcd'),
-                                            tag    = cms.string(str(self.metaConditions['JR_SF_version'])),       
+                                            tag    = cms.string(str(self.metaConditions['JetResolutionParametersCollection_version']["data_sf" if self.options.processType=="data" else "MC_sf"])),       
                                             label  = cms.untracked.string('AK4PFchs')
                                          ),
-                                      ),
-                                      connect = cms.string('frontier://FrontierProd/CMS_CONDITIONS')
-      )
-   
+                                      )
+                                     )
+
       self.process.es_prefer_jer = cms.ESPrefer('PoolDBESSource', 'jer')
       

--- a/Systematics/python/flashggMuonSystematics_cfi.py
+++ b/Systematics/python/flashggMuonSystematics_cfi.py
@@ -22,6 +22,8 @@ class MuonSF_JSONReader :
         format_bins = r'^(?P<VarName>.*):\[(?P<From>-?\d*.\d*),(?P<To>-?\d*.\d*)\]'
         minPt = 1000
         for eta_region in self.Info[sub_branch_name] :
+            if eta_region == 'binning':
+               continue
             for pt_region in self.Info[sub_branch_name][eta_region] :
                 pt_values = re.match( format_bins , pt_region , re.M|re.I )
                 if pt_values and len( pt_values.groups() ) == 3 :
@@ -44,6 +46,8 @@ class MuonSF_JSONReader :
 
 
         for eta_region in self.Info[sub_branch_name] :
+            if eta_region == 'binning':
+               continue
             eta_values = re.match( format_bins , eta_region , re.M|re.I )
             if eta_values and len( eta_values.groups() ) == 3 :
                 eta_from = float( eta_values.group("From") )


### PR DESCRIPTION
This PR designed to include the required updates for the UL 17 dataset. So far just updates the photon systematics file in the MetaConditions (previously not set to the legacy version) and adds the databases needed for the JEC and JER (not yet included in any global tag). 

Expect additional commits from @rchatter but these two aspects should be the most important ones for anyone hoping to run ntuples asap. 