### PR TITLE
Fix the bug for high/low weight due to MC pileup overwritten for UL2017

### DIFF
--- a/MetaData/python/JobConfig.py
+++ b/MetaData/python/JobConfig.py
@@ -181,15 +181,14 @@ class JobConfig(object):
         except Exception:
             print "Failed to load 94X_mc2017 mixing"
 
-	try:
-	    from SimGeneral.MixingModule.mix_2017_25ns_UltraLegacy_PoissonOOTPU_cfi import mix as mix_UL17
-	    self.pu_distribs["Summer19UL17"] = mix_UL17.input.nbPileupEvents
-	except Exception:
-	    print "Failed to load UL17 mixing"
-
+        try:
+            from flashgg.MetaData.mix_2017_25ns_UltraLegacy_PoissonOOTPU_cfi import mix as mix_UL17
+            self.pu_distribs["Summer19UL17"] = mix_UL17.input.nbPileupEvents
+        except Exception:
+            print "Failed to load UL17 mixing"
 
         try:
-            from SimGeneral.MixingModule.mix_2018_25ns_JuneProjectionFull18_PoissonOOTPU_cfi import mix as mix_Autumn18
+            from flashgg.MetaData.mix_2018_25ns_JuneProjectionFull18_PoissonOOTPU_cfi import mix as mix_Autumn18
             self.pu_distribs["Autumn18"] = mix_Autumn18.input.nbPileupEvents
         except Exception:
             print "Failed to load Autumn18 mixing"

--- a/MetaData/python/mix_2017_25ns_UltraLegacy_PoissonOOTPU_cfi.py
+++ b/MetaData/python/mix_2017_25ns_UltraLegacy_PoissonOOTPU_cfi.py
@@ -1,0 +1,71 @@
+import FWCore.ParameterSet.Config as cms
+
+# configuration to model pileup for initial physics phase
+from SimGeneral.MixingModule.mixObjects_cfi import theMixObjects
+from SimGeneral.MixingModule.mixPoolSource_cfi import *
+from SimGeneral.MixingModule.digitizers_cfi import *
+
+mix = cms.EDProducer("MixingModule",
+    digitizers = cms.PSet(theDigitizers),
+    LabelPlayback = cms.string(''),
+    maxBunch = cms.int32(3),
+    minBunch = cms.int32(-12), ## in terms of 25 nsec
+
+    bunchspace = cms.int32(25), ##ns
+    mixProdStep1 = cms.bool(False),
+    mixProdStep2 = cms.bool(False),
+
+    playback = cms.untracked.bool(False),
+    useCurrentProcessOnly = cms.bool(False),
+
+    input = cms.SecSource("EmbeddedRootSource",
+        type = cms.string('probFunction'),
+        nbPileupEvents = cms.PSet(
+            probFunctionVariable = cms.vint32(
+                0, 1, 2, 3, 4, 5, 6, 7, 8, 9,
+                10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
+                20, 21, 22, 23, 24, 25, 26, 27, 28, 29,
+                30, 31, 32, 33, 34, 35, 36, 37, 38, 39,
+                40, 41, 42, 43, 44, 45, 46, 47, 48, 49,
+                50, 51, 52, 53, 54, 55, 56, 57, 58, 59,
+                60, 61, 62, 63, 64, 65, 66, 67, 68, 69,
+                70, 71, 72, 73, 74, 75, 76, 77, 78, 79,
+                80, 81, 82, 83, 84, 85, 86, 87, 88, 89,
+                90, 91, 92, 93, 94, 95, 96, 97, 98
+            ),
+            probValue = cms.vdouble(
+                1.1840841518e-05, 3.46661037703e-05, 8.98772521472e-05, 7.47400487733e-05, 0.000123005176624,
+                0.000156501700614, 0.000154660478659, 0.000177496185603, 0.000324149805611, 0.000737524009713,
+                0.00140432980253, 0.00244424508696, 0.00380027898037, 0.00541093042612, 0.00768803501793,
+                0.010828224552, 0.0146608623707, 0.01887739113, 0.0228418813823, 0.0264817796874,
+                0.0294637401336, 0.0317960986171, 0.0336645950831, 0.0352638818387, 0.036869429333,
+                0.0382797316998, 0.039386705577, 0.0398389681346, 0.039646211131, 0.0388392805703,
+                0.0374195678161, 0.0355377892706, 0.0333383902828, 0.0308286549265, 0.0282914440969,
+                0.0257860718304, 0.02341635055, 0.0213126338243, 0.0195035612803, 0.0181079838989,
+                0.0171991315458, 0.0166377598339, 0.0166445341361, 0.0171943735369, 0.0181980997278,
+                0.0191339792146, 0.0198518804356, 0.0199714909193, 0.0194616474094, 0.0178626975229,
+                0.0153296785464, 0.0126789254325, 0.0100766041988, 0.00773867100481, 0.00592386091874,
+                0.00434706240169, 0.00310217013427, 0.00213213401899, 0.0013996000761, 0.000879148859271,
+                0.000540866009427, 0.000326115560156, 0.000193965828516, 0.000114607606623, 6.74262828734e-05,
+                3.97805301078e-05, 2.19948704638e-05, 9.72007976207e-06, 4.26179259146e-06, 2.80015581327e-06,
+                1.14675436465e-06, 2.52452411995e-07, 9.08394910044e-08, 1.14291987912e-08, 0.0,
+                0.0, 0.0, 0.0, 0.0, 0.0,
+                0.0, 0.0, 0.0, 0.0, 0.0,
+                0.0, 0.0, 0.0, 0.0, 0.0,
+                0.0, 0.0, 0.0, 0.0, 0.0,
+                0.0, 0.0, 0.0, 0.0
+            ),
+            histoFileName = cms.untracked.string('histProbFunction.root'),
+        ),
+        sequential = cms.untracked.bool(False),
+        manage_OOT = cms.untracked.bool(True),  ## manage out-of-time pileup
+        ## setting this to True means that the out-of-time pileup
+        ## will have a different distribution than in-time, given
+        ## by what is described on the next line:
+        OOT_type = cms.untracked.string('Poisson'),  ## generate OOT with a Poisson matching the number chosen for in-time
+        #OOT_type = cms.untracked.string('fixed'),  ## generate OOT with a fixed distribution
+        #intFixed_OOT = cms.untracked.int32(2),
+        fileNames = FileNames
+    ),
+    mixObjects = cms.PSet(theMixObjects)
+)

--- a/MetaData/python/mix_2018_25ns_JuneProjectionFull18_PoissonOOTPU_cfi.py
+++ b/MetaData/python/mix_2018_25ns_JuneProjectionFull18_PoissonOOTPU_cfi.py
@@ -1,0 +1,66 @@
+import FWCore.ParameterSet.Config as cms
+
+# configuration to model pileup for initial physics phase
+from SimGeneral.MixingModule.mixObjects_cfi import theMixObjects
+from SimGeneral.MixingModule.mixPoolSource_cfi import *
+from SimGeneral.MixingModule.digitizers_cfi import *
+
+mix = cms.EDProducer("MixingModule",
+    digitizers = cms.PSet(theDigitizers),
+    LabelPlayback = cms.string(''),
+    maxBunch = cms.int32(3),
+    minBunch = cms.int32(-12), ## in terms of 25 nsec
+
+    bunchspace = cms.int32(25), ##ns
+    mixProdStep1 = cms.bool(False),
+    mixProdStep2 = cms.bool(False),
+
+    playback = cms.untracked.bool(False),
+    useCurrentProcessOnly = cms.bool(False),
+
+    input = cms.SecSource("EmbeddedRootSource",
+        type = cms.string('probFunction'),
+        nbPileupEvents = cms.PSet(
+            probFunctionVariable = cms.vint32(
+                0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
+                20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39,
+                40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59,
+                60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79,
+                80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99
+            ),
+            probValue = cms.vdouble(
+                4.695341e-10, 1.206213e-06, 1.162593e-06, 6.118058e-06, 1.626767e-05,
+                3.508135e-05, 7.12608e-05, 0.0001400641, 0.0002663403, 0.0004867473,
+                0.0008469, 0.001394142, 0.002169081, 0.003198514, 0.004491138,
+                0.006036423, 0.007806509, 0.00976048, 0.0118498, 0.01402411,
+                0.01623639, 0.01844593, 0.02061956, 0.02273221, 0.02476554,
+                0.02670494, 0.02853662, 0.03024538, 0.03181323, 0.03321895,
+                0.03443884, 0.035448, 0.03622242, 0.03674106, 0.0369877,
+                0.03695224, 0.03663157, 0.03602986, 0.03515857, 0.03403612,
+                0.0326868, 0.03113936, 0.02942582, 0.02757999, 0.02563551,
+                0.02362497, 0.02158003, 0.01953143, 0.01750863, 0.01553934,
+                0.01364905, 0.01186035, 0.01019246, 0.008660705, 0.007275915,
+                0.006043917, 0.004965276, 0.004035611, 0.003246373, 0.002585932,
+                0.002040746, 0.001596402, 0.001238498, 0.0009533139, 0.0007282885,
+                0.000552306, 0.0004158005, 0.0003107302, 0.0002304612, 0.0001696012,
+                0.0001238161, 8.96531e-05, 6.438087e-05, 4.585302e-05, 3.23949e-05,
+                2.271048e-05, 1.580622e-05, 1.09286e-05, 7.512748e-06, 5.140304e-06,
+                3.505254e-06, 2.386437e-06, 1.625859e-06, 1.111865e-06, 7.663272e-07,
+                5.350694e-07, 3.808318e-07, 2.781785e-07, 2.098661e-07, 1.642811e-07,
+                1.312835e-07, 1.081326e-07, 9.141993e-08, 7.890983e-08, 6.91468e-08,
+                6.119019e-08, 5.443693e-08, 4.85036e-08, 4.31486e-08, 3.822112e-08
+            ),
+            histoFileName = cms.untracked.string('histProbFunction.root'),
+        ),
+        sequential = cms.untracked.bool(False),
+        manage_OOT = cms.untracked.bool(True),  ## manage out-of-time pileup
+        ## setting this to True means that the out-of-time pileup
+        ## will have a different distribution than in-time, given
+        ## by what is described on the next line:
+        OOT_type = cms.untracked.string('Poisson'),  ## generate OOT with a Poisson matching the number chosen for in-time
+        #OOT_type = cms.untracked.string('fixed'),  ## generate OOT with a fixed distribution
+        #intFixed_OOT = cms.untracked.int32(2),
+        fileNames = FileNames
+    ),
+    mixObjects = cms.PSet(theMixObjects)
+)

--- a/MicroAOD/src/GlobalVariablesComputer.cc
+++ b/MicroAOD/src/GlobalVariablesComputer.cc
@@ -84,7 +84,7 @@ namespace flashgg {
                 }
 
                 auto scl  = std::accumulate(mcpu.begin(),mcpu.end(),0.) / std::accumulate(puWeight_.begin(),puWeight_.end(),0.); // rescale input distribs to unit ara
-                for( size_t ib = 0; ib<puWeight_.size(); ++ib ) { puWeight_[ib] *= scl / mcpu[ib]; }
+                for( size_t ib = 0; ib<puWeight_.size(); ++ib ) { puWeight_[ib] *= ( mcpu[ib] != 0. ? scl / mcpu[ib] : 0. ); }
                 if( cfg.exists("useTruePu") ) { useTruePu_ = cfg.getParameter<bool>("useTruePu"); }
             }
         }

--- a/Systematics/python/flashggDiPhotonSystematics2017_Legacy_cfi.py
+++ b/Systematics/python/flashggDiPhotonSystematics2017_Legacy_cfi.py
@@ -275,19 +275,19 @@ sigmaEOverEShiftBins = cms.PSet(
 RVBins = cms.PSet(
     variables = cms.vstring("pt"),
     bins = cms.VPSet(
-        cms.PSet(lowBounds = cms.vdouble(0),   upBounds = cms.vdouble(5),   values = cms.vdouble(0.97405, 1.02581), uncertainties = cms.vdouble(0.0244223, 0.0244223, 0.0242939, 0.0242939)),
-        cms.PSet(lowBounds = cms.vdouble(5),   upBounds = cms.vdouble(10),  values = cms.vdouble(0.992877, 1.00801), uncertainties = cms.vdouble(0.0259363, 0.0259363, 0.0291707, 0.0291707)),
-        cms.PSet(lowBounds = cms.vdouble(10),  upBounds = cms.vdouble(15),  values = cms.vdouble(0.989147, 1.01497), uncertainties = cms.vdouble(0.0235248, 0.0235248, 0.0324417, 0.0324417)),
-        cms.PSet(lowBounds = cms.vdouble(15),  upBounds = cms.vdouble(20),  values = cms.vdouble(0.977417, 1.03893), uncertainties = cms.vdouble(0.0193127, 0.0193127, 0.033296, 0.033296)),
-        cms.PSet(lowBounds = cms.vdouble(20),  upBounds = cms.vdouble(30),  values = cms.vdouble(0.974667, 1.06613), uncertainties = cms.vdouble(0.0141051, 0.0141051, 0.0368292, 0.0368292)),
-        cms.PSet(lowBounds = cms.vdouble(30),  upBounds = cms.vdouble(40),  values = cms.vdouble(0.979387, 1.09002), uncertainties = cms.vdouble(0.0083176, 0.0083176, 0.0363466, 0.0363466)),
-        cms.PSet(lowBounds = cms.vdouble(40),  upBounds = cms.vdouble(50),  values = cms.vdouble(0.985972, 1.09517), uncertainties = cms.vdouble(0.00576372, 0.00576372, 0.0391516, 0.0391516)),
-        cms.PSet(lowBounds = cms.vdouble(50),  upBounds = cms.vdouble(60),  values = cms.vdouble(0.98862, 1.11167), uncertainties = cms.vdouble(0.00378304, 0.00378304, 0.0372533, 0.0372533)),
-        cms.PSet(lowBounds = cms.vdouble(60),  upBounds = cms.vdouble(80),  values = cms.vdouble(0.991643, 1.12609), uncertainties = cms.vdouble(0.00249869, 0.00249869, 0.0378921, 0.0378921)),
-        cms.PSet(lowBounds = cms.vdouble(80),  upBounds = cms.vdouble(100), values = cms.vdouble(0.994479, 1.1408), uncertainties = cms.vdouble(0.00165178, 0.00165178, 0.0427137, 0.0427137)),
-        cms.PSet(lowBounds = cms.vdouble(100), upBounds = cms.vdouble(140), values = cms.vdouble(0.996918, 1.11227), uncertainties = cms.vdouble(0.00117866, 0.00117866, 0.0434459, 0.0434459)),
-        cms.PSet(lowBounds = cms.vdouble(140), upBounds = cms.vdouble(200), values = cms.vdouble(0.998692, 1.09851), uncertainties = cms.vdouble(0.000855418, 0.000855418, 0.0653476, 0.0653476)),
-        cms.PSet(lowBounds = cms.vdouble(200), upBounds = cms.vdouble(400), values = cms.vdouble(0.999521, 1.07875), uncertainties = cms.vdouble(0.00099373, 0.00099373, 0.1642, 0.1642)),
+        cms.PSet(lowBounds = cms.vdouble(0),   upBounds = cms.vdouble(5),   values = cms.vdouble(0.958392, 1.04357), uncertainties = cms.vdouble(0.0296904, 0.0296904, 0.0310986, 0.0310986)),
+        cms.PSet(lowBounds = cms.vdouble(5),   upBounds = cms.vdouble(10),  values = cms.vdouble(0.977373, 1.0257), uncertainties = cms.vdouble(0.0309958, 0.0309958, 0.0352084, 0.0352084)),
+        cms.PSet(lowBounds = cms.vdouble(10),  upBounds = cms.vdouble(15),  values = cms.vdouble(0.974783, 1.03489), uncertainties = cms.vdouble(0.0296353, 0.0296353, 0.0410014, 0.0410014)),
+        cms.PSet(lowBounds = cms.vdouble(15),  upBounds = cms.vdouble(20),  values = cms.vdouble(0.970213, 1.05195), uncertainties = cms.vdouble(0.0251379, 0.0251379, 0.0438491, 0.0438491)),
+        cms.PSet(lowBounds = cms.vdouble(20),  upBounds = cms.vdouble(30),  values = cms.vdouble(0.972045, 1.0723), uncertainties = cms.vdouble(0.017448, 0.017448, 0.0451307, 0.0451307)),
+        cms.PSet(lowBounds = cms.vdouble(30),  upBounds = cms.vdouble(40),  values = cms.vdouble(0.984069, 1.06876), uncertainties = cms.vdouble(0.0118301, 0.0118301, 0.0510668, 0.0510668)),
+        cms.PSet(lowBounds = cms.vdouble(40),  upBounds = cms.vdouble(50),  values = cms.vdouble(0.989929, 1.06865), uncertainties = cms.vdouble(0.00743091, 0.00743091, 0.0506721, 0.0506721)),
+        cms.PSet(lowBounds = cms.vdouble(50),  upBounds = cms.vdouble(60),  values = cms.vdouble(0.992927, 1.07105), uncertainties = cms.vdouble(0.00536046, 0.00536046, 0.0538791, 0.0538791)),
+        cms.PSet(lowBounds = cms.vdouble(60),  upBounds = cms.vdouble(80),  values = cms.vdouble(0.995524, 1.06772), uncertainties = cms.vdouble(0.00313061, 0.00313061, 0.0474004, 0.0474004)),
+        cms.PSet(lowBounds = cms.vdouble(80),  upBounds = cms.vdouble(100), values = cms.vdouble(0.997446, 1.05604), uncertainties = cms.vdouble(0.00184726, 0.00184726, 0.0405967, 0.0405967)),
+        cms.PSet(lowBounds = cms.vdouble(100), upBounds = cms.vdouble(140), values = cms.vdouble(0.999115, 1.03045), uncertainties = cms.vdouble(0.00119552, 0.00119552, 0.0411651, 0.0411651)),
+        cms.PSet(lowBounds = cms.vdouble(140), upBounds = cms.vdouble(200), values = cms.vdouble(0.99973, 1.02064), uncertainties = cms.vdouble(0.000725067, 0.000725067, 0.0555666, 0.0555666)),
+        cms.PSet(lowBounds = cms.vdouble(200), upBounds = cms.vdouble(400), values = cms.vdouble(0.998152, 1.38258), uncertainties = cms.vdouble(0.000959052, 0.000959052, 0.216813, 0.216813)),
         # maximum energy beyond 7000 because of wonky DiPhotons in data
         cms.PSet(lowBounds = cms.vdouble(400 ) , upBounds = cms.vdouble(999999999 ) , values = cms.vdouble(1,1              ) , uncertainties = cms.vdouble(0.,0.,0.,0.))       
         )

--- a/Systematics/test/UL_runII_v1_2017.json
+++ b/Systematics/test/UL_runII_v1_2017.json
@@ -1,0 +1,19 @@
+{
+    "processes" : {
+
+        "Data" : [
+            "/DoubleEG/alesauva-UL_test-10_6_4-v0-Run2017B-09Aug2019_UL2017-v1-53faf905fdb551f89c40f719673e864f/USER",
+            "/DoubleEG/alesauva-UL_test-10_6_4-v0-Run2017C-09Aug2019_UL2017-v1-53faf905fdb551f89c40f719673e864f/USER",
+            "/DoubleEG/alesauva-UL_test-10_6_4-v0-Run2017D-09Aug2019_UL2017-v1-53faf905fdb551f89c40f719673e864f/USER",
+            "/DoubleEG/alesauva-UL_test-10_6_4-v0-Run2017E-09Aug2019_UL2017-v1-53faf905fdb551f89c40f719673e864f/USER",
+            "/DoubleEG/alesauva-UL_test-10_6_4-v0-Run2017F-09Aug2019_UL2017-v1-53faf905fdb551f89c40f719673e864f/USER"
+        ],
+
+        "wh_125"  : [ 
+            [ "/VHToGG_M125_TuneCP5_13TeV-amcatnloFXFX-madspin-pythia8", { "args" :["outputFile=output_WHToGG_M125_TuneCP5_13TeV-amcatnloFXFX-madspin-pythia8.root"] } ],
+            "/WplusH_HToGG_WToAll_M125_TuneCP5_13TeV-powheg-pythia8"
+        ]
+
+    },
+    "cmdLine"  : "campaign=Era2017_legacy_v1 metaConditions=$CMSSW_BASE/src/flashgg/MetaData/data/MetaConditions/Era2017_legacy_v1.json useAAA=True puTarget=6.238e-06,2.614e-05,4.849e-05,9.107e-05,9.776e-05,0.0001416,0.0001553,0.0001637,0.0002213,0.0005245,0.001052,0.001992,0.00317,0.004549,0.006438,0.009079,0.01267,0.01687,0.02103,0.02487,0.02824,0.03097,0.03307,0.03469,0.03608,0.03739,0.03851,0.0392,0.03932,0.03881,0.03775,0.03623,0.03435,0.03215,0.02974,0.0273,0.02494,0.02277,0.02082,0.01917,0.01791,0.01711,0.01682,0.01702,0.01759,0.01836,0.01906,0.01941,0.01917,0.01821,0.01654,0.01433,0.01184,0.009335,0.007048,0.005114,0.003583,0.002435,0.001613,0.001047,0.0006682,0.0004212,0.0002632,0.0001635,0.0001014,6.299e-05,3.93e-05,2.471e-05,1.568e-05,1.006e-05,6.53e-06,4.28e-06,2.83e-06,1.883e-06,1.259e-06,8.436e-07,5.655e-07,3.787e-07,2.53e-07,1.684e-07,1.116e-07,7.359e-08,4.825e-08,3.143e-08,2.033e-08,1.306e-08,8.322e-09,5.261e-09,3.297e-09,2.049e-09,1.262e-09,7.697e-10,4.652e-10,2.785e-10,1.651e-10,9.691e-11,5.632e-11,3.24e-11,1.845e-11"
+}


### PR DESCRIPTION
- Because when JobConfig.py includes the pileup information,

   mix_2017_25ns_UltraLegacy_PoissonOOTPU_cfi.py 
   mix_2018_25ns_JuneProjectionFull18_PoissonOOTPU_cfi.py 

   in CMSSW [1] come from the same object which is mix_probFunction_25ns_PoissonOOTPU_cfi.py
   Therefore, if mix_2017_25ns_UltraLegacy_PoissonOOTPU_cfi.py is first included and then 
   mix_2018_25ns_JuneProjectionFull18_PoissonOOTPU_cfi.py, the information from later will overwrites the previous which is 
   UL17 and vice versa. This results in huge weights (2018 MC pileup are mis-assigned to UL2017 samples). Now, these two 
   are pulled to flashgg and modified to independent formats and bugs are fixed.
- Note that UL2017 provides only 99 bins for pileup, so I made UL_runII_v1_2017.json as UL2017 example. 
- Commit for diphoton vertex SF of UL2017 is dummy.

[1]
https://github.com/cms-sw/cmssw/blob/CMSSW_10_6_X/SimGeneral/MixingModule/python/mix_2017_25ns_UltraLegacy_PoissonOOTPU_cfi.py#L2
https://github.com/cms-sw/cmssw/blob/CMSSW_10_6_X/SimGeneral/MixingModule/python/mix_2018_25ns_JuneProjectionFull18_PoissonOOTPU_cfi.py#L2