### PR TITLE
Tprime and HTo4g analysis samples

### DIFF
--- a/MetaData/data/Era2016_RR-17Jul2018_v2/datasets_37.json
+++ b/MetaData/data/Era2016_RR-17Jul2018_v2/datasets_37.json
@@ -1,4 +1,4 @@
-{    
+{
     "/GluGluToHHTo2G2l2nu_node_10_TuneCUETP8M1_PSWeights_13TeV-madgraph-pythia8/alesauva-2016_0-10_6_4-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1-c3d8a5638586a0e8df7c55ce908b2878/USER": {
         "dset_type": "mc", 
         "files": [
@@ -150,7 +150,6 @@
         "parent_n_units": 399986, 
         "vetted": true
     }, 
-     
     "/GluGluToHHTo2G2l2nu_node_11_TuneCUETP8M1_PSWeights_13TeV-madgraph-pythia8/alesauva-2016_0-10_6_4-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1-c3d8a5638586a0e8df7c55ce908b2878/USER": {
         "dset_type": "mc", 
         "files": [
@@ -541,7 +540,6 @@
         "parent_n_units": 392490, 
         "vetted": true
     }, 
-    
     "/GluGluToHHTo2G2l2nu_node_1_TuneCUETP8M1_PSWeights_13TeV-madgraph-pythia8/alesauva-2016_0-10_6_4-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1-c3d8a5638586a0e8df7c55ce908b2878/USER": {
         "dset_type": "mc", 
         "files": [
@@ -773,7 +771,6 @@
         "parent_n_units": 398788, 
         "vetted": true
     }, 
-    
     "/GluGluToHHTo2G2l2nu_node_2_TuneCUETP8M1_PSWeights_13TeV-madgraph-pythia8/alesauva-2016_0-10_6_4-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1-c3d8a5638586a0e8df7c55ce908b2878/USER": {
         "dset_type": "mc", 
         "files": [
@@ -925,7 +922,6 @@
         "parent_n_units": 399086, 
         "vetted": true
     }, 
-    
     "/GluGluToHHTo2G2l2nu_node_3_TuneCUETP8M1_PSWeights_13TeV-madgraph-pythia8/alesauva-2016_0-10_6_4-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1-c3d8a5638586a0e8df7c55ce908b2878/USER": {
         "dset_type": "mc", 
         "files": [
@@ -1069,7 +1065,7 @@
         "parent_n_units": null, 
         "vetted": true
     }, 
-        "/GluGluToHHTo2G2l2nu_node_4_TuneCUETP8M1_PSWeights_13TeV-madgraph-pythia8/alesauva-2016_0-10_6_4-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1-c3d8a5638586a0e8df7c55ce908b2878/USER": {
+    "/GluGluToHHTo2G2l2nu_node_4_TuneCUETP8M1_PSWeights_13TeV-madgraph-pythia8/alesauva-2016_0-10_6_4-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1-c3d8a5638586a0e8df7c55ce908b2878/USER": {
         "dset_type": "mc", 
         "files": [
             {
@@ -1212,7 +1208,6 @@
         "parent_n_units": 396990, 
         "vetted": true
     }, 
-     
     "/GluGluToHHTo2G2l2nu_node_5_TuneCUETP8M1_PSWeights_13TeV-madgraph-pythia8/alesauva-2016_0-10_6_4-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1-c3d8a5638586a0e8df7c55ce908b2878/USER": {
         "dset_type": "mc", 
         "files": [
@@ -1603,7 +1598,6 @@
         "parent_n_units": 396984, 
         "vetted": true
     }, 
-     
     "/GluGluToHHTo2G2l2nu_node_7_TuneCUETP8M1_PSWeights_13TeV-madgraph-pythia8/alesauva-2016_0-10_6_4-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1-c3d8a5638586a0e8df7c55ce908b2878/USER": {
         "dset_type": "mc", 
         "files": [
@@ -1755,7 +1749,6 @@
         "parent_n_units": 397487, 
         "vetted": true
     }, 
-     
     "/GluGluToHHTo2G2l2nu_node_8_TuneCUETP8M1_PSWeights_13TeV-madgraph-pythia8/alesauva-2016_0-10_6_4-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1-c3d8a5638586a0e8df7c55ce908b2878/USER": {
         "dset_type": "mc", 
         "files": [
@@ -2114,7 +2107,6 @@
         "parent_n_units": null, 
         "vetted": true
     }, 
-   
     "/GluGluToHHTo2G2l2nu_node_SM_TuneCUETP8M1_PSWeights_13TeV-madgraph-pythia8/alesauva-2016_0-10_6_4-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1-c3d8a5638586a0e8df7c55ce908b2878/USER": {
         "dset_type": "mc", 
         "files": [
@@ -3034,5 +3026,3898 @@
         ], 
         "parent_n_units": 395985, 
         "vetted": true
-    } 
-   }
+    }, 
+    "/HAHMHToAA_AToGG_MA-15GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/lata-Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3-558f94a366de3fc00ec9d9ea7e93aa72/USER": {
+        "dset_type": "mc", 
+        "files": [
+            {
+                "bad": false, 
+                "events": 25028, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-15GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_190939/0000/myMicroAODOutputFile_14.root", 
+                "nevents": 25028, 
+                "totEvents": 25028, 
+                "weights": 25024.017578125
+            }, 
+            {
+                "bad": false, 
+                "events": 24930, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-15GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_190939/0000/myMicroAODOutputFile_15.root", 
+                "nevents": 24930, 
+                "totEvents": 24930, 
+                "weights": 24925.755859375
+            }, 
+            {
+                "bad": false, 
+                "events": 24816, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-15GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_190939/0000/myMicroAODOutputFile_18.root", 
+                "nevents": 24816, 
+                "totEvents": 24816, 
+                "weights": 24811.904296875
+            }, 
+            {
+                "bad": false, 
+                "events": 24836, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-15GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_190939/0000/myMicroAODOutputFile_4.root", 
+                "nevents": 24836, 
+                "totEvents": 24836, 
+                "weights": 24831.80859375
+            }, 
+            {
+                "bad": false, 
+                "events": 24925, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-15GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_190939/0000/myMicroAODOutputFile_5.root", 
+                "nevents": 24925, 
+                "totEvents": 24925, 
+                "weights": 24920.91796875
+            }, 
+            {
+                "bad": false, 
+                "events": 25100, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-15GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_190939/0000/myMicroAODOutputFile_17.root", 
+                "nevents": 25100, 
+                "totEvents": 25100, 
+                "weights": 25095.4765625
+            }, 
+            {
+                "bad": false, 
+                "events": 24738, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-15GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_190939/0000/myMicroAODOutputFile_3.root", 
+                "nevents": 24738, 
+                "totEvents": 24738, 
+                "weights": 24733.94921875
+            }, 
+            {
+                "bad": false, 
+                "events": 25105, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-15GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_190939/0000/myMicroAODOutputFile_6.root", 
+                "nevents": 25105, 
+                "totEvents": 25105, 
+                "weights": 25101.150390625
+            }, 
+            {
+                "bad": false, 
+                "events": 24893, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-15GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_190939/0000/myMicroAODOutputFile_1.root", 
+                "nevents": 24893, 
+                "totEvents": 24893, 
+                "weights": 24889.333984375
+            }, 
+            {
+                "bad": false, 
+                "events": 24999, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-15GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_190939/0000/myMicroAODOutputFile_10.root", 
+                "nevents": 24999, 
+                "totEvents": 24999, 
+                "weights": 24995.033203125
+            }, 
+            {
+                "bad": false, 
+                "events": 24894, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-15GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_190939/0000/myMicroAODOutputFile_16.root", 
+                "nevents": 24894, 
+                "totEvents": 24894, 
+                "weights": 24889.751953125
+            }, 
+            {
+                "bad": false, 
+                "events": 24944, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-15GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_190939/0000/myMicroAODOutputFile_19.root", 
+                "nevents": 24944, 
+                "totEvents": 24944, 
+                "weights": 24939.88671875
+            }, 
+            {
+                "bad": false, 
+                "events": 25174, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-15GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_190939/0000/myMicroAODOutputFile_2.root", 
+                "nevents": 25174, 
+                "totEvents": 25174, 
+                "weights": 25170.326171875
+            }, 
+            {
+                "bad": false, 
+                "events": 24829, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-15GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_190939/0000/myMicroAODOutputFile_8.root", 
+                "nevents": 24829, 
+                "totEvents": 24829, 
+                "weights": 24824.873046875
+            }, 
+            {
+                "bad": false, 
+                "events": 24857, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-15GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_190939/0000/myMicroAODOutputFile_7.root", 
+                "nevents": 24857, 
+                "totEvents": 24857, 
+                "weights": 24852.984375
+            }, 
+            {
+                "bad": false, 
+                "events": 25030, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-15GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_190939/0000/myMicroAODOutputFile_13.root", 
+                "nevents": 25030, 
+                "totEvents": 25030, 
+                "weights": 25025.689453125
+            }, 
+            {
+                "bad": false, 
+                "events": 24916, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-15GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_190939/0000/myMicroAODOutputFile_12.root", 
+                "nevents": 24916, 
+                "totEvents": 24916, 
+                "weights": 24911.98046875
+            }, 
+            {
+                "bad": false, 
+                "events": 24633, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-15GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_190939/0000/myMicroAODOutputFile_11.root", 
+                "nevents": 24633, 
+                "totEvents": 24633, 
+                "weights": 24628.841796875
+            }, 
+            {
+                "bad": false, 
+                "events": 24908, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-15GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_190939/0000/myMicroAODOutputFile_9.root", 
+                "nevents": 24908, 
+                "totEvents": 24908, 
+                "weights": 24903.744140625
+            }
+        ], 
+        "parent_n_units": 473555, 
+        "vetted": true
+    }, 
+    "/HAHMHToAA_AToGG_MA-20GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/lata-Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3-558f94a366de3fc00ec9d9ea7e93aa72/USER": {
+        "dset_type": "mc", 
+        "files": [
+            {
+                "bad": false, 
+                "events": 25060, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-20GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_191226/0000/myMicroAODOutputFile_16.root", 
+                "nevents": 25060, 
+                "totEvents": 25060, 
+                "weights": 25054.802734375
+            }, 
+            {
+                "bad": false, 
+                "events": 25103, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-20GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_191226/0000/myMicroAODOutputFile_17.root", 
+                "nevents": 25103, 
+                "totEvents": 25103, 
+                "weights": 25098.17578125
+            }, 
+            {
+                "bad": false, 
+                "events": 561, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-20GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_191226/0000/myMicroAODOutputFile_20.root", 
+                "nevents": 561, 
+                "totEvents": 561, 
+                "weights": 560.85009765625
+            }, 
+            {
+                "bad": false, 
+                "events": 24979, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-20GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_191226/0000/myMicroAODOutputFile_15.root", 
+                "nevents": 24979, 
+                "totEvents": 24979, 
+                "weights": 24973.748046875
+            }, 
+            {
+                "bad": false, 
+                "events": 24943, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-20GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_191226/0000/myMicroAODOutputFile_12.root", 
+                "nevents": 24943, 
+                "totEvents": 24943, 
+                "weights": 24938.052734375
+            }, 
+            {
+                "bad": false, 
+                "events": 24862, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-20GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_191226/0000/myMicroAODOutputFile_13.root", 
+                "nevents": 24862, 
+                "totEvents": 24862, 
+                "weights": 24856.556640625
+            }, 
+            {
+                "bad": false, 
+                "events": 24782, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-20GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_191226/0000/myMicroAODOutputFile_7.root", 
+                "nevents": 24782, 
+                "totEvents": 24782, 
+                "weights": 24776.916015625
+            }, 
+            {
+                "bad": false, 
+                "events": 24885, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-20GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_191226/0000/myMicroAODOutputFile_10.root", 
+                "nevents": 24885, 
+                "totEvents": 24885, 
+                "weights": 24879.685546875
+            }, 
+            {
+                "bad": false, 
+                "events": 24913, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-20GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_191226/0000/myMicroAODOutputFile_9.root", 
+                "nevents": 24913, 
+                "totEvents": 24913, 
+                "weights": 24907.416015625
+            }, 
+            {
+                "bad": false, 
+                "events": 25088, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-20GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_191226/0000/myMicroAODOutputFile_11.root", 
+                "nevents": 25088, 
+                "totEvents": 25088, 
+                "weights": 25082.990234375
+            }, 
+            {
+                "bad": false, 
+                "events": 24882, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-20GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_191226/0000/myMicroAODOutputFile_8.root", 
+                "nevents": 24882, 
+                "totEvents": 24882, 
+                "weights": 24876.474609375
+            }, 
+            {
+                "bad": false, 
+                "events": 24880, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-20GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_191226/0000/myMicroAODOutputFile_6.root", 
+                "nevents": 24880, 
+                "totEvents": 24880, 
+                "weights": 24875.302734375
+            }, 
+            {
+                "bad": false, 
+                "events": 24856, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-20GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_191226/0000/myMicroAODOutputFile_4.root", 
+                "nevents": 24856, 
+                "totEvents": 24856, 
+                "weights": 24850.572265625
+            }, 
+            {
+                "bad": false, 
+                "events": 24800, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-20GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_191226/0000/myMicroAODOutputFile_5.root", 
+                "nevents": 24800, 
+                "totEvents": 24800, 
+                "weights": 24794.8125
+            }, 
+            {
+                "bad": false, 
+                "events": 25041, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-20GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_191226/0000/myMicroAODOutputFile_3.root", 
+                "nevents": 25041, 
+                "totEvents": 25041, 
+                "weights": 25035.666015625
+            }, 
+            {
+                "bad": false, 
+                "events": 25121, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-20GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_191226/0000/myMicroAODOutputFile_2.root", 
+                "nevents": 25121, 
+                "totEvents": 25121, 
+                "weights": 25116.029296875
+            }, 
+            {
+                "bad": false, 
+                "events": 24854, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-20GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_191226/0000/myMicroAODOutputFile_1.root", 
+                "nevents": 24854, 
+                "totEvents": 24854, 
+                "weights": 24848.697265625
+            }, 
+            {
+                "bad": false, 
+                "events": 24846, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-20GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_191226/0000/myMicroAODOutputFile_14.root", 
+                "nevents": 24846, 
+                "totEvents": 24846, 
+                "weights": 24840.70703125
+            }, 
+            {
+                "bad": false, 
+                "events": 24991, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-20GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_191226/0000/myMicroAODOutputFile_19.root", 
+                "nevents": 24991, 
+                "totEvents": 24991, 
+                "weights": 24986.11328125
+            }, 
+            {
+                "bad": false, 
+                "events": 24856, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-20GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_191226/0000/myMicroAODOutputFile_18.root", 
+                "nevents": 24856, 
+                "totEvents": 24856, 
+                "weights": 24850.646484375
+            }
+        ], 
+        "parent_n_units": 474303, 
+        "vetted": true
+    }, 
+    "/HAHMHToAA_AToGG_MA-25GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/lata-Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3-558f94a366de3fc00ec9d9ea7e93aa72/USER": {
+        "dset_type": "mc", 
+        "files": [
+            {
+                "bad": false, 
+                "events": 24721, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-25GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_191459/0000/myMicroAODOutputFile_17.root", 
+                "nevents": 24721, 
+                "totEvents": 24721, 
+                "weights": 24715.466796875
+            }, 
+            {
+                "bad": false, 
+                "events": 24909, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-25GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_191459/0000/myMicroAODOutputFile_8.root", 
+                "nevents": 24909, 
+                "totEvents": 24909, 
+                "weights": 24903.26953125
+            }, 
+            {
+                "bad": false, 
+                "events": 24898, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-25GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_191459/0000/myMicroAODOutputFile_18.root", 
+                "nevents": 24898, 
+                "totEvents": 24898, 
+                "weights": 24892.44921875
+            }, 
+            {
+                "bad": false, 
+                "events": 24897, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-25GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_191459/0000/myMicroAODOutputFile_9.root", 
+                "nevents": 24897, 
+                "totEvents": 24897, 
+                "weights": 24891.298828125
+            }, 
+            {
+                "bad": false, 
+                "events": 24910, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-25GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_191459/0000/myMicroAODOutputFile_2.root", 
+                "nevents": 24910, 
+                "totEvents": 24910, 
+                "weights": 24904.140625
+            }, 
+            {
+                "bad": false, 
+                "events": 24779, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-25GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_191459/0000/myMicroAODOutputFile_1.root", 
+                "nevents": 24779, 
+                "totEvents": 24779, 
+                "weights": 24773.50390625
+            }, 
+            {
+                "bad": false, 
+                "events": 24778, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-25GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_191459/0000/myMicroAODOutputFile_14.root", 
+                "nevents": 24778, 
+                "totEvents": 24778, 
+                "weights": 24772.375
+            }, 
+            {
+                "bad": false, 
+                "events": 24780, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-25GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_191459/0000/myMicroAODOutputFile_7.root", 
+                "nevents": 24780, 
+                "totEvents": 24780, 
+                "weights": 24774.265625
+            }, 
+            {
+                "bad": false, 
+                "events": 25036, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-25GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_191459/0000/myMicroAODOutputFile_16.root", 
+                "nevents": 25036, 
+                "totEvents": 25036, 
+                "weights": 25030.16796875
+            }, 
+            {
+                "bad": false, 
+                "events": 24946, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-25GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_191459/0000/myMicroAODOutputFile_4.root", 
+                "nevents": 24946, 
+                "totEvents": 24946, 
+                "weights": 24940.072265625
+            }, 
+            {
+                "bad": false, 
+                "events": 25056, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-25GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_191459/0000/myMicroAODOutputFile_12.root", 
+                "nevents": 25056, 
+                "totEvents": 25056, 
+                "weights": 25050.03125
+            }, 
+            {
+                "bad": false, 
+                "events": 25091, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-25GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_191459/0000/myMicroAODOutputFile_6.root", 
+                "nevents": 25091, 
+                "totEvents": 25091, 
+                "weights": 25085.21875
+            }, 
+            {
+                "bad": false, 
+                "events": 25178, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-25GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_191459/0000/myMicroAODOutputFile_19.root", 
+                "nevents": 25178, 
+                "totEvents": 25178, 
+                "weights": 25172.361328125
+            }, 
+            {
+                "bad": false, 
+                "events": 24995, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-25GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_191459/0000/myMicroAODOutputFile_3.root", 
+                "nevents": 24995, 
+                "totEvents": 24995, 
+                "weights": 24989.275390625
+            }, 
+            {
+                "bad": false, 
+                "events": 2268, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-25GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_191459/0000/myMicroAODOutputFile_10.root", 
+                "nevents": 2268, 
+                "totEvents": 2268, 
+                "weights": 2267.44970703125
+            }, 
+            {
+                "bad": false, 
+                "events": 24832, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-25GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_191459/0000/myMicroAODOutputFile_11.root", 
+                "nevents": 24832, 
+                "totEvents": 24832, 
+                "weights": 24826.11328125
+            }, 
+            {
+                "bad": false, 
+                "events": 24731, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-25GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_191459/0000/myMicroAODOutputFile_5.root", 
+                "nevents": 24731, 
+                "totEvents": 24731, 
+                "weights": 24725.40234375
+            }, 
+            {
+                "bad": false, 
+                "events": 24789, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-25GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_191459/0000/myMicroAODOutputFile_15.root", 
+                "nevents": 24789, 
+                "totEvents": 24789, 
+                "weights": 24783.330078125
+            }, 
+            {
+                "bad": false, 
+                "events": 23124, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-25GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_191459/0000/myMicroAODOutputFile_20.root", 
+                "nevents": 23124, 
+                "totEvents": 23124, 
+                "weights": 23118.4609375
+            }, 
+            {
+                "bad": false, 
+                "events": 24843, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-25GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_191459/0000/myMicroAODOutputFile_13.root", 
+                "nevents": 24843, 
+                "totEvents": 24843, 
+                "weights": 24837.525390625
+            }
+        ], 
+        "parent_n_units": 473561, 
+        "vetted": true
+    }, 
+    "/HAHMHToAA_AToGG_MA-30GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/lata-Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3-558f94a366de3fc00ec9d9ea7e93aa72/USER": {
+        "dset_type": "mc", 
+        "files": [
+            {
+                "bad": false, 
+                "events": 24848, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-30GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_191733/0000/myMicroAODOutputFile_3.root", 
+                "nevents": 24848, 
+                "totEvents": 24848, 
+                "weights": 24842.28125
+            }, 
+            {
+                "bad": false, 
+                "events": 24901, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-30GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_191733/0000/myMicroAODOutputFile_2.root", 
+                "nevents": 24901, 
+                "totEvents": 24901, 
+                "weights": 24895.36328125
+            }, 
+            {
+                "bad": false, 
+                "events": 24853, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-30GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_191733/0000/myMicroAODOutputFile_11.root", 
+                "nevents": 24853, 
+                "totEvents": 24853, 
+                "weights": 24847.140625
+            }, 
+            {
+                "bad": false, 
+                "events": 24884, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-30GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_191733/0000/myMicroAODOutputFile_18.root", 
+                "nevents": 24884, 
+                "totEvents": 24884, 
+                "weights": 24877.998046875
+            }, 
+            {
+                "bad": false, 
+                "events": 24843, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-30GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_191733/0000/myMicroAODOutputFile_6.root", 
+                "nevents": 24843, 
+                "totEvents": 24843, 
+                "weights": 24837.173828125
+            }, 
+            {
+                "bad": false, 
+                "events": 25166, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-30GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_191733/0000/myMicroAODOutputFile_5.root", 
+                "nevents": 25166, 
+                "totEvents": 25166, 
+                "weights": 25159.9453125
+            }, 
+            {
+                "bad": false, 
+                "events": 25063, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-30GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_191733/0000/myMicroAODOutputFile_7.root", 
+                "nevents": 25063, 
+                "totEvents": 25063, 
+                "weights": 25056.955078125
+            }, 
+            {
+                "bad": false, 
+                "events": 25128, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-30GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_191733/0000/myMicroAODOutputFile_1.root", 
+                "nevents": 25128, 
+                "totEvents": 25128, 
+                "weights": 25122.02734375
+            }, 
+            {
+                "bad": false, 
+                "events": 24897, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-30GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_191733/0000/myMicroAODOutputFile_15.root", 
+                "nevents": 24897, 
+                "totEvents": 24897, 
+                "weights": 24891.068359375
+            }, 
+            {
+                "bad": false, 
+                "events": 24784, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-30GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_191733/0000/myMicroAODOutputFile_4.root", 
+                "nevents": 24784, 
+                "totEvents": 24784, 
+                "weights": 24778.25390625
+            }, 
+            {
+                "bad": false, 
+                "events": 24360, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-30GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_191733/0000/myMicroAODOutputFile_20.root", 
+                "nevents": 24360, 
+                "totEvents": 24360, 
+                "weights": 24354.615234375
+            }, 
+            {
+                "bad": false, 
+                "events": 25091, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-30GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_191733/0000/myMicroAODOutputFile_8.root", 
+                "nevents": 25091, 
+                "totEvents": 25091, 
+                "weights": 25085.392578125
+            }, 
+            {
+                "bad": false, 
+                "events": 25119, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-30GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_191733/0000/myMicroAODOutputFile_17.root", 
+                "nevents": 25119, 
+                "totEvents": 25119, 
+                "weights": 25113.02734375
+            }, 
+            {
+                "bad": false, 
+                "events": 24944, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-30GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_191733/0000/myMicroAODOutputFile_12.root", 
+                "nevents": 24944, 
+                "totEvents": 24944, 
+                "weights": 24937.7109375
+            }, 
+            {
+                "bad": false, 
+                "events": 24914, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-30GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_191733/0000/myMicroAODOutputFile_9.root", 
+                "nevents": 24914, 
+                "totEvents": 24914, 
+                "weights": 24908.158203125
+            }, 
+            {
+                "bad": false, 
+                "events": 25075, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-30GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_191733/0000/myMicroAODOutputFile_13.root", 
+                "nevents": 25075, 
+                "totEvents": 25075, 
+                "weights": 25069.388671875
+            }, 
+            {
+                "bad": false, 
+                "events": 24652, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-30GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_191733/0000/myMicroAODOutputFile_16.root", 
+                "nevents": 24652, 
+                "totEvents": 24652, 
+                "weights": 24645.849609375
+            }, 
+            {
+                "bad": false, 
+                "events": 480, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-30GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_191733/0000/myMicroAODOutputFile_10.root", 
+                "nevents": 480, 
+                "totEvents": 480, 
+                "weights": 479.8900146484375
+            }, 
+            {
+                "bad": false, 
+                "events": 24890, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-30GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_191733/0000/myMicroAODOutputFile_14.root", 
+                "nevents": 24890, 
+                "totEvents": 24890, 
+                "weights": 24884.103515625
+            }, 
+            {
+                "bad": false, 
+                "events": 24820, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-30GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_191733/0000/myMicroAODOutputFile_19.root", 
+                "nevents": 24820, 
+                "totEvents": 24820, 
+                "weights": 24814.248046875
+            }
+        ], 
+        "parent_n_units": 473712, 
+        "vetted": true
+    }, 
+    "/HAHMHToAA_AToGG_MA-40GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/lata-Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3-558f94a366de3fc00ec9d9ea7e93aa72/USER": {
+        "dset_type": "mc", 
+        "files": [
+            {
+                "bad": false, 
+                "events": 24978, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-40GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_192254/0000/myMicroAODOutputFile_8.root", 
+                "nevents": 24978, 
+                "totEvents": 24978, 
+                "weights": 24972.158203125
+            }, 
+            {
+                "bad": false, 
+                "events": 24910, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-40GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_192254/0000/myMicroAODOutputFile_12.root", 
+                "nevents": 24910, 
+                "totEvents": 24910, 
+                "weights": 24903.728515625
+            }, 
+            {
+                "bad": false, 
+                "events": 24969, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-40GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_192254/0000/myMicroAODOutputFile_7.root", 
+                "nevents": 24969, 
+                "totEvents": 24969, 
+                "weights": 24963.125
+            }, 
+            {
+                "bad": false, 
+                "events": 24770, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-40GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_192254/0000/myMicroAODOutputFile_10.root", 
+                "nevents": 24770, 
+                "totEvents": 24770, 
+                "weights": 24763.96484375
+            }, 
+            {
+                "bad": false, 
+                "events": 24972, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-40GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_192254/0000/myMicroAODOutputFile_11.root", 
+                "nevents": 24972, 
+                "totEvents": 24972, 
+                "weights": 24965.841796875
+            }, 
+            {
+                "bad": false, 
+                "events": 24931, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-40GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_192254/0000/myMicroAODOutputFile_6.root", 
+                "nevents": 24931, 
+                "totEvents": 24931, 
+                "weights": 24924.94140625
+            }, 
+            {
+                "bad": false, 
+                "events": 25016, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-40GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_192254/0000/myMicroAODOutputFile_9.root", 
+                "nevents": 25016, 
+                "totEvents": 25016, 
+                "weights": 25009.998046875
+            }, 
+            {
+                "bad": false, 
+                "events": 24599, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-40GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_192254/0000/myMicroAODOutputFile_2.root", 
+                "nevents": 24599, 
+                "totEvents": 24599, 
+                "weights": 24592.982421875
+            }, 
+            {
+                "bad": false, 
+                "events": 581, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-40GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_192254/0000/myMicroAODOutputFile_20.root", 
+                "nevents": 581, 
+                "totEvents": 581, 
+                "weights": 580.9100341796875
+            }, 
+            {
+                "bad": false, 
+                "events": 24899, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-40GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_192254/0000/myMicroAODOutputFile_13.root", 
+                "nevents": 24899, 
+                "totEvents": 24899, 
+                "weights": 24893.162109375
+            }, 
+            {
+                "bad": false, 
+                "events": 25162, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-40GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_192254/0000/myMicroAODOutputFile_16.root", 
+                "nevents": 25162, 
+                "totEvents": 25162, 
+                "weights": 25156.091796875
+            }, 
+            {
+                "bad": false, 
+                "events": 24826, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-40GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_192254/0000/myMicroAODOutputFile_14.root", 
+                "nevents": 24826, 
+                "totEvents": 24826, 
+                "weights": 24820.015625
+            }, 
+            {
+                "bad": false, 
+                "events": 24903, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-40GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_192254/0000/myMicroAODOutputFile_4.root", 
+                "nevents": 24903, 
+                "totEvents": 24903, 
+                "weights": 24896.67578125
+            }, 
+            {
+                "bad": false, 
+                "events": 25016, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-40GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_192254/0000/myMicroAODOutputFile_18.root", 
+                "nevents": 25016, 
+                "totEvents": 25016, 
+                "weights": 25009.875
+            }, 
+            {
+                "bad": false, 
+                "events": 24980, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-40GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_192254/0000/myMicroAODOutputFile_5.root", 
+                "nevents": 24980, 
+                "totEvents": 24980, 
+                "weights": 24973.853515625
+            }, 
+            {
+                "bad": false, 
+                "events": 24842, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-40GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_192254/0000/myMicroAODOutputFile_1.root", 
+                "nevents": 24842, 
+                "totEvents": 24842, 
+                "weights": 24835.8125
+            }, 
+            {
+                "bad": false, 
+                "events": 24844, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-40GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_192254/0000/myMicroAODOutputFile_17.root", 
+                "nevents": 24844, 
+                "totEvents": 24844, 
+                "weights": 24838.375
+            }, 
+            {
+                "bad": false, 
+                "events": 25032, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-40GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_192254/0000/myMicroAODOutputFile_19.root", 
+                "nevents": 25032, 
+                "totEvents": 25032, 
+                "weights": 25025.857421875
+            }, 
+            {
+                "bad": false, 
+                "events": 24761, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-40GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_192254/0000/myMicroAODOutputFile_15.root", 
+                "nevents": 24761, 
+                "totEvents": 24761, 
+                "weights": 24755.083984375
+            }, 
+            {
+                "bad": false, 
+                "events": 25053, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-40GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_192254/0000/myMicroAODOutputFile_3.root", 
+                "nevents": 25053, 
+                "totEvents": 25053, 
+                "weights": 25046.70703125
+            }
+        ], 
+        "parent_n_units": 474044, 
+        "vetted": true
+    }, 
+    "/HAHMHToAA_AToGG_MA-45GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/lata-Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3-558f94a366de3fc00ec9d9ea7e93aa72/USER": {
+        "dset_type": "mc", 
+        "files": [
+            {
+                "bad": false, 
+                "events": 269, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-45GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_192534/0000/myMicroAODOutputFile_20.root", 
+                "nevents": 269, 
+                "totEvents": 269, 
+                "weights": 268.95001220703125
+            }, 
+            {
+                "bad": false, 
+                "events": 24735, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-45GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_192534/0000/myMicroAODOutputFile_7.root", 
+                "nevents": 24735, 
+                "totEvents": 24735, 
+                "weights": 24729.037109375
+            }, 
+            {
+                "bad": false, 
+                "events": 24944, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-45GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_192534/0000/myMicroAODOutputFile_16.root", 
+                "nevents": 24944, 
+                "totEvents": 24944, 
+                "weights": 24937.716796875
+            }, 
+            {
+                "bad": false, 
+                "events": 25123, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-45GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_192534/0000/myMicroAODOutputFile_19.root", 
+                "nevents": 25123, 
+                "totEvents": 25123, 
+                "weights": 25116.69140625
+            }, 
+            {
+                "bad": false, 
+                "events": 24527, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-45GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_192534/0000/myMicroAODOutputFile_11.root", 
+                "nevents": 24527, 
+                "totEvents": 24527, 
+                "weights": 24521.109375
+            }, 
+            {
+                "bad": false, 
+                "events": 24978, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-45GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_192534/0000/myMicroAODOutputFile_3.root", 
+                "nevents": 24978, 
+                "totEvents": 24978, 
+                "weights": 24971.5546875
+            }, 
+            {
+                "bad": false, 
+                "events": 25165, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-45GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_192534/0000/myMicroAODOutputFile_10.root", 
+                "nevents": 25165, 
+                "totEvents": 25165, 
+                "weights": 25159.193359375
+            }, 
+            {
+                "bad": false, 
+                "events": 25039, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-45GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_192534/0000/myMicroAODOutputFile_1.root", 
+                "nevents": 25039, 
+                "totEvents": 25039, 
+                "weights": 25032.69921875
+            }, 
+            {
+                "bad": false, 
+                "events": 24871, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-45GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_192534/0000/myMicroAODOutputFile_2.root", 
+                "nevents": 24871, 
+                "totEvents": 24871, 
+                "weights": 24865.08203125
+            }, 
+            {
+                "bad": false, 
+                "events": 25150, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-45GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_192534/0000/myMicroAODOutputFile_6.root", 
+                "nevents": 25150, 
+                "totEvents": 25150, 
+                "weights": 25144.154296875
+            }, 
+            {
+                "bad": false, 
+                "events": 24956, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-45GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_192534/0000/myMicroAODOutputFile_17.root", 
+                "nevents": 24956, 
+                "totEvents": 24956, 
+                "weights": 24950.27734375
+            }, 
+            {
+                "bad": false, 
+                "events": 24793, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-45GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_192534/0000/myMicroAODOutputFile_14.root", 
+                "nevents": 24793, 
+                "totEvents": 24793, 
+                "weights": 24787.025390625
+            }, 
+            {
+                "bad": false, 
+                "events": 24979, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-45GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_192534/0000/myMicroAODOutputFile_15.root", 
+                "nevents": 24979, 
+                "totEvents": 24979, 
+                "weights": 24973.39453125
+            }, 
+            {
+                "bad": false, 
+                "events": 24477, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-45GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_192534/0000/myMicroAODOutputFile_18.root", 
+                "nevents": 24477, 
+                "totEvents": 24477, 
+                "weights": 24471.083984375
+            }, 
+            {
+                "bad": false, 
+                "events": 24905, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-45GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_192534/0000/myMicroAODOutputFile_12.root", 
+                "nevents": 24905, 
+                "totEvents": 24905, 
+                "weights": 24899.05078125
+            }, 
+            {
+                "bad": false, 
+                "events": 24916, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-45GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_192534/0000/myMicroAODOutputFile_9.root", 
+                "nevents": 24916, 
+                "totEvents": 24916, 
+                "weights": 24910.185546875
+            }, 
+            {
+                "bad": false, 
+                "events": 24598, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-45GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_192534/0000/myMicroAODOutputFile_5.root", 
+                "nevents": 24598, 
+                "totEvents": 24598, 
+                "weights": 24592.22265625
+            }, 
+            {
+                "bad": false, 
+                "events": 25059, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-45GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_192534/0000/myMicroAODOutputFile_4.root", 
+                "nevents": 25059, 
+                "totEvents": 25059, 
+                "weights": 25052.98046875
+            }, 
+            {
+                "bad": false, 
+                "events": 24955, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-45GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_192534/0000/myMicroAODOutputFile_13.root", 
+                "nevents": 24955, 
+                "totEvents": 24955, 
+                "weights": 24948.564453125
+            }, 
+            {
+                "bad": false, 
+                "events": 25076, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-45GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_192534/0000/myMicroAODOutputFile_8.root", 
+                "nevents": 25076, 
+                "totEvents": 25076, 
+                "weights": 25070.251953125
+            }
+        ], 
+        "parent_n_units": 473515, 
+        "vetted": true
+    }, 
+    "/HAHMHToAA_AToGG_MA-50GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/lata-Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3-558f94a366de3fc00ec9d9ea7e93aa72/USER": {
+        "dset_type": "mc", 
+        "files": [
+            {
+                "bad": false, 
+                "events": 11804, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-50GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_192824/0000/myMicroAODOutputFile_20.root", 
+                "nevents": 11804, 
+                "totEvents": 11804, 
+                "weights": 11801.2744140625
+            }, 
+            {
+                "bad": false, 
+                "events": 24874, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-50GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_192824/0000/myMicroAODOutputFile_18.root", 
+                "nevents": 24874, 
+                "totEvents": 24874, 
+                "weights": 24867.6640625
+            }, 
+            {
+                "bad": false, 
+                "events": 13266, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-50GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_192824/0000/myMicroAODOutputFile_9.root", 
+                "nevents": 13266, 
+                "totEvents": 13266, 
+                "weights": 13262.5810546875
+            }, 
+            {
+                "bad": false, 
+                "events": 25054, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-50GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_192824/0000/myMicroAODOutputFile_8.root", 
+                "nevents": 25054, 
+                "totEvents": 25054, 
+                "weights": 25047.861328125
+            }, 
+            {
+                "bad": false, 
+                "events": 24995, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-50GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_192824/0000/myMicroAODOutputFile_7.root", 
+                "nevents": 24995, 
+                "totEvents": 24995, 
+                "weights": 24989.185546875
+            }, 
+            {
+                "bad": false, 
+                "events": 25128, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-50GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_192824/0000/myMicroAODOutputFile_4.root", 
+                "nevents": 25128, 
+                "totEvents": 25128, 
+                "weights": 25121.646484375
+            }, 
+            {
+                "bad": false, 
+                "events": 24767, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-50GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_192824/0000/myMicroAODOutputFile_5.root", 
+                "nevents": 24767, 
+                "totEvents": 24767, 
+                "weights": 24761.3046875
+            }, 
+            {
+                "bad": false, 
+                "events": 24854, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-50GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_192824/0000/myMicroAODOutputFile_3.root", 
+                "nevents": 24854, 
+                "totEvents": 24854, 
+                "weights": 24848.1484375
+            }, 
+            {
+                "bad": false, 
+                "events": 24868, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-50GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_192824/0000/myMicroAODOutputFile_1.root", 
+                "nevents": 24868, 
+                "totEvents": 24868, 
+                "weights": 24861.9375
+            }, 
+            {
+                "bad": false, 
+                "events": 25090, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-50GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_192824/0000/myMicroAODOutputFile_11.root", 
+                "nevents": 25090, 
+                "totEvents": 25090, 
+                "weights": 25083.880859375
+            }, 
+            {
+                "bad": false, 
+                "events": 25056, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-50GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_192824/0000/myMicroAODOutputFile_6.root", 
+                "nevents": 25056, 
+                "totEvents": 25056, 
+                "weights": 25049.83984375
+            }, 
+            {
+                "bad": false, 
+                "events": 24918, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-50GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_192824/0000/myMicroAODOutputFile_2.root", 
+                "nevents": 24918, 
+                "totEvents": 24918, 
+                "weights": 24911.966796875
+            }, 
+            {
+                "bad": false, 
+                "events": 24920, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-50GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_192824/0000/myMicroAODOutputFile_17.root", 
+                "nevents": 24920, 
+                "totEvents": 24920, 
+                "weights": 24913.763671875
+            }, 
+            {
+                "bad": false, 
+                "events": 25055, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-50GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_192824/0000/myMicroAODOutputFile_10.root", 
+                "nevents": 25055, 
+                "totEvents": 25055, 
+                "weights": 25048.87109375
+            }, 
+            {
+                "bad": false, 
+                "events": 24981, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-50GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_192824/0000/myMicroAODOutputFile_13.root", 
+                "nevents": 24981, 
+                "totEvents": 24981, 
+                "weights": 24974.88671875
+            }, 
+            {
+                "bad": false, 
+                "events": 24773, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-50GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_192824/0000/myMicroAODOutputFile_16.root", 
+                "nevents": 24773, 
+                "totEvents": 24773, 
+                "weights": 24767.00390625
+            }, 
+            {
+                "bad": false, 
+                "events": 24816, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-50GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_192824/0000/myMicroAODOutputFile_15.root", 
+                "nevents": 24816, 
+                "totEvents": 24816, 
+                "weights": 24809.763671875
+            }, 
+            {
+                "bad": false, 
+                "events": 24884, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-50GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_192824/0000/myMicroAODOutputFile_12.root", 
+                "nevents": 24884, 
+                "totEvents": 24884, 
+                "weights": 24878.244140625
+            }, 
+            {
+                "bad": false, 
+                "events": 25006, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-50GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_192824/0000/myMicroAODOutputFile_19.root", 
+                "nevents": 25006, 
+                "totEvents": 25006, 
+                "weights": 25000.03515625
+            }, 
+            {
+                "bad": false, 
+                "events": 24859, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-50GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_192824/0000/myMicroAODOutputFile_14.root", 
+                "nevents": 24859, 
+                "totEvents": 24859, 
+                "weights": 24853.111328125
+            }
+        ], 
+        "parent_n_units": 473968, 
+        "vetted": true
+    }, 
+    "/HAHMHToAA_AToGG_MA-55GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/lata-Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3-558f94a366de3fc00ec9d9ea7e93aa72/USER": {
+        "dset_type": "mc", 
+        "files": [
+            {
+                "bad": false, 
+                "events": 24870, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-55GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_193059/0000/myMicroAODOutputFile_4.root", 
+                "nevents": 24870, 
+                "totEvents": 24870, 
+                "weights": 24864.130859375
+            }, 
+            {
+                "bad": false, 
+                "events": 25108, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-55GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_193059/0000/myMicroAODOutputFile_2.root", 
+                "nevents": 25108, 
+                "totEvents": 25108, 
+                "weights": 25102.0703125
+            }, 
+            {
+                "bad": false, 
+                "events": 24882, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-55GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_193059/0000/myMicroAODOutputFile_5.root", 
+                "nevents": 24882, 
+                "totEvents": 24882, 
+                "weights": 24876.259765625
+            }, 
+            {
+                "bad": false, 
+                "events": 25051, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-55GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_193059/0000/myMicroAODOutputFile_1.root", 
+                "nevents": 25051, 
+                "totEvents": 25051, 
+                "weights": 25044.705078125
+            }, 
+            {
+                "bad": false, 
+                "events": 24697, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-55GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_193059/0000/myMicroAODOutputFile_19.root", 
+                "nevents": 24697, 
+                "totEvents": 24697, 
+                "weights": 24690.970703125
+            }, 
+            {
+                "bad": false, 
+                "events": 24643, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-55GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_193059/0000/myMicroAODOutputFile_9.root", 
+                "nevents": 24643, 
+                "totEvents": 24643, 
+                "weights": 24637.193359375
+            }, 
+            {
+                "bad": false, 
+                "events": 24906, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-55GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_193059/0000/myMicroAODOutputFile_7.root", 
+                "nevents": 24906, 
+                "totEvents": 24906, 
+                "weights": 24899.75
+            }, 
+            {
+                "bad": false, 
+                "events": 25178, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-55GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_193059/0000/myMicroAODOutputFile_17.root", 
+                "nevents": 25178, 
+                "totEvents": 25178, 
+                "weights": 25172.0625
+            }, 
+            {
+                "bad": false, 
+                "events": 25290, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-55GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_193059/0000/myMicroAODOutputFile_14.root", 
+                "nevents": 25290, 
+                "totEvents": 25290, 
+                "weights": 25283.982421875
+            }, 
+            {
+                "bad": false, 
+                "events": 25053, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-55GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_193059/0000/myMicroAODOutputFile_15.root", 
+                "nevents": 25053, 
+                "totEvents": 25053, 
+                "weights": 25047.4375
+            }, 
+            {
+                "bad": false, 
+                "events": 24907, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-55GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_193059/0000/myMicroAODOutputFile_12.root", 
+                "nevents": 24907, 
+                "totEvents": 24907, 
+                "weights": 24900.69140625
+            }, 
+            {
+                "bad": false, 
+                "events": 24590, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-55GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_193059/0000/myMicroAODOutputFile_13.root", 
+                "nevents": 24590, 
+                "totEvents": 24590, 
+                "weights": 24583.263671875
+            }, 
+            {
+                "bad": false, 
+                "events": 24717, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-55GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_193059/0000/myMicroAODOutputFile_11.root", 
+                "nevents": 24717, 
+                "totEvents": 24717, 
+                "weights": 24711.046875
+            }, 
+            {
+                "bad": false, 
+                "events": 24763, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-55GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_193059/0000/myMicroAODOutputFile_10.root", 
+                "nevents": 24763, 
+                "totEvents": 24763, 
+                "weights": 24756.615234375
+            }, 
+            {
+                "bad": false, 
+                "events": 25045, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-55GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_193059/0000/myMicroAODOutputFile_16.root", 
+                "nevents": 25045, 
+                "totEvents": 25045, 
+                "weights": 25039.126953125
+            }, 
+            {
+                "bad": false, 
+                "events": 24894, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-55GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_193059/0000/myMicroAODOutputFile_8.root", 
+                "nevents": 24894, 
+                "totEvents": 24894, 
+                "weights": 24887.87109375
+            }, 
+            {
+                "bad": false, 
+                "events": 24689, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-55GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_193059/0000/myMicroAODOutputFile_18.root", 
+                "nevents": 24689, 
+                "totEvents": 24689, 
+                "weights": 24683.2578125
+            }, 
+            {
+                "bad": false, 
+                "events": 25322, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-55GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_193059/0000/myMicroAODOutputFile_6.root", 
+                "nevents": 25322, 
+                "totEvents": 25322, 
+                "weights": 25315.662109375
+            }, 
+            {
+                "bad": false, 
+                "events": 24697, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-55GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_193059/0000/myMicroAODOutputFile_3.root", 
+                "nevents": 24697, 
+                "totEvents": 24697, 
+                "weights": 24690.296875
+            }
+        ], 
+        "parent_n_units": 473302, 
+        "vetted": true
+    }, 
+    "/HAHMHToAA_AToGG_MA-60GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/lata-Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3-558f94a366de3fc00ec9d9ea7e93aa72/USER": {
+        "dset_type": "mc", 
+        "files": [
+            {
+                "bad": false, 
+                "events": 25004, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-60GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_193332/0000/myMicroAODOutputFile_9.root", 
+                "nevents": 25004, 
+                "totEvents": 25004, 
+                "weights": 24998.158203125
+            }, 
+            {
+                "bad": false, 
+                "events": 25019, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-60GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_193332/0000/myMicroAODOutputFile_6.root", 
+                "nevents": 25019, 
+                "totEvents": 25019, 
+                "weights": 25013.23828125
+            }, 
+            {
+                "bad": false, 
+                "events": 24974, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-60GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_193332/0000/myMicroAODOutputFile_10.root", 
+                "nevents": 24974, 
+                "totEvents": 24974, 
+                "weights": 24967.9296875
+            }, 
+            {
+                "bad": false, 
+                "events": 24967, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-60GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_193332/0000/myMicroAODOutputFile_17.root", 
+                "nevents": 24967, 
+                "totEvents": 24967, 
+                "weights": 24961.1953125
+            }, 
+            {
+                "bad": false, 
+                "events": 24929, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-60GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_193332/0000/myMicroAODOutputFile_2.root", 
+                "nevents": 24929, 
+                "totEvents": 24929, 
+                "weights": 24923.095703125
+            }, 
+            {
+                "bad": false, 
+                "events": 24790, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-60GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_193332/0000/myMicroAODOutputFile_19.root", 
+                "nevents": 24790, 
+                "totEvents": 24790, 
+                "weights": 24784.15625
+            }, 
+            {
+                "bad": false, 
+                "events": 24856, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-60GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_193332/0000/myMicroAODOutputFile_5.root", 
+                "nevents": 24856, 
+                "totEvents": 24856, 
+                "weights": 24849.759765625
+            }, 
+            {
+                "bad": false, 
+                "events": 24856, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-60GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_193332/0000/myMicroAODOutputFile_3.root", 
+                "nevents": 24856, 
+                "totEvents": 24856, 
+                "weights": 24850.232421875
+            }, 
+            {
+                "bad": false, 
+                "events": 24812, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-60GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_193332/0000/myMicroAODOutputFile_1.root", 
+                "nevents": 24812, 
+                "totEvents": 24812, 
+                "weights": 24805.947265625
+            }, 
+            {
+                "bad": false, 
+                "events": 24743, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-60GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_193332/0000/myMicroAODOutputFile_4.root", 
+                "nevents": 24743, 
+                "totEvents": 24743, 
+                "weights": 24737.3203125
+            }, 
+            {
+                "bad": false, 
+                "events": 24822, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-60GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_193332/0000/myMicroAODOutputFile_15.root", 
+                "nevents": 24822, 
+                "totEvents": 24822, 
+                "weights": 24816.076171875
+            }, 
+            {
+                "bad": false, 
+                "events": 24976, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-60GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_193332/0000/myMicroAODOutputFile_7.root", 
+                "nevents": 24976, 
+                "totEvents": 24976, 
+                "weights": 24970.12890625
+            }, 
+            {
+                "bad": false, 
+                "events": 24888, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-60GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_193332/0000/myMicroAODOutputFile_12.root", 
+                "nevents": 24888, 
+                "totEvents": 24888, 
+                "weights": 24881.876953125
+            }, 
+            {
+                "bad": false, 
+                "events": 25062, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-60GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_193332/0000/myMicroAODOutputFile_13.root", 
+                "nevents": 25062, 
+                "totEvents": 25062, 
+                "weights": 25055.9140625
+            }, 
+            {
+                "bad": false, 
+                "events": 24897, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-60GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_193332/0000/myMicroAODOutputFile_8.root", 
+                "nevents": 24897, 
+                "totEvents": 24897, 
+                "weights": 24891.25390625
+            }, 
+            {
+                "bad": false, 
+                "events": 387, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-60GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_193332/0000/myMicroAODOutputFile_20.root", 
+                "nevents": 387, 
+                "totEvents": 387, 
+                "weights": 386.8900146484375
+            }, 
+            {
+                "bad": false, 
+                "events": 24907, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-60GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_193332/0000/myMicroAODOutputFile_11.root", 
+                "nevents": 24907, 
+                "totEvents": 24907, 
+                "weights": 24900.8203125
+            }, 
+            {
+                "bad": false, 
+                "events": 24837, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-60GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_193332/0000/myMicroAODOutputFile_16.root", 
+                "nevents": 24837, 
+                "totEvents": 24837, 
+                "weights": 24830.96875
+            }, 
+            {
+                "bad": false, 
+                "events": 24980, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-60GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_193332/0000/myMicroAODOutputFile_18.root", 
+                "nevents": 24980, 
+                "totEvents": 24980, 
+                "weights": 24973.798828125
+            }, 
+            {
+                "bad": false, 
+                "events": 24794, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-60GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_193332/0000/myMicroAODOutputFile_14.root", 
+                "nevents": 24794, 
+                "totEvents": 24794, 
+                "weights": 24787.990234375
+            }
+        ], 
+        "parent_n_units": 473500, 
+        "vetted": true
+    }, 
+    "/TprimeBToTH_Hgg_M-1000_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/lata-Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1-558f94a366de3fc00ec9d9ea7e93aa72/USER": {
+        "dset_type": "mc", 
+        "files": [
+            {
+                "bad": false, 
+                "events": 25100, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-1000_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_192517/0000/myMicroAODOutputFile_21.root", 
+                "nevents": 25100, 
+                "totEvents": 25100, 
+                "weights": 25082.26171875
+            }, 
+            {
+                "bad": false, 
+                "events": 24900, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-1000_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_192517/0000/myMicroAODOutputFile_3.root", 
+                "nevents": 24900, 
+                "totEvents": 24900, 
+                "weights": 24875.77734375
+            }, 
+            {
+                "bad": false, 
+                "events": 17500, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-1000_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_192517/0000/myMicroAODOutputFile_5.root", 
+                "nevents": 17500, 
+                "totEvents": 17500, 
+                "weights": 17487.876953125
+            }, 
+            {
+                "bad": false, 
+                "events": 1400, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-1000_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_192517/0000/myMicroAODOutputFile_12.root", 
+                "nevents": 1400, 
+                "totEvents": 1400, 
+                "weights": 1397.9365234375
+            }, 
+            {
+                "bad": false, 
+                "events": 2800, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-1000_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_192517/0000/myMicroAODOutputFile_10.root", 
+                "nevents": 2800, 
+                "totEvents": 2800, 
+                "weights": 2798.060546875
+            }, 
+            {
+                "bad": false, 
+                "events": 1400, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-1000_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_192517/0000/myMicroAODOutputFile_6.root", 
+                "nevents": 1400, 
+                "totEvents": 1400, 
+                "weights": 1397.1806640625
+            }, 
+            {
+                "bad": false, 
+                "events": 4200, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-1000_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_192517/0000/myMicroAODOutputFile_7.root", 
+                "nevents": 4200, 
+                "totEvents": 4200, 
+                "weights": 4197.060546875
+            }, 
+            {
+                "bad": false, 
+                "events": 4900, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-1000_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_192517/0000/myMicroAODOutputFile_2.root", 
+                "nevents": 4900, 
+                "totEvents": 4900, 
+                "weights": 4895.40234375
+            }, 
+            {
+                "bad": false, 
+                "events": 24700, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-1000_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_192517/0000/myMicroAODOutputFile_19.root", 
+                "nevents": 24700, 
+                "totEvents": 24700, 
+                "weights": 24678.5390625
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-1000_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_192517/0000/myMicroAODOutputFile_22.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24978.115234375
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-1000_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_192517/0000/myMicroAODOutputFile_13.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24976.896484375
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-1000_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_192517/0000/myMicroAODOutputFile_17.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24975.583984375
+            }, 
+            {
+                "bad": false, 
+                "events": 24800, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-1000_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_192517/0000/myMicroAODOutputFile_4.root", 
+                "nevents": 24800, 
+                "totEvents": 24800, 
+                "weights": 24779.623046875
+            }, 
+            {
+                "bad": false, 
+                "events": 13500, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-1000_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_192517/0000/myMicroAODOutputFile_23.root", 
+                "nevents": 13500, 
+                "totEvents": 13500, 
+                "weights": 13487.841796875
+            }, 
+            {
+                "bad": false, 
+                "events": 25200, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-1000_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_192517/0000/myMicroAODOutputFile_14.root", 
+                "nevents": 25200, 
+                "totEvents": 25200, 
+                "weights": 25174.5078125
+            }, 
+            {
+                "bad": false, 
+                "events": 24700, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-1000_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_192517/0000/myMicroAODOutputFile_16.root", 
+                "nevents": 24700, 
+                "totEvents": 24700, 
+                "weights": 24678.3515625
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-1000_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_192517/0000/myMicroAODOutputFile_15.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24980.58203125
+            }, 
+            {
+                "bad": false, 
+                "events": 24900, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-1000_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_192517/0000/myMicroAODOutputFile_20.root", 
+                "nevents": 24900, 
+                "totEvents": 24900, 
+                "weights": 24881.0546875
+            }, 
+            {
+                "bad": false, 
+                "events": 7000, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-1000_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_192517/0000/myMicroAODOutputFile_11.root", 
+                "nevents": 7000, 
+                "totEvents": 7000, 
+                "weights": 6992.35546875
+            }, 
+            {
+                "bad": false, 
+                "events": 7700, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-1000_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_192517/0000/myMicroAODOutputFile_8.root", 
+                "nevents": 7700, 
+                "totEvents": 7700, 
+                "weights": 7694.56103515625
+            }, 
+            {
+                "bad": false, 
+                "events": 12400, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-1000_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_192517/0000/myMicroAODOutputFile_9.root", 
+                "nevents": 12400, 
+                "totEvents": 12400, 
+                "weights": 12387.060546875
+            }, 
+            {
+                "bad": false, 
+                "events": 24700, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-1000_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_192517/0000/myMicroAODOutputFile_18.root", 
+                "nevents": 24700, 
+                "totEvents": 24700, 
+                "weights": 24678.958984375
+            }, 
+            {
+                "bad": false, 
+                "events": 7000, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-1000_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_192517/0000/myMicroAODOutputFile_1.root", 
+                "nevents": 7000, 
+                "totEvents": 7000, 
+                "weights": 6993.37255859375
+            }
+        ], 
+        "parent_n_units": 378800, 
+        "vetted": true
+    }, 
+    "/TprimeBToTH_Hgg_M-1100_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/lata-Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1-558f94a366de3fc00ec9d9ea7e93aa72/USER": {
+        "dset_type": "mc", 
+        "files": [
+            {
+                "bad": false, 
+                "events": 1500, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-1100_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_192826/0000/myMicroAODOutputFile_25.root", 
+                "nevents": 1500, 
+                "totEvents": 1500, 
+                "weights": 1499.020263671875
+            }, 
+            {
+                "bad": false, 
+                "events": 2000, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-1100_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_192826/0000/myMicroAODOutputFile_24.root", 
+                "nevents": 2000, 
+                "totEvents": 2000, 
+                "weights": 1998.390380859375
+            }, 
+            {
+                "bad": false, 
+                "events": 14000, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-1100_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_192826/0000/myMicroAODOutputFile_14.root", 
+                "nevents": 14000, 
+                "totEvents": 14000, 
+                "weights": 13986.625
+            }, 
+            {
+                "bad": false, 
+                "events": 3000, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-1100_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_192826/0000/myMicroAODOutputFile_19.root", 
+                "nevents": 3000, 
+                "totEvents": 3000, 
+                "weights": 2997.900634765625
+            }, 
+            {
+                "bad": false, 
+                "events": 3200, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-1100_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_192826/0000/myMicroAODOutputFile_20.root", 
+                "nevents": 3200, 
+                "totEvents": 3200, 
+                "weights": 3197.487060546875
+            }, 
+            {
+                "bad": false, 
+                "events": 3500, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-1100_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_192826/0000/myMicroAODOutputFile_10.root", 
+                "nevents": 3500, 
+                "totEvents": 3500, 
+                "weights": 3497.35400390625
+            }, 
+            {
+                "bad": false, 
+                "events": 1500, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-1100_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_192826/0000/myMicroAODOutputFile_9.root", 
+                "nevents": 1500, 
+                "totEvents": 1500, 
+                "weights": 1497.79052734375
+            }, 
+            {
+                "bad": false, 
+                "events": 1000, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-1100_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_192826/0000/myMicroAODOutputFile_12.root", 
+                "nevents": 1000, 
+                "totEvents": 1000, 
+                "weights": 999.3302001953125
+            }, 
+            {
+                "bad": false, 
+                "events": 10700, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-1100_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_192826/0000/myMicroAODOutputFile_8.root", 
+                "nevents": 10700, 
+                "totEvents": 10700, 
+                "weights": 10692.583984375
+            }, 
+            {
+                "bad": false, 
+                "events": 5000, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-1100_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_192826/0000/myMicroAODOutputFile_26.root", 
+                "nevents": 5000, 
+                "totEvents": 5000, 
+                "weights": 4996.5712890625
+            }, 
+            {
+                "bad": false, 
+                "events": 24800, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-1100_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_192826/0000/myMicroAODOutputFile_6.root", 
+                "nevents": 24800, 
+                "totEvents": 24800, 
+                "weights": 24779.70703125
+            }, 
+            {
+                "bad": false, 
+                "events": 6300, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-1100_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_192826/0000/myMicroAODOutputFile_13.root", 
+                "nevents": 6300, 
+                "totEvents": 6300, 
+                "weights": 6295.7314453125
+            }, 
+            {
+                "bad": false, 
+                "events": 24900, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-1100_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_192826/0000/myMicroAODOutputFile_5.root", 
+                "nevents": 24900, 
+                "totEvents": 24900, 
+                "weights": 24880.16015625
+            }, 
+            {
+                "bad": false, 
+                "events": 24800, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-1100_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_192826/0000/myMicroAODOutputFile_22.root", 
+                "nevents": 24800, 
+                "totEvents": 24800, 
+                "weights": 24776.02734375
+            }, 
+            {
+                "bad": false, 
+                "events": 24900, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-1100_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_192826/0000/myMicroAODOutputFile_21.root", 
+                "nevents": 24900, 
+                "totEvents": 24900, 
+                "weights": 24878.203125
+            }, 
+            {
+                "bad": false, 
+                "events": 24800, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-1100_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_192826/0000/myMicroAODOutputFile_4.root", 
+                "nevents": 24800, 
+                "totEvents": 24800, 
+                "weights": 24777.17578125
+            }, 
+            {
+                "bad": false, 
+                "events": 12500, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-1100_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_192826/0000/myMicroAODOutputFile_1.root", 
+                "nevents": 12500, 
+                "totEvents": 12500, 
+                "weights": 12488.7001953125
+            }, 
+            {
+                "bad": false, 
+                "events": 24800, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-1100_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_192826/0000/myMicroAODOutputFile_7.root", 
+                "nevents": 24800, 
+                "totEvents": 24800, 
+                "weights": 24778.068359375
+            }, 
+            {
+                "bad": false, 
+                "events": 13800, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-1100_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_192826/0000/myMicroAODOutputFile_23.root", 
+                "nevents": 13800, 
+                "totEvents": 13800, 
+                "weights": 13786.7236328125
+            }, 
+            {
+                "bad": false, 
+                "events": 3000, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-1100_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_192826/0000/myMicroAODOutputFile_2.root", 
+                "nevents": 3000, 
+                "totEvents": 3000, 
+                "weights": 2997.650634765625
+            }, 
+            {
+                "bad": false, 
+                "events": 3200, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-1100_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_192826/0000/myMicroAODOutputFile_11.root", 
+                "nevents": 3200, 
+                "totEvents": 3200, 
+                "weights": 3196.803955078125
+            }
+        ], 
+        "parent_n_units": 233200, 
+        "vetted": true
+    }, 
+    "/TprimeBToTH_Hgg_M-1200_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/lata-Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1-558f94a366de3fc00ec9d9ea7e93aa72/USER": {
+        "dset_type": "mc", 
+        "files": [
+            {
+                "bad": false, 
+                "events": 1800, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-1200_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_193126/0000/myMicroAODOutputFile_30.root", 
+                "nevents": 1800, 
+                "totEvents": 1800, 
+                "weights": 1797.7413330078125
+            }, 
+            {
+                "bad": false, 
+                "events": 2400, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-1200_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_193126/0000/myMicroAODOutputFile_21.root", 
+                "nevents": 2400, 
+                "totEvents": 2400, 
+                "weights": 2397.210205078125
+            }, 
+            {
+                "bad": false, 
+                "events": 7200, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-1200_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_193126/0000/myMicroAODOutputFile_2.root", 
+                "nevents": 7200, 
+                "totEvents": 7200, 
+                "weights": 7193.49267578125
+            }, 
+            {
+                "bad": false, 
+                "events": 600, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-1200_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_193126/0000/myMicroAODOutputFile_10.root", 
+                "nevents": 600, 
+                "totEvents": 600, 
+                "weights": 599.5601196289062
+            }, 
+            {
+                "bad": false, 
+                "events": 1200, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-1200_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_193126/0000/myMicroAODOutputFile_19.root", 
+                "nevents": 1200, 
+                "totEvents": 1200, 
+                "weights": 1198.890380859375
+            }, 
+            {
+                "bad": false, 
+                "events": 12600, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-1200_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_193126/0000/myMicroAODOutputFile_24.root", 
+                "nevents": 12600, 
+                "totEvents": 12600, 
+                "weights": 12586.908203125
+            }, 
+            {
+                "bad": false, 
+                "events": 1200, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-1200_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_193126/0000/myMicroAODOutputFile_3.root", 
+                "nevents": 1200, 
+                "totEvents": 1200, 
+                "weights": 1199.1602783203125
+            }, 
+            {
+                "bad": false, 
+                "events": 600, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-1200_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_193126/0000/myMicroAODOutputFile_15.root", 
+                "nevents": 600, 
+                "totEvents": 600, 
+                "weights": 599.5902099609375
+            }, 
+            {
+                "bad": false, 
+                "events": 16800, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-1200_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_193126/0000/myMicroAODOutputFile_1.root", 
+                "nevents": 16800, 
+                "totEvents": 16800, 
+                "weights": 16783.140625
+            }, 
+            {
+                "bad": false, 
+                "events": 10200, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-1200_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_193126/0000/myMicroAODOutputFile_11.root", 
+                "nevents": 10200, 
+                "totEvents": 10200, 
+                "weights": 10190.5341796875
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-1200_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_193126/0000/myMicroAODOutputFile_7.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24978.33203125
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-1200_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_193126/0000/myMicroAODOutputFile_5.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24973.443359375
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-1200_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_193126/0000/myMicroAODOutputFile_4.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24974.95703125
+            }, 
+            {
+                "bad": false, 
+                "events": 1800, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-1200_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_193126/0000/myMicroAODOutputFile_34.root", 
+                "nevents": 1800, 
+                "totEvents": 1800, 
+                "weights": 1798.3804931640625
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-1200_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_193126/0000/myMicroAODOutputFile_8.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24976.443359375
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-1200_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_193126/0000/myMicroAODOutputFile_27.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24977.787109375
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-1200_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_193126/0000/myMicroAODOutputFile_22.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24976.125
+            }, 
+            {
+                "bad": false, 
+                "events": 11400, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-1200_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_193126/0000/myMicroAODOutputFile_26.root", 
+                "nevents": 11400, 
+                "totEvents": 11400, 
+                "weights": 11387.64453125
+            }, 
+            {
+                "bad": false, 
+                "events": 8400, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-1200_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_193126/0000/myMicroAODOutputFile_16.root", 
+                "nevents": 8400, 
+                "totEvents": 8400, 
+                "weights": 8391.576171875
+            }, 
+            {
+                "bad": false, 
+                "events": 16400, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-1200_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_193126/0000/myMicroAODOutputFile_18.root", 
+                "nevents": 16400, 
+                "totEvents": 16400, 
+                "weights": 16386.876953125
+            }, 
+            {
+                "bad": false, 
+                "events": 12600, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-1200_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_193126/0000/myMicroAODOutputFile_33.root", 
+                "nevents": 12600, 
+                "totEvents": 12600, 
+                "weights": 12588.103515625
+            }, 
+            {
+                "bad": false, 
+                "events": 10200, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-1200_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_193126/0000/myMicroAODOutputFile_12.root", 
+                "nevents": 10200, 
+                "totEvents": 10200, 
+                "weights": 10189.7099609375
+            }, 
+            {
+                "bad": false, 
+                "events": 6200, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-1200_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_193126/0000/myMicroAODOutputFile_23.root", 
+                "nevents": 6200, 
+                "totEvents": 6200, 
+                "weights": 6191.25537109375
+            }, 
+            {
+                "bad": false, 
+                "events": 5200, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-1200_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_193126/0000/myMicroAODOutputFile_9.root", 
+                "nevents": 5200, 
+                "totEvents": 5200, 
+                "weights": 5195.97119140625
+            }, 
+            {
+                "bad": false, 
+                "events": 5400, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-1200_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_193126/0000/myMicroAODOutputFile_31.root", 
+                "nevents": 5400, 
+                "totEvents": 5400, 
+                "weights": 5395.7119140625
+            }, 
+            {
+                "bad": false, 
+                "events": 4200, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-1200_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_193126/0000/myMicroAODOutputFile_14.root", 
+                "nevents": 4200, 
+                "totEvents": 4200, 
+                "weights": 4196.791015625
+            }, 
+            {
+                "bad": false, 
+                "events": 6000, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-1200_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_193126/0000/myMicroAODOutputFile_25.root", 
+                "nevents": 6000, 
+                "totEvents": 6000, 
+                "weights": 5994.78662109375
+            }, 
+            {
+                "bad": false, 
+                "events": 4200, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-1200_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_193126/0000/myMicroAODOutputFile_13.root", 
+                "nevents": 4200, 
+                "totEvents": 4200, 
+                "weights": 4195.87158203125
+            }, 
+            {
+                "bad": false, 
+                "events": 2400, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-1200_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_193126/0000/myMicroAODOutputFile_20.root", 
+                "nevents": 2400, 
+                "totEvents": 2400, 
+                "weights": 2398.34033203125
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-1200_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_193126/0000/myMicroAODOutputFile_6.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24974.4453125
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-1200_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_193126/0000/myMicroAODOutputFile_32.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24976.884765625
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-1200_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_193126/0000/myMicroAODOutputFile_17.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24979.171875
+            }, 
+            {
+                "bad": false, 
+                "events": 10200, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-1200_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_193126/0000/myMicroAODOutputFile_29.root", 
+                "nevents": 10200, 
+                "totEvents": 10200, 
+                "weights": 10190.0078125
+            }, 
+            {
+                "bad": false, 
+                "events": 15200, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-1200_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_193126/0000/myMicroAODOutputFile_28.root", 
+                "nevents": 15200, 
+                "totEvents": 15200, 
+                "weights": 15185.7353515625
+            }
+        ], 
+        "parent_n_units": 399400, 
+        "vetted": true
+    }, 
+    "/TprimeBToTH_Hgg_M-600_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/lata-Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1-558f94a366de3fc00ec9d9ea7e93aa72/USER": {
+        "dset_type": "mc", 
+        "files": [
+            {
+                "bad": false, 
+                "events": 5900, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-600_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_193414/0000/myMicroAODOutputFile_11.root", 
+                "nevents": 5900, 
+                "totEvents": 5900, 
+                "weights": 5896.39111328125
+            }, 
+            {
+                "bad": false, 
+                "events": 3600, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-600_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_193414/0000/myMicroAODOutputFile_29.root", 
+                "nevents": 3600, 
+                "totEvents": 3600, 
+                "weights": 3597.840576171875
+            }, 
+            {
+                "bad": false, 
+                "events": 2700, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-600_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_193414/0000/myMicroAODOutputFile_5.root", 
+                "nevents": 2700, 
+                "totEvents": 2700, 
+                "weights": 2697.45361328125
+            }, 
+            {
+                "bad": false, 
+                "events": 900, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-600_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_193414/0000/myMicroAODOutputFile_30.root", 
+                "nevents": 900, 
+                "totEvents": 900, 
+                "weights": 899.3501586914062
+            }, 
+            {
+                "bad": false, 
+                "events": 1800, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-600_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_193414/0000/myMicroAODOutputFile_28.root", 
+                "nevents": 1800, 
+                "totEvents": 1800, 
+                "weights": 1799.08056640625
+            }, 
+            {
+                "bad": false, 
+                "events": 20700, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-600_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_193414/0000/myMicroAODOutputFile_31.root", 
+                "nevents": 20700, 
+                "totEvents": 20700, 
+                "weights": 20686.46875
+            }, 
+            {
+                "bad": false, 
+                "events": 24700, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-600_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_193414/0000/myMicroAODOutputFile_7.root", 
+                "nevents": 24700, 
+                "totEvents": 24700, 
+                "weights": 24685.365234375
+            }, 
+            {
+                "bad": false, 
+                "events": 24900, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-600_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_193414/0000/myMicroAODOutputFile_17.root", 
+                "nevents": 24900, 
+                "totEvents": 24900, 
+                "weights": 24883.384765625
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-600_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_193414/0000/myMicroAODOutputFile_8.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24984.84765625
+            }, 
+            {
+                "bad": false, 
+                "events": 24800, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-600_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_193414/0000/myMicroAODOutputFile_16.root", 
+                "nevents": 24800, 
+                "totEvents": 24800, 
+                "weights": 24780.533203125
+            }, 
+            {
+                "bad": false, 
+                "events": 24800, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-600_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_193414/0000/myMicroAODOutputFile_9.root", 
+                "nevents": 24800, 
+                "totEvents": 24800, 
+                "weights": 24783.26953125
+            }, 
+            {
+                "bad": false, 
+                "events": 24900, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-600_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_193414/0000/myMicroAODOutputFile_20.root", 
+                "nevents": 24900, 
+                "totEvents": 24900, 
+                "weights": 24882.439453125
+            }, 
+            {
+                "bad": false, 
+                "events": 24800, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-600_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_193414/0000/myMicroAODOutputFile_21.root", 
+                "nevents": 24800, 
+                "totEvents": 24800, 
+                "weights": 24778.251953125
+            }, 
+            {
+                "bad": false, 
+                "events": 24900, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-600_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_193414/0000/myMicroAODOutputFile_15.root", 
+                "nevents": 24900, 
+                "totEvents": 24900, 
+                "weights": 24880.359375
+            }, 
+            {
+                "bad": false, 
+                "events": 19600, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-600_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_193414/0000/myMicroAODOutputFile_22.root", 
+                "nevents": 19600, 
+                "totEvents": 19600, 
+                "weights": 19588.677734375
+            }, 
+            {
+                "bad": false, 
+                "events": 16200, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-600_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_193414/0000/myMicroAODOutputFile_1.root", 
+                "nevents": 16200, 
+                "totEvents": 16200, 
+                "weights": 16190.0634765625
+            }, 
+            {
+                "bad": false, 
+                "events": 12600, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-600_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_193414/0000/myMicroAODOutputFile_24.root", 
+                "nevents": 12600, 
+                "totEvents": 12600, 
+                "weights": 12592.375
+            }, 
+            {
+                "bad": false, 
+                "events": 9000, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-600_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_193414/0000/myMicroAODOutputFile_2.root", 
+                "nevents": 9000, 
+                "totEvents": 9000, 
+                "weights": 8994.7109375
+            }, 
+            {
+                "bad": false, 
+                "events": 9900, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-600_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_193414/0000/myMicroAODOutputFile_14.root", 
+                "nevents": 9900, 
+                "totEvents": 9900, 
+                "weights": 9892.78515625
+            }, 
+            {
+                "bad": false, 
+                "events": 7200, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-600_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_193414/0000/myMicroAODOutputFile_6.root", 
+                "nevents": 7200, 
+                "totEvents": 7200, 
+                "weights": 7196.0615234375
+            }, 
+            {
+                "bad": false, 
+                "events": 6300, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-600_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_193414/0000/myMicroAODOutputFile_27.root", 
+                "nevents": 6300, 
+                "totEvents": 6300, 
+                "weights": 6296.0615234375
+            }, 
+            {
+                "bad": false, 
+                "events": 3700, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-600_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_193414/0000/myMicroAODOutputFile_18.root", 
+                "nevents": 3700, 
+                "totEvents": 3700, 
+                "weights": 3697.6005859375
+            }, 
+            {
+                "bad": false, 
+                "events": 4500, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-600_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_193414/0000/myMicroAODOutputFile_12.root", 
+                "nevents": 4500, 
+                "totEvents": 4500, 
+                "weights": 4497.50048828125
+            }, 
+            {
+                "bad": false, 
+                "events": 4500, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-600_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_193414/0000/myMicroAODOutputFile_25.root", 
+                "nevents": 4500, 
+                "totEvents": 4500, 
+                "weights": 4496.60986328125
+            }, 
+            {
+                "bad": false, 
+                "events": 4800, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-600_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_193414/0000/myMicroAODOutputFile_3.root", 
+                "nevents": 4800, 
+                "totEvents": 4800, 
+                "weights": 4795.85498046875
+            }, 
+            {
+                "bad": false, 
+                "events": 900, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-600_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_193414/0000/myMicroAODOutputFile_19.root", 
+                "nevents": 900, 
+                "totEvents": 900, 
+                "weights": 899.60009765625
+            }, 
+            {
+                "bad": false, 
+                "events": 7200, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-600_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_193414/0000/myMicroAODOutputFile_26.root", 
+                "nevents": 7200, 
+                "totEvents": 7200, 
+                "weights": 7192.61669921875
+            }, 
+            {
+                "bad": false, 
+                "events": 2700, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-600_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_193414/0000/myMicroAODOutputFile_23.root", 
+                "nevents": 2700, 
+                "totEvents": 2700, 
+                "weights": 2697.6015625
+            }, 
+            {
+                "bad": false, 
+                "events": 12100, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-600_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_193414/0000/myMicroAODOutputFile_32.root", 
+                "nevents": 12100, 
+                "totEvents": 12100, 
+                "weights": 12091.7744140625
+            }, 
+            {
+                "bad": false, 
+                "events": 1800, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-600_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_193414/0000/myMicroAODOutputFile_13.root", 
+                "nevents": 1800, 
+                "totEvents": 1800, 
+                "weights": 1798.870361328125
+            }, 
+            {
+                "bad": false, 
+                "events": 17700, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-600_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_193414/0000/myMicroAODOutputFile_4.root", 
+                "nevents": 17700, 
+                "totEvents": 17700, 
+                "weights": 17686.52734375
+            }, 
+            {
+                "bad": false, 
+                "events": 24900, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-600_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_193414/0000/myMicroAODOutputFile_10.root", 
+                "nevents": 24900, 
+                "totEvents": 24900, 
+                "weights": 24883.30859375
+            }
+        ], 
+        "parent_n_units": 400000, 
+        "vetted": true
+    }, 
+    "/TprimeBToTH_Hgg_M-625_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/alesauva-2016_1-10_6_4-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1-c006dcd9fa3985d1c579b6127ed603c3/USER": {
+        "dset_type": "mc", 
+        "files": [
+            {
+                "bad": false, 
+                "events": 24800, 
+                "name": "/store/user/alesauva/flashgg/2016_1/10_6_4/TprimeBToTH_Hgg_M-625_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/2016_1-10_6_4-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201207_135230/0000/myMicroAODOutputFile_26.root", 
+                "nevents": 24800, 
+                "totEvents": 24800, 
+                "weights": 24784.767578125
+            }, 
+            {
+                "bad": false, 
+                "events": 24800, 
+                "name": "/store/user/alesauva/flashgg/2016_1/10_6_4/TprimeBToTH_Hgg_M-625_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/2016_1-10_6_4-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201207_135230/0000/myMicroAODOutputFile_24.root", 
+                "nevents": 24800, 
+                "totEvents": 24800, 
+                "weights": 24784.275390625
+            }, 
+            {
+                "bad": false, 
+                "events": 24800, 
+                "name": "/store/user/alesauva/flashgg/2016_1/10_6_4/TprimeBToTH_Hgg_M-625_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/2016_1-10_6_4-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201207_135230/0000/myMicroAODOutputFile_15.root", 
+                "nevents": 24800, 
+                "totEvents": 24800, 
+                "weights": 24783.3203125
+            }, 
+            {
+                "bad": false, 
+                "events": 24600, 
+                "name": "/store/user/alesauva/flashgg/2016_1/10_6_4/TprimeBToTH_Hgg_M-625_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/2016_1-10_6_4-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201207_135230/0000/myMicroAODOutputFile_18.root", 
+                "nevents": 24600, 
+                "totEvents": 24600, 
+                "weights": 24580.380859375
+            }, 
+            {
+                "bad": false, 
+                "events": 24700, 
+                "name": "/store/user/alesauva/flashgg/2016_1/10_6_4/TprimeBToTH_Hgg_M-625_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/2016_1-10_6_4-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201207_135230/0000/myMicroAODOutputFile_14.root", 
+                "nevents": 24700, 
+                "totEvents": 24700, 
+                "weights": 24683.453125
+            }, 
+            {
+                "bad": false, 
+                "events": 24900, 
+                "name": "/store/user/alesauva/flashgg/2016_1/10_6_4/TprimeBToTH_Hgg_M-625_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/2016_1-10_6_4-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201207_135230/0000/myMicroAODOutputFile_12.root", 
+                "nevents": 24900, 
+                "totEvents": 24900, 
+                "weights": 24884.443359375
+            }, 
+            {
+                "bad": false, 
+                "events": 25100, 
+                "name": "/store/user/alesauva/flashgg/2016_1/10_6_4/TprimeBToTH_Hgg_M-625_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/2016_1-10_6_4-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201207_135230/0000/myMicroAODOutputFile_17.root", 
+                "nevents": 25100, 
+                "totEvents": 25100, 
+                "weights": 25084.787109375
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/alesauva/flashgg/2016_1/10_6_4/TprimeBToTH_Hgg_M-625_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/2016_1-10_6_4-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201207_135230/0000/myMicroAODOutputFile_16.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24984.650390625
+            }, 
+            {
+                "bad": false, 
+                "events": 24800, 
+                "name": "/store/user/alesauva/flashgg/2016_1/10_6_4/TprimeBToTH_Hgg_M-625_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/2016_1-10_6_4-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201207_135230/0000/myMicroAODOutputFile_13.root", 
+                "nevents": 24800, 
+                "totEvents": 24800, 
+                "weights": 24780.443359375
+            }, 
+            {
+                "bad": false, 
+                "events": 25100, 
+                "name": "/store/user/alesauva/flashgg/2016_1/10_6_4/TprimeBToTH_Hgg_M-625_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/2016_1-10_6_4-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201207_135230/0000/myMicroAODOutputFile_11.root", 
+                "nevents": 25100, 
+                "totEvents": 25100, 
+                "weights": 25083.25390625
+            }, 
+            {
+                "bad": false, 
+                "events": 4500, 
+                "name": "/store/user/alesauva/flashgg/2016_1/10_6_4/TprimeBToTH_Hgg_M-625_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/2016_1-10_6_4-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201207_135230/0000/myMicroAODOutputFile_3.root", 
+                "nevents": 4500, 
+                "totEvents": 4500, 
+                "weights": 4497.22998046875
+            }, 
+            {
+                "bad": false, 
+                "events": 5000, 
+                "name": "/store/user/alesauva/flashgg/2016_1/10_6_4/TprimeBToTH_Hgg_M-625_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/2016_1-10_6_4-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201207_135230/0000/myMicroAODOutputFile_6.root", 
+                "nevents": 5000, 
+                "totEvents": 5000, 
+                "weights": 4997.23095703125
+            }, 
+            {
+                "bad": false, 
+                "events": 1500, 
+                "name": "/store/user/alesauva/flashgg/2016_1/10_6_4/TprimeBToTH_Hgg_M-625_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/2016_1-10_6_4-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201207_135230/0000/myMicroAODOutputFile_8.root", 
+                "nevents": 1500, 
+                "totEvents": 1500, 
+                "weights": 1499.14013671875
+            }, 
+            {
+                "bad": false, 
+                "events": 3000, 
+                "name": "/store/user/alesauva/flashgg/2016_1/10_6_4/TprimeBToTH_Hgg_M-625_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/2016_1-10_6_4-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201207_135230/0000/myMicroAODOutputFile_9.root", 
+                "nevents": 3000, 
+                "totEvents": 3000, 
+                "weights": 2998.140380859375
+            }, 
+            {
+                "bad": false, 
+                "events": 1500, 
+                "name": "/store/user/alesauva/flashgg/2016_1/10_6_4/TprimeBToTH_Hgg_M-625_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/2016_1-10_6_4-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201207_135230/0000/myMicroAODOutputFile_28.root", 
+                "nevents": 1500, 
+                "totEvents": 1500, 
+                "weights": 1499.16015625
+            }, 
+            {
+                "bad": false, 
+                "events": 1000, 
+                "name": "/store/user/alesauva/flashgg/2016_1/10_6_4/TprimeBToTH_Hgg_M-625_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/2016_1-10_6_4-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201207_135230/0000/myMicroAODOutputFile_5.root", 
+                "nevents": 1000, 
+                "totEvents": 1000, 
+                "weights": 999.3801879882812
+            }, 
+            {
+                "bad": false, 
+                "events": 2000, 
+                "name": "/store/user/alesauva/flashgg/2016_1/10_6_4/TprimeBToTH_Hgg_M-625_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/2016_1-10_6_4-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201207_135230/0000/myMicroAODOutputFile_21.root", 
+                "nevents": 2000, 
+                "totEvents": 2000, 
+                "weights": 1998.85009765625
+            }, 
+            {
+                "bad": false, 
+                "events": 2500, 
+                "name": "/store/user/alesauva/flashgg/2016_1/10_6_4/TprimeBToTH_Hgg_M-625_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/2016_1-10_6_4-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201207_135230/0000/myMicroAODOutputFile_30.root", 
+                "nevents": 2500, 
+                "totEvents": 2500, 
+                "weights": 2498.32080078125
+            }, 
+            {
+                "bad": false, 
+                "events": 1000, 
+                "name": "/store/user/alesauva/flashgg/2016_1/10_6_4/TprimeBToTH_Hgg_M-625_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/2016_1-10_6_4-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201207_135230/0000/myMicroAODOutputFile_4.root", 
+                "nevents": 1000, 
+                "totEvents": 1000, 
+                "weights": 999.3804321289062
+            }, 
+            {
+                "bad": false, 
+                "events": 1000, 
+                "name": "/store/user/alesauva/flashgg/2016_1/10_6_4/TprimeBToTH_Hgg_M-625_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/2016_1-10_6_4-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201207_135230/0000/myMicroAODOutputFile_31.root", 
+                "nevents": 1000, 
+                "totEvents": 1000, 
+                "weights": 999.2904663085938
+            }, 
+            {
+                "bad": false, 
+                "events": 500, 
+                "name": "/store/user/alesauva/flashgg/2016_1/10_6_4/TprimeBToTH_Hgg_M-625_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/2016_1-10_6_4-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201207_135230/0000/myMicroAODOutputFile_2.root", 
+                "nevents": 500, 
+                "totEvents": 500, 
+                "weights": 499.8299865722656
+            }, 
+            {
+                "bad": false, 
+                "events": 2000, 
+                "name": "/store/user/alesauva/flashgg/2016_1/10_6_4/TprimeBToTH_Hgg_M-625_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/2016_1-10_6_4-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201207_135230/0000/myMicroAODOutputFile_10.root", 
+                "nevents": 2000, 
+                "totEvents": 2000, 
+                "weights": 1997.7845458984375
+            }, 
+            {
+                "bad": false, 
+                "events": 24800, 
+                "name": "/store/user/alesauva/flashgg/2016_1/10_6_4/TprimeBToTH_Hgg_M-625_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/2016_1-10_6_4-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201207_135230/0000/myMicroAODOutputFile_23.root", 
+                "nevents": 24800, 
+                "totEvents": 24800, 
+                "weights": 24782.79296875
+            }, 
+            {
+                "bad": false, 
+                "events": 24900, 
+                "name": "/store/user/alesauva/flashgg/2016_1/10_6_4/TprimeBToTH_Hgg_M-625_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/2016_1-10_6_4-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201207_135230/0000/myMicroAODOutputFile_22.root", 
+                "nevents": 24900, 
+                "totEvents": 24900, 
+                "weights": 24881.173828125
+            }, 
+            {
+                "bad": false, 
+                "events": 24900, 
+                "name": "/store/user/alesauva/flashgg/2016_1/10_6_4/TprimeBToTH_Hgg_M-625_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/2016_1-10_6_4-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201207_135230/0000/myMicroAODOutputFile_25.root", 
+                "nevents": 24900, 
+                "totEvents": 24900, 
+                "weights": 24882.5703125
+            }, 
+            {
+                "bad": false, 
+                "events": 8000, 
+                "name": "/store/user/alesauva/flashgg/2016_1/10_6_4/TprimeBToTH_Hgg_M-625_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/2016_1-10_6_4-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201207_135230/0000/myMicroAODOutputFile_19.root", 
+                "nevents": 8000, 
+                "totEvents": 8000, 
+                "weights": 7994.03466796875
+            }, 
+            {
+                "bad": false, 
+                "events": 7000, 
+                "name": "/store/user/alesauva/flashgg/2016_1/10_6_4/TprimeBToTH_Hgg_M-625_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/2016_1-10_6_4-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201207_135230/0000/myMicroAODOutputFile_7.root", 
+                "nevents": 7000, 
+                "totEvents": 7000, 
+                "weights": 6994.17626953125
+            }, 
+            {
+                "bad": false, 
+                "events": 14000, 
+                "name": "/store/user/alesauva/flashgg/2016_1/10_6_4/TprimeBToTH_Hgg_M-625_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/2016_1-10_6_4-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201207_135230/0000/myMicroAODOutputFile_20.root", 
+                "nevents": 14000, 
+                "totEvents": 14000, 
+                "weights": 13989.9912109375
+            }, 
+            {
+                "bad": false, 
+                "events": 2500, 
+                "name": "/store/user/alesauva/flashgg/2016_1/10_6_4/TprimeBToTH_Hgg_M-625_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/2016_1-10_6_4-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201207_135230/0000/myMicroAODOutputFile_1.root", 
+                "nevents": 2500, 
+                "totEvents": 2500, 
+                "weights": 2498.500732421875
+            }, 
+            {
+                "bad": false, 
+                "events": 9300, 
+                "name": "/store/user/alesauva/flashgg/2016_1/10_6_4/TprimeBToTH_Hgg_M-625_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/2016_1-10_6_4-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201207_135230/0000/myMicroAODOutputFile_27.root", 
+                "nevents": 9300, 
+                "totEvents": 9300, 
+                "weights": 9292.994140625
+            }, 
+            {
+                "bad": false, 
+                "events": 8500, 
+                "name": "/store/user/alesauva/flashgg/2016_1/10_6_4/TprimeBToTH_Hgg_M-625_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/2016_1-10_6_4-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201207_135230/0000/myMicroAODOutputFile_29.root", 
+                "nevents": 8500, 
+                "totEvents": 8500, 
+                "weights": 8495.1328125
+            }
+        ], 
+        "parent_n_units": 398000, 
+        "vetted": true
+    }, 
+    "/TprimeBToTH_Hgg_M-650_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/lata-Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1-558f94a366de3fc00ec9d9ea7e93aa72/USER": {
+        "dset_type": "mc", 
+        "files": [
+            {
+                "bad": false, 
+                "events": 1200, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-650_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_194030/0000/myMicroAODOutputFile_9.root", 
+                "nevents": 1200, 
+                "totEvents": 1200, 
+                "weights": 1199.2303466796875
+            }, 
+            {
+                "bad": false, 
+                "events": 1200, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-650_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_194030/0000/myMicroAODOutputFile_10.root", 
+                "nevents": 1200, 
+                "totEvents": 1200, 
+                "weights": 1199.360107421875
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-650_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_194030/0000/myMicroAODOutputFile_28.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24984.72265625
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-650_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_194030/0000/myMicroAODOutputFile_23.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24981.47265625
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-650_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_194030/0000/myMicroAODOutputFile_15.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24982.9296875
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-650_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_194030/0000/myMicroAODOutputFile_22.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24981.859375
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-650_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_194030/0000/myMicroAODOutputFile_16.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24982.890625
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-650_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_194030/0000/myMicroAODOutputFile_26.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24982.5859375
+            }, 
+            {
+                "bad": false, 
+                "events": 400, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-650_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_194030/0000/myMicroAODOutputFile_14.root", 
+                "nevents": 400, 
+                "totEvents": 400, 
+                "weights": 399.70001220703125
+            }, 
+            {
+                "bad": false, 
+                "events": 600, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-650_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_194030/0000/myMicroAODOutputFile_12.root", 
+                "nevents": 600, 
+                "totEvents": 600, 
+                "weights": 599.6701049804688
+            }, 
+            {
+                "bad": false, 
+                "events": 600, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-650_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_194030/0000/myMicroAODOutputFile_8.root", 
+                "nevents": 600, 
+                "totEvents": 600, 
+                "weights": 599.6500244140625
+            }, 
+            {
+                "bad": false, 
+                "events": 1200, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-650_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_194030/0000/myMicroAODOutputFile_30.root", 
+                "nevents": 1200, 
+                "totEvents": 1200, 
+                "weights": 1199.300048828125
+            }, 
+            {
+                "bad": false, 
+                "events": 2400, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-650_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_194030/0000/myMicroAODOutputFile_2.root", 
+                "nevents": 2400, 
+                "totEvents": 2400, 
+                "weights": 2398.71044921875
+            }, 
+            {
+                "bad": false, 
+                "events": 600, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-650_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_194030/0000/myMicroAODOutputFile_11.root", 
+                "nevents": 600, 
+                "totEvents": 600, 
+                "weights": 599.6102294921875
+            }, 
+            {
+                "bad": false, 
+                "events": 3600, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-650_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_194030/0000/myMicroAODOutputFile_4.root", 
+                "nevents": 3600, 
+                "totEvents": 3600, 
+                "weights": 3597.3642578125
+            }, 
+            {
+                "bad": false, 
+                "events": 1800, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-650_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_194030/0000/myMicroAODOutputFile_13.root", 
+                "nevents": 1800, 
+                "totEvents": 1800, 
+                "weights": 1798.810302734375
+            }, 
+            {
+                "bad": false, 
+                "events": 600, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-650_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_194030/0000/myMicroAODOutputFile_6.root", 
+                "nevents": 600, 
+                "totEvents": 600, 
+                "weights": 599.5501098632812
+            }, 
+            {
+                "bad": false, 
+                "events": 1200, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-650_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_194030/0000/myMicroAODOutputFile_1.root", 
+                "nevents": 1200, 
+                "totEvents": 1200, 
+                "weights": 1199.400390625
+            }, 
+            {
+                "bad": false, 
+                "events": 1800, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-650_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_194030/0000/myMicroAODOutputFile_7.root", 
+                "nevents": 1800, 
+                "totEvents": 1800, 
+                "weights": 1798.0777587890625
+            }, 
+            {
+                "bad": false, 
+                "events": 4800, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-650_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_194030/0000/myMicroAODOutputFile_5.root", 
+                "nevents": 4800, 
+                "totEvents": 4800, 
+                "weights": 4797.140625
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-650_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_194030/0000/myMicroAODOutputFile_25.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24984.166015625
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-650_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_194030/0000/myMicroAODOutputFile_18.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24982.30859375
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-650_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_194030/0000/myMicroAODOutputFile_19.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24984.005859375
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-650_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_194030/0000/myMicroAODOutputFile_27.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24983.16015625
+            }, 
+            {
+                "bad": false, 
+                "events": 16000, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-650_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_194030/0000/myMicroAODOutputFile_29.root", 
+                "nevents": 16000, 
+                "totEvents": 16000, 
+                "weights": 15989.171875
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-650_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_194030/0000/myMicroAODOutputFile_20.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24981.75390625
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-650_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_194030/0000/myMicroAODOutputFile_21.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24983.74609375
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-650_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_194030/0000/myMicroAODOutputFile_17.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24983.17578125
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-650_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_194030/0000/myMicroAODOutputFile_24.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24981.998046875
+            }, 
+            {
+                "bad": false, 
+                "events": 1800, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-650_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_194030/0000/myMicroAODOutputFile_3.root", 
+                "nevents": 1800, 
+                "totEvents": 1800, 
+                "weights": 1798.9603271484375
+            }, 
+            {
+                "bad": false, 
+                "events": 8400, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-650_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_194030/0000/myMicroAODOutputFile_31.root", 
+                "nevents": 8400, 
+                "totEvents": 8400, 
+                "weights": 8394.8330078125
+            }
+        ], 
+        "parent_n_units": 398200, 
+        "vetted": true
+    }, 
+    "/TprimeBToTH_Hgg_M-675_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/alesauva-2016_1-10_6_4-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1-c006dcd9fa3985d1c579b6127ed603c3/USER": {
+        "dset_type": "mc", 
+        "files": [
+            {
+                "bad": false, 
+                "events": 7200, 
+                "name": "/store/user/alesauva/flashgg/2016_1/10_6_4/TprimeBToTH_Hgg_M-675_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/2016_1-10_6_4-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201207_135937/0000/myMicroAODOutputFile_5.root", 
+                "nevents": 7200, 
+                "totEvents": 7200, 
+                "weights": 7194.2705078125
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/alesauva/flashgg/2016_1/10_6_4/TprimeBToTH_Hgg_M-675_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/2016_1-10_6_4-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201207_135937/0000/myMicroAODOutputFile_2.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24982.232421875
+            }, 
+            {
+                "bad": false, 
+                "events": 3200, 
+                "name": "/store/user/alesauva/flashgg/2016_1/10_6_4/TprimeBToTH_Hgg_M-675_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/2016_1-10_6_4-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201207_135937/0000/myMicroAODOutputFile_27.root", 
+                "nevents": 3200, 
+                "totEvents": 3200, 
+                "weights": 3198.140380859375
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/alesauva/flashgg/2016_1/10_6_4/TprimeBToTH_Hgg_M-675_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/2016_1-10_6_4-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201207_135937/0000/myMicroAODOutputFile_23.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24982.013671875
+            }, 
+            {
+                "bad": false, 
+                "events": 6400, 
+                "name": "/store/user/alesauva/flashgg/2016_1/10_6_4/TprimeBToTH_Hgg_M-675_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/2016_1-10_6_4-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201207_135937/0000/myMicroAODOutputFile_1.root", 
+                "nevents": 6400, 
+                "totEvents": 6400, 
+                "weights": 6395.88134765625
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/alesauva/flashgg/2016_1/10_6_4/TprimeBToTH_Hgg_M-675_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/2016_1-10_6_4-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201207_135937/0000/myMicroAODOutputFile_14.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24980.642578125
+            }, 
+            {
+                "bad": false, 
+                "events": 3200, 
+                "name": "/store/user/alesauva/flashgg/2016_1/10_6_4/TprimeBToTH_Hgg_M-675_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/2016_1-10_6_4-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201207_135937/0000/myMicroAODOutputFile_16.root", 
+                "nevents": 3200, 
+                "totEvents": 3200, 
+                "weights": 3198.060546875
+            }, 
+            {
+                "bad": false, 
+                "events": 4800, 
+                "name": "/store/user/alesauva/flashgg/2016_1/10_6_4/TprimeBToTH_Hgg_M-675_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/2016_1-10_6_4-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201207_135937/0000/myMicroAODOutputFile_21.root", 
+                "nevents": 4800, 
+                "totEvents": 4800, 
+                "weights": 4796.97021484375
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/alesauva/flashgg/2016_1/10_6_4/TprimeBToTH_Hgg_M-675_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/2016_1-10_6_4-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201207_135937/0000/myMicroAODOutputFile_13.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24980.939453125
+            }, 
+            {
+                "bad": false, 
+                "events": 8600, 
+                "name": "/store/user/alesauva/flashgg/2016_1/10_6_4/TprimeBToTH_Hgg_M-675_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/2016_1-10_6_4-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201207_135937/0000/myMicroAODOutputFile_3.root", 
+                "nevents": 8600, 
+                "totEvents": 8600, 
+                "weights": 8592.345703125
+            }, 
+            {
+                "bad": false, 
+                "events": 800, 
+                "name": "/store/user/alesauva/flashgg/2016_1/10_6_4/TprimeBToTH_Hgg_M-675_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/2016_1-10_6_4-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201207_135937/0000/myMicroAODOutputFile_8.root", 
+                "nevents": 800, 
+                "totEvents": 800, 
+                "weights": 799.5801391601562
+            }, 
+            {
+                "bad": false, 
+                "events": 6400, 
+                "name": "/store/user/alesauva/flashgg/2016_1/10_6_4/TprimeBToTH_Hgg_M-675_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/2016_1-10_6_4-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201207_135937/0000/myMicroAODOutputFile_9.root", 
+                "nevents": 6400, 
+                "totEvents": 6400, 
+                "weights": 6394.23095703125
+            }, 
+            {
+                "bad": false, 
+                "events": 13600, 
+                "name": "/store/user/alesauva/flashgg/2016_1/10_6_4/TprimeBToTH_Hgg_M-675_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/2016_1-10_6_4-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201207_135937/0000/myMicroAODOutputFile_10.root", 
+                "nevents": 13600, 
+                "totEvents": 13600, 
+                "weights": 13589.501953125
+            }, 
+            {
+                "bad": false, 
+                "events": 4000, 
+                "name": "/store/user/alesauva/flashgg/2016_1/10_6_4/TprimeBToTH_Hgg_M-675_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/2016_1-10_6_4-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201207_135937/0000/myMicroAODOutputFile_22.root", 
+                "nevents": 4000, 
+                "totEvents": 4000, 
+                "weights": 3996.56103515625
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/alesauva/flashgg/2016_1/10_6_4/TprimeBToTH_Hgg_M-675_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/2016_1-10_6_4-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201207_135937/0000/myMicroAODOutputFile_11.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24982.197265625
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/alesauva/flashgg/2016_1/10_6_4/TprimeBToTH_Hgg_M-675_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/2016_1-10_6_4-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201207_135937/0000/myMicroAODOutputFile_12.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24981.4296875
+            }, 
+            {
+                "bad": false, 
+                "events": 16000, 
+                "name": "/store/user/alesauva/flashgg/2016_1/10_6_4/TprimeBToTH_Hgg_M-675_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/2016_1-10_6_4-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201207_135937/0000/myMicroAODOutputFile_6.root", 
+                "nevents": 16000, 
+                "totEvents": 16000, 
+                "weights": 15987.875
+            }, 
+            {
+                "bad": false, 
+                "events": 18400, 
+                "name": "/store/user/alesauva/flashgg/2016_1/10_6_4/TprimeBToTH_Hgg_M-675_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/2016_1-10_6_4-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201207_135937/0000/myMicroAODOutputFile_26.root", 
+                "nevents": 18400, 
+                "totEvents": 18400, 
+                "weights": 18386.46484375
+            }, 
+            {
+                "bad": false, 
+                "events": 19000, 
+                "name": "/store/user/alesauva/flashgg/2016_1/10_6_4/TprimeBToTH_Hgg_M-675_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/2016_1-10_6_4-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201207_135937/0000/myMicroAODOutputFile_24.root", 
+                "nevents": 19000, 
+                "totEvents": 19000, 
+                "weights": 18986.248046875
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/alesauva/flashgg/2016_1/10_6_4/TprimeBToTH_Hgg_M-675_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/2016_1-10_6_4-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201207_135937/0000/myMicroAODOutputFile_18.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24981.6875
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/alesauva/flashgg/2016_1/10_6_4/TprimeBToTH_Hgg_M-675_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/2016_1-10_6_4-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201207_135937/0000/myMicroAODOutputFile_20.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24983.056640625
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/alesauva/flashgg/2016_1/10_6_4/TprimeBToTH_Hgg_M-675_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/2016_1-10_6_4-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201207_135937/0000/myMicroAODOutputFile_17.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24982.611328125
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/alesauva/flashgg/2016_1/10_6_4/TprimeBToTH_Hgg_M-675_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/2016_1-10_6_4-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201207_135937/0000/myMicroAODOutputFile_19.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24981.2421875
+            }, 
+            {
+                "bad": false, 
+                "events": 4000, 
+                "name": "/store/user/alesauva/flashgg/2016_1/10_6_4/TprimeBToTH_Hgg_M-675_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/2016_1-10_6_4-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201207_135937/0000/myMicroAODOutputFile_28.root", 
+                "nevents": 4000, 
+                "totEvents": 4000, 
+                "weights": 3996.442138671875
+            }, 
+            {
+                "bad": false, 
+                "events": 6400, 
+                "name": "/store/user/alesauva/flashgg/2016_1/10_6_4/TprimeBToTH_Hgg_M-675_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/2016_1-10_6_4-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201207_135937/0000/myMicroAODOutputFile_7.root", 
+                "nevents": 6400, 
+                "totEvents": 6400, 
+                "weights": 6396.10107421875
+            }, 
+            {
+                "bad": false, 
+                "events": 10400, 
+                "name": "/store/user/alesauva/flashgg/2016_1/10_6_4/TprimeBToTH_Hgg_M-675_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/2016_1-10_6_4-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201207_135937/0000/myMicroAODOutputFile_25.root", 
+                "nevents": 10400, 
+                "totEvents": 10400, 
+                "weights": 10392.1123046875
+            }, 
+            {
+                "bad": false, 
+                "events": 4000, 
+                "name": "/store/user/alesauva/flashgg/2016_1/10_6_4/TprimeBToTH_Hgg_M-675_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/2016_1-10_6_4-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201207_135937/0000/myMicroAODOutputFile_15.root", 
+                "nevents": 4000, 
+                "totEvents": 4000, 
+                "weights": 3996.57861328125
+            }, 
+            {
+                "bad": false, 
+                "events": 12000, 
+                "name": "/store/user/alesauva/flashgg/2016_1/10_6_4/TprimeBToTH_Hgg_M-675_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/2016_1-10_6_4-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201207_135937/0000/myMicroAODOutputFile_4.root", 
+                "nevents": 12000, 
+                "totEvents": 12000, 
+                "weights": 11990.439453125
+            }
+        ], 
+        "parent_n_units": 398400, 
+        "vetted": true
+    }, 
+    "/TprimeBToTH_Hgg_M-700_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/alesauva-2016_1-10_6_4-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1-c006dcd9fa3985d1c579b6127ed603c3/USER": {
+        "dset_type": "mc", 
+        "files": [
+            {
+                "bad": false, 
+                "events": 4500, 
+                "name": "/store/user/alesauva/flashgg/2016_1/10_6_4/TprimeBToTH_Hgg_M-700_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/2016_1-10_6_4-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201207_140722/0000/myMicroAODOutputFile_20.root", 
+                "nevents": 4500, 
+                "totEvents": 4500, 
+                "weights": 4496.56982421875
+            }, 
+            {
+                "bad": false, 
+                "events": 11000, 
+                "name": "/store/user/alesauva/flashgg/2016_1/10_6_4/TprimeBToTH_Hgg_M-700_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/2016_1-10_6_4-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201207_140722/0000/myMicroAODOutputFile_22.root", 
+                "nevents": 11000, 
+                "totEvents": 11000, 
+                "weights": 10991.8359375
+            }, 
+            {
+                "bad": false, 
+                "events": 1500, 
+                "name": "/store/user/alesauva/flashgg/2016_1/10_6_4/TprimeBToTH_Hgg_M-700_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/2016_1-10_6_4-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201207_140722/0000/myMicroAODOutputFile_28.root", 
+                "nevents": 1500, 
+                "totEvents": 1500, 
+                "weights": 1498.930419921875
+            }, 
+            {
+                "bad": false, 
+                "events": 10300, 
+                "name": "/store/user/alesauva/flashgg/2016_1/10_6_4/TprimeBToTH_Hgg_M-700_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/2016_1-10_6_4-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201207_140722/0000/myMicroAODOutputFile_21.root", 
+                "nevents": 10300, 
+                "totEvents": 10300, 
+                "weights": 10293.341796875
+            }, 
+            {
+                "bad": false, 
+                "events": 5500, 
+                "name": "/store/user/alesauva/flashgg/2016_1/10_6_4/TprimeBToTH_Hgg_M-700_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/2016_1-10_6_4-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201207_140722/0000/myMicroAODOutputFile_1.root", 
+                "nevents": 5500, 
+                "totEvents": 5500, 
+                "weights": 5495.75390625
+            }, 
+            {
+                "bad": false, 
+                "events": 11200, 
+                "name": "/store/user/alesauva/flashgg/2016_1/10_6_4/TprimeBToTH_Hgg_M-700_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/2016_1-10_6_4-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201207_140722/0000/myMicroAODOutputFile_27.root", 
+                "nevents": 11200, 
+                "totEvents": 11200, 
+                "weights": 11192.9794921875
+            }, 
+            {
+                "bad": false, 
+                "events": 2500, 
+                "name": "/store/user/alesauva/flashgg/2016_1/10_6_4/TprimeBToTH_Hgg_M-700_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/2016_1-10_6_4-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201207_140722/0000/myMicroAODOutputFile_24.root", 
+                "nevents": 2500, 
+                "totEvents": 2500, 
+                "weights": 2498.780029296875
+            }, 
+            {
+                "bad": false, 
+                "events": 11000, 
+                "name": "/store/user/alesauva/flashgg/2016_1/10_6_4/TprimeBToTH_Hgg_M-700_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/2016_1-10_6_4-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201207_140722/0000/myMicroAODOutputFile_14.root", 
+                "nevents": 11000, 
+                "totEvents": 11000, 
+                "weights": 10991.5576171875
+            }, 
+            {
+                "bad": false, 
+                "events": 2000, 
+                "name": "/store/user/alesauva/flashgg/2016_1/10_6_4/TprimeBToTH_Hgg_M-700_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/2016_1-10_6_4-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201207_140722/0000/myMicroAODOutputFile_19.root", 
+                "nevents": 2000, 
+                "totEvents": 2000, 
+                "weights": 1998.6209716796875
+            }, 
+            {
+                "bad": false, 
+                "events": 23000, 
+                "name": "/store/user/alesauva/flashgg/2016_1/10_6_4/TprimeBToTH_Hgg_M-700_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/2016_1-10_6_4-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201207_140722/0000/myMicroAODOutputFile_18.root", 
+                "nevents": 23000, 
+                "totEvents": 23000, 
+                "weights": 22980.734375
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/alesauva/flashgg/2016_1/10_6_4/TprimeBToTH_Hgg_M-700_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/2016_1-10_6_4-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201207_140722/0000/myMicroAODOutputFile_10.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24981.458984375
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/alesauva/flashgg/2016_1/10_6_4/TprimeBToTH_Hgg_M-700_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/2016_1-10_6_4-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201207_140722/0000/myMicroAODOutputFile_5.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24982.4921875
+            }, 
+            {
+                "bad": false, 
+                "events": 24800, 
+                "name": "/store/user/alesauva/flashgg/2016_1/10_6_4/TprimeBToTH_Hgg_M-700_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/2016_1-10_6_4-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201207_140722/0000/myMicroAODOutputFile_9.root", 
+                "nevents": 24800, 
+                "totEvents": 24800, 
+                "weights": 24781.791015625
+            }, 
+            {
+                "bad": false, 
+                "events": 21000, 
+                "name": "/store/user/alesauva/flashgg/2016_1/10_6_4/TprimeBToTH_Hgg_M-700_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/2016_1-10_6_4-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201207_140722/0000/myMicroAODOutputFile_16.root", 
+                "nevents": 21000, 
+                "totEvents": 21000, 
+                "weights": 20981.845703125
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/alesauva/flashgg/2016_1/10_6_4/TprimeBToTH_Hgg_M-700_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/2016_1-10_6_4-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201207_140722/0000/myMicroAODOutputFile_4.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24980.060546875
+            }, 
+            {
+                "bad": false, 
+                "events": 24900, 
+                "name": "/store/user/alesauva/flashgg/2016_1/10_6_4/TprimeBToTH_Hgg_M-700_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/2016_1-10_6_4-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201207_140722/0000/myMicroAODOutputFile_7.root", 
+                "nevents": 24900, 
+                "totEvents": 24900, 
+                "weights": 24884.20703125
+            }, 
+            {
+                "bad": false, 
+                "events": 24600, 
+                "name": "/store/user/alesauva/flashgg/2016_1/10_6_4/TprimeBToTH_Hgg_M-700_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/2016_1-10_6_4-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201207_140722/0000/myMicroAODOutputFile_8.root", 
+                "nevents": 24600, 
+                "totEvents": 24600, 
+                "weights": 24585.099609375
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/alesauva/flashgg/2016_1/10_6_4/TprimeBToTH_Hgg_M-700_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/2016_1-10_6_4-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201207_140722/0000/myMicroAODOutputFile_13.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24983.103515625
+            }, 
+            {
+                "bad": false, 
+                "events": 25400, 
+                "name": "/store/user/alesauva/flashgg/2016_1/10_6_4/TprimeBToTH_Hgg_M-700_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/2016_1-10_6_4-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201207_140722/0000/myMicroAODOutputFile_12.root", 
+                "nevents": 25400, 
+                "totEvents": 25400, 
+                "weights": 25381.62890625
+            }, 
+            {
+                "bad": false, 
+                "events": 24400, 
+                "name": "/store/user/alesauva/flashgg/2016_1/10_6_4/TprimeBToTH_Hgg_M-700_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/2016_1-10_6_4-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201207_140722/0000/myMicroAODOutputFile_6.root", 
+                "nevents": 24400, 
+                "totEvents": 24400, 
+                "weights": 24382.123046875
+            }, 
+            {
+                "bad": false, 
+                "events": 24900, 
+                "name": "/store/user/alesauva/flashgg/2016_1/10_6_4/TprimeBToTH_Hgg_M-700_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/2016_1-10_6_4-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201207_140722/0000/myMicroAODOutputFile_11.root", 
+                "nevents": 24900, 
+                "totEvents": 24900, 
+                "weights": 24884.376953125
+            }, 
+            {
+                "bad": false, 
+                "events": 10000, 
+                "name": "/store/user/alesauva/flashgg/2016_1/10_6_4/TprimeBToTH_Hgg_M-700_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/2016_1-10_6_4-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201207_140722/0000/myMicroAODOutputFile_15.root", 
+                "nevents": 10000, 
+                "totEvents": 10000, 
+                "weights": 9992.3330078125
+            }, 
+            {
+                "bad": false, 
+                "events": 4500, 
+                "name": "/store/user/alesauva/flashgg/2016_1/10_6_4/TprimeBToTH_Hgg_M-700_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/2016_1-10_6_4-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201207_140722/0000/myMicroAODOutputFile_17.root", 
+                "nevents": 4500, 
+                "totEvents": 4500, 
+                "weights": 4496.10400390625
+            }, 
+            {
+                "bad": false, 
+                "events": 16000, 
+                "name": "/store/user/alesauva/flashgg/2016_1/10_6_4/TprimeBToTH_Hgg_M-700_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/2016_1-10_6_4-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201207_140722/0000/myMicroAODOutputFile_29.root", 
+                "nevents": 16000, 
+                "totEvents": 16000, 
+                "weights": 15987.1953125
+            }, 
+            {
+                "bad": false, 
+                "events": 2500, 
+                "name": "/store/user/alesauva/flashgg/2016_1/10_6_4/TprimeBToTH_Hgg_M-700_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/2016_1-10_6_4-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201207_140722/0000/myMicroAODOutputFile_3.root", 
+                "nevents": 2500, 
+                "totEvents": 2500, 
+                "weights": 2498.4501953125
+            }, 
+            {
+                "bad": false, 
+                "events": 1000, 
+                "name": "/store/user/alesauva/flashgg/2016_1/10_6_4/TprimeBToTH_Hgg_M-700_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/2016_1-10_6_4-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201207_140722/0000/myMicroAODOutputFile_25.root", 
+                "nevents": 1000, 
+                "totEvents": 1000, 
+                "weights": 999.4902954101562
+            }, 
+            {
+                "bad": false, 
+                "events": 500, 
+                "name": "/store/user/alesauva/flashgg/2016_1/10_6_4/TprimeBToTH_Hgg_M-700_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/2016_1-10_6_4-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201207_140722/0000/myMicroAODOutputFile_2.root", 
+                "nevents": 500, 
+                "totEvents": 500, 
+                "weights": 499.63031005859375
+            }, 
+            {
+                "bad": false, 
+                "events": 500, 
+                "name": "/store/user/alesauva/flashgg/2016_1/10_6_4/TprimeBToTH_Hgg_M-700_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/2016_1-10_6_4-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201207_140722/0000/myMicroAODOutputFile_26.root", 
+                "nevents": 500, 
+                "totEvents": 500, 
+                "weights": 499.67999267578125
+            }, 
+            {
+                "bad": false, 
+                "events": 3500, 
+                "name": "/store/user/alesauva/flashgg/2016_1/10_6_4/TprimeBToTH_Hgg_M-700_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/2016_1-10_6_4-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201207_140722/0000/myMicroAODOutputFile_23.root", 
+                "nevents": 3500, 
+                "totEvents": 3500, 
+                "weights": 3497.791015625
+            }
+        ], 
+        "parent_n_units": 391000, 
+        "vetted": true
+    }, 
+    "/TprimeBToTH_Hgg_M-800_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/lata-Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1-558f94a366de3fc00ec9d9ea7e93aa72/USER": {
+        "dset_type": "mc", 
+        "files": [
+            {
+                "bad": false, 
+                "events": 1400, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-800_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_195106/0000/myMicroAODOutputFile_33.root", 
+                "nevents": 1400, 
+                "totEvents": 1400, 
+                "weights": 1399.190185546875
+            }, 
+            {
+                "bad": false, 
+                "events": 11200, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-800_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_195106/0000/myMicroAODOutputFile_25.root", 
+                "nevents": 11200, 
+                "totEvents": 11200, 
+                "weights": 11192.955078125
+            }, 
+            {
+                "bad": false, 
+                "events": 2800, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-800_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_195106/0000/myMicroAODOutputFile_22.root", 
+                "nevents": 2800, 
+                "totEvents": 2800, 
+                "weights": 2797.9814453125
+            }, 
+            {
+                "bad": false, 
+                "events": 1400, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-800_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_195106/0000/myMicroAODOutputFile_31.root", 
+                "nevents": 1400, 
+                "totEvents": 1400, 
+                "weights": 1398.890625
+            }, 
+            {
+                "bad": false, 
+                "events": 16800, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-800_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_195106/0000/myMicroAODOutputFile_30.root", 
+                "nevents": 16800, 
+                "totEvents": 16800, 
+                "weights": 16788.994140625
+            }, 
+            {
+                "bad": false, 
+                "events": 700, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-800_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_195106/0000/myMicroAODOutputFile_13.root", 
+                "nevents": 700, 
+                "totEvents": 700, 
+                "weights": 699.5
+            }, 
+            {
+                "bad": false, 
+                "events": 12600, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-800_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_195106/0000/myMicroAODOutputFile_17.root", 
+                "nevents": 12600, 
+                "totEvents": 12600, 
+                "weights": 12591.8203125
+            }, 
+            {
+                "bad": false, 
+                "events": 24900, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-800_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_195106/0000/myMicroAODOutputFile_26.root", 
+                "nevents": 24900, 
+                "totEvents": 24900, 
+                "weights": 24880.708984375
+            }, 
+            {
+                "bad": false, 
+                "events": 24800, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-800_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_195106/0000/myMicroAODOutputFile_27.root", 
+                "nevents": 24800, 
+                "totEvents": 24800, 
+                "weights": 24781.03125
+            }, 
+            {
+                "bad": false, 
+                "events": 24900, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-800_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_195106/0000/myMicroAODOutputFile_20.root", 
+                "nevents": 24900, 
+                "totEvents": 24900, 
+                "weights": 24881.251953125
+            }, 
+            {
+                "bad": false, 
+                "events": 24900, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-800_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_195106/0000/myMicroAODOutputFile_28.root", 
+                "nevents": 24900, 
+                "totEvents": 24900, 
+                "weights": 24880.5234375
+            }, 
+            {
+                "bad": false, 
+                "events": 700, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-800_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_195106/0000/myMicroAODOutputFile_18.root", 
+                "nevents": 700, 
+                "totEvents": 700, 
+                "weights": 699.0101318359375
+            }, 
+            {
+                "bad": false, 
+                "events": 700, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-800_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_195106/0000/myMicroAODOutputFile_6.root", 
+                "nevents": 700, 
+                "totEvents": 700, 
+                "weights": 698.6239013671875
+            }, 
+            {
+                "bad": false, 
+                "events": 24800, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-800_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_195106/0000/myMicroAODOutputFile_3.root", 
+                "nevents": 24800, 
+                "totEvents": 24800, 
+                "weights": 24783.41796875
+            }, 
+            {
+                "bad": false, 
+                "events": 16800, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-800_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_195106/0000/myMicroAODOutputFile_7.root", 
+                "nevents": 16800, 
+                "totEvents": 16800, 
+                "weights": 16788.97265625
+            }, 
+            {
+                "bad": false, 
+                "events": 16800, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-800_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_195106/0000/myMicroAODOutputFile_14.root", 
+                "nevents": 16800, 
+                "totEvents": 16800, 
+                "weights": 16788.298828125
+            }, 
+            {
+                "bad": false, 
+                "events": 11900, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-800_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_195106/0000/myMicroAODOutputFile_15.root", 
+                "nevents": 11900, 
+                "totEvents": 11900, 
+                "weights": 11889.8583984375
+            }, 
+            {
+                "bad": false, 
+                "events": 13700, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-800_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_195106/0000/myMicroAODOutputFile_21.root", 
+                "nevents": 13700, 
+                "totEvents": 13700, 
+                "weights": 13689.41796875
+            }, 
+            {
+                "bad": false, 
+                "events": 16100, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-800_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_195106/0000/myMicroAODOutputFile_2.root", 
+                "nevents": 16100, 
+                "totEvents": 16100, 
+                "weights": 16089.640625
+            }, 
+            {
+                "bad": false, 
+                "events": 10900, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-800_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_195106/0000/myMicroAODOutputFile_4.root", 
+                "nevents": 10900, 
+                "totEvents": 10900, 
+                "weights": 10892.00390625
+            }, 
+            {
+                "bad": false, 
+                "events": 11200, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-800_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_195106/0000/myMicroAODOutputFile_10.root", 
+                "nevents": 11200, 
+                "totEvents": 11200, 
+                "weights": 11189.4072265625
+            }, 
+            {
+                "bad": false, 
+                "events": 10500, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-800_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_195106/0000/myMicroAODOutputFile_23.root", 
+                "nevents": 10500, 
+                "totEvents": 10500, 
+                "weights": 10493.04296875
+            }, 
+            {
+                "bad": false, 
+                "events": 5600, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-800_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_195106/0000/myMicroAODOutputFile_1.root", 
+                "nevents": 5600, 
+                "totEvents": 5600, 
+                "weights": 5596.03271484375
+            }, 
+            {
+                "bad": false, 
+                "events": 2400, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-800_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_195106/0000/myMicroAODOutputFile_29.root", 
+                "nevents": 2400, 
+                "totEvents": 2400, 
+                "weights": 2397.927001953125
+            }, 
+            {
+                "bad": false, 
+                "events": 2100, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-800_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_195106/0000/myMicroAODOutputFile_5.root", 
+                "nevents": 2100, 
+                "totEvents": 2100, 
+                "weights": 2098.5205078125
+            }, 
+            {
+                "bad": false, 
+                "events": 7700, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-800_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_195106/0000/myMicroAODOutputFile_16.root", 
+                "nevents": 7700, 
+                "totEvents": 7700, 
+                "weights": 7693.2841796875
+            }, 
+            {
+                "bad": false, 
+                "events": 25100, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-800_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_195106/0000/myMicroAODOutputFile_11.root", 
+                "nevents": 25100, 
+                "totEvents": 25100, 
+                "weights": 25079.986328125
+            }, 
+            {
+                "bad": false, 
+                "events": 24700, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-800_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_195106/0000/myMicroAODOutputFile_19.root", 
+                "nevents": 24700, 
+                "totEvents": 24700, 
+                "weights": 24681.298828125
+            }, 
+            {
+                "bad": false, 
+                "events": 7000, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-800_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_195106/0000/myMicroAODOutputFile_8.root", 
+                "nevents": 7000, 
+                "totEvents": 7000, 
+                "weights": 6995.3017578125
+            }, 
+            {
+                "bad": false, 
+                "events": 3500, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-800_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_195106/0000/myMicroAODOutputFile_32.root", 
+                "nevents": 3500, 
+                "totEvents": 3500, 
+                "weights": 3496.4013671875
+            }, 
+            {
+                "bad": false, 
+                "events": 21000, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-800_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_195106/0000/myMicroAODOutputFile_24.root", 
+                "nevents": 21000, 
+                "totEvents": 21000, 
+                "weights": 20985.861328125
+            }, 
+            {
+                "bad": false, 
+                "events": 9100, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-800_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_195106/0000/myMicroAODOutputFile_9.root", 
+                "nevents": 9100, 
+                "totEvents": 9100, 
+                "weights": 9094.2412109375
+            }, 
+            {
+                "bad": false, 
+                "events": 11300, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-800_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_195106/0000/myMicroAODOutputFile_12.root", 
+                "nevents": 11300, 
+                "totEvents": 11300, 
+                "weights": 11289.1318359375
+            }
+        ], 
+        "parent_n_units": 400000, 
+        "vetted": true
+    }, 
+    "/TprimeBToTH_Hgg_M-900_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/lata-Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1-558f94a366de3fc00ec9d9ea7e93aa72/USER": {
+        "dset_type": "mc", 
+        "files": [
+            {
+                "bad": false, 
+                "events": 3000, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-900_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_195356/0000/myMicroAODOutputFile_1.root", 
+                "nevents": 3000, 
+                "totEvents": 3000, 
+                "weights": 2996.721435546875
+            }, 
+            {
+                "bad": false, 
+                "events": 1800, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-900_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_195356/0000/myMicroAODOutputFile_2.root", 
+                "nevents": 1800, 
+                "totEvents": 1800, 
+                "weights": 1798.5064697265625
+            }, 
+            {
+                "bad": false, 
+                "events": 22800, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-900_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_195356/0000/myMicroAODOutputFile_9.root", 
+                "nevents": 22800, 
+                "totEvents": 22800, 
+                "weights": 22782.8359375
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-900_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_195356/0000/myMicroAODOutputFile_6.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24980.669921875
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-900_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_195356/0000/myMicroAODOutputFile_17.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24980.357421875
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-900_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_195356/0000/myMicroAODOutputFile_16.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24980.6484375
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-900_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_195356/0000/myMicroAODOutputFile_7.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24981.521484375
+            }, 
+            {
+                "bad": false, 
+                "events": 20600, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-900_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_195356/0000/myMicroAODOutputFile_12.root", 
+                "nevents": 20600, 
+                "totEvents": 20600, 
+                "weights": 20582.15234375
+            }, 
+            {
+                "bad": false, 
+                "events": 16200, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-900_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_195356/0000/myMicroAODOutputFile_14.root", 
+                "nevents": 16200, 
+                "totEvents": 16200, 
+                "weights": 16183.4013671875
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-900_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_195356/0000/myMicroAODOutputFile_29.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24980.998046875
+            }, 
+            {
+                "bad": false, 
+                "events": 22200, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-900_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_195356/0000/myMicroAODOutputFile_22.root", 
+                "nevents": 22200, 
+                "totEvents": 22200, 
+                "weights": 22182.421875
+            }, 
+            {
+                "bad": false, 
+                "events": 18600, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-900_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_195356/0000/myMicroAODOutputFile_10.root", 
+                "nevents": 18600, 
+                "totEvents": 18600, 
+                "weights": 18583.76171875
+            }, 
+            {
+                "bad": false, 
+                "events": 17400, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-900_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_195356/0000/myMicroAODOutputFile_15.root", 
+                "nevents": 17400, 
+                "totEvents": 17400, 
+                "weights": 17383.34375
+            }, 
+            {
+                "bad": false, 
+                "events": 7800, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-900_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_195356/0000/myMicroAODOutputFile_19.root", 
+                "nevents": 7800, 
+                "totEvents": 7800, 
+                "weights": 7793.4716796875
+            }, 
+            {
+                "bad": false, 
+                "events": 8000, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-900_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_195356/0000/myMicroAODOutputFile_28.root", 
+                "nevents": 8000, 
+                "totEvents": 8000, 
+                "weights": 7994.3525390625
+            }, 
+            {
+                "bad": false, 
+                "events": 7200, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-900_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_195356/0000/myMicroAODOutputFile_4.root", 
+                "nevents": 7200, 
+                "totEvents": 7200, 
+                "weights": 7193.18359375
+            }, 
+            {
+                "bad": false, 
+                "events": 9200, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-900_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_195356/0000/myMicroAODOutputFile_27.root", 
+                "nevents": 9200, 
+                "totEvents": 9200, 
+                "weights": 9192.994140625
+            }, 
+            {
+                "bad": false, 
+                "events": 5000, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-900_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_195356/0000/myMicroAODOutputFile_30.root", 
+                "nevents": 5000, 
+                "totEvents": 5000, 
+                "weights": 4996.81005859375
+            }, 
+            {
+                "bad": false, 
+                "events": 4200, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-900_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_195356/0000/myMicroAODOutputFile_23.root", 
+                "nevents": 4200, 
+                "totEvents": 4200, 
+                "weights": 4196.10107421875
+            }, 
+            {
+                "bad": false, 
+                "events": 1200, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-900_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_195356/0000/myMicroAODOutputFile_13.root", 
+                "nevents": 1200, 
+                "totEvents": 1200, 
+                "weights": 1199.3602294921875
+            }, 
+            {
+                "bad": false, 
+                "events": 600, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-900_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_195356/0000/myMicroAODOutputFile_24.root", 
+                "nevents": 600, 
+                "totEvents": 600, 
+                "weights": 599.5499877929688
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-900_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_195356/0000/myMicroAODOutputFile_8.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24981.609375
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-900_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_195356/0000/myMicroAODOutputFile_11.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24980.9375
+            }, 
+            {
+                "bad": false, 
+                "events": 600, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-900_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_195356/0000/myMicroAODOutputFile_26.root", 
+                "nevents": 600, 
+                "totEvents": 600, 
+                "weights": 599.5300903320312
+            }, 
+            {
+                "bad": false, 
+                "events": 600, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-900_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_195356/0000/myMicroAODOutputFile_25.root", 
+                "nevents": 600, 
+                "totEvents": 600, 
+                "weights": 599.5303955078125
+            }, 
+            {
+                "bad": false, 
+                "events": 15600, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-900_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_195356/0000/myMicroAODOutputFile_21.root", 
+                "nevents": 15600, 
+                "totEvents": 15600, 
+                "weights": 15589.544921875
+            }, 
+            {
+                "bad": false, 
+                "events": 9000, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-900_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_195356/0000/myMicroAODOutputFile_20.root", 
+                "nevents": 9000, 
+                "totEvents": 9000, 
+                "weights": 8993.3623046875
+            }, 
+            {
+                "bad": false, 
+                "events": 600, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-900_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_195356/0000/myMicroAODOutputFile_5.root", 
+                "nevents": 600, 
+                "totEvents": 600, 
+                "weights": 599.690185546875
+            }, 
+            {
+                "bad": false, 
+                "events": 18600, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-900_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_195356/0000/myMicroAODOutputFile_3.root", 
+                "nevents": 18600, 
+                "totEvents": 18600, 
+                "weights": 18584.759765625
+            }, 
+            {
+                "bad": false, 
+                "events": 11000, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018/v2_p12/TprimeBToTH_Hgg_M-900_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018-v2_p12-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/201104_195356/0000/myMicroAODOutputFile_18.root", 
+                "nevents": 11000, 
+                "totEvents": 11000, 
+                "weights": 10992.9404296875
+            }
+        ], 
+        "parent_n_units": 396800, 
+        "vetted": true
+    }
+}

--- a/MetaData/data/Era2016_RR-17Jul2018_v2/datasets_9.json
+++ b/MetaData/data/Era2016_RR-17Jul2018_v2/datasets_9.json
@@ -1429,6 +1429,173 @@
         "parent_n_units": 175000, 
         "vetted": true
     }, 
+    "/HAHMHToAA_AToGG_MA-35GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/lata-Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3-558f94a366de3fc00ec9d9ea7e93aa72/USER": {
+        "dset_type": "mc", 
+        "files": [
+            {
+                "bad": false, 
+                "events": 25045, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-35GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_192021/0000/myMicroAODOutputFile_5.root", 
+                "nevents": 25045, 
+                "totEvents": 25045, 
+                "weights": 25038.822265625
+            }, 
+            {
+                "bad": false, 
+                "events": 24886, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-35GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_192021/0000/myMicroAODOutputFile_8.root", 
+                "nevents": 24886, 
+                "totEvents": 24886, 
+                "weights": 24880.353515625
+            }, 
+            {
+                "bad": false, 
+                "events": 24731, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-35GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_192021/0000/myMicroAODOutputFile_6.root", 
+                "nevents": 24731, 
+                "totEvents": 24731, 
+                "weights": 24725.15625
+            }, 
+            {
+                "bad": false, 
+                "events": 24629, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-35GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_192021/0000/myMicroAODOutputFile_7.root", 
+                "nevents": 24629, 
+                "totEvents": 24629, 
+                "weights": 24623.001953125
+            }, 
+            {
+                "bad": false, 
+                "events": 25104, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-35GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_192021/0000/myMicroAODOutputFile_9.root", 
+                "nevents": 25104, 
+                "totEvents": 25104, 
+                "weights": 25097.611328125
+            }, 
+            {
+                "bad": false, 
+                "events": 24838, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-35GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_192021/0000/myMicroAODOutputFile_1.root", 
+                "nevents": 24838, 
+                "totEvents": 24838, 
+                "weights": 24831.8671875
+            }, 
+            {
+                "bad": false, 
+                "events": 24945, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-35GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_192021/0000/myMicroAODOutputFile_11.root", 
+                "nevents": 24945, 
+                "totEvents": 24945, 
+                "weights": 24939.05078125
+            }, 
+            {
+                "bad": false, 
+                "events": 25212, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-35GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_192021/0000/myMicroAODOutputFile_13.root", 
+                "nevents": 25212, 
+                "totEvents": 25212, 
+                "weights": 25205.876953125
+            }, 
+            {
+                "bad": false, 
+                "events": 25379, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-35GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_192021/0000/myMicroAODOutputFile_15.root", 
+                "nevents": 25379, 
+                "totEvents": 25379, 
+                "weights": 25373.21875
+            }, 
+            {
+                "bad": false, 
+                "events": 24851, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-35GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_192021/0000/myMicroAODOutputFile_12.root", 
+                "nevents": 24851, 
+                "totEvents": 24851, 
+                "weights": 24844.982421875
+            }, 
+            {
+                "bad": false, 
+                "events": 20158, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-35GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_192021/0000/myMicroAODOutputFile_3.root", 
+                "nevents": 20158, 
+                "totEvents": 20158, 
+                "weights": 20152.998046875
+            }, 
+            {
+                "bad": false, 
+                "events": 24820, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-35GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_192021/0000/myMicroAODOutputFile_18.root", 
+                "nevents": 24820, 
+                "totEvents": 24820, 
+                "weights": 24814.185546875
+            }, 
+            {
+                "bad": false, 
+                "events": 24934, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-35GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_192021/0000/myMicroAODOutputFile_17.root", 
+                "nevents": 24934, 
+                "totEvents": 24934, 
+                "weights": 24928.2109375
+            }, 
+            {
+                "bad": false, 
+                "events": 24820, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-35GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_192021/0000/myMicroAODOutputFile_19.root", 
+                "nevents": 24820, 
+                "totEvents": 24820, 
+                "weights": 24813.884765625
+            }, 
+            {
+                "bad": false, 
+                "events": 25231, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-35GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_192021/0000/myMicroAODOutputFile_14.root", 
+                "nevents": 25231, 
+                "totEvents": 25231, 
+                "weights": 25224.80078125
+            }, 
+            {
+                "bad": false, 
+                "events": 24730, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-35GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_192021/0000/myMicroAODOutputFile_4.root", 
+                "nevents": 24730, 
+                "totEvents": 24730, 
+                "weights": 24723.986328125
+            }, 
+            {
+                "bad": false, 
+                "events": 24635, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-35GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_192021/0000/myMicroAODOutputFile_16.root", 
+                "nevents": 24635, 
+                "totEvents": 24635, 
+                "weights": 24629.078125
+            }, 
+            {
+                "bad": false, 
+                "events": 24537, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-35GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_192021/0000/myMicroAODOutputFile_10.root", 
+                "nevents": 24537, 
+                "totEvents": 24537, 
+                "weights": 24530.830078125
+            }, 
+            {
+                "bad": false, 
+                "events": 2421, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-35GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_192021/0000/myMicroAODOutputFile_20.root", 
+                "nevents": 2421, 
+                "totEvents": 2421, 
+                "weights": 2420.5
+            }, 
+            {
+                "bad": false, 
+                "events": 24760, 
+                "name": "/store/user/lata/Era2016_RR-17Jul2018_v2/v2_p12/HAHMHToAA_AToGG_MA-35GeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/Era2016_RR-17Jul2018_v2-v2_p12-v0-RunIISummer16MiniAODv3/201028_192021/0000/myMicroAODOutputFile_2.root", 
+                "nevents": 24760, 
+                "totEvents": 24760, 
+                "weights": 24753.7578125
+            }
+        ], 
+        "parent_n_units": 470666, 
+        "vetted": true
+    }, 
     "/VBFHHTo2B2G_CV_1_C2V_2_C3_1_dipoleRecoilOff-TuneCUETP8M1_PSweights_13TeV-madgraph-pythia8/spigazzi-Era2016_RR-17Jul2018_v2-legacyRun2FullV1-v0-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1-c8aa281774d4d922561c9fdec6c7be19/USER": {
         "dset_type": "mc", 
         "files": [

--- a/MetaData/data/Era2017_RR-31Mar2018_v2/datasets_41.json
+++ b/MetaData/data/Era2017_RR-31Mar2018_v2/datasets_41.json
@@ -1,0 +1,3119 @@
+{
+    "/HAHMHToAA_AToGG_MA-15GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/lata-Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1-6f64939368112792100a27fcb8918a00/USER": {
+        "dset_type": "mc", 
+        "files": [
+            {
+                "bad": true, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-15GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201014_171953/0000/myMicroAODOutputFile_21.root", 
+                "nevents": 9863
+            }, 
+            {
+                "bad": false, 
+                "events": 24789, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-15GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201022_184738/0000/myMicroAODOutputFile_13.root", 
+                "nevents": 24789, 
+                "totEvents": 24789, 
+                "weights": 24785.080078125
+            }, 
+            {
+                "bad": false, 
+                "events": 24784, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-15GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201022_184738/0000/myMicroAODOutputFile_12.root", 
+                "nevents": 24784, 
+                "totEvents": 24784, 
+                "weights": 24780.021484375
+            }, 
+            {
+                "bad": false, 
+                "events": 24798, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-15GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201022_184738/0000/myMicroAODOutputFile_8.root", 
+                "nevents": 24798, 
+                "totEvents": 24798, 
+                "weights": 24793.87890625
+            }, 
+            {
+                "bad": false, 
+                "events": 24795, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-15GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201022_184738/0000/myMicroAODOutputFile_2.root", 
+                "nevents": 24795, 
+                "totEvents": 24795, 
+                "weights": 24790.9921875
+            }, 
+            {
+                "bad": false, 
+                "events": 24530, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-15GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201022_184738/0000/myMicroAODOutputFile_11.root", 
+                "nevents": 24530, 
+                "totEvents": 24530, 
+                "weights": 24525.9296875
+            }, 
+            {
+                "bad": false, 
+                "events": 24750, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-15GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201022_184738/0000/myMicroAODOutputFile_1.root", 
+                "nevents": 24750, 
+                "totEvents": 24750, 
+                "weights": 24746.08984375
+            }, 
+            {
+                "bad": false, 
+                "events": 24789, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-15GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201022_184738/0000/myMicroAODOutputFile_6.root", 
+                "nevents": 24789, 
+                "totEvents": 24789, 
+                "weights": 24785.169921875
+            }, 
+            {
+                "bad": false, 
+                "events": 24812, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-15GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201022_184738/0000/myMicroAODOutputFile_16.root", 
+                "nevents": 24812, 
+                "totEvents": 24812, 
+                "weights": 24807.947265625
+            }, 
+            {
+                "bad": false, 
+                "events": 24797, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-15GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201022_184738/0000/myMicroAODOutputFile_19.root", 
+                "nevents": 24797, 
+                "totEvents": 24797, 
+                "weights": 24793.26171875
+            }, 
+            {
+                "bad": false, 
+                "events": 24927, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-15GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201022_184738/0000/myMicroAODOutputFile_9.root", 
+                "nevents": 24927, 
+                "totEvents": 24927, 
+                "weights": 24922.87109375
+            }, 
+            {
+                "bad": false, 
+                "events": 24516, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-15GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201022_184738/0000/myMicroAODOutputFile_10.root", 
+                "nevents": 24516, 
+                "totEvents": 24516, 
+                "weights": 24512.513671875
+            }, 
+            {
+                "bad": false, 
+                "events": 24918, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-15GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201022_184738/0000/myMicroAODOutputFile_3.root", 
+                "nevents": 24918, 
+                "totEvents": 24918, 
+                "weights": 24914.013671875
+            }, 
+            {
+                "bad": false, 
+                "events": 24956, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-15GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201022_184738/0000/myMicroAODOutputFile_15.root", 
+                "nevents": 24956, 
+                "totEvents": 24956, 
+                "weights": 24951.951171875
+            }, 
+            {
+                "bad": false, 
+                "events": 24873, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-15GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201022_184738/0000/myMicroAODOutputFile_5.root", 
+                "nevents": 24873, 
+                "totEvents": 24873, 
+                "weights": 24868.98828125
+            }, 
+            {
+                "bad": false, 
+                "events": 24846, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-15GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201022_184738/0000/myMicroAODOutputFile_14.root", 
+                "nevents": 24846, 
+                "totEvents": 24846, 
+                "weights": 24841.9609375
+            }, 
+            {
+                "bad": false, 
+                "events": 24608, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-15GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201022_184738/0000/myMicroAODOutputFile_18.root", 
+                "nevents": 24608, 
+                "totEvents": 24608, 
+                "weights": 24603.857421875
+            }, 
+            {
+                "bad": false, 
+                "events": 14740, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-15GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201022_184738/0000/myMicroAODOutputFile_20.root", 
+                "nevents": 14740, 
+                "totEvents": 14740, 
+                "weights": 14737.75
+            }, 
+            {
+                "bad": false, 
+                "events": 24792, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-15GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201022_184738/0000/myMicroAODOutputFile_7.root", 
+                "nevents": 24792, 
+                "totEvents": 24792, 
+                "weights": 24787.740234375
+            }, 
+            {
+                "bad": false, 
+                "events": 24652, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-15GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201022_184738/0000/myMicroAODOutputFile_17.root", 
+                "nevents": 24652, 
+                "totEvents": 24652, 
+                "weights": 24647.37109375
+            }, 
+            {
+                "bad": false, 
+                "events": 24702, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-15GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201022_184738/0000/myMicroAODOutputFile_4.root", 
+                "nevents": 24702, 
+                "totEvents": 24702, 
+                "weights": 24698.12890625
+            }
+        ], 
+        "parent_n_units": 485374, 
+        "vetted": true
+    }, 
+    "/HAHMHToAA_AToGG_MA-20GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/lata-Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1-6f64939368112792100a27fcb8918a00/USER": {
+        "dset_type": "mc", 
+        "files": [
+            {
+                "bad": false, 
+                "events": 24713, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-20GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201020_182437/0000/myMicroAODOutputFile_11.root", 
+                "nevents": 24713, 
+                "totEvents": 24713, 
+                "weights": 24707.919921875
+            }, 
+            {
+                "bad": false, 
+                "events": 24639, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-20GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201020_182437/0000/myMicroAODOutputFile_17.root", 
+                "nevents": 24639, 
+                "totEvents": 24639, 
+                "weights": 24633.8984375
+            }, 
+            {
+                "bad": false, 
+                "events": 24805, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-20GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201020_182437/0000/myMicroAODOutputFile_5.root", 
+                "nevents": 24805, 
+                "totEvents": 24805, 
+                "weights": 24799.083984375
+            }, 
+            {
+                "bad": false, 
+                "events": 24714, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-20GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201020_182437/0000/myMicroAODOutputFile_8.root", 
+                "nevents": 24714, 
+                "totEvents": 24714, 
+                "weights": 24709.267578125
+            }, 
+            {
+                "bad": false, 
+                "events": 24778, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-20GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201020_182437/0000/myMicroAODOutputFile_4.root", 
+                "nevents": 24778, 
+                "totEvents": 24778, 
+                "weights": 24773.302734375
+            }, 
+            {
+                "bad": false, 
+                "events": 24708, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-20GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201020_182437/0000/myMicroAODOutputFile_12.root", 
+                "nevents": 24708, 
+                "totEvents": 24708, 
+                "weights": 24702.55859375
+            }, 
+            {
+                "bad": false, 
+                "events": 24644, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-20GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201020_182437/0000/myMicroAODOutputFile_15.root", 
+                "nevents": 24644, 
+                "totEvents": 24644, 
+                "weights": 24637.158203125
+            }, 
+            {
+                "bad": false, 
+                "events": 24669, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-20GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201020_182437/0000/myMicroAODOutputFile_13.root", 
+                "nevents": 24669, 
+                "totEvents": 24669, 
+                "weights": 24663.66015625
+            }, 
+            {
+                "bad": false, 
+                "events": 24654, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-20GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201020_182437/0000/myMicroAODOutputFile_10.root", 
+                "nevents": 24654, 
+                "totEvents": 24654, 
+                "weights": 24649.08203125
+            }, 
+            {
+                "bad": false, 
+                "events": 24715, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-20GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201020_182437/0000/myMicroAODOutputFile_16.root", 
+                "nevents": 24715, 
+                "totEvents": 24715, 
+                "weights": 24709.85546875
+            }, 
+            {
+                "bad": false, 
+                "events": 24581, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-20GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201020_182437/0000/myMicroAODOutputFile_2.root", 
+                "nevents": 24581, 
+                "totEvents": 24581, 
+                "weights": 24576.12109375
+            }, 
+            {
+                "bad": false, 
+                "events": 24739, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-20GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201020_182437/0000/myMicroAODOutputFile_6.root", 
+                "nevents": 24739, 
+                "totEvents": 24739, 
+                "weights": 24731.6015625
+            }, 
+            {
+                "bad": false, 
+                "events": 24638, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-20GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201020_182437/0000/myMicroAODOutputFile_7.root", 
+                "nevents": 24638, 
+                "totEvents": 24638, 
+                "weights": 24632.76953125
+            }, 
+            {
+                "bad": false, 
+                "events": 24773, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-20GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201020_182437/0000/myMicroAODOutputFile_18.root", 
+                "nevents": 24773, 
+                "totEvents": 24773, 
+                "weights": 24768.380859375
+            }, 
+            {
+                "bad": false, 
+                "events": 24706, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-20GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201020_182437/0000/myMicroAODOutputFile_19.root", 
+                "nevents": 24706, 
+                "totEvents": 24706, 
+                "weights": 24701.23046875
+            }, 
+            {
+                "bad": false, 
+                "events": 24905, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-20GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201020_182437/0000/myMicroAODOutputFile_1.root", 
+                "nevents": 24905, 
+                "totEvents": 24905, 
+                "weights": 24900.0078125
+            }, 
+            {
+                "bad": false, 
+                "events": 24842, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-20GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201020_182437/0000/myMicroAODOutputFile_3.root", 
+                "nevents": 24842, 
+                "totEvents": 24842, 
+                "weights": 24836.857421875
+            }, 
+            {
+                "bad": false, 
+                "events": 24804, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-20GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201020_182437/0000/myMicroAODOutputFile_14.root", 
+                "nevents": 24804, 
+                "totEvents": 24804, 
+                "weights": 24798.91796875
+            }, 
+            {
+                "bad": false, 
+                "events": 15793, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-20GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201020_182437/0000/myMicroAODOutputFile_20.root", 
+                "nevents": 15793, 
+                "totEvents": 15793, 
+                "weights": 15789.759765625
+            }, 
+            {
+                "bad": false, 
+                "events": 24758, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-20GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201020_182437/0000/myMicroAODOutputFile_9.root", 
+                "nevents": 24758, 
+                "totEvents": 24758, 
+                "weights": 24752.70703125
+            }
+        ], 
+        "parent_n_units": 485578, 
+        "vetted": true
+    }, 
+    "/HAHMHToAA_AToGG_MA-25GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/lata-Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1-6f64939368112792100a27fcb8918a00/USER": {
+        "dset_type": "mc", 
+        "files": [
+            {
+                "bad": false, 
+                "events": 24611, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-25GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201022_190020/0000/myMicroAODOutputFile_2.root", 
+                "nevents": 24611, 
+                "totEvents": 24611, 
+                "weights": 24605.400390625
+            }, 
+            {
+                "bad": false, 
+                "events": 24659, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-25GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201022_190020/0000/myMicroAODOutputFile_7.root", 
+                "nevents": 24659, 
+                "totEvents": 24659, 
+                "weights": 24652.841796875
+            }, 
+            {
+                "bad": false, 
+                "events": 24722, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-25GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201022_190020/0000/myMicroAODOutputFile_19.root", 
+                "nevents": 24722, 
+                "totEvents": 24722, 
+                "weights": 24716.640625
+            }, 
+            {
+                "bad": false, 
+                "events": 24642, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-25GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201022_190020/0000/myMicroAODOutputFile_3.root", 
+                "nevents": 24642, 
+                "totEvents": 24642, 
+                "weights": 24635.98046875
+            }, 
+            {
+                "bad": false, 
+                "events": 24719, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-25GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201022_190020/0000/myMicroAODOutputFile_15.root", 
+                "nevents": 24719, 
+                "totEvents": 24719, 
+                "weights": 24712.470703125
+            }, 
+            {
+                "bad": false, 
+                "events": 24775, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-25GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201022_190020/0000/myMicroAODOutputFile_8.root", 
+                "nevents": 24775, 
+                "totEvents": 24775, 
+                "weights": 24769.48828125
+            }, 
+            {
+                "bad": false, 
+                "events": 24831, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-25GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201022_190020/0000/myMicroAODOutputFile_5.root", 
+                "nevents": 24831, 
+                "totEvents": 24831, 
+                "weights": 24825.759765625
+            }, 
+            {
+                "bad": false, 
+                "events": 24868, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-25GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201022_190020/0000/myMicroAODOutputFile_10.root", 
+                "nevents": 24868, 
+                "totEvents": 24868, 
+                "weights": 24862.103515625
+            }, 
+            {
+                "bad": false, 
+                "events": 24793, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-25GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201022_190020/0000/myMicroAODOutputFile_16.root", 
+                "nevents": 24793, 
+                "totEvents": 24793, 
+                "weights": 24787.400390625
+            }, 
+            {
+                "bad": false, 
+                "events": 24720, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-25GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201022_190020/0000/myMicroAODOutputFile_14.root", 
+                "nevents": 24720, 
+                "totEvents": 24720, 
+                "weights": 24714.560546875
+            }, 
+            {
+                "bad": false, 
+                "events": 24697, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-25GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201022_190020/0000/myMicroAODOutputFile_1.root", 
+                "nevents": 24697, 
+                "totEvents": 24697, 
+                "weights": 24691.5625
+            }, 
+            {
+                "bad": false, 
+                "events": 24691, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-25GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201022_190020/0000/myMicroAODOutputFile_11.root", 
+                "nevents": 24691, 
+                "totEvents": 24691, 
+                "weights": 24685.41796875
+            }, 
+            {
+                "bad": false, 
+                "events": 24675, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-25GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201022_190020/0000/myMicroAODOutputFile_13.root", 
+                "nevents": 24675, 
+                "totEvents": 24675, 
+                "weights": 24669.62109375
+            }, 
+            {
+                "bad": false, 
+                "events": 24762, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-25GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201022_190020/0000/myMicroAODOutputFile_4.root", 
+                "nevents": 24762, 
+                "totEvents": 24762, 
+                "weights": 24756.384765625
+            }, 
+            {
+                "bad": false, 
+                "events": 24824, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-25GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201022_190020/0000/myMicroAODOutputFile_6.root", 
+                "nevents": 24824, 
+                "totEvents": 24824, 
+                "weights": 24818.458984375
+            }, 
+            {
+                "bad": false, 
+                "events": 24627, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-25GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201022_190020/0000/myMicroAODOutputFile_12.root", 
+                "nevents": 24627, 
+                "totEvents": 24627, 
+                "weights": 24621.3671875
+            }, 
+            {
+                "bad": false, 
+                "events": 24696, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-25GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201022_190020/0000/myMicroAODOutputFile_9.root", 
+                "nevents": 24696, 
+                "totEvents": 24696, 
+                "weights": 24690.16015625
+            }, 
+            {
+                "bad": false, 
+                "events": 24815, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-25GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201022_190020/0000/myMicroAODOutputFile_17.root", 
+                "nevents": 24815, 
+                "totEvents": 24815, 
+                "weights": 24808.431640625
+            }, 
+            {
+                "bad": false, 
+                "events": 17015, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-25GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201022_190020/0000/myMicroAODOutputFile_20.root", 
+                "nevents": 17015, 
+                "totEvents": 17015, 
+                "weights": 17009.97265625
+            }, 
+            {
+                "bad": false, 
+                "events": 24777, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-25GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201022_190020/0000/myMicroAODOutputFile_18.root", 
+                "nevents": 24777, 
+                "totEvents": 24777, 
+                "weights": 24771.751953125
+            }
+        ], 
+        "parent_n_units": 486919, 
+        "vetted": true
+    }, 
+    "/HAHMHToAA_AToGG_MA-30GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/lata-Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1-6f64939368112792100a27fcb8918a00/USER": {
+        "dset_type": "mc", 
+        "files": [
+            {
+                "bad": false, 
+                "events": 24844, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-30GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201022_190504/0000/myMicroAODOutputFile_2.root", 
+                "nevents": 24844, 
+                "totEvents": 24844, 
+                "weights": 24836.849609375
+            }, 
+            {
+                "bad": false, 
+                "events": 24784, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-30GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201022_190504/0000/myMicroAODOutputFile_18.root", 
+                "nevents": 24784, 
+                "totEvents": 24784, 
+                "weights": 24778.58203125
+            }, 
+            {
+                "bad": false, 
+                "events": 24689, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-30GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201022_190504/0000/myMicroAODOutputFile_17.root", 
+                "nevents": 24689, 
+                "totEvents": 24689, 
+                "weights": 24683.322265625
+            }, 
+            {
+                "bad": false, 
+                "events": 24704, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-30GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201022_190504/0000/myMicroAODOutputFile_14.root", 
+                "nevents": 24704, 
+                "totEvents": 24704, 
+                "weights": 24696.078125
+            }, 
+            {
+                "bad": false, 
+                "events": 24675, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-30GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201022_190504/0000/myMicroAODOutputFile_1.root", 
+                "nevents": 24675, 
+                "totEvents": 24675, 
+                "weights": 24669.220703125
+            }, 
+            {
+                "bad": false, 
+                "events": 24743, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-30GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201022_190504/0000/myMicroAODOutputFile_16.root", 
+                "nevents": 24743, 
+                "totEvents": 24743, 
+                "weights": 24735.921875
+            }, 
+            {
+                "bad": false, 
+                "events": 24907, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-30GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201022_190504/0000/myMicroAODOutputFile_5.root", 
+                "nevents": 24907, 
+                "totEvents": 24907, 
+                "weights": 24901.44140625
+            }, 
+            {
+                "bad": false, 
+                "events": 24010, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-30GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201022_190504/0000/myMicroAODOutputFile_10.root", 
+                "nevents": 24010, 
+                "totEvents": 24010, 
+                "weights": 24004.75
+            }, 
+            {
+                "bad": false, 
+                "events": 24843, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-30GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201022_190504/0000/myMicroAODOutputFile_15.root", 
+                "nevents": 24843, 
+                "totEvents": 24843, 
+                "weights": 24837.33984375
+            }, 
+            {
+                "bad": false, 
+                "events": 24729, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-30GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201022_190504/0000/myMicroAODOutputFile_4.root", 
+                "nevents": 24729, 
+                "totEvents": 24729, 
+                "weights": 24723.44140625
+            }, 
+            {
+                "bad": false, 
+                "events": 24718, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-30GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201022_190504/0000/myMicroAODOutputFile_3.root", 
+                "nevents": 24718, 
+                "totEvents": 24718, 
+                "weights": 24712.509765625
+            }, 
+            {
+                "bad": false, 
+                "events": 24713, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-30GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201022_190504/0000/myMicroAODOutputFile_9.root", 
+                "nevents": 24713, 
+                "totEvents": 24713, 
+                "weights": 24707.111328125
+            }, 
+            {
+                "bad": false, 
+                "events": 24523, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-30GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201022_190504/0000/myMicroAODOutputFile_6.root", 
+                "nevents": 24523, 
+                "totEvents": 24523, 
+                "weights": 24517.498046875
+            }, 
+            {
+                "bad": false, 
+                "events": 24807, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-30GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201022_190504/0000/myMicroAODOutputFile_7.root", 
+                "nevents": 24807, 
+                "totEvents": 24807, 
+                "weights": 24801.361328125
+            }, 
+            {
+                "bad": false, 
+                "events": 24762, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-30GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201022_190504/0000/myMicroAODOutputFile_13.root", 
+                "nevents": 24762, 
+                "totEvents": 24762, 
+                "weights": 24756.349609375
+            }, 
+            {
+                "bad": false, 
+                "events": 8875, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-30GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201022_190504/0000/myMicroAODOutputFile_20.root", 
+                "nevents": 8875, 
+                "totEvents": 8875, 
+                "weights": 8873.111328125
+            }, 
+            {
+                "bad": false, 
+                "events": 24830, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-30GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201022_190504/0000/myMicroAODOutputFile_19.root", 
+                "nevents": 24830, 
+                "totEvents": 24830, 
+                "weights": 24824.33984375
+            }, 
+            {
+                "bad": false, 
+                "events": 24517, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-30GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201022_190504/0000/myMicroAODOutputFile_8.root", 
+                "nevents": 24517, 
+                "totEvents": 24517, 
+                "weights": 24510.873046875
+            }, 
+            {
+                "bad": false, 
+                "events": 24717, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-30GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201022_190504/0000/myMicroAODOutputFile_11.root", 
+                "nevents": 24717, 
+                "totEvents": 24717, 
+                "weights": 24710.279296875
+            }, 
+            {
+                "bad": false, 
+                "events": 24829, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-30GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201022_190504/0000/myMicroAODOutputFile_12.root", 
+                "nevents": 24829, 
+                "totEvents": 24829, 
+                "weights": 24822.62890625
+            }
+        ], 
+        "parent_n_units": 478219, 
+        "vetted": true
+    }, 
+    "/HAHMHToAA_AToGG_MA-40GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/lata-Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1-6f64939368112792100a27fcb8918a00/USER": {
+        "dset_type": "mc", 
+        "files": [
+            {
+                "bad": false, 
+                "events": 24724, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-40GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201026_172633/0000/myMicroAODOutputFile_13.root", 
+                "nevents": 24724, 
+                "totEvents": 24724, 
+                "weights": 24717.91015625
+            }, 
+            {
+                "bad": false, 
+                "events": 24736, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-40GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201026_172633/0000/myMicroAODOutputFile_8.root", 
+                "nevents": 24736, 
+                "totEvents": 24736, 
+                "weights": 24730.09375
+            }, 
+            {
+                "bad": false, 
+                "events": 24786, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-40GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201026_172633/0000/myMicroAODOutputFile_17.root", 
+                "nevents": 24786, 
+                "totEvents": 24786, 
+                "weights": 24780.3203125
+            }, 
+            {
+                "bad": false, 
+                "events": 17118, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-40GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201026_172633/0000/myMicroAODOutputFile_20.root", 
+                "nevents": 17118, 
+                "totEvents": 17118, 
+                "weights": 17113.958984375
+            }, 
+            {
+                "bad": false, 
+                "events": 24806, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-40GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201026_172633/0000/myMicroAODOutputFile_12.root", 
+                "nevents": 24806, 
+                "totEvents": 24806, 
+                "weights": 24800.26953125
+            }, 
+            {
+                "bad": false, 
+                "events": 24717, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-40GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201026_172633/0000/myMicroAODOutputFile_14.root", 
+                "nevents": 24717, 
+                "totEvents": 24717, 
+                "weights": 24711.28515625
+            }, 
+            {
+                "bad": false, 
+                "events": 24555, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-40GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201026_172633/0000/myMicroAODOutputFile_10.root", 
+                "nevents": 24555, 
+                "totEvents": 24555, 
+                "weights": 24548.9296875
+            }, 
+            {
+                "bad": false, 
+                "events": 24584, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-40GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201026_172633/0000/myMicroAODOutputFile_19.root", 
+                "nevents": 24584, 
+                "totEvents": 24584, 
+                "weights": 24578.44921875
+            }, 
+            {
+                "bad": false, 
+                "events": 24763, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-40GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201026_172633/0000/myMicroAODOutputFile_11.root", 
+                "nevents": 24763, 
+                "totEvents": 24763, 
+                "weights": 24756.107421875
+            }, 
+            {
+                "bad": false, 
+                "events": 24768, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-40GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201026_172633/0000/myMicroAODOutputFile_6.root", 
+                "nevents": 24768, 
+                "totEvents": 24768, 
+                "weights": 24761.43359375
+            }, 
+            {
+                "bad": false, 
+                "events": 24816, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-40GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201026_172633/0000/myMicroAODOutputFile_1.root", 
+                "nevents": 24816, 
+                "totEvents": 24816, 
+                "weights": 24809.62109375
+            }, 
+            {
+                "bad": false, 
+                "events": 24812, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-40GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201026_172633/0000/myMicroAODOutputFile_5.root", 
+                "nevents": 24812, 
+                "totEvents": 24812, 
+                "weights": 24805.990234375
+            }, 
+            {
+                "bad": false, 
+                "events": 24944, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-40GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201026_172633/0000/myMicroAODOutputFile_2.root", 
+                "nevents": 24944, 
+                "totEvents": 24944, 
+                "weights": 24938.28125
+            }, 
+            {
+                "bad": false, 
+                "events": 24619, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-40GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201026_172633/0000/myMicroAODOutputFile_15.root", 
+                "nevents": 24619, 
+                "totEvents": 24619, 
+                "weights": 24613.5390625
+            }, 
+            {
+                "bad": false, 
+                "events": 24747, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-40GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201026_172633/0000/myMicroAODOutputFile_4.root", 
+                "nevents": 24747, 
+                "totEvents": 24747, 
+                "weights": 24741.2578125
+            }, 
+            {
+                "bad": false, 
+                "events": 24737, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-40GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201026_172633/0000/myMicroAODOutputFile_9.root", 
+                "nevents": 24737, 
+                "totEvents": 24737, 
+                "weights": 24731.169921875
+            }, 
+            {
+                "bad": false, 
+                "events": 24744, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-40GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201026_172633/0000/myMicroAODOutputFile_3.root", 
+                "nevents": 24744, 
+                "totEvents": 24744, 
+                "weights": 24738.509765625
+            }, 
+            {
+                "bad": false, 
+                "events": 24877, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-40GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201026_172633/0000/myMicroAODOutputFile_16.root", 
+                "nevents": 24877, 
+                "totEvents": 24877, 
+                "weights": 24870.9140625
+            }, 
+            {
+                "bad": false, 
+                "events": 24769, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-40GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201026_172633/0000/myMicroAODOutputFile_18.root", 
+                "nevents": 24769, 
+                "totEvents": 24769, 
+                "weights": 24762.630859375
+            }, 
+            {
+                "bad": false, 
+                "events": 24702, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-40GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201026_172633/0000/myMicroAODOutputFile_7.root", 
+                "nevents": 24702, 
+                "totEvents": 24702, 
+                "weights": 24695.921875
+            }
+        ], 
+        "parent_n_units": 487324, 
+        "vetted": true
+    }, 
+    "/HAHMHToAA_AToGG_MA-45GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/lata-Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1-6f64939368112792100a27fcb8918a00/USER": {
+        "dset_type": "mc", 
+        "files": [
+            {
+                "bad": false, 
+                "events": 24733, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-45GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201014_173857/0000/myMicroAODOutputFile_1.root", 
+                "nevents": 24733, 
+                "totEvents": 24733, 
+                "weights": 24726.03125
+            }, 
+            {
+                "bad": false, 
+                "events": 24746, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-45GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201014_173857/0000/myMicroAODOutputFile_3.root", 
+                "nevents": 24746, 
+                "totEvents": 24746, 
+                "weights": 24740.298828125
+            }, 
+            {
+                "bad": false, 
+                "events": 24687, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-45GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201014_173857/0000/myMicroAODOutputFile_17.root", 
+                "nevents": 24687, 
+                "totEvents": 24687, 
+                "weights": 24680.95703125
+            }, 
+            {
+                "bad": false, 
+                "events": 24772, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-45GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201014_173857/0000/myMicroAODOutputFile_7.root", 
+                "nevents": 24772, 
+                "totEvents": 24772, 
+                "weights": 24766.19921875
+            }, 
+            {
+                "bad": false, 
+                "events": 24820, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-45GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201014_173857/0000/myMicroAODOutputFile_5.root", 
+                "nevents": 24820, 
+                "totEvents": 24820, 
+                "weights": 24814.470703125
+            }, 
+            {
+                "bad": false, 
+                "events": 24780, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-45GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201014_173857/0000/myMicroAODOutputFile_2.root", 
+                "nevents": 24780, 
+                "totEvents": 24780, 
+                "weights": 24773.98046875
+            }, 
+            {
+                "bad": false, 
+                "events": 24791, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-45GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201014_173857/0000/myMicroAODOutputFile_6.root", 
+                "nevents": 24791, 
+                "totEvents": 24791, 
+                "weights": 24784.98046875
+            }, 
+            {
+                "bad": false, 
+                "events": 24825, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-45GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201014_173857/0000/myMicroAODOutputFile_9.root", 
+                "nevents": 24825, 
+                "totEvents": 24825, 
+                "weights": 24819.12890625
+            }, 
+            {
+                "bad": false, 
+                "events": 24776, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-45GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201014_173857/0000/myMicroAODOutputFile_18.root", 
+                "nevents": 24776, 
+                "totEvents": 24776, 
+                "weights": 24770.658203125
+            }, 
+            {
+                "bad": false, 
+                "events": 24691, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-45GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201014_173857/0000/myMicroAODOutputFile_19.root", 
+                "nevents": 24691, 
+                "totEvents": 24691, 
+                "weights": 24685.142578125
+            }, 
+            {
+                "bad": false, 
+                "events": 24787, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-45GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201014_173857/0000/myMicroAODOutputFile_12.root", 
+                "nevents": 24787, 
+                "totEvents": 24787, 
+                "weights": 24780.931640625
+            }, 
+            {
+                "bad": false, 
+                "events": 24712, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-45GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201014_173857/0000/myMicroAODOutputFile_11.root", 
+                "nevents": 24712, 
+                "totEvents": 24712, 
+                "weights": 24705.94140625
+            }, 
+            {
+                "bad": false, 
+                "events": 24652, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-45GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201014_173857/0000/myMicroAODOutputFile_15.root", 
+                "nevents": 24652, 
+                "totEvents": 24652, 
+                "weights": 24645.951171875
+            }, 
+            {
+                "bad": false, 
+                "events": 22874, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-45GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201014_173857/0000/myMicroAODOutputFile_20.root", 
+                "nevents": 22874, 
+                "totEvents": 22874, 
+                "weights": 22868.8828125
+            }, 
+            {
+                "bad": false, 
+                "events": 24581, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-45GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201014_173857/0000/myMicroAODOutputFile_4.root", 
+                "nevents": 24581, 
+                "totEvents": 24581, 
+                "weights": 24575.30078125
+            }, 
+            {
+                "bad": false, 
+                "events": 24740, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-45GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201014_173857/0000/myMicroAODOutputFile_14.root", 
+                "nevents": 24740, 
+                "totEvents": 24740, 
+                "weights": 24734.337890625
+            }, 
+            {
+                "bad": false, 
+                "events": 24716, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-45GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201014_173857/0000/myMicroAODOutputFile_13.root", 
+                "nevents": 24716, 
+                "totEvents": 24716, 
+                "weights": 24709.990234375
+            }, 
+            {
+                "bad": false, 
+                "events": 24566, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-45GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201014_173857/0000/myMicroAODOutputFile_8.root", 
+                "nevents": 24566, 
+                "totEvents": 24566, 
+                "weights": 24560.3125
+            }, 
+            {
+                "bad": false, 
+                "events": 24801, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-45GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201014_173857/0000/myMicroAODOutputFile_16.root", 
+                "nevents": 24801, 
+                "totEvents": 24801, 
+                "weights": 24794.72265625
+            }, 
+            {
+                "bad": false, 
+                "events": 24786, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-45GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201014_173857/0000/myMicroAODOutputFile_10.root", 
+                "nevents": 24786, 
+                "totEvents": 24786, 
+                "weights": 24780.0
+            }
+        ], 
+        "parent_n_units": 492836, 
+        "vetted": true
+    }, 
+    "/HAHMHToAA_AToGG_MA-50GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/lata-Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1-6f64939368112792100a27fcb8918a00/USER": {
+        "dset_type": "mc", 
+        "files": [
+            {
+                "bad": false, 
+                "events": 24929, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-50GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201014_174300/0000/myMicroAODOutputFile_2.root", 
+                "nevents": 24929, 
+                "totEvents": 24929, 
+                "weights": 24922.998046875
+            }, 
+            {
+                "bad": false, 
+                "events": 24716, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-50GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201014_174300/0000/myMicroAODOutputFile_12.root", 
+                "nevents": 24716, 
+                "totEvents": 24716, 
+                "weights": 24710.025390625
+            }, 
+            {
+                "bad": false, 
+                "events": 24819, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-50GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201014_174300/0000/myMicroAODOutputFile_5.root", 
+                "nevents": 24819, 
+                "totEvents": 24819, 
+                "weights": 24813.0625
+            }, 
+            {
+                "bad": false, 
+                "events": 24682, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-50GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201014_174300/0000/myMicroAODOutputFile_17.root", 
+                "nevents": 24682, 
+                "totEvents": 24682, 
+                "weights": 24675.640625
+            }, 
+            {
+                "bad": false, 
+                "events": 24757, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-50GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201014_174300/0000/myMicroAODOutputFile_6.root", 
+                "nevents": 24757, 
+                "totEvents": 24757, 
+                "weights": 24750.6796875
+            }, 
+            {
+                "bad": false, 
+                "events": 24563, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-50GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201014_174300/0000/myMicroAODOutputFile_10.root", 
+                "nevents": 24563, 
+                "totEvents": 24563, 
+                "weights": 24556.970703125
+            }, 
+            {
+                "bad": false, 
+                "events": 24954, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-50GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201014_174300/0000/myMicroAODOutputFile_1.root", 
+                "nevents": 24954, 
+                "totEvents": 24954, 
+                "weights": 24948.212890625
+            }, 
+            {
+                "bad": false, 
+                "events": 24878, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-50GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201014_174300/0000/myMicroAODOutputFile_3.root", 
+                "nevents": 24878, 
+                "totEvents": 24878, 
+                "weights": 24872.033203125
+            }, 
+            {
+                "bad": false, 
+                "events": 24668, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-50GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201014_174300/0000/myMicroAODOutputFile_19.root", 
+                "nevents": 24668, 
+                "totEvents": 24668, 
+                "weights": 24661.759765625
+            }, 
+            {
+                "bad": false, 
+                "events": 21895, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-50GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201014_174300/0000/myMicroAODOutputFile_20.root", 
+                "nevents": 21895, 
+                "totEvents": 21895, 
+                "weights": 21889.77734375
+            }, 
+            {
+                "bad": false, 
+                "events": 24756, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-50GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201014_174300/0000/myMicroAODOutputFile_16.root", 
+                "nevents": 24756, 
+                "totEvents": 24756, 
+                "weights": 24750.1171875
+            }, 
+            {
+                "bad": false, 
+                "events": 24712, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-50GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201014_174300/0000/myMicroAODOutputFile_9.root", 
+                "nevents": 24712, 
+                "totEvents": 24712, 
+                "weights": 24706.05078125
+            }, 
+            {
+                "bad": false, 
+                "events": 24647, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-50GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201014_174300/0000/myMicroAODOutputFile_7.root", 
+                "nevents": 24647, 
+                "totEvents": 24647, 
+                "weights": 24641.16796875
+            }, 
+            {
+                "bad": false, 
+                "events": 24624, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-50GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201014_174300/0000/myMicroAODOutputFile_18.root", 
+                "nevents": 24624, 
+                "totEvents": 24624, 
+                "weights": 24618.400390625
+            }, 
+            {
+                "bad": false, 
+                "events": 24848, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-50GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201014_174300/0000/myMicroAODOutputFile_15.root", 
+                "nevents": 24848, 
+                "totEvents": 24848, 
+                "weights": 24841.908203125
+            }, 
+            {
+                "bad": false, 
+                "events": 24801, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-50GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201014_174300/0000/myMicroAODOutputFile_14.root", 
+                "nevents": 24801, 
+                "totEvents": 24801, 
+                "weights": 24795.13671875
+            }, 
+            {
+                "bad": false, 
+                "events": 24033, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-50GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201014_174300/0000/myMicroAODOutputFile_8.root", 
+                "nevents": 24033, 
+                "totEvents": 24033, 
+                "weights": 24027.330078125
+            }, 
+            {
+                "bad": false, 
+                "events": 24819, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-50GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201014_174300/0000/myMicroAODOutputFile_11.root", 
+                "nevents": 24819, 
+                "totEvents": 24819, 
+                "weights": 24812.931640625
+            }, 
+            {
+                "bad": false, 
+                "events": 24783, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-50GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201014_174300/0000/myMicroAODOutputFile_13.root", 
+                "nevents": 24783, 
+                "totEvents": 24783, 
+                "weights": 24777.369140625
+            }, 
+            {
+                "bad": false, 
+                "events": 24776, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-50GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201014_174300/0000/myMicroAODOutputFile_4.root", 
+                "nevents": 24776, 
+                "totEvents": 24776, 
+                "weights": 24768.171875
+            }
+        ], 
+        "parent_n_units": 491660, 
+        "vetted": true
+    }, 
+    "/HAHMHToAA_AToGG_MA-55GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/lata-Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1-6f64939368112792100a27fcb8918a00/USER": {
+        "dset_type": "mc", 
+        "files": [
+            {
+                "bad": false, 
+                "events": 24781, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-55GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201022_191454/0000/myMicroAODOutputFile_10.root", 
+                "nevents": 24781, 
+                "totEvents": 24781, 
+                "weights": 24774.98828125
+            }, 
+            {
+                "bad": false, 
+                "events": 24873, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-55GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201022_191454/0000/myMicroAODOutputFile_1.root", 
+                "nevents": 24873, 
+                "totEvents": 24873, 
+                "weights": 24866.94140625
+            }, 
+            {
+                "bad": false, 
+                "events": 24955, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-55GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201022_191454/0000/myMicroAODOutputFile_2.root", 
+                "nevents": 24955, 
+                "totEvents": 24955, 
+                "weights": 24948.220703125
+            }, 
+            {
+                "bad": false, 
+                "events": 24675, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-55GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201022_191454/0000/myMicroAODOutputFile_20.root", 
+                "nevents": 24675, 
+                "totEvents": 24675, 
+                "weights": 24669.171875
+            }, 
+            {
+                "bad": false, 
+                "events": 968, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-55GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201022_191454/0000/myMicroAODOutputFile_21.root", 
+                "nevents": 968, 
+                "totEvents": 968, 
+                "weights": 967.7600708007812
+            }, 
+            {
+                "bad": false, 
+                "events": 24771, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-55GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201022_191454/0000/myMicroAODOutputFile_16.root", 
+                "nevents": 24771, 
+                "totEvents": 24771, 
+                "weights": 24764.869140625
+            }, 
+            {
+                "bad": false, 
+                "events": 24656, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-55GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201022_191454/0000/myMicroAODOutputFile_14.root", 
+                "nevents": 24656, 
+                "totEvents": 24656, 
+                "weights": 24649.173828125
+            }, 
+            {
+                "bad": false, 
+                "events": 24750, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-55GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201022_191454/0000/myMicroAODOutputFile_12.root", 
+                "nevents": 24750, 
+                "totEvents": 24750, 
+                "weights": 24744.08984375
+            }, 
+            {
+                "bad": false, 
+                "events": 24850, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-55GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201022_191454/0000/myMicroAODOutputFile_3.root", 
+                "nevents": 24850, 
+                "totEvents": 24850, 
+                "weights": 24844.013671875
+            }, 
+            {
+                "bad": false, 
+                "events": 24778, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-55GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201022_191454/0000/myMicroAODOutputFile_5.root", 
+                "nevents": 24778, 
+                "totEvents": 24778, 
+                "weights": 24772.119140625
+            }, 
+            {
+                "bad": false, 
+                "events": 24909, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-55GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201022_191454/0000/myMicroAODOutputFile_6.root", 
+                "nevents": 24909, 
+                "totEvents": 24909, 
+                "weights": 24903.01171875
+            }, 
+            {
+                "bad": false, 
+                "events": 24792, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-55GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201022_191454/0000/myMicroAODOutputFile_15.root", 
+                "nevents": 24792, 
+                "totEvents": 24792, 
+                "weights": 24785.73046875
+            }, 
+            {
+                "bad": false, 
+                "events": 24816, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-55GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201022_191454/0000/myMicroAODOutputFile_8.root", 
+                "nevents": 24816, 
+                "totEvents": 24816, 
+                "weights": 24810.109375
+            }, 
+            {
+                "bad": false, 
+                "events": 24627, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-55GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201022_191454/0000/myMicroAODOutputFile_17.root", 
+                "nevents": 24627, 
+                "totEvents": 24627, 
+                "weights": 24621.19140625
+            }, 
+            {
+                "bad": false, 
+                "events": 24877, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-55GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201022_191454/0000/myMicroAODOutputFile_19.root", 
+                "nevents": 24877, 
+                "totEvents": 24877, 
+                "weights": 24869.697265625
+            }, 
+            {
+                "bad": false, 
+                "events": 24848, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-55GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201022_191454/0000/myMicroAODOutputFile_11.root", 
+                "nevents": 24848, 
+                "totEvents": 24848, 
+                "weights": 24842.171875
+            }, 
+            {
+                "bad": false, 
+                "events": 24725, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-55GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201022_191454/0000/myMicroAODOutputFile_13.root", 
+                "nevents": 24725, 
+                "totEvents": 24725, 
+                "weights": 24718.921875
+            }, 
+            {
+                "bad": false, 
+                "events": 24831, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-55GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201022_191454/0000/myMicroAODOutputFile_18.root", 
+                "nevents": 24831, 
+                "totEvents": 24831, 
+                "weights": 24823.779296875
+            }, 
+            {
+                "bad": false, 
+                "events": 23878, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-55GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201022_191454/0000/myMicroAODOutputFile_9.root", 
+                "nevents": 23878, 
+                "totEvents": 23878, 
+                "weights": 23872.103515625
+            }, 
+            {
+                "bad": false, 
+                "events": 24726, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-55GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201022_191454/0000/myMicroAODOutputFile_4.root", 
+                "nevents": 24726, 
+                "totEvents": 24726, 
+                "weights": 24720.10546875
+            }, 
+            {
+                "bad": false, 
+                "events": 24662, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-55GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201022_191454/0000/myMicroAODOutputFile_7.root", 
+                "nevents": 24662, 
+                "totEvents": 24662, 
+                "weights": 24655.27734375
+            }
+        ], 
+        "parent_n_units": 495748, 
+        "vetted": true
+    }, 
+    "/HAHMHToAA_AToGG_MA-60GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/lata-Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1-6f64939368112792100a27fcb8918a00/USER": {
+        "dset_type": "mc", 
+        "files": [
+            {
+                "bad": false, 
+                "events": 14870, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-60GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201014_175039/0000/myMicroAODOutputFile_20.root", 
+                "nevents": 14870, 
+                "totEvents": 14870, 
+                "weights": 14866.4697265625
+            }, 
+            {
+                "bad": false, 
+                "events": 24675, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-60GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201014_175039/0000/myMicroAODOutputFile_3.root", 
+                "nevents": 24675, 
+                "totEvents": 24675, 
+                "weights": 24669.5390625
+            }, 
+            {
+                "bad": false, 
+                "events": 24939, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-60GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201014_175039/0000/myMicroAODOutputFile_14.root", 
+                "nevents": 24939, 
+                "totEvents": 24939, 
+                "weights": 24933.697265625
+            }, 
+            {
+                "bad": false, 
+                "events": 24861, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-60GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201014_175039/0000/myMicroAODOutputFile_13.root", 
+                "nevents": 24861, 
+                "totEvents": 24861, 
+                "weights": 24854.453125
+            }, 
+            {
+                "bad": false, 
+                "events": 24870, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-60GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201014_175039/0000/myMicroAODOutputFile_8.root", 
+                "nevents": 24870, 
+                "totEvents": 24870, 
+                "weights": 24864.169921875
+            }, 
+            {
+                "bad": false, 
+                "events": 24782, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-60GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201014_175039/0000/myMicroAODOutputFile_15.root", 
+                "nevents": 24782, 
+                "totEvents": 24782, 
+                "weights": 24775.732421875
+            }, 
+            {
+                "bad": false, 
+                "events": 24761, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-60GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201014_175039/0000/myMicroAODOutputFile_6.root", 
+                "nevents": 24761, 
+                "totEvents": 24761, 
+                "weights": 24754.01953125
+            }, 
+            {
+                "bad": false, 
+                "events": 24762, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-60GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201014_175039/0000/myMicroAODOutputFile_11.root", 
+                "nevents": 24762, 
+                "totEvents": 24762, 
+                "weights": 24755.890625
+            }, 
+            {
+                "bad": false, 
+                "events": 24814, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-60GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201014_175039/0000/myMicroAODOutputFile_12.root", 
+                "nevents": 24814, 
+                "totEvents": 24814, 
+                "weights": 24808.068359375
+            }, 
+            {
+                "bad": false, 
+                "events": 24866, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-60GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201014_175039/0000/myMicroAODOutputFile_5.root", 
+                "nevents": 24866, 
+                "totEvents": 24866, 
+                "weights": 24860.66015625
+            }, 
+            {
+                "bad": false, 
+                "events": 20836, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-60GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201014_175039/0000/myMicroAODOutputFile_19.root", 
+                "nevents": 20836, 
+                "totEvents": 20836, 
+                "weights": 20830.892578125
+            }, 
+            {
+                "bad": false, 
+                "events": 24591, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-60GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201014_175039/0000/myMicroAODOutputFile_18.root", 
+                "nevents": 24591, 
+                "totEvents": 24591, 
+                "weights": 24584.939453125
+            }, 
+            {
+                "bad": false, 
+                "events": 24737, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-60GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201014_175039/0000/myMicroAODOutputFile_2.root", 
+                "nevents": 24737, 
+                "totEvents": 24737, 
+                "weights": 24731.150390625
+            }, 
+            {
+                "bad": false, 
+                "events": 24888, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-60GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201014_175039/0000/myMicroAODOutputFile_17.root", 
+                "nevents": 24888, 
+                "totEvents": 24888, 
+                "weights": 24882.087890625
+            }, 
+            {
+                "bad": false, 
+                "events": 24886, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-60GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201014_175039/0000/myMicroAODOutputFile_1.root", 
+                "nevents": 24886, 
+                "totEvents": 24886, 
+                "weights": 24880.462890625
+            }, 
+            {
+                "bad": false, 
+                "events": 24671, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-60GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201014_175039/0000/myMicroAODOutputFile_7.root", 
+                "nevents": 24671, 
+                "totEvents": 24671, 
+                "weights": 24664.962890625
+            }, 
+            {
+                "bad": false, 
+                "events": 24541, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-60GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201014_175039/0000/myMicroAODOutputFile_10.root", 
+                "nevents": 24541, 
+                "totEvents": 24541, 
+                "weights": 24535.380859375
+            }, 
+            {
+                "bad": false, 
+                "events": 24719, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-60GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201014_175039/0000/myMicroAODOutputFile_16.root", 
+                "nevents": 24719, 
+                "totEvents": 24719, 
+                "weights": 24713.130859375
+            }, 
+            {
+                "bad": false, 
+                "events": 24921, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-60GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201014_175039/0000/myMicroAODOutputFile_4.root", 
+                "nevents": 24921, 
+                "totEvents": 24921, 
+                "weights": 24914.1328125
+            }, 
+            {
+                "bad": false, 
+                "events": 24757, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/HAHMHToAA_AToGG_MA-60GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/201014_175039/0000/myMicroAODOutputFile_9.root", 
+                "nevents": 24757, 
+                "totEvents": 24757, 
+                "weights": 24751.501953125
+            }
+        ], 
+        "parent_n_units": 481747, 
+        "vetted": true
+    }, 
+    "/TprimeBToTH_Hgg_M-1000_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/lata-Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2-6f64939368112792100a27fcb8918a00/USER": {
+        "dset_type": "mc", 
+        "files": [
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-1000_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_125406/0000/myMicroAODOutputFile_22.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24978.29296875
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-1000_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_125406/0000/myMicroAODOutputFile_19.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24975.947265625
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-1000_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_125406/0000/myMicroAODOutputFile_7.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24978.859375
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-1000_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_125406/0000/myMicroAODOutputFile_11.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24979.0078125
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-1000_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_125406/0000/myMicroAODOutputFile_13.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24979.93359375
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-1000_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_125406/0000/myMicroAODOutputFile_12.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24975.7578125
+            }, 
+            {
+                "bad": false, 
+                "events": 9000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-1000_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_125406/0000/myMicroAODOutputFile_23.root", 
+                "nevents": 9000, 
+                "totEvents": 9000, 
+                "weights": 8994.1708984375
+            }, 
+            {
+                "bad": false, 
+                "events": 8000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-1000_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_125406/0000/myMicroAODOutputFile_24.root", 
+                "nevents": 8000, 
+                "totEvents": 8000, 
+                "weights": 7993.4228515625
+            }, 
+            {
+                "bad": false, 
+                "events": 1000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-1000_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_125406/0000/myMicroAODOutputFile_8.root", 
+                "nevents": 1000, 
+                "totEvents": 1000, 
+                "weights": 999.340087890625
+            }, 
+            {
+                "bad": false, 
+                "events": 1000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-1000_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_125406/0000/myMicroAODOutputFile_10.root", 
+                "nevents": 1000, 
+                "totEvents": 1000, 
+                "weights": 999.2103271484375
+            }, 
+            {
+                "bad": false, 
+                "events": 1000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-1000_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_125406/0000/myMicroAODOutputFile_3.root", 
+                "nevents": 1000, 
+                "totEvents": 1000, 
+                "weights": 999.5501708984375
+            }, 
+            {
+                "bad": false, 
+                "events": 16000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-1000_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_125406/0000/myMicroAODOutputFile_15.root", 
+                "nevents": 16000, 
+                "totEvents": 16000, 
+                "weights": 15987.0419921875
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-1000_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_125406/0000/myMicroAODOutputFile_9.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24978.25
+            }, 
+            {
+                "bad": false, 
+                "events": 9000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-1000_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_125406/0000/myMicroAODOutputFile_17.root", 
+                "nevents": 9000, 
+                "totEvents": 9000, 
+                "weights": 8992.8212890625
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-1000_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_125406/0000/myMicroAODOutputFile_2.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24981.033203125
+            }, 
+            {
+                "bad": false, 
+                "events": 16000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-1000_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_125406/0000/myMicroAODOutputFile_4.root", 
+                "nevents": 16000, 
+                "totEvents": 16000, 
+                "weights": 15985.3173828125
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-1000_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_125406/0000/myMicroAODOutputFile_14.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24977.009765625
+            }, 
+            {
+                "bad": false, 
+                "events": 12000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-1000_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_125406/0000/myMicroAODOutputFile_25.root", 
+                "nevents": 12000, 
+                "totEvents": 12000, 
+                "weights": 11988.201171875
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-1000_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_125406/0000/myMicroAODOutputFile_20.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24976.19140625
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-1000_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_125406/0000/myMicroAODOutputFile_18.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24975.208984375
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-1000_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_125406/0000/myMicroAODOutputFile_16.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24979.8515625
+            }, 
+            {
+                "bad": false, 
+                "events": 8000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-1000_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_125406/0000/myMicroAODOutputFile_5.root", 
+                "nevents": 8000, 
+                "totEvents": 8000, 
+                "weights": 7994.3134765625
+            }, 
+            {
+                "bad": false, 
+                "events": 4000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-1000_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_125406/0000/myMicroAODOutputFile_6.root", 
+                "nevents": 4000, 
+                "totEvents": 4000, 
+                "weights": 3997.260986328125
+            }, 
+            {
+                "bad": false, 
+                "events": 10000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-1000_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_125406/0000/myMicroAODOutputFile_1.root", 
+                "nevents": 10000, 
+                "totEvents": 10000, 
+                "weights": 9990.95703125
+            }, 
+            {
+                "bad": false, 
+                "events": 5000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-1000_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_125406/0000/myMicroAODOutputFile_21.root", 
+                "nevents": 5000, 
+                "totEvents": 5000, 
+                "weights": 4994.21044921875
+            }
+        ], 
+        "parent_n_units": 400000, 
+        "vetted": true
+    }, 
+    "/TprimeBToTH_Hgg_M-1100_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/lata-Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2-6f64939368112792100a27fcb8918a00/USER": {
+        "dset_type": "mc", 
+        "files": [
+            {
+                "bad": false, 
+                "events": 22000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-1100_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_125648/0000/myMicroAODOutputFile_23.root", 
+                "nevents": 22000, 
+                "totEvents": 22000, 
+                "weights": 21978.484375
+            }, 
+            {
+                "bad": false, 
+                "events": 18000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-1100_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_125648/0000/myMicroAODOutputFile_5.root", 
+                "nevents": 18000, 
+                "totEvents": 18000, 
+                "weights": 17983.966796875
+            }, 
+            {
+                "bad": false, 
+                "events": 1000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-1100_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_125648/0000/myMicroAODOutputFile_25.root", 
+                "nevents": 1000, 
+                "totEvents": 1000, 
+                "weights": 998.862548828125
+            }, 
+            {
+                "bad": false, 
+                "events": 2000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-1100_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_125648/0000/myMicroAODOutputFile_20.root", 
+                "nevents": 2000, 
+                "totEvents": 2000, 
+                "weights": 1998.590576171875
+            }, 
+            {
+                "bad": false, 
+                "events": 6000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-1100_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_125648/0000/myMicroAODOutputFile_9.root", 
+                "nevents": 6000, 
+                "totEvents": 6000, 
+                "weights": 5995.64111328125
+            }, 
+            {
+                "bad": false, 
+                "events": 12000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-1100_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_125648/0000/myMicroAODOutputFile_3.root", 
+                "nevents": 12000, 
+                "totEvents": 12000, 
+                "weights": 11990.142578125
+            }, 
+            {
+                "bad": false, 
+                "events": 11000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-1100_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_125648/0000/myMicroAODOutputFile_22.root", 
+                "nevents": 11000, 
+                "totEvents": 11000, 
+                "weights": 10990.927734375
+            }, 
+            {
+                "bad": false, 
+                "events": 8000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-1100_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_125648/0000/myMicroAODOutputFile_4.root", 
+                "nevents": 8000, 
+                "totEvents": 8000, 
+                "weights": 7994.3115234375
+            }, 
+            {
+                "bad": false, 
+                "events": 10000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-1100_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_125648/0000/myMicroAODOutputFile_11.root", 
+                "nevents": 10000, 
+                "totEvents": 10000, 
+                "weights": 9991.9658203125
+            }, 
+            {
+                "bad": false, 
+                "events": 24000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-1100_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_125648/0000/myMicroAODOutputFile_10.root", 
+                "nevents": 24000, 
+                "totEvents": 24000, 
+                "weights": 23978.857421875
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-1100_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_125648/0000/myMicroAODOutputFile_12.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24979.052734375
+            }, 
+            {
+                "bad": false, 
+                "events": 22000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-1100_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_125648/0000/myMicroAODOutputFile_14.root", 
+                "nevents": 22000, 
+                "totEvents": 22000, 
+                "weights": 21974.3046875
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-1100_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_125648/0000/myMicroAODOutputFile_21.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24980.26171875
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-1100_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_125648/0000/myMicroAODOutputFile_13.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24975.8515625
+            }, 
+            {
+                "bad": false, 
+                "events": 22000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-1100_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_125648/0000/myMicroAODOutputFile_6.root", 
+                "nevents": 22000, 
+                "totEvents": 22000, 
+                "weights": 21982.89453125
+            }, 
+            {
+                "bad": false, 
+                "events": 18000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-1100_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_125648/0000/myMicroAODOutputFile_17.root", 
+                "nevents": 18000, 
+                "totEvents": 18000, 
+                "weights": 17982.56640625
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-1100_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_125648/0000/myMicroAODOutputFile_24.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24978.201171875
+            }, 
+            {
+                "bad": false, 
+                "events": 16000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-1100_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_125648/0000/myMicroAODOutputFile_2.root", 
+                "nevents": 16000, 
+                "totEvents": 16000, 
+                "weights": 15985.986328125
+            }, 
+            {
+                "bad": false, 
+                "events": 8000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-1100_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_125648/0000/myMicroAODOutputFile_1.root", 
+                "nevents": 8000, 
+                "totEvents": 8000, 
+                "weights": 7993.193359375
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-1100_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_125648/0000/myMicroAODOutputFile_7.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24976.67578125
+            }, 
+            {
+                "bad": false, 
+                "events": 2000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-1100_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_125648/0000/myMicroAODOutputFile_18.root", 
+                "nevents": 2000, 
+                "totEvents": 2000, 
+                "weights": 1998.560546875
+            }, 
+            {
+                "bad": false, 
+                "events": 5000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-1100_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_125648/0000/myMicroAODOutputFile_8.root", 
+                "nevents": 5000, 
+                "totEvents": 5000, 
+                "weights": 4994.83984375
+            }, 
+            {
+                "bad": false, 
+                "events": 2000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-1100_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_125648/0000/myMicroAODOutputFile_26.root", 
+                "nevents": 2000, 
+                "totEvents": 2000, 
+                "weights": 1997.610595703125
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-1100_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_125648/0000/myMicroAODOutputFile_16.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24974.939453125
+            }, 
+            {
+                "bad": false, 
+                "events": 10000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-1100_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_125648/0000/myMicroAODOutputFile_19.root", 
+                "nevents": 10000, 
+                "totEvents": 10000, 
+                "weights": 9991.66015625
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-1100_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_125648/0000/myMicroAODOutputFile_15.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24975.05078125
+            }
+        ], 
+        "parent_n_units": 394000, 
+        "vetted": true
+    }, 
+    "/TprimeBToTH_Hgg_M-1200_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/lata-Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2-6f64939368112792100a27fcb8918a00/USER": {
+        "dset_type": "mc", 
+        "files": [
+            {
+                "bad": false, 
+                "events": 12000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-1200_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_125930/0000/myMicroAODOutputFile_15.root", 
+                "nevents": 12000, 
+                "totEvents": 12000, 
+                "weights": 11990.3828125
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-1200_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_125930/0000/myMicroAODOutputFile_6.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24974.25
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-1200_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_125930/0000/myMicroAODOutputFile_21.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24979.740234375
+            }, 
+            {
+                "bad": false, 
+                "events": 6000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-1200_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_125930/0000/myMicroAODOutputFile_20.root", 
+                "nevents": 6000, 
+                "totEvents": 6000, 
+                "weights": 5994.6611328125
+            }, 
+            {
+                "bad": false, 
+                "events": 4000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-1200_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_125930/0000/myMicroAODOutputFile_19.root", 
+                "nevents": 4000, 
+                "totEvents": 4000, 
+                "weights": 3995.0244140625
+            }, 
+            {
+                "bad": false, 
+                "events": 4000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-1200_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_125930/0000/myMicroAODOutputFile_17.root", 
+                "nevents": 4000, 
+                "totEvents": 4000, 
+                "weights": 3995.8017578125
+            }, 
+            {
+                "bad": false, 
+                "events": 4000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-1200_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_125930/0000/myMicroAODOutputFile_13.root", 
+                "nevents": 4000, 
+                "totEvents": 4000, 
+                "weights": 3996.436279296875
+            }, 
+            {
+                "bad": false, 
+                "events": 3000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-1200_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_125930/0000/myMicroAODOutputFile_26.root", 
+                "nevents": 3000, 
+                "totEvents": 3000, 
+                "weights": 2995.70751953125
+            }, 
+            {
+                "bad": false, 
+                "events": 16000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-1200_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_125930/0000/myMicroAODOutputFile_14.root", 
+                "nevents": 16000, 
+                "totEvents": 16000, 
+                "weights": 15981.3525390625
+            }, 
+            {
+                "bad": false, 
+                "events": 16000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-1200_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_125930/0000/myMicroAODOutputFile_12.root", 
+                "nevents": 16000, 
+                "totEvents": 16000, 
+                "weights": 15984.732421875
+            }, 
+            {
+                "bad": false, 
+                "events": 20000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-1200_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_125930/0000/myMicroAODOutputFile_1.root", 
+                "nevents": 20000, 
+                "totEvents": 20000, 
+                "weights": 19983.3359375
+            }, 
+            {
+                "bad": false, 
+                "events": 6000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-1200_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_125930/0000/myMicroAODOutputFile_24.root", 
+                "nevents": 6000, 
+                "totEvents": 6000, 
+                "weights": 5995.623046875
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-1200_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_125930/0000/myMicroAODOutputFile_22.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24980.17578125
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-1200_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_125930/0000/myMicroAODOutputFile_5.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24972.65625
+            }, 
+            {
+                "bad": false, 
+                "events": 8000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-1200_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_125930/0000/myMicroAODOutputFile_11.root", 
+                "nevents": 8000, 
+                "totEvents": 8000, 
+                "weights": 7993.33447265625
+            }, 
+            {
+                "bad": false, 
+                "events": 6000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-1200_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_125930/0000/myMicroAODOutputFile_10.root", 
+                "nevents": 6000, 
+                "totEvents": 6000, 
+                "weights": 5994.3623046875
+            }, 
+            {
+                "bad": false, 
+                "events": 22000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-1200_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_125930/0000/myMicroAODOutputFile_27.root", 
+                "nevents": 22000, 
+                "totEvents": 22000, 
+                "weights": 21976.748046875
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-1200_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_125930/0000/myMicroAODOutputFile_25.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24974.990234375
+            }, 
+            {
+                "bad": false, 
+                "events": 22000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-1200_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_125930/0000/myMicroAODOutputFile_2.root", 
+                "nevents": 22000, 
+                "totEvents": 22000, 
+                "weights": 21982.35546875
+            }, 
+            {
+                "bad": false, 
+                "events": 5000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-1200_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_125930/0000/myMicroAODOutputFile_9.root", 
+                "nevents": 5000, 
+                "totEvents": 5000, 
+                "weights": 4996.25146484375
+            }, 
+            {
+                "bad": false, 
+                "events": 8000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-1200_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_125930/0000/myMicroAODOutputFile_18.root", 
+                "nevents": 8000, 
+                "totEvents": 8000, 
+                "weights": 7992.451171875
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-1200_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_125930/0000/myMicroAODOutputFile_4.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24974.517578125
+            }, 
+            {
+                "bad": false, 
+                "events": 20000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-1200_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_125930/0000/myMicroAODOutputFile_3.root", 
+                "nevents": 20000, 
+                "totEvents": 20000, 
+                "weights": 19980.2421875
+            }, 
+            {
+                "bad": false, 
+                "events": 12000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-1200_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_125930/0000/myMicroAODOutputFile_16.root", 
+                "nevents": 12000, 
+                "totEvents": 12000, 
+                "weights": 11989.6220703125
+            }, 
+            {
+                "bad": false, 
+                "events": 6000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-1200_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_125930/0000/myMicroAODOutputFile_23.root", 
+                "nevents": 6000, 
+                "totEvents": 6000, 
+                "weights": 5995.591796875
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-1200_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_125930/0000/myMicroAODOutputFile_8.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24969.9765625
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-1200_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_125930/0000/myMicroAODOutputFile_7.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24974.203125
+            }
+        ], 
+        "parent_n_units": 400000, 
+        "vetted": true
+    }, 
+    "/TprimeBToTH_Hgg_M-600_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/lata-Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2-6f64939368112792100a27fcb8918a00/USER": {
+        "dset_type": "mc", 
+        "files": [
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-600_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_130213/0000/myMicroAODOutputFile_8.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24982.88671875
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-600_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_130213/0000/myMicroAODOutputFile_9.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24983.021484375
+            }, 
+            {
+                "bad": false, 
+                "events": 21000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-600_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_130213/0000/myMicroAODOutputFile_16.root", 
+                "nevents": 21000, 
+                "totEvents": 21000, 
+                "weights": 20987.77734375
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-600_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_130213/0000/myMicroAODOutputFile_2.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24981.505859375
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-600_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_130213/0000/myMicroAODOutputFile_10.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24985.3125
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-600_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_130213/0000/myMicroAODOutputFile_4.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24982.998046875
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-600_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_130213/0000/myMicroAODOutputFile_6.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24982.380859375
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-600_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_130213/0000/myMicroAODOutputFile_12.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24983.421875
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-600_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_130213/0000/myMicroAODOutputFile_1.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24983.787109375
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-600_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_130213/0000/myMicroAODOutputFile_15.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24983.904296875
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-600_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_130213/0000/myMicroAODOutputFile_13.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24983.279296875
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-600_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_130213/0000/myMicroAODOutputFile_5.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24984.564453125
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-600_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_130213/0000/myMicroAODOutputFile_7.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24985.76171875
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-600_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_130213/0000/myMicroAODOutputFile_14.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24982.5625
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-600_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_130213/0000/myMicroAODOutputFile_3.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24983.25
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-600_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_130213/0000/myMicroAODOutputFile_11.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24984.2265625
+            }
+        ], 
+        "parent_n_units": 396000, 
+        "vetted": true
+    },  
+    "/TprimeBToTH_Hgg_M-650_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/lata-Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2-6f64939368112792100a27fcb8918a00/USER": {
+        "dset_type": "mc", 
+        "files": [
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-650_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_130807/0000/myMicroAODOutputFile_23.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24983.4375
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-650_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_130807/0000/myMicroAODOutputFile_17.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24979.4921875
+            }, 
+            {
+                "bad": false, 
+                "events": 7000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-650_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_130807/0000/myMicroAODOutputFile_18.root", 
+                "nevents": 7000, 
+                "totEvents": 7000, 
+                "weights": 6993.72021484375
+            }, 
+            {
+                "bad": false, 
+                "events": 7000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-650_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_130807/0000/myMicroAODOutputFile_4.root", 
+                "nevents": 7000, 
+                "totEvents": 7000, 
+                "weights": 6995.64208984375
+            }, 
+            {
+                "bad": false, 
+                "events": 7000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-650_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_130807/0000/myMicroAODOutputFile_10.root", 
+                "nevents": 7000, 
+                "totEvents": 7000, 
+                "weights": 6994.27392578125
+            }, 
+            {
+                "bad": false, 
+                "events": 10000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-650_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_130807/0000/myMicroAODOutputFile_12.root", 
+                "nevents": 10000, 
+                "totEvents": 10000, 
+                "weights": 9993.732421875
+            }, 
+            {
+                "bad": false, 
+                "events": 18000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-650_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_130807/0000/myMicroAODOutputFile_11.root", 
+                "nevents": 18000, 
+                "totEvents": 18000, 
+                "weights": 17987.833984375
+            }, 
+            {
+                "bad": false, 
+                "events": 16000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-650_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_130807/0000/myMicroAODOutputFile_7.root", 
+                "nevents": 16000, 
+                "totEvents": 16000, 
+                "weights": 15989.330078125
+            }, 
+            {
+                "bad": false, 
+                "events": 1000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-650_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_130807/0000/myMicroAODOutputFile_21.root", 
+                "nevents": 1000, 
+                "totEvents": 1000, 
+                "weights": 999.5100708007812
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-650_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_130807/0000/myMicroAODOutputFile_3.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24981.994140625
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-650_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_130807/0000/myMicroAODOutputFile_22.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24982.474609375
+            }, 
+            {
+                "bad": false, 
+                "events": 24000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-650_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_130807/0000/myMicroAODOutputFile_24.root", 
+                "nevents": 24000, 
+                "totEvents": 24000, 
+                "weights": 23984.220703125
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-650_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_130807/0000/myMicroAODOutputFile_6.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24983.955078125
+            }, 
+            {
+                "bad": false, 
+                "events": 4000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-650_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_130807/0000/myMicroAODOutputFile_2.root", 
+                "nevents": 4000, 
+                "totEvents": 4000, 
+                "weights": 3997.530029296875
+            }, 
+            {
+                "bad": false, 
+                "events": 2000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-650_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_130807/0000/myMicroAODOutputFile_19.root", 
+                "nevents": 2000, 
+                "totEvents": 2000, 
+                "weights": 1997.740478515625
+            }, 
+            {
+                "bad": false, 
+                "events": 2000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-650_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_130807/0000/myMicroAODOutputFile_13.root", 
+                "nevents": 2000, 
+                "totEvents": 2000, 
+                "weights": 1998.790283203125
+            }, 
+            {
+                "bad": false, 
+                "events": 2000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-650_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_130807/0000/myMicroAODOutputFile_14.root", 
+                "nevents": 2000, 
+                "totEvents": 2000, 
+                "weights": 1997.889892578125
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-650_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_130807/0000/myMicroAODOutputFile_5.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24982.126953125
+            }, 
+            {
+                "bad": false, 
+                "events": 10000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-650_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_130807/0000/myMicroAODOutputFile_8.root", 
+                "nevents": 10000, 
+                "totEvents": 10000, 
+                "weights": 9992.8544921875
+            }, 
+            {
+                "bad": false, 
+                "events": 8000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-650_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_130807/0000/myMicroAODOutputFile_1.root", 
+                "nevents": 8000, 
+                "totEvents": 8000, 
+                "weights": 7993.90234375
+            }, 
+            {
+                "bad": false, 
+                "events": 22000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-650_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_130807/0000/myMicroAODOutputFile_25.root", 
+                "nevents": 22000, 
+                "totEvents": 22000, 
+                "weights": 21985.060546875
+            }, 
+            {
+                "bad": false, 
+                "events": 12000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-650_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_130807/0000/myMicroAODOutputFile_26.root", 
+                "nevents": 12000, 
+                "totEvents": 12000, 
+                "weights": 11992.048828125
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-650_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_130807/0000/myMicroAODOutputFile_20.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24982.92578125
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-650_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_130807/0000/myMicroAODOutputFile_15.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24981.123046875
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-650_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_130807/0000/myMicroAODOutputFile_9.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24979.083984375
+            }, 
+            {
+                "bad": false, 
+                "events": 9000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-650_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_130807/0000/myMicroAODOutputFile_16.root", 
+                "nevents": 9000, 
+                "totEvents": 9000, 
+                "weights": 8993.8154296875
+            }
+        ], 
+        "parent_n_units": 386000, 
+        "vetted": true
+    },  
+    "/TprimeBToTH_Hgg_M-700_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/lata-Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2-6f64939368112792100a27fcb8918a00/USER": {
+        "dset_type": "mc", 
+        "files": [
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-700_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_131331/0000/myMicroAODOutputFile_1.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24982.25
+            }, 
+            {
+                "bad": false, 
+                "events": 4000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-700_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_131331/0000/myMicroAODOutputFile_7.root", 
+                "nevents": 4000, 
+                "totEvents": 4000, 
+                "weights": 3997.4306640625
+            }, 
+            {
+                "bad": false, 
+                "events": 4000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-700_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_131331/0000/myMicroAODOutputFile_6.root", 
+                "nevents": 4000, 
+                "totEvents": 4000, 
+                "weights": 3996.65087890625
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-700_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_131331/0000/myMicroAODOutputFile_17.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24983.484375
+            }, 
+            {
+                "bad": false, 
+                "events": 10000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-700_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_131331/0000/myMicroAODOutputFile_18.root", 
+                "nevents": 10000, 
+                "totEvents": 10000, 
+                "weights": 9992.974609375
+            }, 
+            {
+                "bad": false, 
+                "events": 8000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-700_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_131331/0000/myMicroAODOutputFile_9.root", 
+                "nevents": 8000, 
+                "totEvents": 8000, 
+                "weights": 7994.22265625
+            }, 
+            {
+                "bad": false, 
+                "events": 12000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-700_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_131331/0000/myMicroAODOutputFile_15.root", 
+                "nevents": 12000, 
+                "totEvents": 12000, 
+                "weights": 11992.53125
+            }, 
+            {
+                "bad": false, 
+                "events": 12000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-700_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_131331/0000/myMicroAODOutputFile_10.root", 
+                "nevents": 12000, 
+                "totEvents": 12000, 
+                "weights": 11991.533203125
+            }, 
+            {
+                "bad": false, 
+                "events": 7000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-700_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_131331/0000/myMicroAODOutputFile_23.root", 
+                "nevents": 7000, 
+                "totEvents": 7000, 
+                "weights": 6995.791015625
+            }, 
+            {
+                "bad": false, 
+                "events": 20000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-700_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_131331/0000/myMicroAODOutputFile_24.root", 
+                "nevents": 20000, 
+                "totEvents": 20000, 
+                "weights": 19986.384765625
+            }, 
+            {
+                "bad": false, 
+                "events": 16000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-700_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_131331/0000/myMicroAODOutputFile_5.root", 
+                "nevents": 16000, 
+                "totEvents": 16000, 
+                "weights": 15989.357421875
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-700_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_131331/0000/myMicroAODOutputFile_22.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24982.3203125
+            }, 
+            {
+                "bad": false, 
+                "events": 13000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-700_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_131331/0000/myMicroAODOutputFile_14.root", 
+                "nevents": 13000, 
+                "totEvents": 13000, 
+                "weights": 12988.140625
+            }, 
+            {
+                "bad": false, 
+                "events": 20000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-700_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_131331/0000/myMicroAODOutputFile_3.root", 
+                "nevents": 20000, 
+                "totEvents": 20000, 
+                "weights": 19984.330078125
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-700_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_131331/0000/myMicroAODOutputFile_2.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24983.94140625
+            }, 
+            {
+                "bad": false, 
+                "events": 20000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-700_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_131331/0000/myMicroAODOutputFile_19.root", 
+                "nevents": 20000, 
+                "totEvents": 20000, 
+                "weights": 19982.513671875
+            }, 
+            {
+                "bad": false, 
+                "events": 10000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-700_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_131331/0000/myMicroAODOutputFile_4.root", 
+                "nevents": 10000, 
+                "totEvents": 10000, 
+                "weights": 9992.236328125
+            }, 
+            {
+                "bad": false, 
+                "events": 2000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-700_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_131331/0000/myMicroAODOutputFile_21.root", 
+                "nevents": 2000, 
+                "totEvents": 2000, 
+                "weights": 1998.820556640625
+            }, 
+            {
+                "bad": false, 
+                "events": 16000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-700_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_131331/0000/myMicroAODOutputFile_11.root", 
+                "nevents": 16000, 
+                "totEvents": 16000, 
+                "weights": 15988.513671875
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-700_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_131331/0000/myMicroAODOutputFile_16.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24983.33984375
+            }, 
+            {
+                "bad": false, 
+                "events": 24000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-700_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_131331/0000/myMicroAODOutputFile_8.root", 
+                "nevents": 24000, 
+                "totEvents": 24000, 
+                "weights": 23981.25
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-700_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_131331/0000/myMicroAODOutputFile_13.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24982.30078125
+            }, 
+            {
+                "bad": false, 
+                "events": 22000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-700_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_131331/0000/myMicroAODOutputFile_20.root", 
+                "nevents": 22000, 
+                "totEvents": 22000, 
+                "weights": 21985.490234375
+            }
+        ], 
+        "parent_n_units": 370000, 
+        "vetted": true
+    }, 
+    "/TprimeBToTH_Hgg_M-800_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/lata-Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2-6f64939368112792100a27fcb8918a00/USER": {
+        "dset_type": "mc", 
+        "files": [
+            {
+                "bad": false, 
+                "events": 12000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-800_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_131614/0000/myMicroAODOutputFile_6.root", 
+                "nevents": 12000, 
+                "totEvents": 12000, 
+                "weights": 11991.0556640625
+            }, 
+            {
+                "bad": false, 
+                "events": 10000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-800_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_131614/0000/myMicroAODOutputFile_16.root", 
+                "nevents": 10000, 
+                "totEvents": 10000, 
+                "weights": 9993.94140625
+            }, 
+            {
+                "bad": false, 
+                "events": 12000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-800_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_131614/0000/myMicroAODOutputFile_4.root", 
+                "nevents": 12000, 
+                "totEvents": 12000, 
+                "weights": 11989.8955078125
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-800_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_131614/0000/myMicroAODOutputFile_22.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24981.833984375
+            }, 
+            {
+                "bad": false, 
+                "events": 20000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-800_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_131614/0000/myMicroAODOutputFile_21.root", 
+                "nevents": 20000, 
+                "totEvents": 20000, 
+                "weights": 19985.625
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-800_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_131614/0000/myMicroAODOutputFile_20.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24978.208984375
+            }, 
+            {
+                "bad": false, 
+                "events": 10000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-800_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_131614/0000/myMicroAODOutputFile_15.root", 
+                "nevents": 10000, 
+                "totEvents": 10000, 
+                "weights": 9991.0478515625
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-800_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_131614/0000/myMicroAODOutputFile_9.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24983.4453125
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-800_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_131614/0000/myMicroAODOutputFile_23.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24981.275390625
+            }, 
+            {
+                "bad": false, 
+                "events": 10000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-800_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_131614/0000/myMicroAODOutputFile_12.root", 
+                "nevents": 10000, 
+                "totEvents": 10000, 
+                "weights": 9993.6513671875
+            }, 
+            {
+                "bad": false, 
+                "events": 12000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-800_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_131614/0000/myMicroAODOutputFile_7.root", 
+                "nevents": 12000, 
+                "totEvents": 12000, 
+                "weights": 11991.4130859375
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-800_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_131614/0000/myMicroAODOutputFile_2.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24978.703125
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-800_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_131614/0000/myMicroAODOutputFile_3.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24982.923828125
+            }, 
+            {
+                "bad": false, 
+                "events": 14000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-800_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_131614/0000/myMicroAODOutputFile_18.root", 
+                "nevents": 14000, 
+                "totEvents": 14000, 
+                "weights": 13989.0537109375
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-800_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_131614/0000/myMicroAODOutputFile_24.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24976.5859375
+            }, 
+            {
+                "bad": false, 
+                "events": 15000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-800_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_131614/0000/myMicroAODOutputFile_25.root", 
+                "nevents": 15000, 
+                "totEvents": 15000, 
+                "weights": 14990.4921875
+            }, 
+            {
+                "bad": false, 
+                "events": 3000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-800_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_131614/0000/myMicroAODOutputFile_14.root", 
+                "nevents": 3000, 
+                "totEvents": 3000, 
+                "weights": 2998.160888671875
+            }, 
+            {
+                "bad": false, 
+                "events": 2000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-800_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_131614/0000/myMicroAODOutputFile_5.root", 
+                "nevents": 2000, 
+                "totEvents": 2000, 
+                "weights": 1998.617919921875
+            }, 
+            {
+                "bad": false, 
+                "events": 8000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-800_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_131614/0000/myMicroAODOutputFile_17.root", 
+                "nevents": 8000, 
+                "totEvents": 8000, 
+                "weights": 7994.6318359375
+            }, 
+            {
+                "bad": false, 
+                "events": 6000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-800_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_131614/0000/myMicroAODOutputFile_11.root", 
+                "nevents": 6000, 
+                "totEvents": 6000, 
+                "weights": 5994.80322265625
+            }, 
+            {
+                "bad": false, 
+                "events": 13000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-800_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_131614/0000/myMicroAODOutputFile_10.root", 
+                "nevents": 13000, 
+                "totEvents": 13000, 
+                "weights": 12990.6728515625
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-800_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_131614/0000/myMicroAODOutputFile_13.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24980.201171875
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-800_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_131614/0000/myMicroAODOutputFile_19.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24979.0
+            }, 
+            {
+                "bad": false, 
+                "events": 22000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-800_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_131614/0000/myMicroAODOutputFile_8.root", 
+                "nevents": 22000, 
+                "totEvents": 22000, 
+                "weights": 21983.205078125
+            }, 
+            {
+                "bad": false, 
+                "events": 6000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-800_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_131614/0000/myMicroAODOutputFile_1.root", 
+                "nevents": 6000, 
+                "totEvents": 6000, 
+                "weights": 5996.34130859375
+            }
+        ], 
+        "parent_n_units": 400000, 
+        "vetted": true
+    }, 
+    "/TprimeBToTH_Hgg_M-900_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/lata-Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2-6f64939368112792100a27fcb8918a00/USER": {
+        "dset_type": "mc", 
+        "files": [
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-900_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_131855/0000/myMicroAODOutputFile_23.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24978.462890625
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-900_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_131855/0000/myMicroAODOutputFile_6.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24980.59375
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-900_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_131855/0000/myMicroAODOutputFile_21.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24979.583984375
+            }, 
+            {
+                "bad": false, 
+                "events": 5000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-900_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_131855/0000/myMicroAODOutputFile_2.root", 
+                "nevents": 5000, 
+                "totEvents": 5000, 
+                "weights": 4995.66259765625
+            }, 
+            {
+                "bad": false, 
+                "events": 20000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-900_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_131855/0000/myMicroAODOutputFile_13.root", 
+                "nevents": 20000, 
+                "totEvents": 20000, 
+                "weights": 19982.759765625
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-900_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_131855/0000/myMicroAODOutputFile_7.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24978.798828125
+            }, 
+            {
+                "bad": false, 
+                "events": 23000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-900_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_131855/0000/myMicroAODOutputFile_24.root", 
+                "nevents": 23000, 
+                "totEvents": 23000, 
+                "weights": 22983.1015625
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-900_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_131855/0000/myMicroAODOutputFile_9.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24980.76171875
+            }, 
+            {
+                "bad": false, 
+                "events": 8000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-900_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_131855/0000/myMicroAODOutputFile_14.root", 
+                "nevents": 8000, 
+                "totEvents": 8000, 
+                "weights": 7993.54443359375
+            }, 
+            {
+                "bad": false, 
+                "events": 19000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-900_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_131855/0000/myMicroAODOutputFile_26.root", 
+                "nevents": 19000, 
+                "totEvents": 19000, 
+                "weights": 18985.064453125
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-900_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_131855/0000/myMicroAODOutputFile_25.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24978.376953125
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-900_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_131855/0000/myMicroAODOutputFile_1.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24982.09375
+            }, 
+            {
+                "bad": false, 
+                "events": 6000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-900_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_131855/0000/myMicroAODOutputFile_17.root", 
+                "nevents": 6000, 
+                "totEvents": 6000, 
+                "weights": 5995.015625
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-900_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_131855/0000/myMicroAODOutputFile_3.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24979.283203125
+            }, 
+            {
+                "bad": false, 
+                "events": 10000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-900_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_131855/0000/myMicroAODOutputFile_15.root", 
+                "nevents": 10000, 
+                "totEvents": 10000, 
+                "weights": 9990.962890625
+            }, 
+            {
+                "bad": false, 
+                "events": 8000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-900_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_131855/0000/myMicroAODOutputFile_11.root", 
+                "nevents": 8000, 
+                "totEvents": 8000, 
+                "weights": 7994.47265625
+            }, 
+            {
+                "bad": false, 
+                "events": 4000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-900_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_131855/0000/myMicroAODOutputFile_5.root", 
+                "nevents": 4000, 
+                "totEvents": 4000, 
+                "weights": 3997.12060546875
+            }, 
+            {
+                "bad": false, 
+                "events": 2000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-900_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_131855/0000/myMicroAODOutputFile_8.root", 
+                "nevents": 2000, 
+                "totEvents": 2000, 
+                "weights": 1997.6103515625
+            }, 
+            {
+                "bad": false, 
+                "events": 2000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-900_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_131855/0000/myMicroAODOutputFile_18.root", 
+                "nevents": 2000, 
+                "totEvents": 2000, 
+                "weights": 1998.531005859375
+            }, 
+            {
+                "bad": false, 
+                "events": 1000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-900_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_131855/0000/myMicroAODOutputFile_10.root", 
+                "nevents": 1000, 
+                "totEvents": 1000, 
+                "weights": 999.1802978515625
+            }, 
+            {
+                "bad": false, 
+                "events": 8000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-900_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_131855/0000/myMicroAODOutputFile_12.root", 
+                "nevents": 8000, 
+                "totEvents": 8000, 
+                "weights": 7992.65673828125
+            }, 
+            {
+                "bad": false, 
+                "events": 24000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-900_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_131855/0000/myMicroAODOutputFile_16.root", 
+                "nevents": 24000, 
+                "totEvents": 24000, 
+                "weights": 23978.822265625
+            }, 
+            {
+                "bad": false, 
+                "events": 14000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-900_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_131855/0000/myMicroAODOutputFile_19.root", 
+                "nevents": 14000, 
+                "totEvents": 14000, 
+                "weights": 13986.6328125
+            }, 
+            {
+                "bad": false, 
+                "events": 13000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-900_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_131855/0000/myMicroAODOutputFile_4.root", 
+                "nevents": 13000, 
+                "totEvents": 13000, 
+                "weights": 12989.4169921875
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2017_RR-31Mar2018_v2/v2_p11/TprimeBToTH_Hgg_M-900_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201110_131855/0000/myMicroAODOutputFile_22.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24978.083984375
+            }
+        ], 
+        "parent_n_units": 392000, 
+        "vetted": true
+    }
+}
+

--- a/MetaData/data/Era2017_RR-31Mar2018_v2/datasets_41.json
+++ b/MetaData/data/Era2017_RR-31Mar2018_v2/datasets_41.json
@@ -1,4 +1,426 @@
 {
+    "/TprimeBToTH_Hgg_M-625_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/alesauva-2017_1-10_6_4-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2-212521accf5a8c5254b74c728917b9b7/USER": {
+        "dset_type": "mc", 
+        "files": [
+            {
+                "bad": false, 
+                "events": 24000, 
+                "name": "/store/user/alesauva/flashgg/2017_1/10_6_4/TprimeBToTH_Hgg_M-625_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/2017_1-10_6_4-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201207_145128/0000/myMicroAODOutputFile_12.root", 
+                "nevents": 24000, 
+                "totEvents": 24000, 
+                "weights": 23984.86328125
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/alesauva/flashgg/2017_1/10_6_4/TprimeBToTH_Hgg_M-625_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/2017_1-10_6_4-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201207_145128/0000/myMicroAODOutputFile_18.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24980.3046875
+            }, 
+            {
+                "bad": false, 
+                "events": 11000, 
+                "name": "/store/user/alesauva/flashgg/2017_1/10_6_4/TprimeBToTH_Hgg_M-625_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/2017_1-10_6_4-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201207_145128/0000/myMicroAODOutputFile_11.root", 
+                "nevents": 11000, 
+                "totEvents": 11000, 
+                "weights": 10992.1162109375
+            }, 
+            {
+                "bad": false, 
+                "events": 10000, 
+                "name": "/store/user/alesauva/flashgg/2017_1/10_6_4/TprimeBToTH_Hgg_M-625_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/2017_1-10_6_4-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201207_145128/0000/myMicroAODOutputFile_19.root", 
+                "nevents": 10000, 
+                "totEvents": 10000, 
+                "weights": 9993.453125
+            }, 
+            {
+                "bad": false, 
+                "events": 8000, 
+                "name": "/store/user/alesauva/flashgg/2017_1/10_6_4/TprimeBToTH_Hgg_M-625_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/2017_1-10_6_4-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201207_145128/0000/myMicroAODOutputFile_24.root", 
+                "nevents": 8000, 
+                "totEvents": 8000, 
+                "weights": 7994.287109375
+            }, 
+            {
+                "bad": false, 
+                "events": 10000, 
+                "name": "/store/user/alesauva/flashgg/2017_1/10_6_4/TprimeBToTH_Hgg_M-625_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/2017_1-10_6_4-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201207_145128/0000/myMicroAODOutputFile_8.root", 
+                "nevents": 10000, 
+                "totEvents": 10000, 
+                "weights": 9992.970703125
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/alesauva/flashgg/2017_1/10_6_4/TprimeBToTH_Hgg_M-625_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/2017_1-10_6_4-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201207_145128/0000/myMicroAODOutputFile_17.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24981.671875
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/alesauva/flashgg/2017_1/10_6_4/TprimeBToTH_Hgg_M-625_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/2017_1-10_6_4-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201207_145128/0000/myMicroAODOutputFile_25.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24982.11328125
+            }, 
+            {
+                "bad": false, 
+                "events": 17000, 
+                "name": "/store/user/alesauva/flashgg/2017_1/10_6_4/TprimeBToTH_Hgg_M-625_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/2017_1-10_6_4-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201207_145128/0000/myMicroAODOutputFile_7.root", 
+                "nevents": 17000, 
+                "totEvents": 17000, 
+                "weights": 16987.880859375
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/alesauva/flashgg/2017_1/10_6_4/TprimeBToTH_Hgg_M-625_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/2017_1-10_6_4-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201207_145128/0000/myMicroAODOutputFile_4.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24981.841796875
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/alesauva/flashgg/2017_1/10_6_4/TprimeBToTH_Hgg_M-625_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/2017_1-10_6_4-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201207_145128/0000/myMicroAODOutputFile_10.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24983.80078125
+            }, 
+            {
+                "bad": false, 
+                "events": 18000, 
+                "name": "/store/user/alesauva/flashgg/2017_1/10_6_4/TprimeBToTH_Hgg_M-625_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/2017_1-10_6_4-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201207_145128/0000/myMicroAODOutputFile_27.root", 
+                "nevents": 18000, 
+                "totEvents": 18000, 
+                "weights": 17988.64453125
+            }, 
+            {
+                "bad": false, 
+                "events": 8000, 
+                "name": "/store/user/alesauva/flashgg/2017_1/10_6_4/TprimeBToTH_Hgg_M-625_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/2017_1-10_6_4-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201207_145128/0000/myMicroAODOutputFile_22.root", 
+                "nevents": 8000, 
+                "totEvents": 8000, 
+                "weights": 7995.310546875
+            }, 
+            {
+                "bad": false, 
+                "events": 6000, 
+                "name": "/store/user/alesauva/flashgg/2017_1/10_6_4/TprimeBToTH_Hgg_M-625_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/2017_1-10_6_4-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201207_145128/0000/myMicroAODOutputFile_20.root", 
+                "nevents": 6000, 
+                "totEvents": 6000, 
+                "weights": 5995.58837890625
+            }, 
+            {
+                "bad": false, 
+                "events": 8000, 
+                "name": "/store/user/alesauva/flashgg/2017_1/10_6_4/TprimeBToTH_Hgg_M-625_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/2017_1-10_6_4-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201207_145128/0000/myMicroAODOutputFile_23.root", 
+                "nevents": 8000, 
+                "totEvents": 8000, 
+                "weights": 7993.71826171875
+            }, 
+            {
+                "bad": false, 
+                "events": 2000, 
+                "name": "/store/user/alesauva/flashgg/2017_1/10_6_4/TprimeBToTH_Hgg_M-625_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/2017_1-10_6_4-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201207_145128/0000/myMicroAODOutputFile_3.root", 
+                "nevents": 2000, 
+                "totEvents": 2000, 
+                "weights": 1998.8603515625
+            }, 
+            {
+                "bad": false, 
+                "events": 17000, 
+                "name": "/store/user/alesauva/flashgg/2017_1/10_6_4/TprimeBToTH_Hgg_M-625_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/2017_1-10_6_4-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201207_145128/0000/myMicroAODOutputFile_15.root", 
+                "nevents": 17000, 
+                "totEvents": 17000, 
+                "weights": 16987.51171875
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/alesauva/flashgg/2017_1/10_6_4/TprimeBToTH_Hgg_M-625_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/2017_1-10_6_4-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201207_145128/0000/myMicroAODOutputFile_2.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24981.69921875
+            }, 
+            {
+                "bad": false, 
+                "events": 4000, 
+                "name": "/store/user/alesauva/flashgg/2017_1/10_6_4/TprimeBToTH_Hgg_M-625_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/2017_1-10_6_4-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201207_145128/0000/myMicroAODOutputFile_9.root", 
+                "nevents": 4000, 
+                "totEvents": 4000, 
+                "weights": 3996.680419921875
+            }, 
+            {
+                "bad": false, 
+                "events": 2000, 
+                "name": "/store/user/alesauva/flashgg/2017_1/10_6_4/TprimeBToTH_Hgg_M-625_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/2017_1-10_6_4-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201207_145128/0000/myMicroAODOutputFile_13.root", 
+                "nevents": 2000, 
+                "totEvents": 2000, 
+                "weights": 1998.6907958984375
+            }, 
+            {
+                "bad": false, 
+                "events": 2000, 
+                "name": "/store/user/alesauva/flashgg/2017_1/10_6_4/TprimeBToTH_Hgg_M-625_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/2017_1-10_6_4-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201207_145128/0000/myMicroAODOutputFile_16.root", 
+                "nevents": 2000, 
+                "totEvents": 2000, 
+                "weights": 1998.710205078125
+            }, 
+            {
+                "bad": false, 
+                "events": 15000, 
+                "name": "/store/user/alesauva/flashgg/2017_1/10_6_4/TprimeBToTH_Hgg_M-625_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/2017_1-10_6_4-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201207_145128/0000/myMicroAODOutputFile_26.root", 
+                "nevents": 15000, 
+                "totEvents": 15000, 
+                "weights": 14990.521484375
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/alesauva/flashgg/2017_1/10_6_4/TprimeBToTH_Hgg_M-625_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/2017_1-10_6_4-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201207_145128/0000/myMicroAODOutputFile_6.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24980.455078125
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/alesauva/flashgg/2017_1/10_6_4/TprimeBToTH_Hgg_M-625_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/2017_1-10_6_4-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201207_145128/0000/myMicroAODOutputFile_1.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24981.580078125
+            }, 
+            {
+                "bad": false, 
+                "events": 12000, 
+                "name": "/store/user/alesauva/flashgg/2017_1/10_6_4/TprimeBToTH_Hgg_M-625_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/2017_1-10_6_4-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201207_145128/0000/myMicroAODOutputFile_21.root", 
+                "nevents": 12000, 
+                "totEvents": 12000, 
+                "weights": 11993.0517578125
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/alesauva/flashgg/2017_1/10_6_4/TprimeBToTH_Hgg_M-625_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/2017_1-10_6_4-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201207_145128/0000/myMicroAODOutputFile_14.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24982.291015625
+            }, 
+            {
+                "bad": false, 
+                "events": 1000, 
+                "name": "/store/user/alesauva/flashgg/2017_1/10_6_4/TprimeBToTH_Hgg_M-625_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/2017_1-10_6_4-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201207_145128/0000/myMicroAODOutputFile_5.root", 
+                "nevents": 1000, 
+                "totEvents": 1000, 
+                "weights": 999.489990234375
+            }
+        ], 
+        "parent_n_units": 400000, 
+        "vetted": false
+    }, 
+    "/TprimeBToTH_Hgg_M-675_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/alesauva-2017_1-10_6_4-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2-212521accf5a8c5254b74c728917b9b7/USER": {
+        "dset_type": "mc", 
+        "files": [
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/alesauva/flashgg/2017_1/10_6_4/TprimeBToTH_Hgg_M-675_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/2017_1-10_6_4-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201207_150157/0000/myMicroAODOutputFile_21.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24984.6015625
+            }, 
+            {
+                "bad": false, 
+                "events": 10000, 
+                "name": "/store/user/alesauva/flashgg/2017_1/10_6_4/TprimeBToTH_Hgg_M-675_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/2017_1-10_6_4-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201207_150157/0000/myMicroAODOutputFile_8.root", 
+                "nevents": 10000, 
+                "totEvents": 10000, 
+                "weights": 9992.7841796875
+            }, 
+            {
+                "bad": false, 
+                "events": 1000, 
+                "name": "/store/user/alesauva/flashgg/2017_1/10_6_4/TprimeBToTH_Hgg_M-675_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/2017_1-10_6_4-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201207_150157/0000/myMicroAODOutputFile_2.root", 
+                "nevents": 1000, 
+                "totEvents": 1000, 
+                "weights": 999.4600830078125
+            }, 
+            {
+                "bad": false, 
+                "events": 2000, 
+                "name": "/store/user/alesauva/flashgg/2017_1/10_6_4/TprimeBToTH_Hgg_M-675_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/2017_1-10_6_4-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201207_150157/0000/myMicroAODOutputFile_17.root", 
+                "nevents": 2000, 
+                "totEvents": 2000, 
+                "weights": 1997.510986328125
+            }, 
+            {
+                "bad": false, 
+                "events": 2000, 
+                "name": "/store/user/alesauva/flashgg/2017_1/10_6_4/TprimeBToTH_Hgg_M-675_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/2017_1-10_6_4-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201207_150157/0000/myMicroAODOutputFile_11.root", 
+                "nevents": 2000, 
+                "totEvents": 2000, 
+                "weights": 1998.770263671875
+            }, 
+            {
+                "bad": false, 
+                "events": 5000, 
+                "name": "/store/user/alesauva/flashgg/2017_1/10_6_4/TprimeBToTH_Hgg_M-675_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/2017_1-10_6_4-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201207_150157/0000/myMicroAODOutputFile_20.root", 
+                "nevents": 5000, 
+                "totEvents": 5000, 
+                "weights": 4996.564453125
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/alesauva/flashgg/2017_1/10_6_4/TprimeBToTH_Hgg_M-675_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/2017_1-10_6_4-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201207_150157/0000/myMicroAODOutputFile_22.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24982.970703125
+            }, 
+            {
+                "bad": false, 
+                "events": 18000, 
+                "name": "/store/user/alesauva/flashgg/2017_1/10_6_4/TprimeBToTH_Hgg_M-675_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/2017_1-10_6_4-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201207_150157/0000/myMicroAODOutputFile_10.root", 
+                "nevents": 18000, 
+                "totEvents": 18000, 
+                "weights": 17986.904296875
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/alesauva/flashgg/2017_1/10_6_4/TprimeBToTH_Hgg_M-675_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/2017_1-10_6_4-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201207_150157/0000/myMicroAODOutputFile_15.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24980.5625
+            }, 
+            {
+                "bad": false, 
+                "events": 15000, 
+                "name": "/store/user/alesauva/flashgg/2017_1/10_6_4/TprimeBToTH_Hgg_M-675_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/2017_1-10_6_4-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201207_150157/0000/myMicroAODOutputFile_24.root", 
+                "nevents": 15000, 
+                "totEvents": 15000, 
+                "weights": 14990.2109375
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/alesauva/flashgg/2017_1/10_6_4/TprimeBToTH_Hgg_M-675_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/2017_1-10_6_4-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201207_150157/0000/myMicroAODOutputFile_4.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24982.71875
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/alesauva/flashgg/2017_1/10_6_4/TprimeBToTH_Hgg_M-675_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/2017_1-10_6_4-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201207_150157/0000/myMicroAODOutputFile_6.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24979.95703125
+            }, 
+            {
+                "bad": false, 
+                "events": 18000, 
+                "name": "/store/user/alesauva/flashgg/2017_1/10_6_4/TprimeBToTH_Hgg_M-675_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/2017_1-10_6_4-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201207_150157/0000/myMicroAODOutputFile_7.root", 
+                "nevents": 18000, 
+                "totEvents": 18000, 
+                "weights": 17989.234375
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/alesauva/flashgg/2017_1/10_6_4/TprimeBToTH_Hgg_M-675_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/2017_1-10_6_4-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201207_150157/0000/myMicroAODOutputFile_5.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24982.685546875
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/alesauva/flashgg/2017_1/10_6_4/TprimeBToTH_Hgg_M-675_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/2017_1-10_6_4-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201207_150157/0000/myMicroAODOutputFile_3.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24983.501953125
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/alesauva/flashgg/2017_1/10_6_4/TprimeBToTH_Hgg_M-675_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/2017_1-10_6_4-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201207_150157/0000/myMicroAODOutputFile_12.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24981.09765625
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/alesauva/flashgg/2017_1/10_6_4/TprimeBToTH_Hgg_M-675_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/2017_1-10_6_4-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201207_150157/0000/myMicroAODOutputFile_19.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24982.978515625
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/alesauva/flashgg/2017_1/10_6_4/TprimeBToTH_Hgg_M-675_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/2017_1-10_6_4-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201207_150157/0000/myMicroAODOutputFile_23.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24982.640625
+            }, 
+            {
+                "bad": false, 
+                "events": 1000, 
+                "name": "/store/user/alesauva/flashgg/2017_1/10_6_4/TprimeBToTH_Hgg_M-675_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/2017_1-10_6_4-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201207_150157/0000/myMicroAODOutputFile_16.root", 
+                "nevents": 1000, 
+                "totEvents": 1000, 
+                "weights": 998.4403686523438
+            }, 
+            {
+                "bad": false, 
+                "events": 2000, 
+                "name": "/store/user/alesauva/flashgg/2017_1/10_6_4/TprimeBToTH_Hgg_M-675_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/2017_1-10_6_4-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201207_150157/0000/myMicroAODOutputFile_9.root", 
+                "nevents": 2000, 
+                "totEvents": 2000, 
+                "weights": 1997.5018310546875
+            }, 
+            {
+                "bad": false, 
+                "events": 15000, 
+                "name": "/store/user/alesauva/flashgg/2017_1/10_6_4/TprimeBToTH_Hgg_M-675_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/2017_1-10_6_4-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201207_150157/0000/myMicroAODOutputFile_13.root", 
+                "nevents": 15000, 
+                "totEvents": 15000, 
+                "weights": 14988.091796875
+            }, 
+            {
+                "bad": false, 
+                "events": 18000, 
+                "name": "/store/user/alesauva/flashgg/2017_1/10_6_4/TprimeBToTH_Hgg_M-675_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/2017_1-10_6_4-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201207_150157/0000/myMicroAODOutputFile_18.root", 
+                "nevents": 18000, 
+                "totEvents": 18000, 
+                "weights": 17986.65234375
+            }, 
+            {
+                "bad": false, 
+                "events": 18000, 
+                "name": "/store/user/alesauva/flashgg/2017_1/10_6_4/TprimeBToTH_Hgg_M-675_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/2017_1-10_6_4-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201207_150157/0000/myMicroAODOutputFile_14.root", 
+                "nevents": 18000, 
+                "totEvents": 18000, 
+                "weights": 17986.60546875
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/alesauva/flashgg/2017_1/10_6_4/TprimeBToTH_Hgg_M-675_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/2017_1-10_6_4-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/201207_150157/0000/myMicroAODOutputFile_1.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24985.380859375
+            }
+        ], 
+        "parent_n_units": 400000, 
+        "vetted": false
+    }, 
     "/HAHMHToAA_AToGG_MA-15GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/lata-Era2017_RR-31Mar2018_v2-v2_p11-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1-6f64939368112792100a27fcb8918a00/USER": {
         "dset_type": "mc", 
         "files": [

--- a/MetaData/data/Era2018_RR-17Sep2018_v2/datasets_29.json
+++ b/MetaData/data/Era2018_RR-17Sep2018_v2/datasets_29.json
@@ -1,0 +1,4105 @@
+{
+    "/ttHToGG_M125_TuneCP5_PSweights_13TeV-powheg-pythia8/lata-Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1-62341cae7c75662e5c5fd4059fe8cecc/USER": {
+        "dset_type": "mc", 
+        "files": [
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/ttHToGG_M125_TuneCP5_PSweights_13TeV-powheg-pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/201023_174207/0000/myMicroAODOutputFile_36.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 13165.9462890625
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/ttHToGG_M125_TuneCP5_PSweights_13TeV-powheg-pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/201023_174207/0000/myMicroAODOutputFile_1.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 13174.40625
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/ttHToGG_M125_TuneCP5_PSweights_13TeV-powheg-pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/201023_174207/0000/myMicroAODOutputFile_35.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 13175.26953125
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/ttHToGG_M125_TuneCP5_PSweights_13TeV-powheg-pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/201023_174207/0000/myMicroAODOutputFile_40.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 13179.705078125
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/ttHToGG_M125_TuneCP5_PSweights_13TeV-powheg-pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/201023_174207/0000/myMicroAODOutputFile_4.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 13140.9619140625
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/ttHToGG_M125_TuneCP5_PSweights_13TeV-powheg-pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/201023_174207/0000/myMicroAODOutputFile_21.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 13173.4541015625
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/ttHToGG_M125_TuneCP5_PSweights_13TeV-powheg-pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/201023_174207/0000/myMicroAODOutputFile_12.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 13157.1396484375
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/ttHToGG_M125_TuneCP5_PSweights_13TeV-powheg-pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/201023_174207/0000/myMicroAODOutputFile_29.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 13177.5029296875
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/ttHToGG_M125_TuneCP5_PSweights_13TeV-powheg-pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/201023_174207/0000/myMicroAODOutputFile_37.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 13178.8486328125
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/ttHToGG_M125_TuneCP5_PSweights_13TeV-powheg-pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/201023_174207/0000/myMicroAODOutputFile_20.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 13175.2744140625
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/ttHToGG_M125_TuneCP5_PSweights_13TeV-powheg-pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/201023_174207/0000/myMicroAODOutputFile_18.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 13130.2236328125
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/ttHToGG_M125_TuneCP5_PSweights_13TeV-powheg-pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/201023_174207/0000/myMicroAODOutputFile_26.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 13173.2392578125
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/ttHToGG_M125_TuneCP5_PSweights_13TeV-powheg-pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/201023_174207/0000/myMicroAODOutputFile_39.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 13175.5380859375
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/ttHToGG_M125_TuneCP5_PSweights_13TeV-powheg-pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/201023_174207/0000/myMicroAODOutputFile_13.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 13177.53125
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/ttHToGG_M125_TuneCP5_PSweights_13TeV-powheg-pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/201023_174207/0000/myMicroAODOutputFile_23.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 13150.9072265625
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/ttHToGG_M125_TuneCP5_PSweights_13TeV-powheg-pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/201023_174207/0000/myMicroAODOutputFile_30.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 13138.8740234375
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/ttHToGG_M125_TuneCP5_PSweights_13TeV-powheg-pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/201023_174207/0000/myMicroAODOutputFile_5.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 13154.869140625
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/ttHToGG_M125_TuneCP5_PSweights_13TeV-powheg-pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/201023_174207/0000/myMicroAODOutputFile_16.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 13185.2158203125
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/ttHToGG_M125_TuneCP5_PSweights_13TeV-powheg-pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/201023_174207/0000/myMicroAODOutputFile_3.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 13134.5087890625
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/ttHToGG_M125_TuneCP5_PSweights_13TeV-powheg-pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/201023_174207/0000/myMicroAODOutputFile_15.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 13158.255859375
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/ttHToGG_M125_TuneCP5_PSweights_13TeV-powheg-pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/201023_174207/0000/myMicroAODOutputFile_17.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 13140.1875
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/ttHToGG_M125_TuneCP5_PSweights_13TeV-powheg-pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/201023_174207/0000/myMicroAODOutputFile_11.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 13187.357421875
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/ttHToGG_M125_TuneCP5_PSweights_13TeV-powheg-pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/201023_174207/0000/myMicroAODOutputFile_38.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 13153.4189453125
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/ttHToGG_M125_TuneCP5_PSweights_13TeV-powheg-pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/201023_174207/0000/myMicroAODOutputFile_33.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 13178.80859375
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/ttHToGG_M125_TuneCP5_PSweights_13TeV-powheg-pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/201023_174207/0000/myMicroAODOutputFile_19.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 13155.05078125
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/ttHToGG_M125_TuneCP5_PSweights_13TeV-powheg-pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/201023_174207/0000/myMicroAODOutputFile_2.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 13190.7587890625
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/ttHToGG_M125_TuneCP5_PSweights_13TeV-powheg-pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/201023_174207/0000/myMicroAODOutputFile_27.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 13172.2314453125
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/ttHToGG_M125_TuneCP5_PSweights_13TeV-powheg-pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/201023_174207/0000/myMicroAODOutputFile_8.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 13172.4423828125
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/ttHToGG_M125_TuneCP5_PSweights_13TeV-powheg-pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/201023_174207/0000/myMicroAODOutputFile_25.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 13165.896484375
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/ttHToGG_M125_TuneCP5_PSweights_13TeV-powheg-pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/201023_174207/0000/myMicroAODOutputFile_31.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 13153.115234375
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/ttHToGG_M125_TuneCP5_PSweights_13TeV-powheg-pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/201023_174207/0000/myMicroAODOutputFile_24.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 13166.8076171875
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/ttHToGG_M125_TuneCP5_PSweights_13TeV-powheg-pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/201023_174207/0000/myMicroAODOutputFile_32.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 13167.771484375
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/ttHToGG_M125_TuneCP5_PSweights_13TeV-powheg-pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/201023_174207/0000/myMicroAODOutputFile_7.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 13181.8525390625
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/ttHToGG_M125_TuneCP5_PSweights_13TeV-powheg-pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/201023_174207/0000/myMicroAODOutputFile_10.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 13136.9189453125
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/ttHToGG_M125_TuneCP5_PSweights_13TeV-powheg-pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/201023_174207/0000/myMicroAODOutputFile_34.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 13170.2314453125
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/ttHToGG_M125_TuneCP5_PSweights_13TeV-powheg-pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/201023_174207/0000/myMicroAODOutputFile_22.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 13161.408203125
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/ttHToGG_M125_TuneCP5_PSweights_13TeV-powheg-pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/201023_174207/0000/myMicroAODOutputFile_28.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 13170.380859375
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/ttHToGG_M125_TuneCP5_PSweights_13TeV-powheg-pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/201023_174207/0000/myMicroAODOutputFile_9.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 13138.7236328125
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/ttHToGG_M125_TuneCP5_PSweights_13TeV-powheg-pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/201023_174207/0000/myMicroAODOutputFile_14.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 13166.943359375
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/ttHToGG_M125_TuneCP5_PSweights_13TeV-powheg-pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/201023_174207/0000/myMicroAODOutputFile_6.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 13167.2099609375
+            }
+        ], 
+        "parent_n_units": 1000000, 
+        "vetted": true
+    },
+    "/HAHMHToAA_AToGG_MA-15GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/lata-Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2-c8742baf38d1e270734b273d38e0b81b/USER": {
+        "dset_type": "mc", 
+        "files": [
+            {
+                "bad": false, 
+                "events": 24820, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-15GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201014_194838/0000/myMicroAODOutputFile_20.root", 
+                "nevents": 24820, 
+                "totEvents": 24820, 
+                "weights": 24816.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24910, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-15GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201014_194838/0000/myMicroAODOutputFile_9.root", 
+                "nevents": 24910, 
+                "totEvents": 24910, 
+                "weights": 24906.12890625
+            }, 
+            {
+                "bad": false, 
+                "events": 24668, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-15GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201014_194838/0000/myMicroAODOutputFile_3.root", 
+                "nevents": 24668, 
+                "totEvents": 24668, 
+                "weights": 24663.9296875
+            }, 
+            {
+                "bad": false, 
+                "events": 24692, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-15GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201014_194838/0000/myMicroAODOutputFile_5.root", 
+                "nevents": 24692, 
+                "totEvents": 24692, 
+                "weights": 24688.060546875
+            }, 
+            {
+                "bad": false, 
+                "events": 24770, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-15GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201014_194838/0000/myMicroAODOutputFile_10.root", 
+                "nevents": 24770, 
+                "totEvents": 24770, 
+                "weights": 24765.98046875
+            }, 
+            {
+                "bad": false, 
+                "events": 24838, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-15GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201014_194838/0000/myMicroAODOutputFile_16.root", 
+                "nevents": 24838, 
+                "totEvents": 24838, 
+                "weights": 24833.138671875
+            }, 
+            {
+                "bad": false, 
+                "events": 24573, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-15GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201014_194838/0000/myMicroAODOutputFile_7.root", 
+                "nevents": 24573, 
+                "totEvents": 24573, 
+                "weights": 24567.912109375
+            }, 
+            {
+                "bad": false, 
+                "events": 24777, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-15GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201014_194838/0000/myMicroAODOutputFile_1.root", 
+                "nevents": 24777, 
+                "totEvents": 24777, 
+                "weights": 24773.279296875
+            }, 
+            {
+                "bad": false, 
+                "events": 24708, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-15GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201014_194838/0000/myMicroAODOutputFile_12.root", 
+                "nevents": 24708, 
+                "totEvents": 24708, 
+                "weights": 24703.8125
+            }, 
+            {
+                "bad": false, 
+                "events": 24641, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-15GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201014_194838/0000/myMicroAODOutputFile_13.root", 
+                "nevents": 24641, 
+                "totEvents": 24641, 
+                "weights": 24636.16796875
+            }, 
+            {
+                "bad": false, 
+                "events": 24679, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-15GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201014_194838/0000/myMicroAODOutputFile_4.root", 
+                "nevents": 24679, 
+                "totEvents": 24679, 
+                "weights": 24675.056640625
+            }, 
+            {
+                "bad": false, 
+                "events": 24938, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-15GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201014_194838/0000/myMicroAODOutputFile_2.root", 
+                "nevents": 24938, 
+                "totEvents": 24938, 
+                "weights": 24934.021484375
+            }, 
+            {
+                "bad": false, 
+                "events": 24703, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-15GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201014_194838/0000/myMicroAODOutputFile_14.root", 
+                "nevents": 24703, 
+                "totEvents": 24703, 
+                "weights": 24699.04296875
+            }, 
+            {
+                "bad": false, 
+                "events": 24771, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-15GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201014_194838/0000/myMicroAODOutputFile_11.root", 
+                "nevents": 24771, 
+                "totEvents": 24771, 
+                "weights": 24766.478515625
+            }, 
+            {
+                "bad": false, 
+                "events": 24627, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-15GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201014_194838/0000/myMicroAODOutputFile_8.root", 
+                "nevents": 24627, 
+                "totEvents": 24627, 
+                "weights": 24622.951171875
+            }, 
+            {
+                "bad": false, 
+                "events": 24590, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-15GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201014_194838/0000/myMicroAODOutputFile_17.root", 
+                "nevents": 24590, 
+                "totEvents": 24590, 
+                "weights": 24586.51171875
+            }, 
+            {
+                "bad": false, 
+                "events": 24866, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-15GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201014_194838/0000/myMicroAODOutputFile_18.root", 
+                "nevents": 24866, 
+                "totEvents": 24866, 
+                "weights": 24861.98046875
+            }, 
+            {
+                "bad": false, 
+                "events": 24694, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-15GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201014_194838/0000/myMicroAODOutputFile_15.root", 
+                "nevents": 24694, 
+                "totEvents": 24694, 
+                "weights": 24689.83984375
+            }, 
+            {
+                "bad": false, 
+                "events": 24793, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-15GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201014_194838/0000/myMicroAODOutputFile_19.root", 
+                "nevents": 24793, 
+                "totEvents": 24793, 
+                "weights": 24789.33203125
+            }, 
+            {
+                "bad": false, 
+                "events": 24633, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-15GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201014_194838/0000/myMicroAODOutputFile_6.root", 
+                "nevents": 24633, 
+                "totEvents": 24633, 
+                "weights": 24629.16015625
+            }
+        ], 
+        "parent_n_units": 494691, 
+        "vetted": true
+    }, 
+    "/HAHMHToAA_AToGG_MA-20GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/lata-Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2-c8742baf38d1e270734b273d38e0b81b/USER": {
+        "dset_type": "mc", 
+        "files": [
+            {
+                "bad": false, 
+                "events": 24722, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-20GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201022_181216/0000/myMicroAODOutputFile_2.root", 
+                "nevents": 24722, 
+                "totEvents": 24722, 
+                "weights": 24716.951171875
+            }, 
+            {
+                "bad": false, 
+                "events": 24594, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-20GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201022_181216/0000/myMicroAODOutputFile_18.root", 
+                "nevents": 24594, 
+                "totEvents": 24594, 
+                "weights": 24588.6484375
+            }, 
+            {
+                "bad": false, 
+                "events": 24730, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-20GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201022_181216/0000/myMicroAODOutputFile_9.root", 
+                "nevents": 24730, 
+                "totEvents": 24730, 
+                "weights": 24725.01953125
+            }, 
+            {
+                "bad": false, 
+                "events": 24648, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-20GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201022_181216/0000/myMicroAODOutputFile_10.root", 
+                "nevents": 24648, 
+                "totEvents": 24648, 
+                "weights": 24643.189453125
+            }, 
+            {
+                "bad": false, 
+                "events": 21047, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-20GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201022_181216/0000/myMicroAODOutputFile_21.root", 
+                "nevents": 21047, 
+                "totEvents": 21047, 
+                "weights": 21043.01953125
+            }, 
+            {
+                "bad": false, 
+                "events": 24729, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-20GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201022_181216/0000/myMicroAODOutputFile_5.root", 
+                "nevents": 24729, 
+                "totEvents": 24729, 
+                "weights": 24723.9296875
+            }, 
+            {
+                "bad": false, 
+                "events": 24616, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-20GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201022_181216/0000/myMicroAODOutputFile_17.root", 
+                "nevents": 24616, 
+                "totEvents": 24616, 
+                "weights": 24610.99609375
+            }, 
+            {
+                "bad": false, 
+                "events": 24957, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-20GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201022_181216/0000/myMicroAODOutputFile_11.root", 
+                "nevents": 24957, 
+                "totEvents": 24957, 
+                "weights": 24951.501953125
+            }, 
+            {
+                "bad": false, 
+                "events": 24868, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-20GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201022_181216/0000/myMicroAODOutputFile_20.root", 
+                "nevents": 24868, 
+                "totEvents": 24868, 
+                "weights": 24862.580078125
+            }, 
+            {
+                "bad": false, 
+                "events": 24651, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-20GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201022_181216/0000/myMicroAODOutputFile_6.root", 
+                "nevents": 24651, 
+                "totEvents": 24651, 
+                "weights": 24646.107421875
+            }, 
+            {
+                "bad": false, 
+                "events": 3914, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-20GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201022_181216/0000/myMicroAODOutputFile_1.root", 
+                "nevents": 3914, 
+                "totEvents": 3914, 
+                "weights": 3913.210205078125
+            }, 
+            {
+                "bad": false, 
+                "events": 24947, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-20GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201022_181216/0000/myMicroAODOutputFile_16.root", 
+                "nevents": 24947, 
+                "totEvents": 24947, 
+                "weights": 24941.658203125
+            }, 
+            {
+                "bad": false, 
+                "events": 24865, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-20GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201022_181216/0000/myMicroAODOutputFile_19.root", 
+                "nevents": 24865, 
+                "totEvents": 24865, 
+                "weights": 24859.462890625
+            }, 
+            {
+                "bad": false, 
+                "events": 24738, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-20GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201022_181216/0000/myMicroAODOutputFile_13.root", 
+                "nevents": 24738, 
+                "totEvents": 24738, 
+                "weights": 24732.908203125
+            }, 
+            {
+                "bad": false, 
+                "events": 24674, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-20GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201022_181216/0000/myMicroAODOutputFile_12.root", 
+                "nevents": 24674, 
+                "totEvents": 24674, 
+                "weights": 24668.931640625
+            }, 
+            {
+                "bad": false, 
+                "events": 24781, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-20GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201022_181216/0000/myMicroAODOutputFile_3.root", 
+                "nevents": 24781, 
+                "totEvents": 24781, 
+                "weights": 24776.369140625
+            }, 
+            {
+                "bad": false, 
+                "events": 24726, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-20GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201022_181216/0000/myMicroAODOutputFile_4.root", 
+                "nevents": 24726, 
+                "totEvents": 24726, 
+                "weights": 24721.109375
+            }, 
+            {
+                "bad": false, 
+                "events": 24712, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-20GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201022_181216/0000/myMicroAODOutputFile_15.root", 
+                "nevents": 24712, 
+                "totEvents": 24712, 
+                "weights": 24707.232421875
+            }, 
+            {
+                "bad": false, 
+                "events": 24803, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-20GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201022_181216/0000/myMicroAODOutputFile_7.root", 
+                "nevents": 24803, 
+                "totEvents": 24803, 
+                "weights": 24796.875
+            }, 
+            {
+                "bad": false, 
+                "events": 24752, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-20GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201022_181216/0000/myMicroAODOutputFile_8.root", 
+                "nevents": 24752, 
+                "totEvents": 24752, 
+                "weights": 24746.70703125
+            }, 
+            {
+                "bad": false, 
+                "events": 24873, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-20GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201022_181216/0000/myMicroAODOutputFile_14.root", 
+                "nevents": 24873, 
+                "totEvents": 24873, 
+                "weights": 24867.94921875
+            }
+        ], 
+        "parent_n_units": 495347, 
+        "vetted": true
+    }, 
+    "/HAHMHToAA_AToGG_MA-25GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/lata-Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2-c8742baf38d1e270734b273d38e0b81b/USER": {
+        "dset_type": "mc", 
+        "files": [
+            {
+                "bad": false, 
+                "events": 24988, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-25GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201015_153644/0000/myMicroAODOutputFile_17.root", 
+                "nevents": 24988, 
+                "totEvents": 24988, 
+                "weights": 24982.560546875
+            }, 
+            {
+                "bad": false, 
+                "events": 24655, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-25GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201015_153644/0000/myMicroAODOutputFile_9.root", 
+                "nevents": 24655, 
+                "totEvents": 24655, 
+                "weights": 24649.359375
+            }, 
+            {
+                "bad": false, 
+                "events": 16779, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-25GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201015_153644/0000/myMicroAODOutputFile_21.root", 
+                "nevents": 16779, 
+                "totEvents": 16779, 
+                "weights": 16775.3515625
+            }, 
+            {
+                "bad": false, 
+                "events": 7874, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-25GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201015_153644/0000/myMicroAODOutputFile_1.root", 
+                "nevents": 7874, 
+                "totEvents": 7874, 
+                "weights": 7872.16015625
+            }, 
+            {
+                "bad": false, 
+                "events": 24918, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-25GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201015_153644/0000/myMicroAODOutputFile_18.root", 
+                "nevents": 24918, 
+                "totEvents": 24918, 
+                "weights": 24912.5390625
+            }, 
+            {
+                "bad": false, 
+                "events": 24790, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-25GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201015_153644/0000/myMicroAODOutputFile_8.root", 
+                "nevents": 24790, 
+                "totEvents": 24790, 
+                "weights": 24784.76953125
+            }, 
+            {
+                "bad": false, 
+                "events": 24614, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-25GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201015_153644/0000/myMicroAODOutputFile_16.root", 
+                "nevents": 24614, 
+                "totEvents": 24614, 
+                "weights": 24608.693359375
+            }, 
+            {
+                "bad": false, 
+                "events": 24749, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-25GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201015_153644/0000/myMicroAODOutputFile_14.root", 
+                "nevents": 24749, 
+                "totEvents": 24749, 
+                "weights": 24743.55859375
+            }, 
+            {
+                "bad": false, 
+                "events": 24877, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-25GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201015_153644/0000/myMicroAODOutputFile_15.root", 
+                "nevents": 24877, 
+                "totEvents": 24877, 
+                "weights": 24871.541015625
+            }, 
+            {
+                "bad": false, 
+                "events": 24763, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-25GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201015_153644/0000/myMicroAODOutputFile_11.root", 
+                "nevents": 24763, 
+                "totEvents": 24763, 
+                "weights": 24757.5390625
+            }, 
+            {
+                "bad": false, 
+                "events": 24699, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-25GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201015_153644/0000/myMicroAODOutputFile_12.root", 
+                "nevents": 24699, 
+                "totEvents": 24699, 
+                "weights": 24693.451171875
+            }, 
+            {
+                "bad": false, 
+                "events": 24727, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-25GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201015_153644/0000/myMicroAODOutputFile_6.root", 
+                "nevents": 24727, 
+                "totEvents": 24727, 
+                "weights": 24721.59765625
+            }, 
+            {
+                "bad": false, 
+                "events": 24971, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-25GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201015_153644/0000/myMicroAODOutputFile_4.root", 
+                "nevents": 24971, 
+                "totEvents": 24971, 
+                "weights": 24965.427734375
+            }, 
+            {
+                "bad": false, 
+                "events": 24721, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-25GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201015_153644/0000/myMicroAODOutputFile_3.root", 
+                "nevents": 24721, 
+                "totEvents": 24721, 
+                "weights": 24715.517578125
+            }, 
+            {
+                "bad": false, 
+                "events": 24972, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-25GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201015_153644/0000/myMicroAODOutputFile_13.root", 
+                "nevents": 24972, 
+                "totEvents": 24972, 
+                "weights": 24965.392578125
+            }, 
+            {
+                "bad": false, 
+                "events": 24830, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-25GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201015_153644/0000/myMicroAODOutputFile_10.root", 
+                "nevents": 24830, 
+                "totEvents": 24830, 
+                "weights": 24824.521484375
+            }, 
+            {
+                "bad": false, 
+                "events": 24816, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-25GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201015_153644/0000/myMicroAODOutputFile_2.root", 
+                "nevents": 24816, 
+                "totEvents": 24816, 
+                "weights": 24810.01953125
+            }, 
+            {
+                "bad": false, 
+                "events": 24766, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-25GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201015_153644/0000/myMicroAODOutputFile_20.root", 
+                "nevents": 24766, 
+                "totEvents": 24766, 
+                "weights": 24760.498046875
+            }, 
+            {
+                "bad": false, 
+                "events": 24799, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-25GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201015_153644/0000/myMicroAODOutputFile_7.root", 
+                "nevents": 24799, 
+                "totEvents": 24799, 
+                "weights": 24793.689453125
+            }, 
+            {
+                "bad": false, 
+                "events": 24876, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-25GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201015_153644/0000/myMicroAODOutputFile_19.root", 
+                "nevents": 24876, 
+                "totEvents": 24876, 
+                "weights": 24870.33984375
+            }, 
+            {
+                "bad": false, 
+                "events": 24615, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-25GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201015_153644/0000/myMicroAODOutputFile_5.root", 
+                "nevents": 24615, 
+                "totEvents": 24615, 
+                "weights": 24609.45703125
+            }
+        ], 
+        "parent_n_units": 495799, 
+        "vetted": true
+    }, 
+    "/HAHMHToAA_AToGG_MA-30GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/lata-Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2-c8742baf38d1e270734b273d38e0b81b/USER": {
+        "dset_type": "mc", 
+        "files": [
+            {
+                "bad": false, 
+                "events": 197, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-30GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201014_195954/0000/myMicroAODOutputFile_12.root", 
+                "nevents": 197, 
+                "totEvents": 197, 
+                "weights": 196.97999572753906
+            }, 
+            {
+                "bad": false, 
+                "events": 24774, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-30GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201014_195954/0000/myMicroAODOutputFile_21.root", 
+                "nevents": 24774, 
+                "totEvents": 24774, 
+                "weights": 24768.69140625
+            }, 
+            {
+                "bad": false, 
+                "events": 24837, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-30GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201014_195954/0000/myMicroAODOutputFile_2.root", 
+                "nevents": 24837, 
+                "totEvents": 24837, 
+                "weights": 24831.73828125
+            }, 
+            {
+                "bad": false, 
+                "events": 24933, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-30GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201014_195954/0000/myMicroAODOutputFile_19.root", 
+                "nevents": 24933, 
+                "totEvents": 24933, 
+                "weights": 24927.41015625
+            }, 
+            {
+                "bad": false, 
+                "events": 24914, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-30GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201014_195954/0000/myMicroAODOutputFile_6.root", 
+                "nevents": 24914, 
+                "totEvents": 24914, 
+                "weights": 24908.298828125
+            }, 
+            {
+                "bad": false, 
+                "events": 24786, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-30GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201014_195954/0000/myMicroAODOutputFile_7.root", 
+                "nevents": 24786, 
+                "totEvents": 24786, 
+                "weights": 24780.05078125
+            }, 
+            {
+                "bad": false, 
+                "events": 24855, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-30GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201014_195954/0000/myMicroAODOutputFile_1.root", 
+                "nevents": 24855, 
+                "totEvents": 24855, 
+                "weights": 24848.810546875
+            }, 
+            {
+                "bad": false, 
+                "events": 24748, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-30GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201014_195954/0000/myMicroAODOutputFile_8.root", 
+                "nevents": 24748, 
+                "totEvents": 24748, 
+                "weights": 24742.009765625
+            }, 
+            {
+                "bad": false, 
+                "events": 24721, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-30GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201014_195954/0000/myMicroAODOutputFile_9.root", 
+                "nevents": 24721, 
+                "totEvents": 24721, 
+                "weights": 24715.51171875
+            }, 
+            {
+                "bad": false, 
+                "events": 24671, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-30GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201014_195954/0000/myMicroAODOutputFile_17.root", 
+                "nevents": 24671, 
+                "totEvents": 24671, 
+                "weights": 24665.337890625
+            }, 
+            {
+                "bad": false, 
+                "events": 24822, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-30GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201014_195954/0000/myMicroAODOutputFile_5.root", 
+                "nevents": 24822, 
+                "totEvents": 24822, 
+                "weights": 24815.80078125
+            }, 
+            {
+                "bad": false, 
+                "events": 24837, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-30GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201014_195954/0000/myMicroAODOutputFile_4.root", 
+                "nevents": 24837, 
+                "totEvents": 24837, 
+                "weights": 24831.466796875
+            }, 
+            {
+                "bad": false, 
+                "events": 24819, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-30GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201014_195954/0000/myMicroAODOutputFile_20.root", 
+                "nevents": 24819, 
+                "totEvents": 24819, 
+                "weights": 24813.05078125
+            }, 
+            {
+                "bad": false, 
+                "events": 24775, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-30GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201014_195954/0000/myMicroAODOutputFile_3.root", 
+                "nevents": 24775, 
+                "totEvents": 24775, 
+                "weights": 24768.12890625
+            }, 
+            {
+                "bad": false, 
+                "events": 24858, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-30GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201014_195954/0000/myMicroAODOutputFile_11.root", 
+                "nevents": 24858, 
+                "totEvents": 24858, 
+                "weights": 24852.220703125
+            }, 
+            {
+                "bad": false, 
+                "events": 24717, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-30GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201014_195954/0000/myMicroAODOutputFile_10.root", 
+                "nevents": 24717, 
+                "totEvents": 24717, 
+                "weights": 24711.607421875
+            }, 
+            {
+                "bad": false, 
+                "events": 24698, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-30GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201014_195954/0000/myMicroAODOutputFile_14.root", 
+                "nevents": 24698, 
+                "totEvents": 24698, 
+                "weights": 24692.181640625
+            }, 
+            {
+                "bad": false, 
+                "events": 24733, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-30GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201014_195954/0000/myMicroAODOutputFile_13.root", 
+                "nevents": 24733, 
+                "totEvents": 24733, 
+                "weights": 24726.990234375
+            }, 
+            {
+                "bad": false, 
+                "events": 24772, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-30GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201014_195954/0000/myMicroAODOutputFile_16.root", 
+                "nevents": 24772, 
+                "totEvents": 24772, 
+                "weights": 24766.73046875
+            }, 
+            {
+                "bad": false, 
+                "events": 24757, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-30GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201014_195954/0000/myMicroAODOutputFile_18.root", 
+                "nevents": 24757, 
+                "totEvents": 24757, 
+                "weights": 24751.310546875
+            }, 
+            {
+                "bad": false, 
+                "events": 24764, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-30GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201014_195954/0000/myMicroAODOutputFile_15.root", 
+                "nevents": 24764, 
+                "totEvents": 24764, 
+                "weights": 24758.08984375
+            }
+        ], 
+        "parent_n_units": 495988, 
+        "vetted": true
+    }, 
+    "/HAHMHToAA_AToGG_MA-35GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/lata-Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2-c8742baf38d1e270734b273d38e0b81b/USER": {
+        "dset_type": "mc", 
+        "files": [
+            {
+                "bad": true, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-35GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201014_200408/0000/myMicroAODOutputFile_5.root", 
+                "nevents": 24895
+            }, 
+            {
+                "bad": false, 
+                "events": 24878, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-35GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201026_180322/0000/myMicroAODOutputFile_20.root", 
+                "nevents": 24878, 
+                "totEvents": 24878, 
+                "weights": 24872.080078125
+            }, 
+            {
+                "bad": false, 
+                "events": 24028, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-35GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201026_180322/0000/myMicroAODOutputFile_14.root", 
+                "nevents": 24028, 
+                "totEvents": 24028, 
+                "weights": 24021.19140625
+            }, 
+            {
+                "bad": false, 
+                "events": 24853, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-35GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201026_180322/0000/myMicroAODOutputFile_18.root", 
+                "nevents": 24853, 
+                "totEvents": 24853, 
+                "weights": 24845.564453125
+            }, 
+            {
+                "bad": false, 
+                "events": 24777, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-35GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201026_180322/0000/myMicroAODOutputFile_3.root", 
+                "nevents": 24777, 
+                "totEvents": 24777, 
+                "weights": 24771.37890625
+            }, 
+            {
+                "bad": false, 
+                "events": 24805, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-35GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201026_180322/0000/myMicroAODOutputFile_15.root", 
+                "nevents": 24805, 
+                "totEvents": 24805, 
+                "weights": 24798.958984375
+            }, 
+            {
+                "bad": false, 
+                "events": 24668, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-35GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201026_180322/0000/myMicroAODOutputFile_2.root", 
+                "nevents": 24668, 
+                "totEvents": 24668, 
+                "weights": 24661.78125
+            }, 
+            {
+                "bad": false, 
+                "events": 24759, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-35GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201026_180322/0000/myMicroAODOutputFile_19.root", 
+                "nevents": 24759, 
+                "totEvents": 24759, 
+                "weights": 24753.36328125
+            }, 
+            {
+                "bad": false, 
+                "events": 24761, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-35GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201026_180322/0000/myMicroAODOutputFile_1.root", 
+                "nevents": 24761, 
+                "totEvents": 24761, 
+                "weights": 24755.44921875
+            }, 
+            {
+                "bad": false, 
+                "events": 24895, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-35GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201026_180322/0000/myMicroAODOutputFile_5.root", 
+                "nevents": 24895, 
+                "totEvents": 24895, 
+                "weights": 24888.373046875
+            }, 
+            {
+                "bad": false, 
+                "events": 24820, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-35GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201026_180322/0000/myMicroAODOutputFile_7.root", 
+                "nevents": 24820, 
+                "totEvents": 24820, 
+                "weights": 24814.20703125
+            }, 
+            {
+                "bad": false, 
+                "events": 24654, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-35GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201026_180322/0000/myMicroAODOutputFile_17.root", 
+                "nevents": 24654, 
+                "totEvents": 24654, 
+                "weights": 24648.13671875
+            }, 
+            {
+                "bad": false, 
+                "events": 24845, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-35GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201026_180322/0000/myMicroAODOutputFile_11.root", 
+                "nevents": 24845, 
+                "totEvents": 24845, 
+                "weights": 24838.6875
+            }, 
+            {
+                "bad": false, 
+                "events": 24697, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-35GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201026_180322/0000/myMicroAODOutputFile_6.root", 
+                "nevents": 24697, 
+                "totEvents": 24697, 
+                "weights": 24691.419921875
+            }, 
+            {
+                "bad": false, 
+                "events": 24943, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-35GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201026_180322/0000/myMicroAODOutputFile_4.root", 
+                "nevents": 24943, 
+                "totEvents": 24943, 
+                "weights": 24936.28515625
+            }, 
+            {
+                "bad": false, 
+                "events": 24589, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-35GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201026_180322/0000/myMicroAODOutputFile_10.root", 
+                "nevents": 24589, 
+                "totEvents": 24589, 
+                "weights": 24582.2109375
+            }, 
+            {
+                "bad": false, 
+                "events": 24669, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-35GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201026_180322/0000/myMicroAODOutputFile_16.root", 
+                "nevents": 24669, 
+                "totEvents": 24669, 
+                "weights": 24662.771484375
+            }, 
+            {
+                "bad": false, 
+                "events": 24752, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-35GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201026_180322/0000/myMicroAODOutputFile_13.root", 
+                "nevents": 24752, 
+                "totEvents": 24752, 
+                "weights": 24745.890625
+            }, 
+            {
+                "bad": false, 
+                "events": 975, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-35GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201026_180322/0000/myMicroAODOutputFile_21.root", 
+                "nevents": 975, 
+                "totEvents": 975, 
+                "weights": 974.75
+            }, 
+            {
+                "bad": false, 
+                "events": 24735, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-35GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201026_180322/0000/myMicroAODOutputFile_8.root", 
+                "nevents": 24735, 
+                "totEvents": 24735, 
+                "weights": 24728.16015625
+            }, 
+            {
+                "bad": false, 
+                "events": 24841, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-35GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201026_180322/0000/myMicroAODOutputFile_9.root", 
+                "nevents": 24841, 
+                "totEvents": 24841, 
+                "weights": 24834.66015625
+            }, 
+            {
+                "bad": false, 
+                "events": 24711, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-35GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201026_180322/0000/myMicroAODOutputFile_12.root", 
+                "nevents": 24711, 
+                "totEvents": 24711, 
+                "weights": 24705.099609375
+            }
+        ], 
+        "parent_n_units": 495655, 
+        "vetted": true
+    }, 
+    "/HAHMHToAA_AToGG_MA-40GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/lata-Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2-c8742baf38d1e270734b273d38e0b81b/USER": {
+        "dset_type": "mc", 
+        "files": [
+            {
+                "bad": false, 
+                "events": 24750, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-40GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201014_200811/0000/myMicroAODOutputFile_2.root", 
+                "nevents": 24750, 
+                "totEvents": 24750, 
+                "weights": 24743.921875
+            }, 
+            {
+                "bad": false, 
+                "events": 24678, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-40GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201014_200811/0000/myMicroAODOutputFile_13.root", 
+                "nevents": 24678, 
+                "totEvents": 24678, 
+                "weights": 24672.169921875
+            }, 
+            {
+                "bad": false, 
+                "events": 24702, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-40GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201014_200811/0000/myMicroAODOutputFile_17.root", 
+                "nevents": 24702, 
+                "totEvents": 24702, 
+                "weights": 24696.287109375
+            }, 
+            {
+                "bad": false, 
+                "events": 24748, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-40GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201014_200811/0000/myMicroAODOutputFile_6.root", 
+                "nevents": 24748, 
+                "totEvents": 24748, 
+                "weights": 24742.142578125
+            }, 
+            {
+                "bad": false, 
+                "events": 24652, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-40GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201014_200811/0000/myMicroAODOutputFile_19.root", 
+                "nevents": 24652, 
+                "totEvents": 24652, 
+                "weights": 24646.3125
+            }, 
+            {
+                "bad": false, 
+                "events": 24798, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-40GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201014_200811/0000/myMicroAODOutputFile_1.root", 
+                "nevents": 24798, 
+                "totEvents": 24798, 
+                "weights": 24792.259765625
+            }, 
+            {
+                "bad": false, 
+                "events": 24608, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-40GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201014_200811/0000/myMicroAODOutputFile_12.root", 
+                "nevents": 24608, 
+                "totEvents": 24608, 
+                "weights": 24602.759765625
+            }, 
+            {
+                "bad": false, 
+                "events": 24864, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-40GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201014_200811/0000/myMicroAODOutputFile_10.root", 
+                "nevents": 24864, 
+                "totEvents": 24864, 
+                "weights": 24856.87109375
+            }, 
+            {
+                "bad": false, 
+                "events": 24791, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-40GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201014_200811/0000/myMicroAODOutputFile_11.root", 
+                "nevents": 24791, 
+                "totEvents": 24791, 
+                "weights": 24784.75
+            }, 
+            {
+                "bad": false, 
+                "events": 24620, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-40GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201014_200811/0000/myMicroAODOutputFile_8.root", 
+                "nevents": 24620, 
+                "totEvents": 24620, 
+                "weights": 24614.26171875
+            }, 
+            {
+                "bad": false, 
+                "events": 24885, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-40GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201014_200811/0000/myMicroAODOutputFile_7.root", 
+                "nevents": 24885, 
+                "totEvents": 24885, 
+                "weights": 24879.2734375
+            }, 
+            {
+                "bad": false, 
+                "events": 24782, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-40GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201014_200811/0000/myMicroAODOutputFile_18.root", 
+                "nevents": 24782, 
+                "totEvents": 24782, 
+                "weights": 24776.5
+            }, 
+            {
+                "bad": false, 
+                "events": 24854, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-40GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201014_200811/0000/myMicroAODOutputFile_14.root", 
+                "nevents": 24854, 
+                "totEvents": 24854, 
+                "weights": 24848.232421875
+            }, 
+            {
+                "bad": false, 
+                "events": 24672, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-40GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201014_200811/0000/myMicroAODOutputFile_4.root", 
+                "nevents": 24672, 
+                "totEvents": 24672, 
+                "weights": 24666.279296875
+            }, 
+            {
+                "bad": false, 
+                "events": 24729, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-40GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201014_200811/0000/myMicroAODOutputFile_15.root", 
+                "nevents": 24729, 
+                "totEvents": 24729, 
+                "weights": 24722.140625
+            }, 
+            {
+                "bad": false, 
+                "events": 24837, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-40GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201014_200811/0000/myMicroAODOutputFile_5.root", 
+                "nevents": 24837, 
+                "totEvents": 24837, 
+                "weights": 24831.048828125
+            }, 
+            {
+                "bad": false, 
+                "events": 24678, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-40GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201014_200811/0000/myMicroAODOutputFile_3.root", 
+                "nevents": 24678, 
+                "totEvents": 24678, 
+                "weights": 24672.361328125
+            }, 
+            {
+                "bad": false, 
+                "events": 24706, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-40GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201014_200811/0000/myMicroAODOutputFile_9.root", 
+                "nevents": 24706, 
+                "totEvents": 24706, 
+                "weights": 24700.0078125
+            }, 
+            {
+                "bad": false, 
+                "events": 24655, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-40GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201014_200811/0000/myMicroAODOutputFile_16.root", 
+                "nevents": 24655, 
+                "totEvents": 24655, 
+                "weights": 24649.23046875
+            }, 
+            {
+                "bad": false, 
+                "events": 24874, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-40GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201014_200811/0000/myMicroAODOutputFile_20.root", 
+                "nevents": 24874, 
+                "totEvents": 24874, 
+                "weights": 24868.48046875
+            }
+        ], 
+        "parent_n_units": 494883, 
+        "vetted": true
+    }, 
+    "/HAHMHToAA_AToGG_MA-45GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/lata-Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2-c8742baf38d1e270734b273d38e0b81b/USER": {
+        "dset_type": "mc", 
+        "files": [
+            {
+                "bad": false, 
+                "events": 24629, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-45GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201014_201137/0000/myMicroAODOutputFile_19.root", 
+                "nevents": 24629, 
+                "totEvents": 24629, 
+                "weights": 24623.171875
+            }, 
+            {
+                "bad": false, 
+                "events": 24711, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-45GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201014_201137/0000/myMicroAODOutputFile_5.root", 
+                "nevents": 24711, 
+                "totEvents": 24711, 
+                "weights": 24705.240234375
+            }, 
+            {
+                "bad": false, 
+                "events": 24696, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-45GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201014_201137/0000/myMicroAODOutputFile_11.root", 
+                "nevents": 24696, 
+                "totEvents": 24696, 
+                "weights": 24690.150390625
+            }, 
+            {
+                "bad": false, 
+                "events": 24887, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-45GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201014_201137/0000/myMicroAODOutputFile_1.root", 
+                "nevents": 24887, 
+                "totEvents": 24887, 
+                "weights": 24881.208984375
+            }, 
+            {
+                "bad": false, 
+                "events": 24777, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-45GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201014_201137/0000/myMicroAODOutputFile_7.root", 
+                "nevents": 24777, 
+                "totEvents": 24777, 
+                "weights": 24770.931640625
+            }, 
+            {
+                "bad": false, 
+                "events": 24701, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-45GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201014_201137/0000/myMicroAODOutputFile_10.root", 
+                "nevents": 24701, 
+                "totEvents": 24701, 
+                "weights": 24695.05859375
+            }, 
+            {
+                "bad": false, 
+                "events": 24714, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-45GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201014_201137/0000/myMicroAODOutputFile_3.root", 
+                "nevents": 24714, 
+                "totEvents": 24714, 
+                "weights": 24708.140625
+            }, 
+            {
+                "bad": false, 
+                "events": 24839, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-45GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201014_201137/0000/myMicroAODOutputFile_4.root", 
+                "nevents": 24839, 
+                "totEvents": 24839, 
+                "weights": 24833.2421875
+            }, 
+            {
+                "bad": false, 
+                "events": 24588, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-45GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201014_201137/0000/myMicroAODOutputFile_2.root", 
+                "nevents": 24588, 
+                "totEvents": 24588, 
+                "weights": 24582.203125
+            }, 
+            {
+                "bad": false, 
+                "events": 24607, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-45GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201014_201137/0000/myMicroAODOutputFile_13.root", 
+                "nevents": 24607, 
+                "totEvents": 24607, 
+                "weights": 24600.373046875
+            }, 
+            {
+                "bad": false, 
+                "events": 24640, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-45GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201014_201137/0000/myMicroAODOutputFile_15.root", 
+                "nevents": 24640, 
+                "totEvents": 24640, 
+                "weights": 24633.16796875
+            }, 
+            {
+                "bad": false, 
+                "events": 24618, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-45GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201014_201137/0000/myMicroAODOutputFile_17.root", 
+                "nevents": 24618, 
+                "totEvents": 24618, 
+                "weights": 24612.072265625
+            }, 
+            {
+                "bad": false, 
+                "events": 24883, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-45GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201014_201137/0000/myMicroAODOutputFile_20.root", 
+                "nevents": 24883, 
+                "totEvents": 24883, 
+                "weights": 24876.662109375
+            }, 
+            {
+                "bad": false, 
+                "events": 24707, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-45GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201014_201137/0000/myMicroAODOutputFile_18.root", 
+                "nevents": 24707, 
+                "totEvents": 24707, 
+                "weights": 24700.8203125
+            }, 
+            {
+                "bad": false, 
+                "events": 24842, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-45GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201014_201137/0000/myMicroAODOutputFile_14.root", 
+                "nevents": 24842, 
+                "totEvents": 24842, 
+                "weights": 24836.203125
+            }, 
+            {
+                "bad": false, 
+                "events": 24703, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-45GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201014_201137/0000/myMicroAODOutputFile_12.root", 
+                "nevents": 24703, 
+                "totEvents": 24703, 
+                "weights": 24697.41796875
+            }, 
+            {
+                "bad": false, 
+                "events": 24736, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-45GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201014_201137/0000/myMicroAODOutputFile_8.root", 
+                "nevents": 24736, 
+                "totEvents": 24736, 
+                "weights": 24730.041015625
+            }, 
+            {
+                "bad": false, 
+                "events": 24827, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-45GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201014_201137/0000/myMicroAODOutputFile_16.root", 
+                "nevents": 24827, 
+                "totEvents": 24827, 
+                "weights": 24821.2109375
+            }, 
+            {
+                "bad": false, 
+                "events": 24859, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-45GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201014_201137/0000/myMicroAODOutputFile_6.root", 
+                "nevents": 24859, 
+                "totEvents": 24859, 
+                "weights": 24852.66796875
+            }, 
+            {
+                "bad": false, 
+                "events": 24668, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-45GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201014_201137/0000/myMicroAODOutputFile_9.root", 
+                "nevents": 24668, 
+                "totEvents": 24668, 
+                "weights": 24661.3515625
+            }
+        ], 
+        "parent_n_units": 494632, 
+        "vetted": true
+    }, 
+    "/HAHMHToAA_AToGG_MA-50GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/lata-Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2-c8742baf38d1e270734b273d38e0b81b/USER": {
+        "dset_type": "mc", 
+        "files": [
+            {
+                "bad": false, 
+                "events": 24841, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-50GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201014_201510/0000/myMicroAODOutputFile_17.root", 
+                "nevents": 24841, 
+                "totEvents": 24841, 
+                "weights": 24835.12109375
+            }, 
+            {
+                "bad": false, 
+                "events": 24747, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-50GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201014_201510/0000/myMicroAODOutputFile_15.root", 
+                "nevents": 24747, 
+                "totEvents": 24747, 
+                "weights": 24741.212890625
+            }, 
+            {
+                "bad": false, 
+                "events": 24627, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-50GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201014_201510/0000/myMicroAODOutputFile_10.root", 
+                "nevents": 24627, 
+                "totEvents": 24627, 
+                "weights": 24621.017578125
+            }, 
+            {
+                "bad": false, 
+                "events": 24589, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-50GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201014_201510/0000/myMicroAODOutputFile_19.root", 
+                "nevents": 24589, 
+                "totEvents": 24589, 
+                "weights": 24582.962890625
+            }, 
+            {
+                "bad": false, 
+                "events": 24669, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-50GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201014_201510/0000/myMicroAODOutputFile_9.root", 
+                "nevents": 24669, 
+                "totEvents": 24669, 
+                "weights": 24663.248046875
+            }, 
+            {
+                "bad": false, 
+                "events": 24767, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-50GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201014_201510/0000/myMicroAODOutputFile_12.root", 
+                "nevents": 24767, 
+                "totEvents": 24767, 
+                "weights": 24760.458984375
+            }, 
+            {
+                "bad": false, 
+                "events": 24959, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-50GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201014_201510/0000/myMicroAODOutputFile_20.root", 
+                "nevents": 24959, 
+                "totEvents": 24959, 
+                "weights": 24953.13671875
+            }, 
+            {
+                "bad": false, 
+                "events": 24782, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-50GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201014_201510/0000/myMicroAODOutputFile_8.root", 
+                "nevents": 24782, 
+                "totEvents": 24782, 
+                "weights": 24775.841796875
+            }, 
+            {
+                "bad": false, 
+                "events": 24903, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-50GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201014_201510/0000/myMicroAODOutputFile_5.root", 
+                "nevents": 24903, 
+                "totEvents": 24903, 
+                "weights": 24896.3984375
+            }, 
+            {
+                "bad": false, 
+                "events": 24829, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-50GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201014_201510/0000/myMicroAODOutputFile_13.root", 
+                "nevents": 24829, 
+                "totEvents": 24829, 
+                "weights": 24822.51953125
+            }, 
+            {
+                "bad": false, 
+                "events": 24756, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-50GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201014_201510/0000/myMicroAODOutputFile_7.root", 
+                "nevents": 24756, 
+                "totEvents": 24756, 
+                "weights": 24749.861328125
+            }, 
+            {
+                "bad": false, 
+                "events": 24838, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-50GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201014_201510/0000/myMicroAODOutputFile_14.root", 
+                "nevents": 24838, 
+                "totEvents": 24838, 
+                "weights": 24832.517578125
+            }, 
+            {
+                "bad": false, 
+                "events": 24775, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-50GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201014_201510/0000/myMicroAODOutputFile_3.root", 
+                "nevents": 24775, 
+                "totEvents": 24775, 
+                "weights": 24768.87109375
+            }, 
+            {
+                "bad": false, 
+                "events": 24619, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-50GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201014_201510/0000/myMicroAODOutputFile_16.root", 
+                "nevents": 24619, 
+                "totEvents": 24619, 
+                "weights": 24612.892578125
+            }, 
+            {
+                "bad": false, 
+                "events": 24849, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-50GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201014_201510/0000/myMicroAODOutputFile_1.root", 
+                "nevents": 24849, 
+                "totEvents": 24849, 
+                "weights": 24842.669921875
+            }, 
+            {
+                "bad": false, 
+                "events": 24765, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-50GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201014_201510/0000/myMicroAODOutputFile_6.root", 
+                "nevents": 24765, 
+                "totEvents": 24765, 
+                "weights": 24758.943359375
+            }, 
+            {
+                "bad": false, 
+                "events": 24643, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-50GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201014_201510/0000/myMicroAODOutputFile_2.root", 
+                "nevents": 24643, 
+                "totEvents": 24643, 
+                "weights": 24635.541015625
+            }, 
+            {
+                "bad": false, 
+                "events": 24783, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-50GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201014_201510/0000/myMicroAODOutputFile_11.root", 
+                "nevents": 24783, 
+                "totEvents": 24783, 
+                "weights": 24777.1015625
+            }, 
+            {
+                "bad": false, 
+                "events": 24837, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-50GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201014_201510/0000/myMicroAODOutputFile_18.root", 
+                "nevents": 24837, 
+                "totEvents": 24837, 
+                "weights": 24831.240234375
+            }, 
+            {
+                "bad": false, 
+                "events": 24750, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-50GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201014_201510/0000/myMicroAODOutputFile_4.root", 
+                "nevents": 24750, 
+                "totEvents": 24750, 
+                "weights": 24743.416015625
+            }
+        ], 
+        "parent_n_units": 495328, 
+        "vetted": true
+    }, 
+    "/HAHMHToAA_AToGG_MA-55GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/lata-Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2-c8742baf38d1e270734b273d38e0b81b/USER": {
+        "dset_type": "mc", 
+        "files": [
+            {
+                "bad": false, 
+                "events": 24820, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-55GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201022_183911/0000/myMicroAODOutputFile_14.root", 
+                "nevents": 24820, 
+                "totEvents": 24820, 
+                "weights": 24813.791015625
+            }, 
+            {
+                "bad": false, 
+                "events": 24888, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-55GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201022_183911/0000/myMicroAODOutputFile_9.root", 
+                "nevents": 24888, 
+                "totEvents": 24888, 
+                "weights": 24881.708984375
+            }, 
+            {
+                "bad": false, 
+                "events": 24732, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-55GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201022_183911/0000/myMicroAODOutputFile_4.root", 
+                "nevents": 24732, 
+                "totEvents": 24732, 
+                "weights": 24726.359375
+            }, 
+            {
+                "bad": false, 
+                "events": 24718, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-55GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201022_183911/0000/myMicroAODOutputFile_1.root", 
+                "nevents": 24718, 
+                "totEvents": 24718, 
+                "weights": 24711.970703125
+            }, 
+            {
+                "bad": false, 
+                "events": 24852, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-55GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201022_183911/0000/myMicroAODOutputFile_17.root", 
+                "nevents": 24852, 
+                "totEvents": 24852, 
+                "weights": 24846.322265625
+            }, 
+            {
+                "bad": false, 
+                "events": 24692, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-55GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201022_183911/0000/myMicroAODOutputFile_2.root", 
+                "nevents": 24692, 
+                "totEvents": 24692, 
+                "weights": 24686.232421875
+            }, 
+            {
+                "bad": false, 
+                "events": 24855, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-55GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201022_183911/0000/myMicroAODOutputFile_5.root", 
+                "nevents": 24855, 
+                "totEvents": 24855, 
+                "weights": 24849.08984375
+            }, 
+            {
+                "bad": false, 
+                "events": 24667, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-55GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201022_183911/0000/myMicroAODOutputFile_12.root", 
+                "nevents": 24667, 
+                "totEvents": 24667, 
+                "weights": 24661.169921875
+            }, 
+            {
+                "bad": false, 
+                "events": 24588, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-55GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201022_183911/0000/myMicroAODOutputFile_7.root", 
+                "nevents": 24588, 
+                "totEvents": 24588, 
+                "weights": 24582.34765625
+            }, 
+            {
+                "bad": false, 
+                "events": 24813, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-55GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201022_183911/0000/myMicroAODOutputFile_8.root", 
+                "nevents": 24813, 
+                "totEvents": 24813, 
+                "weights": 24807.17578125
+            }, 
+            {
+                "bad": false, 
+                "events": 24702, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-55GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201022_183911/0000/myMicroAODOutputFile_19.root", 
+                "nevents": 24702, 
+                "totEvents": 24702, 
+                "weights": 24694.021484375
+            }, 
+            {
+                "bad": false, 
+                "events": 24917, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-55GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201022_183911/0000/myMicroAODOutputFile_20.root", 
+                "nevents": 24917, 
+                "totEvents": 24917, 
+                "weights": 24911.267578125
+            }, 
+            {
+                "bad": false, 
+                "events": 24708, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-55GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201022_183911/0000/myMicroAODOutputFile_3.root", 
+                "nevents": 24708, 
+                "totEvents": 24708, 
+                "weights": 24702.021484375
+            }, 
+            {
+                "bad": false, 
+                "events": 24483, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-55GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201022_183911/0000/myMicroAODOutputFile_13.root", 
+                "nevents": 24483, 
+                "totEvents": 24483, 
+                "weights": 24476.83203125
+            }, 
+            {
+                "bad": false, 
+                "events": 24609, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-55GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201022_183911/0000/myMicroAODOutputFile_6.root", 
+                "nevents": 24609, 
+                "totEvents": 24609, 
+                "weights": 24603.19140625
+            }, 
+            {
+                "bad": false, 
+                "events": 24782, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-55GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201022_183911/0000/myMicroAODOutputFile_18.root", 
+                "nevents": 24782, 
+                "totEvents": 24782, 
+                "weights": 24775.970703125
+            }, 
+            {
+                "bad": false, 
+                "events": 24582, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-55GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201022_183911/0000/myMicroAODOutputFile_15.root", 
+                "nevents": 24582, 
+                "totEvents": 24582, 
+                "weights": 24576.033203125
+            }, 
+            {
+                "bad": false, 
+                "events": 24872, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-55GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201022_183911/0000/myMicroAODOutputFile_10.root", 
+                "nevents": 24872, 
+                "totEvents": 24872, 
+                "weights": 24865.76953125
+            }, 
+            {
+                "bad": false, 
+                "events": 24634, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-55GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201022_183911/0000/myMicroAODOutputFile_11.root", 
+                "nevents": 24634, 
+                "totEvents": 24634, 
+                "weights": 24627.302734375
+            }, 
+            {
+                "bad": false, 
+                "events": 24678, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-55GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201022_183911/0000/myMicroAODOutputFile_16.root", 
+                "nevents": 24678, 
+                "totEvents": 24678, 
+                "weights": 24672.208984375
+            }
+        ], 
+        "parent_n_units": 494592, 
+        "vetted": true
+    }, 
+    "/HAHMHToAA_AToGG_MA-60GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/lata-Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2-c8742baf38d1e270734b273d38e0b81b/USER": {
+        "dset_type": "mc", 
+        "files": [
+            {
+                "bad": false, 
+                "events": 24846, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-60GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201014_202142/0000/myMicroAODOutputFile_17.root", 
+                "nevents": 24846, 
+                "totEvents": 24846, 
+                "weights": 24839.91015625
+            }, 
+            {
+                "bad": false, 
+                "events": 24811, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-60GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201014_202142/0000/myMicroAODOutputFile_4.root", 
+                "nevents": 24811, 
+                "totEvents": 24811, 
+                "weights": 24805.54296875
+            }, 
+            {
+                "bad": false, 
+                "events": 24846, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-60GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201014_202142/0000/myMicroAODOutputFile_16.root", 
+                "nevents": 24846, 
+                "totEvents": 24846, 
+                "weights": 24840.06640625
+            }, 
+            {
+                "bad": false, 
+                "events": 24828, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-60GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201014_202142/0000/myMicroAODOutputFile_18.root", 
+                "nevents": 24828, 
+                "totEvents": 24828, 
+                "weights": 24822.318359375
+            }, 
+            {
+                "bad": false, 
+                "events": 24923, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-60GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201014_202142/0000/myMicroAODOutputFile_13.root", 
+                "nevents": 24923, 
+                "totEvents": 24923, 
+                "weights": 24917.2890625
+            }, 
+            {
+                "bad": false, 
+                "events": 24717, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-60GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201014_202142/0000/myMicroAODOutputFile_15.root", 
+                "nevents": 24717, 
+                "totEvents": 24717, 
+                "weights": 24711.2890625
+            }, 
+            {
+                "bad": false, 
+                "events": 24735, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-60GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201014_202142/0000/myMicroAODOutputFile_12.root", 
+                "nevents": 24735, 
+                "totEvents": 24735, 
+                "weights": 24728.11328125
+            }, 
+            {
+                "bad": false, 
+                "events": 24674, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-60GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201014_202142/0000/myMicroAODOutputFile_19.root", 
+                "nevents": 24674, 
+                "totEvents": 24674, 
+                "weights": 24668.310546875
+            }, 
+            {
+                "bad": false, 
+                "events": 24725, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-60GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201014_202142/0000/myMicroAODOutputFile_8.root", 
+                "nevents": 24725, 
+                "totEvents": 24725, 
+                "weights": 24719.041015625
+            }, 
+            {
+                "bad": false, 
+                "events": 24800, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-60GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201014_202142/0000/myMicroAODOutputFile_11.root", 
+                "nevents": 24800, 
+                "totEvents": 24800, 
+                "weights": 24794.1328125
+            }, 
+            {
+                "bad": false, 
+                "events": 24644, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-60GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201014_202142/0000/myMicroAODOutputFile_1.root", 
+                "nevents": 24644, 
+                "totEvents": 24644, 
+                "weights": 24637.93359375
+            }, 
+            {
+                "bad": false, 
+                "events": 24898, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-60GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201014_202142/0000/myMicroAODOutputFile_14.root", 
+                "nevents": 24898, 
+                "totEvents": 24898, 
+                "weights": 24892.138671875
+            }, 
+            {
+                "bad": false, 
+                "events": 9040, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-60GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201014_202142/0000/myMicroAODOutputFile_20.root", 
+                "nevents": 9040, 
+                "totEvents": 9040, 
+                "weights": 9037.7705078125
+            }, 
+            {
+                "bad": false, 
+                "events": 15825, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-60GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201014_202142/0000/myMicroAODOutputFile_21.root", 
+                "nevents": 15825, 
+                "totEvents": 15825, 
+                "weights": 15821.1708984375
+            }, 
+            {
+                "bad": false, 
+                "events": 24719, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-60GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201014_202142/0000/myMicroAODOutputFile_7.root", 
+                "nevents": 24719, 
+                "totEvents": 24719, 
+                "weights": 24713.31640625
+            }, 
+            {
+                "bad": false, 
+                "events": 24751, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-60GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201014_202142/0000/myMicroAODOutputFile_9.root", 
+                "nevents": 24751, 
+                "totEvents": 24751, 
+                "weights": 24745.828125
+            }, 
+            {
+                "bad": false, 
+                "events": 24862, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-60GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201014_202142/0000/myMicroAODOutputFile_10.root", 
+                "nevents": 24862, 
+                "totEvents": 24862, 
+                "weights": 24856.28125
+            }, 
+            {
+                "bad": false, 
+                "events": 24656, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-60GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201014_202142/0000/myMicroAODOutputFile_2.root", 
+                "nevents": 24656, 
+                "totEvents": 24656, 
+                "weights": 24650.169921875
+            }, 
+            {
+                "bad": false, 
+                "events": 24823, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-60GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201014_202142/0000/myMicroAODOutputFile_3.root", 
+                "nevents": 24823, 
+                "totEvents": 24823, 
+                "weights": 24817.109375
+            }, 
+            {
+                "bad": false, 
+                "events": 24832, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-60GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201014_202142/0000/myMicroAODOutputFile_6.root", 
+                "nevents": 24832, 
+                "totEvents": 24832, 
+                "weights": 24826.359375
+            }, 
+            {
+                "bad": false, 
+                "events": 24759, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/HAHMHToAA_AToGG_MA-60GeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201014_202142/0000/myMicroAODOutputFile_5.root", 
+                "nevents": 24759, 
+                "totEvents": 24759, 
+                "weights": 24752.8515625
+            }
+        ], 
+        "parent_n_units": 495714, 
+        "vetted": true
+    }, 
+    "/TprimeBToTH_Hgg_M-1000_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/lata-Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2-c8742baf38d1e270734b273d38e0b81b/USER": {
+        "dset_type": "mc", 
+        "files": [
+            {
+                "bad": false, 
+                "events": 14000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-1000_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_185500/0000/myMicroAODOutputFile_6.root", 
+                "nevents": 14000, 
+                "totEvents": 14000, 
+                "weights": 13989.5654296875
+            }, 
+            {
+                "bad": false, 
+                "events": 20000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-1000_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_185500/0000/myMicroAODOutputFile_19.root", 
+                "nevents": 20000, 
+                "totEvents": 20000, 
+                "weights": 19982.4609375
+            }, 
+            {
+                "bad": false, 
+                "events": 20000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-1000_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_185500/0000/myMicroAODOutputFile_3.root", 
+                "nevents": 20000, 
+                "totEvents": 20000, 
+                "weights": 19981.044921875
+            }, 
+            {
+                "bad": false, 
+                "events": 12000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-1000_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_185500/0000/myMicroAODOutputFile_12.root", 
+                "nevents": 12000, 
+                "totEvents": 12000, 
+                "weights": 11992.3017578125
+            }, 
+            {
+                "bad": false, 
+                "events": 12000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-1000_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_185500/0000/myMicroAODOutputFile_11.root", 
+                "nevents": 12000, 
+                "totEvents": 12000, 
+                "weights": 11990.7841796875
+            }, 
+            {
+                "bad": false, 
+                "events": 4000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-1000_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_185500/0000/myMicroAODOutputFile_9.root", 
+                "nevents": 4000, 
+                "totEvents": 4000, 
+                "weights": 3996.49267578125
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-1000_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_185500/0000/myMicroAODOutputFile_14.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24980.947265625
+            }, 
+            {
+                "bad": false, 
+                "events": 24000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-1000_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_185500/0000/myMicroAODOutputFile_20.root", 
+                "nevents": 24000, 
+                "totEvents": 24000, 
+                "weights": 23983.51953125
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-1000_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_185500/0000/myMicroAODOutputFile_13.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24978.771484375
+            }, 
+            {
+                "bad": false, 
+                "events": 4000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-1000_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_185500/0000/myMicroAODOutputFile_8.root", 
+                "nevents": 4000, 
+                "totEvents": 4000, 
+                "weights": 3997.061279296875
+            }, 
+            {
+                "bad": false, 
+                "events": 24000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-1000_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_185500/0000/myMicroAODOutputFile_10.root", 
+                "nevents": 24000, 
+                "totEvents": 24000, 
+                "weights": 23977.06640625
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-1000_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_185500/0000/myMicroAODOutputFile_15.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24974.287109375
+            }, 
+            {
+                "bad": false, 
+                "events": 19000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-1000_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_185500/0000/myMicroAODOutputFile_18.root", 
+                "nevents": 19000, 
+                "totEvents": 19000, 
+                "weights": 18982.7890625
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-1000_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_185500/0000/myMicroAODOutputFile_16.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24977.626953125
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-1000_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_185500/0000/myMicroAODOutputFile_5.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24979.724609375
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-1000_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_185500/0000/myMicroAODOutputFile_4.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24979.509765625
+            }, 
+            {
+                "bad": false, 
+                "events": 12000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-1000_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_185500/0000/myMicroAODOutputFile_7.root", 
+                "nevents": 12000, 
+                "totEvents": 12000, 
+                "weights": 11989.30078125
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-1000_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_185500/0000/myMicroAODOutputFile_1.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24976.310546875
+            }, 
+            {
+                "bad": false, 
+                "events": 16000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-1000_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_185500/0000/myMicroAODOutputFile_21.root", 
+                "nevents": 16000, 
+                "totEvents": 16000, 
+                "weights": 15984.1484375
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-1000_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_185500/0000/myMicroAODOutputFile_17.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24978.96875
+            }, 
+            {
+                "bad": false, 
+                "events": 19000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-1000_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_185500/0000/myMicroAODOutputFile_2.root", 
+                "nevents": 19000, 
+                "totEvents": 19000, 
+                "weights": 18986.490234375
+            }
+        ], 
+        "parent_n_units": 400000, 
+        "vetted": true
+    }, 
+    "/TprimeBToTH_Hgg_M-1100_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/lata-Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2-c8742baf38d1e270734b273d38e0b81b/USER": {
+        "dset_type": "mc", 
+        "files": [
+            {
+                "bad": false, 
+                "events": 9000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-1100_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_185746/0000/myMicroAODOutputFile_7.root", 
+                "nevents": 9000, 
+                "totEvents": 9000, 
+                "weights": 8992.5419921875
+            }, 
+            {
+                "bad": false, 
+                "events": 7000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-1100_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_185746/0000/myMicroAODOutputFile_19.root", 
+                "nevents": 7000, 
+                "totEvents": 7000, 
+                "weights": 6994.30615234375
+            }, 
+            {
+                "bad": false, 
+                "events": 6000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-1100_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_185746/0000/myMicroAODOutputFile_11.root", 
+                "nevents": 6000, 
+                "totEvents": 6000, 
+                "weights": 5993.58251953125
+            }, 
+            {
+                "bad": false, 
+                "events": 8000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-1100_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_185746/0000/myMicroAODOutputFile_21.root", 
+                "nevents": 8000, 
+                "totEvents": 8000, 
+                "weights": 7993.724609375
+            }, 
+            {
+                "bad": false, 
+                "events": 13000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-1100_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_185746/0000/myMicroAODOutputFile_10.root", 
+                "nevents": 13000, 
+                "totEvents": 13000, 
+                "weights": 12987.19140625
+            }, 
+            {
+                "bad": false, 
+                "events": 8000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-1100_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_185746/0000/myMicroAODOutputFile_26.root", 
+                "nevents": 8000, 
+                "totEvents": 8000, 
+                "weights": 7992.611328125
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-1100_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_185746/0000/myMicroAODOutputFile_25.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24978.48046875
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-1100_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_185746/0000/myMicroAODOutputFile_22.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24974.099609375
+            }, 
+            {
+                "bad": false, 
+                "events": 15000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-1100_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_185746/0000/myMicroAODOutputFile_13.root", 
+                "nevents": 15000, 
+                "totEvents": 15000, 
+                "weights": 14987.68359375
+            }, 
+            {
+                "bad": false, 
+                "events": 24000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-1100_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_185746/0000/myMicroAODOutputFile_28.root", 
+                "nevents": 24000, 
+                "totEvents": 24000, 
+                "weights": 23981.205078125
+            }, 
+            {
+                "bad": false, 
+                "events": 3000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-1100_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_185746/0000/myMicroAODOutputFile_1.root", 
+                "nevents": 3000, 
+                "totEvents": 3000, 
+                "weights": 2997.59130859375
+            }, 
+            {
+                "bad": false, 
+                "events": 2000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-1100_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_185746/0000/myMicroAODOutputFile_6.root", 
+                "nevents": 2000, 
+                "totEvents": 2000, 
+                "weights": 1998.557373046875
+            }, 
+            {
+                "bad": false, 
+                "events": 6000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-1100_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_185746/0000/myMicroAODOutputFile_27.root", 
+                "nevents": 6000, 
+                "totEvents": 6000, 
+                "weights": 5994.35205078125
+            }, 
+            {
+                "bad": false, 
+                "events": 6000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-1100_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_185746/0000/myMicroAODOutputFile_3.root", 
+                "nevents": 6000, 
+                "totEvents": 6000, 
+                "weights": 5995.6416015625
+            }, 
+            {
+                "bad": false, 
+                "events": 6000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-1100_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_185746/0000/myMicroAODOutputFile_2.root", 
+                "nevents": 6000, 
+                "totEvents": 6000, 
+                "weights": 5994.70166015625
+            }, 
+            {
+                "bad": false, 
+                "events": 3000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-1100_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_185746/0000/myMicroAODOutputFile_12.root", 
+                "nevents": 3000, 
+                "totEvents": 3000, 
+                "weights": 2997.83056640625
+            }, 
+            {
+                "bad": false, 
+                "events": 3000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-1100_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_185746/0000/myMicroAODOutputFile_9.root", 
+                "nevents": 3000, 
+                "totEvents": 3000, 
+                "weights": 2996.871337890625
+            }, 
+            {
+                "bad": false, 
+                "events": 3000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-1100_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_185746/0000/myMicroAODOutputFile_8.root", 
+                "nevents": 3000, 
+                "totEvents": 3000, 
+                "weights": 2994.802734375
+            }, 
+            {
+                "bad": false, 
+                "events": 3000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-1100_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_185746/0000/myMicroAODOutputFile_4.root", 
+                "nevents": 3000, 
+                "totEvents": 3000, 
+                "weights": 2995.901123046875
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-1100_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_185746/0000/myMicroAODOutputFile_16.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24978.060546875
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-1100_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_185746/0000/myMicroAODOutputFile_14.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24973.98828125
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-1100_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_185746/0000/myMicroAODOutputFile_20.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24975.794921875
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-1100_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_185746/0000/myMicroAODOutputFile_15.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24976.681640625
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-1100_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_185746/0000/myMicroAODOutputFile_23.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24976.1875
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-1100_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_185746/0000/myMicroAODOutputFile_18.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24976.19921875
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-1100_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_185746/0000/myMicroAODOutputFile_5.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24978.92578125
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-1100_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_185746/0000/myMicroAODOutputFile_17.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24977.47265625
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-1100_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_185746/0000/myMicroAODOutputFile_24.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24978.720703125
+            }
+        ], 
+        "parent_n_units": 400000, 
+        "vetted": true
+    }, 
+    "/TprimeBToTH_Hgg_M-1200_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/lata-Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2-c8742baf38d1e270734b273d38e0b81b/USER": {
+        "dset_type": "mc", 
+        "files": [
+            {
+                "bad": false, 
+                "events": 9000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-1200_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_190047/0000/myMicroAODOutputFile_21.root", 
+                "nevents": 9000, 
+                "totEvents": 9000, 
+                "weights": 8993.197265625
+            }, 
+            {
+                "bad": false, 
+                "events": 3000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-1200_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_190047/0000/myMicroAODOutputFile_14.root", 
+                "nevents": 3000, 
+                "totEvents": 3000, 
+                "weights": 2997.651123046875
+            }, 
+            {
+                "bad": false, 
+                "events": 3000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-1200_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_190047/0000/myMicroAODOutputFile_13.root", 
+                "nevents": 3000, 
+                "totEvents": 3000, 
+                "weights": 2997.801025390625
+            }, 
+            {
+                "bad": false, 
+                "events": 8000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-1200_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_190047/0000/myMicroAODOutputFile_12.root", 
+                "nevents": 8000, 
+                "totEvents": 8000, 
+                "weights": 7992.2724609375
+            }, 
+            {
+                "bad": false, 
+                "events": 10000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-1200_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_190047/0000/myMicroAODOutputFile_20.root", 
+                "nevents": 10000, 
+                "totEvents": 10000, 
+                "weights": 9989.056640625
+            }, 
+            {
+                "bad": false, 
+                "events": 6000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-1200_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_190047/0000/myMicroAODOutputFile_22.root", 
+                "nevents": 6000, 
+                "totEvents": 6000, 
+                "weights": 5992.25634765625
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-1200_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_190047/0000/myMicroAODOutputFile_19.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24978.697265625
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-1200_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_190047/0000/myMicroAODOutputFile_8.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24977.17578125
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-1200_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_190047/0000/myMicroAODOutputFile_11.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24977.1640625
+            }, 
+            {
+                "bad": false, 
+                "events": 17000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-1200_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_190047/0000/myMicroAODOutputFile_6.root", 
+                "nevents": 17000, 
+                "totEvents": 17000, 
+                "weights": 16983.197265625
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-1200_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_190047/0000/myMicroAODOutputFile_17.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24978.880859375
+            }, 
+            {
+                "bad": false, 
+                "events": 3000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-1200_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_190047/0000/myMicroAODOutputFile_1.root", 
+                "nevents": 3000, 
+                "totEvents": 3000, 
+                "weights": 2996.970947265625
+            }, 
+            {
+                "bad": false, 
+                "events": 1000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-1200_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_190047/0000/myMicroAODOutputFile_23.root", 
+                "nevents": 1000, 
+                "totEvents": 1000, 
+                "weights": 999.2501220703125
+            }, 
+            {
+                "bad": false, 
+                "events": 15000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-1200_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_190047/0000/myMicroAODOutputFile_7.root", 
+                "nevents": 15000, 
+                "totEvents": 15000, 
+                "weights": 14985.544921875
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-1200_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_190047/0000/myMicroAODOutputFile_9.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24974.12890625
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-1200_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_190047/0000/myMicroAODOutputFile_3.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24975.138671875
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-1200_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_190047/0000/myMicroAODOutputFile_5.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24979.4140625
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-1200_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_190047/0000/myMicroAODOutputFile_2.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24976.55859375
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-1200_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_190047/0000/myMicroAODOutputFile_18.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24977.08984375
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-1200_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_190047/0000/myMicroAODOutputFile_15.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24978.240234375
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-1200_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_190047/0000/myMicroAODOutputFile_4.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24977.35546875
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-1200_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_190047/0000/myMicroAODOutputFile_16.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24975.859375
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-1200_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_190047/0000/myMicroAODOutputFile_10.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24978.23828125
+            }
+        ], 
+        "parent_n_units": 400000, 
+        "vetted": true
+    }, 
+    "/TprimeBToTH_Hgg_M-600_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/lata-Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2-c8742baf38d1e270734b273d38e0b81b/USER": {
+        "dset_type": "mc", 
+        "files": [
+            {
+                "bad": false, 
+                "events": 12000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-600_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_190333/0000/myMicroAODOutputFile_13.root", 
+                "nevents": 12000, 
+                "totEvents": 12000, 
+                "weights": 11992.119140625
+            }, 
+            {
+                "bad": false, 
+                "events": 11000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-600_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_190333/0000/myMicroAODOutputFile_7.root", 
+                "nevents": 11000, 
+                "totEvents": 11000, 
+                "weights": 10991.931640625
+            }, 
+            {
+                "bad": false, 
+                "events": 8000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-600_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_190333/0000/myMicroAODOutputFile_15.root", 
+                "nevents": 8000, 
+                "totEvents": 8000, 
+                "weights": 7993.1787109375
+            }, 
+            {
+                "bad": false, 
+                "events": 8000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-600_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_190333/0000/myMicroAODOutputFile_1.root", 
+                "nevents": 8000, 
+                "totEvents": 8000, 
+                "weights": 7995.6416015625
+            }, 
+            {
+                "bad": false, 
+                "events": 8000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-600_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_190333/0000/myMicroAODOutputFile_9.root", 
+                "nevents": 8000, 
+                "totEvents": 8000, 
+                "weights": 7993.94677734375
+            }, 
+            {
+                "bad": false, 
+                "events": 4000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-600_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_190333/0000/myMicroAODOutputFile_8.root", 
+                "nevents": 4000, 
+                "totEvents": 4000, 
+                "weights": 3997.40966796875
+            }, 
+            {
+                "bad": false, 
+                "events": 8000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-600_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_190333/0000/myMicroAODOutputFile_14.root", 
+                "nevents": 8000, 
+                "totEvents": 8000, 
+                "weights": 7994.33447265625
+            }, 
+            {
+                "bad": false, 
+                "events": 15000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-600_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_190333/0000/myMicroAODOutputFile_17.root", 
+                "nevents": 15000, 
+                "totEvents": 15000, 
+                "weights": 14990.8037109375
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-600_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_190333/0000/myMicroAODOutputFile_3.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24983.51171875
+            }, 
+            {
+                "bad": false, 
+                "events": 19000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-600_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_190333/0000/myMicroAODOutputFile_11.root", 
+                "nevents": 19000, 
+                "totEvents": 19000, 
+                "weights": 18988.216796875
+            }, 
+            {
+                "bad": false, 
+                "events": 4000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-600_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_190333/0000/myMicroAODOutputFile_12.root", 
+                "nevents": 4000, 
+                "totEvents": 4000, 
+                "weights": 3997.524658203125
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-600_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_190333/0000/myMicroAODOutputFile_16.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24982.169921875
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-600_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_190333/0000/myMicroAODOutputFile_6.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24985.6640625
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-600_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_190333/0000/myMicroAODOutputFile_5.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24979.25390625
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-600_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_190333/0000/myMicroAODOutputFile_10.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24983.80078125
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-600_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_190333/0000/myMicroAODOutputFile_4.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24983.6953125
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-600_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_190333/0000/myMicroAODOutputFile_2.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24980.171875
+            }
+        ], 
+        "parent_n_units": 272000, 
+        "vetted": true
+    }, 
+    "/TprimeBToTH_Hgg_M-625_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/lata-Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2-c8742baf38d1e270734b273d38e0b81b/USER": {
+        "dset_type": "mc", 
+        "files": [
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-625_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_190623/0000/myMicroAODOutputFile_5.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24982.904296875
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-625_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_190623/0000/myMicroAODOutputFile_18.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24983.125
+            }, 
+            {
+                "bad": false, 
+                "events": 4000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-625_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_190623/0000/myMicroAODOutputFile_2.root", 
+                "nevents": 4000, 
+                "totEvents": 4000, 
+                "weights": 3995.42236328125
+            }, 
+            {
+                "bad": false, 
+                "events": 3000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-625_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_190623/0000/myMicroAODOutputFile_23.root", 
+                "nevents": 3000, 
+                "totEvents": 3000, 
+                "weights": 2998.260498046875
+            }, 
+            {
+                "bad": false, 
+                "events": 4000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-625_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_190623/0000/myMicroAODOutputFile_7.root", 
+                "nevents": 4000, 
+                "totEvents": 4000, 
+                "weights": 3996.6064453125
+            }, 
+            {
+                "bad": false, 
+                "events": 4000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-625_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_190623/0000/myMicroAODOutputFile_9.root", 
+                "nevents": 4000, 
+                "totEvents": 4000, 
+                "weights": 3994.689208984375
+            }, 
+            {
+                "bad": false, 
+                "events": 9000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-625_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_190623/0000/myMicroAODOutputFile_13.root", 
+                "nevents": 9000, 
+                "totEvents": 9000, 
+                "weights": 8992.501953125
+            }, 
+            {
+                "bad": false, 
+                "events": 8000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-625_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_190623/0000/myMicroAODOutputFile_1.root", 
+                "nevents": 8000, 
+                "totEvents": 8000, 
+                "weights": 7993.5546875
+            }, 
+            {
+                "bad": false, 
+                "events": 12000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-625_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_190623/0000/myMicroAODOutputFile_24.root", 
+                "nevents": 12000, 
+                "totEvents": 12000, 
+                "weights": 11989.5751953125
+            }, 
+            {
+                "bad": false, 
+                "events": 4000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-625_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_190623/0000/myMicroAODOutputFile_3.root", 
+                "nevents": 4000, 
+                "totEvents": 4000, 
+                "weights": 3996.71044921875
+            }, 
+            {
+                "bad": false, 
+                "events": 4000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-625_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_190623/0000/myMicroAODOutputFile_8.root", 
+                "nevents": 4000, 
+                "totEvents": 4000, 
+                "weights": 3997.87060546875
+            }, 
+            {
+                "bad": false, 
+                "events": 11000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-625_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_190623/0000/myMicroAODOutputFile_6.root", 
+                "nevents": 11000, 
+                "totEvents": 11000, 
+                "weights": 10990.072265625
+            }, 
+            {
+                "bad": false, 
+                "events": 8000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-625_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_190623/0000/myMicroAODOutputFile_25.root", 
+                "nevents": 8000, 
+                "totEvents": 8000, 
+                "weights": 7993.9521484375
+            }, 
+            {
+                "bad": false, 
+                "events": 16000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-625_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_190623/0000/myMicroAODOutputFile_4.root", 
+                "nevents": 16000, 
+                "totEvents": 16000, 
+                "weights": 15989.0546875
+            }, 
+            {
+                "bad": false, 
+                "events": 13000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-625_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_190623/0000/myMicroAODOutputFile_21.root", 
+                "nevents": 13000, 
+                "totEvents": 13000, 
+                "weights": 12988.6884765625
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-625_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_190623/0000/myMicroAODOutputFile_16.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24983.33203125
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-625_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_190623/0000/myMicroAODOutputFile_22.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24979.541015625
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-625_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_190623/0000/myMicroAODOutputFile_19.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24984.22265625
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-625_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_190623/0000/myMicroAODOutputFile_11.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24983.35546875
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-625_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_190623/0000/myMicroAODOutputFile_15.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24984.576171875
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-625_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_190623/0000/myMicroAODOutputFile_14.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24983.16796875
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-625_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_190623/0000/myMicroAODOutputFile_17.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24982.8046875
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-625_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_190623/0000/myMicroAODOutputFile_20.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24981.955078125
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-625_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_190623/0000/myMicroAODOutputFile_12.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24980.7421875
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-625_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_190623/0000/myMicroAODOutputFile_10.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24984.45703125
+            }
+        ], 
+        "parent_n_units": 400000, 
+        "vetted": true
+    }, 
+    "/TprimeBToTH_Hgg_M-650_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/lata-Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2-c8742baf38d1e270734b273d38e0b81b/USER": {
+        "dset_type": "mc", 
+        "files": [
+            {
+                "bad": false, 
+                "events": 15000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-650_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_190928/0000/myMicroAODOutputFile_21.root", 
+                "nevents": 15000, 
+                "totEvents": 15000, 
+                "weights": 14990.07421875
+            }, 
+            {
+                "bad": false, 
+                "events": 12000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-650_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_190928/0000/myMicroAODOutputFile_16.root", 
+                "nevents": 12000, 
+                "totEvents": 12000, 
+                "weights": 11991.72265625
+            }, 
+            {
+                "bad": false, 
+                "events": 17000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-650_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_190928/0000/myMicroAODOutputFile_13.root", 
+                "nevents": 17000, 
+                "totEvents": 17000, 
+                "weights": 16988.9140625
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-650_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_190928/0000/myMicroAODOutputFile_12.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24981.150390625
+            }, 
+            {
+                "bad": false, 
+                "events": 14000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-650_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_190928/0000/myMicroAODOutputFile_9.root", 
+                "nevents": 14000, 
+                "totEvents": 14000, 
+                "weights": 13990.4228515625
+            }, 
+            {
+                "bad": false, 
+                "events": 3000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-650_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_190928/0000/myMicroAODOutputFile_3.root", 
+                "nevents": 3000, 
+                "totEvents": 3000, 
+                "weights": 2998.25048828125
+            }, 
+            {
+                "bad": false, 
+                "events": 3000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-650_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_190928/0000/myMicroAODOutputFile_22.root", 
+                "nevents": 3000, 
+                "totEvents": 3000, 
+                "weights": 2998.0908203125
+            }, 
+            {
+                "bad": false, 
+                "events": 10000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-650_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_190928/0000/myMicroAODOutputFile_20.root", 
+                "nevents": 10000, 
+                "totEvents": 10000, 
+                "weights": 9992.5634765625
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-650_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_190928/0000/myMicroAODOutputFile_4.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24982.296875
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-650_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_190928/0000/myMicroAODOutputFile_18.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24983.63671875
+            }, 
+            {
+                "bad": false, 
+                "events": 21000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-650_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_190928/0000/myMicroAODOutputFile_15.root", 
+                "nevents": 21000, 
+                "totEvents": 21000, 
+                "weights": 20984.529296875
+            }, 
+            {
+                "bad": false, 
+                "events": 15000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-650_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_190928/0000/myMicroAODOutputFile_14.root", 
+                "nevents": 15000, 
+                "totEvents": 15000, 
+                "weights": 14989.38671875
+            }, 
+            {
+                "bad": false, 
+                "events": 7000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-650_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_190928/0000/myMicroAODOutputFile_6.root", 
+                "nevents": 7000, 
+                "totEvents": 7000, 
+                "weights": 6995.69189453125
+            }, 
+            {
+                "bad": false, 
+                "events": 6000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-650_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_190928/0000/myMicroAODOutputFile_1.root", 
+                "nevents": 6000, 
+                "totEvents": 6000, 
+                "weights": 5995.39111328125
+            }, 
+            {
+                "bad": false, 
+                "events": 9000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-650_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_190928/0000/myMicroAODOutputFile_2.root", 
+                "nevents": 9000, 
+                "totEvents": 9000, 
+                "weights": 8991.5146484375
+            }, 
+            {
+                "bad": false, 
+                "events": 6000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-650_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_190928/0000/myMicroAODOutputFile_7.root", 
+                "nevents": 6000, 
+                "totEvents": 6000, 
+                "weights": 5995.5595703125
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-650_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_190928/0000/myMicroAODOutputFile_8.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24983.42578125
+            }, 
+            {
+                "bad": false, 
+                "events": 15000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-650_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_190928/0000/myMicroAODOutputFile_23.root", 
+                "nevents": 15000, 
+                "totEvents": 15000, 
+                "weights": 14988.5126953125
+            }, 
+            {
+                "bad": false, 
+                "events": 23000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-650_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_190928/0000/myMicroAODOutputFile_11.root", 
+                "nevents": 23000, 
+                "totEvents": 23000, 
+                "weights": 22982.296875
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-650_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_190928/0000/myMicroAODOutputFile_10.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24981.16015625
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-650_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_190928/0000/myMicroAODOutputFile_5.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24980.32421875
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-650_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_190928/0000/myMicroAODOutputFile_17.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24982.951171875
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-650_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_190928/0000/myMicroAODOutputFile_19.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24982.12109375
+            }
+        ], 
+        "parent_n_units": 376000, 
+        "vetted": true
+    }, 
+    "/TprimeBToTH_Hgg_M-675_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/lata-Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2-c8742baf38d1e270734b273d38e0b81b/USER": {
+        "dset_type": "mc", 
+        "files": [
+            {
+                "bad": false, 
+                "events": 12000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-675_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_191215/0000/myMicroAODOutputFile_10.root", 
+                "nevents": 12000, 
+                "totEvents": 12000, 
+                "weights": 11990.6630859375
+            }, 
+            {
+                "bad": false, 
+                "events": 3000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-675_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_191215/0000/myMicroAODOutputFile_5.root", 
+                "nevents": 3000, 
+                "totEvents": 3000, 
+                "weights": 2997.8505859375
+            }, 
+            {
+                "bad": false, 
+                "events": 3000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-675_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_191215/0000/myMicroAODOutputFile_6.root", 
+                "nevents": 3000, 
+                "totEvents": 3000, 
+                "weights": 2997.79052734375
+            }, 
+            {
+                "bad": false, 
+                "events": 20000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-675_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_191215/0000/myMicroAODOutputFile_12.root", 
+                "nevents": 20000, 
+                "totEvents": 20000, 
+                "weights": 19986.572265625
+            }, 
+            {
+                "bad": false, 
+                "events": 20000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-675_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_191215/0000/myMicroAODOutputFile_9.root", 
+                "nevents": 20000, 
+                "totEvents": 20000, 
+                "weights": 19984.990234375
+            }, 
+            {
+                "bad": false, 
+                "events": 3000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-675_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_191215/0000/myMicroAODOutputFile_23.root", 
+                "nevents": 3000, 
+                "totEvents": 3000, 
+                "weights": 2997.33642578125
+            }, 
+            {
+                "bad": false, 
+                "events": 9000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-675_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_191215/0000/myMicroAODOutputFile_24.root", 
+                "nevents": 9000, 
+                "totEvents": 9000, 
+                "weights": 8993.353515625
+            }, 
+            {
+                "bad": false, 
+                "events": 5000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-675_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_191215/0000/myMicroAODOutputFile_22.root", 
+                "nevents": 5000, 
+                "totEvents": 5000, 
+                "weights": 4996.85205078125
+            }, 
+            {
+                "bad": false, 
+                "events": 5000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-675_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_191215/0000/myMicroAODOutputFile_4.root", 
+                "nevents": 5000, 
+                "totEvents": 5000, 
+                "weights": 4997.03125
+            }, 
+            {
+                "bad": false, 
+                "events": 9000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-675_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_191215/0000/myMicroAODOutputFile_2.root", 
+                "nevents": 9000, 
+                "totEvents": 9000, 
+                "weights": 8993.5537109375
+            }, 
+            {
+                "bad": false, 
+                "events": 9000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-675_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_191215/0000/myMicroAODOutputFile_1.root", 
+                "nevents": 9000, 
+                "totEvents": 9000, 
+                "weights": 8994.7314453125
+            }, 
+            {
+                "bad": false, 
+                "events": 9000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-675_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_191215/0000/myMicroAODOutputFile_25.root", 
+                "nevents": 9000, 
+                "totEvents": 9000, 
+                "weights": 8992.5126953125
+            }, 
+            {
+                "bad": false, 
+                "events": 6000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-675_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_191215/0000/myMicroAODOutputFile_7.root", 
+                "nevents": 6000, 
+                "totEvents": 6000, 
+                "weights": 5996.26171875
+            }, 
+            {
+                "bad": false, 
+                "events": 6000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-675_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_191215/0000/myMicroAODOutputFile_13.root", 
+                "nevents": 6000, 
+                "totEvents": 6000, 
+                "weights": 5996.18115234375
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-675_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_191215/0000/myMicroAODOutputFile_15.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24983.310546875
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-675_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_191215/0000/myMicroAODOutputFile_17.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24981.212890625
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-675_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_191215/0000/myMicroAODOutputFile_8.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24980.064453125
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-675_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_191215/0000/myMicroAODOutputFile_11.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24980.541015625
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-675_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_191215/0000/myMicroAODOutputFile_3.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24983.060546875
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-675_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_191215/0000/myMicroAODOutputFile_16.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24981.935546875
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-675_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_191215/0000/myMicroAODOutputFile_14.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24981.3515625
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-675_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_191215/0000/myMicroAODOutputFile_19.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24979.048828125
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-675_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_191215/0000/myMicroAODOutputFile_20.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24981.3828125
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-675_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_191215/0000/myMicroAODOutputFile_18.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24981.2421875
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-675_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_191215/0000/myMicroAODOutputFile_21.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24982.82421875
+            }
+        ], 
+        "parent_n_units": 394000, 
+        "vetted": true
+    }, 
+    "/TprimeBToTH_Hgg_M-700_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/lata-Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2-c8742baf38d1e270734b273d38e0b81b/USER": {
+        "dset_type": "mc", 
+        "files": [
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-700_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_191502/0000/myMicroAODOutputFile_22.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24982.171875
+            }, 
+            {
+                "bad": false, 
+                "events": 17000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-700_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_191502/0000/myMicroAODOutputFile_23.root", 
+                "nevents": 17000, 
+                "totEvents": 17000, 
+                "weights": 16989.54296875
+            }, 
+            {
+                "bad": false, 
+                "events": 16000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-700_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_191502/0000/myMicroAODOutputFile_17.root", 
+                "nevents": 16000, 
+                "totEvents": 16000, 
+                "weights": 15988.53515625
+            }, 
+            {
+                "bad": false, 
+                "events": 21000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-700_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_191502/0000/myMicroAODOutputFile_21.root", 
+                "nevents": 21000, 
+                "totEvents": 21000, 
+                "weights": 20981.849609375
+            }, 
+            {
+                "bad": false, 
+                "events": 3000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-700_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_191502/0000/myMicroAODOutputFile_14.root", 
+                "nevents": 3000, 
+                "totEvents": 3000, 
+                "weights": 2997.25439453125
+            }, 
+            {
+                "bad": false, 
+                "events": 3000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-700_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_191502/0000/myMicroAODOutputFile_12.root", 
+                "nevents": 3000, 
+                "totEvents": 3000, 
+                "weights": 2998.0009765625
+            }, 
+            {
+                "bad": false, 
+                "events": 4000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-700_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_191502/0000/myMicroAODOutputFile_3.root", 
+                "nevents": 4000, 
+                "totEvents": 4000, 
+                "weights": 3997.270751953125
+            }, 
+            {
+                "bad": false, 
+                "events": 2000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-700_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_191502/0000/myMicroAODOutputFile_10.root", 
+                "nevents": 2000, 
+                "totEvents": 2000, 
+                "weights": 1998.8104248046875
+            }, 
+            {
+                "bad": false, 
+                "events": 15000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-700_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_191502/0000/myMicroAODOutputFile_24.root", 
+                "nevents": 15000, 
+                "totEvents": 15000, 
+                "weights": 14989.8984375
+            }, 
+            {
+                "bad": false, 
+                "events": 18000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-700_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_191502/0000/myMicroAODOutputFile_6.root", 
+                "nevents": 18000, 
+                "totEvents": 18000, 
+                "weights": 17985.431640625
+            }, 
+            {
+                "bad": false, 
+                "events": 15000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-700_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_191502/0000/myMicroAODOutputFile_13.root", 
+                "nevents": 15000, 
+                "totEvents": 15000, 
+                "weights": 14989.6044921875
+            }, 
+            {
+                "bad": false, 
+                "events": 9000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-700_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_191502/0000/myMicroAODOutputFile_5.root", 
+                "nevents": 9000, 
+                "totEvents": 9000, 
+                "weights": 8992.4736328125
+            }, 
+            {
+                "bad": false, 
+                "events": 9000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-700_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_191502/0000/myMicroAODOutputFile_20.root", 
+                "nevents": 9000, 
+                "totEvents": 9000, 
+                "weights": 8992.60546875
+            }, 
+            {
+                "bad": false, 
+                "events": 12000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-700_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_191502/0000/myMicroAODOutputFile_7.root", 
+                "nevents": 12000, 
+                "totEvents": 12000, 
+                "weights": 11990.0693359375
+            }, 
+            {
+                "bad": false, 
+                "events": 6000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-700_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_191502/0000/myMicroAODOutputFile_11.root", 
+                "nevents": 6000, 
+                "totEvents": 6000, 
+                "weights": 5996.0615234375
+            }, 
+            {
+                "bad": false, 
+                "events": 6000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-700_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_191502/0000/myMicroAODOutputFile_8.root", 
+                "nevents": 6000, 
+                "totEvents": 6000, 
+                "weights": 5996.0810546875
+            }, 
+            {
+                "bad": false, 
+                "events": 24000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-700_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_191502/0000/myMicroAODOutputFile_18.root", 
+                "nevents": 24000, 
+                "totEvents": 24000, 
+                "weights": 23983.4609375
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-700_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_191502/0000/myMicroAODOutputFile_9.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24981.880859375
+            }, 
+            {
+                "bad": false, 
+                "events": 21000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-700_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_191502/0000/myMicroAODOutputFile_4.root", 
+                "nevents": 21000, 
+                "totEvents": 21000, 
+                "weights": 20984.197265625
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-700_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_191502/0000/myMicroAODOutputFile_15.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24982.7421875
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-700_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_191502/0000/myMicroAODOutputFile_16.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24984.447265625
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-700_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_191502/0000/myMicroAODOutputFile_1.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24980.603515625
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-700_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_191502/0000/myMicroAODOutputFile_2.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24984.6015625
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-700_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_191502/0000/myMicroAODOutputFile_19.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24982.611328125
+            }
+        ], 
+        "parent_n_units": 376000, 
+        "vetted": true
+    }, 
+    "/TprimeBToTH_Hgg_M-800_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/lata-Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2-c8742baf38d1e270734b273d38e0b81b/USER": {
+        "dset_type": "mc", 
+        "files": [
+            {
+                "bad": false, 
+                "events": 3000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-800_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_191755/0000/myMicroAODOutputFile_8.root", 
+                "nevents": 3000, 
+                "totEvents": 3000, 
+                "weights": 2997.09130859375
+            }, 
+            {
+                "bad": false, 
+                "events": 3000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-800_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_191755/0000/myMicroAODOutputFile_13.root", 
+                "nevents": 3000, 
+                "totEvents": 3000, 
+                "weights": 2998.310546875
+            }, 
+            {
+                "bad": false, 
+                "events": 3000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-800_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_191755/0000/myMicroAODOutputFile_6.root", 
+                "nevents": 3000, 
+                "totEvents": 3000, 
+                "weights": 2998.0205078125
+            }, 
+            {
+                "bad": false, 
+                "events": 4000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-800_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_191755/0000/myMicroAODOutputFile_18.root", 
+                "nevents": 4000, 
+                "totEvents": 4000, 
+                "weights": 3996.152099609375
+            }, 
+            {
+                "bad": false, 
+                "events": 4000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-800_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_191755/0000/myMicroAODOutputFile_14.root", 
+                "nevents": 4000, 
+                "totEvents": 4000, 
+                "weights": 3996.66064453125
+            }, 
+            {
+                "bad": false, 
+                "events": 7000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-800_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_191755/0000/myMicroAODOutputFile_28.root", 
+                "nevents": 7000, 
+                "totEvents": 7000, 
+                "weights": 6991.25537109375
+            }, 
+            {
+                "bad": false, 
+                "events": 4000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-800_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_191755/0000/myMicroAODOutputFile_3.root", 
+                "nevents": 4000, 
+                "totEvents": 4000, 
+                "weights": 3996.271240234375
+            }, 
+            {
+                "bad": false, 
+                "events": 4000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-800_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_191755/0000/myMicroAODOutputFile_9.root", 
+                "nevents": 4000, 
+                "totEvents": 4000, 
+                "weights": 3997.470703125
+            }, 
+            {
+                "bad": false, 
+                "events": 4000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-800_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_191755/0000/myMicroAODOutputFile_19.root", 
+                "nevents": 4000, 
+                "totEvents": 4000, 
+                "weights": 3997.36083984375
+            }, 
+            {
+                "bad": false, 
+                "events": 11000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-800_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_191755/0000/myMicroAODOutputFile_11.root", 
+                "nevents": 11000, 
+                "totEvents": 11000, 
+                "weights": 10991.5146484375
+            }, 
+            {
+                "bad": false, 
+                "events": 7000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-800_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_191755/0000/myMicroAODOutputFile_22.root", 
+                "nevents": 7000, 
+                "totEvents": 7000, 
+                "weights": 6994.95263671875
+            }, 
+            {
+                "bad": false, 
+                "events": 8000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-800_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_191755/0000/myMicroAODOutputFile_2.root", 
+                "nevents": 8000, 
+                "totEvents": 8000, 
+                "weights": 7993.4560546875
+            }, 
+            {
+                "bad": false, 
+                "events": 11000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-800_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_191755/0000/myMicroAODOutputFile_26.root", 
+                "nevents": 11000, 
+                "totEvents": 11000, 
+                "weights": 10991.4765625
+            }, 
+            {
+                "bad": false, 
+                "events": 4000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-800_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_191755/0000/myMicroAODOutputFile_20.root", 
+                "nevents": 4000, 
+                "totEvents": 4000, 
+                "weights": 3997.3603515625
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-800_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_191755/0000/myMicroAODOutputFile_10.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24981.49609375
+            }, 
+            {
+                "bad": false, 
+                "events": 24000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-800_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_191755/0000/myMicroAODOutputFile_1.root", 
+                "nevents": 24000, 
+                "totEvents": 24000, 
+                "weights": 23981.57421875
+            }, 
+            {
+                "bad": false, 
+                "events": 16000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-800_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_191755/0000/myMicroAODOutputFile_24.root", 
+                "nevents": 16000, 
+                "totEvents": 16000, 
+                "weights": 15988.3466796875
+            }, 
+            {
+                "bad": false, 
+                "events": 16000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-800_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_191755/0000/myMicroAODOutputFile_4.root", 
+                "nevents": 16000, 
+                "totEvents": 16000, 
+                "weights": 15988.0927734375
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-800_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_191755/0000/myMicroAODOutputFile_27.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24982.642578125
+            }, 
+            {
+                "bad": false, 
+                "events": 14000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-800_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_191755/0000/myMicroAODOutputFile_17.root", 
+                "nevents": 14000, 
+                "totEvents": 14000, 
+                "weights": 13988.71484375
+            }, 
+            {
+                "bad": false, 
+                "events": 24000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-800_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_191755/0000/myMicroAODOutputFile_23.root", 
+                "nevents": 24000, 
+                "totEvents": 24000, 
+                "weights": 23982.74609375
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-800_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_191755/0000/myMicroAODOutputFile_12.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24979.5546875
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-800_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_191755/0000/myMicroAODOutputFile_25.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24982.2890625
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-800_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_191755/0000/myMicroAODOutputFile_15.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24980.6953125
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-800_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_191755/0000/myMicroAODOutputFile_7.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24982.337890625
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-800_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_191755/0000/myMicroAODOutputFile_5.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24982.38671875
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-800_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_191755/0000/myMicroAODOutputFile_21.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24981.0078125
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-800_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_191755/0000/myMicroAODOutputFile_16.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24980.10546875
+            }
+        ], 
+        "parent_n_units": 396000, 
+        "vetted": true
+    }, 
+    "/TprimeBToTH_Hgg_M-900_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/lata-Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2-c8742baf38d1e270734b273d38e0b81b/USER": {
+        "dset_type": "mc", 
+        "files": [
+            {
+                "bad": false, 
+                "events": 8000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-900_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_192044/0000/myMicroAODOutputFile_1.root", 
+                "nevents": 8000, 
+                "totEvents": 8000, 
+                "weights": 7994.70166015625
+            }, 
+            {
+                "bad": false, 
+                "events": 12000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-900_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_192044/0000/myMicroAODOutputFile_16.root", 
+                "nevents": 12000, 
+                "totEvents": 12000, 
+                "weights": 11990.658203125
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-900_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_192044/0000/myMicroAODOutputFile_4.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24980.80078125
+            }, 
+            {
+                "bad": false, 
+                "events": 6000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-900_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_192044/0000/myMicroAODOutputFile_6.root", 
+                "nevents": 6000, 
+                "totEvents": 6000, 
+                "weights": 5995.4619140625
+            }, 
+            {
+                "bad": false, 
+                "events": 8000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-900_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_192044/0000/myMicroAODOutputFile_15.root", 
+                "nevents": 8000, 
+                "totEvents": 8000, 
+                "weights": 7992.49267578125
+            }, 
+            {
+                "bad": false, 
+                "events": 8000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-900_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_192044/0000/myMicroAODOutputFile_7.root", 
+                "nevents": 8000, 
+                "totEvents": 8000, 
+                "weights": 7994.58203125
+            }, 
+            {
+                "bad": false, 
+                "events": 10000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-900_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_192044/0000/myMicroAODOutputFile_19.root", 
+                "nevents": 10000, 
+                "totEvents": 10000, 
+                "weights": 9993.140625
+            }, 
+            {
+                "bad": false, 
+                "events": 11000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-900_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_192044/0000/myMicroAODOutputFile_10.root", 
+                "nevents": 11000, 
+                "totEvents": 11000, 
+                "weights": 10989.9228515625
+            }, 
+            {
+                "bad": false, 
+                "events": 15000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-900_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_192044/0000/myMicroAODOutputFile_21.root", 
+                "nevents": 15000, 
+                "totEvents": 15000, 
+                "weights": 14987.7353515625
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-900_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_192044/0000/myMicroAODOutputFile_9.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24979.873046875
+            }, 
+            {
+                "bad": false, 
+                "events": 4000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-900_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_192044/0000/myMicroAODOutputFile_12.root", 
+                "nevents": 4000, 
+                "totEvents": 4000, 
+                "weights": 3996.980712890625
+            }, 
+            {
+                "bad": false, 
+                "events": 23000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-900_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_192044/0000/myMicroAODOutputFile_14.root", 
+                "nevents": 23000, 
+                "totEvents": 23000, 
+                "weights": 22983.0078125
+            }, 
+            {
+                "bad": false, 
+                "events": 16000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-900_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_192044/0000/myMicroAODOutputFile_2.root", 
+                "nevents": 16000, 
+                "totEvents": 16000, 
+                "weights": 15987.373046875
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-900_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_192044/0000/myMicroAODOutputFile_13.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24980.3359375
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-900_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_192044/0000/myMicroAODOutputFile_18.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24978.833984375
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-900_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_192044/0000/myMicroAODOutputFile_17.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24982.775390625
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-900_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_192044/0000/myMicroAODOutputFile_20.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24977.796875
+            }, 
+            {
+                "bad": false, 
+                "events": 20000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-900_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_192044/0000/myMicroAODOutputFile_3.root", 
+                "nevents": 20000, 
+                "totEvents": 20000, 
+                "weights": 19980.90625
+            }, 
+            {
+                "bad": false, 
+                "events": 12000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-900_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_192044/0000/myMicroAODOutputFile_8.root", 
+                "nevents": 12000, 
+                "totEvents": 12000, 
+                "weights": 11990.8369140625
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-900_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_192044/0000/myMicroAODOutputFile_5.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24981.0859375
+            }, 
+            {
+                "bad": false, 
+                "events": 12000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-900_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_192044/0000/myMicroAODOutputFile_11.root", 
+                "nevents": 12000, 
+                "totEvents": 12000, 
+                "weights": 11987.958984375
+            }, 
+            {
+                "bad": false, 
+                "events": 20000, 
+                "name": "/store/user/lata/Era2018_RR-17Sep2018_v2/v2_p12/TprimeBToTH_Hgg_M-900_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2-v2_p12-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/201116_192044/0000/myMicroAODOutputFile_22.root", 
+                "nevents": 20000, 
+                "totEvents": 20000, 
+                "weights": 19985.330078125
+            }
+        ], 
+        "parent_n_units": 360000, 
+        "vetted": true
+    }, 
+    "/TprimeBToTH_M-700_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/lata-Era2018_RR-17Sep2018_v2_p2-v2_p2-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1-cb307715c84d00545a381c20bd4e6a9f/USER": {
+        "dset_type": "mc", 
+        "files": [
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/group/phys_higgs/resonant_HH/RunII/MicroAOD/Era2018_RR-17Sep2018_v2_p2/v2_p2/TprimeBToTH_M-700_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2_p2-v2_p2-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/200331_133307/0000/myMicroAODOutputFile_2.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24845.8046875
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/group/phys_higgs/resonant_HH/RunII/MicroAOD/Era2018_RR-17Sep2018_v2_p2/v2_p2/TprimeBToTH_M-700_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2_p2-v2_p2-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/200331_133307/0000/myMicroAODOutputFile_8.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24819.392578125
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/group/phys_higgs/resonant_HH/RunII/MicroAOD/Era2018_RR-17Sep2018_v2_p2/v2_p2/TprimeBToTH_M-700_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2_p2-v2_p2-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/200331_133307/0000/myMicroAODOutputFile_3.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24837.28125
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/group/phys_higgs/resonant_HH/RunII/MicroAOD/Era2018_RR-17Sep2018_v2_p2/v2_p2/TprimeBToTH_M-700_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2_p2-v2_p2-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/200331_133307/0000/myMicroAODOutputFile_4.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24867.6875
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/group/phys_higgs/resonant_HH/RunII/MicroAOD/Era2018_RR-17Sep2018_v2_p2/v2_p2/TprimeBToTH_M-700_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2_p2-v2_p2-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/200331_133307/0000/myMicroAODOutputFile_9.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24816.001953125
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/group/phys_higgs/resonant_HH/RunII/MicroAOD/Era2018_RR-17Sep2018_v2_p2/v2_p2/TprimeBToTH_M-700_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2_p2-v2_p2-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/200331_133307/0000/myMicroAODOutputFile_1.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24850.734375
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/group/phys_higgs/resonant_HH/RunII/MicroAOD/Era2018_RR-17Sep2018_v2_p2/v2_p2/TprimeBToTH_M-700_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2_p2-v2_p2-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/200331_133307/0000/myMicroAODOutputFile_7.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24868.642578125
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/group/phys_higgs/resonant_HH/RunII/MicroAOD/Era2018_RR-17Sep2018_v2_p2/v2_p2/TprimeBToTH_M-700_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2_p2-v2_p2-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/200331_133307/0000/myMicroAODOutputFile_12.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24865.4140625
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/group/phys_higgs/resonant_HH/RunII/MicroAOD/Era2018_RR-17Sep2018_v2_p2/v2_p2/TprimeBToTH_M-700_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2_p2-v2_p2-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/200331_133307/0000/myMicroAODOutputFile_11.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24826.353515625
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/group/phys_higgs/resonant_HH/RunII/MicroAOD/Era2018_RR-17Sep2018_v2_p2/v2_p2/TprimeBToTH_M-700_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2_p2-v2_p2-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/200331_133307/0000/myMicroAODOutputFile_5.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24854.8125
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/group/phys_higgs/resonant_HH/RunII/MicroAOD/Era2018_RR-17Sep2018_v2_p2/v2_p2/TprimeBToTH_M-700_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2_p2-v2_p2-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/200331_133307/0000/myMicroAODOutputFile_10.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24850.22265625
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/group/phys_higgs/resonant_HH/RunII/MicroAOD/Era2018_RR-17Sep2018_v2_p2/v2_p2/TprimeBToTH_M-700_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2018_RR-17Sep2018_v2_p2-v2_p2-v0-RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/200331_133307/0000/myMicroAODOutputFile_6.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 24817.841796875
+            }
+        ], 
+        "parent_n_units": 300000, 
+        "vetted": true
+    }
+}


### PR DESCRIPTION
adding 2016, 2017 and 2018 samples for low mass and Tprime analyses

**TprimeToBToTH analysis**

2016: /TprimeBToTH_Hgg_M-*_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/MINIAODSIM

2017: /TprimeBToTH_Hgg_M-*_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/MINIAODSIM

2018: /TprimeBToTH_Hgg_M-*_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/MINIAODSIM

Mass points = 600,625,650,675,700,800,900,1000,1100,1200

**H--> 4g analysis**
2016: /HAHMHToAA_AToGG_MA-XXGeV_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/RunIISummer16MiniAODv3-94X_mcRun2_asymptotic_v3-v1/MINIAODSIM

2017: /HAHMHToAA_AToGG_MA-XXGeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM

2018: /HAHMHToAA_AToGG_MA-XXGeV_TuneCP5_PSweights_13TeV-madgraph_pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/MINIAODSIM

where XX = 15,20,25,30,35,40,45,50,55,60  

(NOTE: 2017 35 GeV mass point not available in DAS)