### PR TITLE
Shower shapes corrections for 2018 Legacy

### DIFF
--- a/MetaData/data/MetaConditions/Era2018_legacy_v1.json
+++ b/MetaData/data/MetaConditions/Era2018_legacy_v1.json
@@ -1,11 +1,35 @@
 {
     "globalTags" :
     {
-        "data" : "106X_dataRun2_v28",
-        "MC" : "106X_upgrade2018_realistic_v11_L1v1"
+        "data" : "102X_dataRun2_v13",
+        "MC" : "102X_upgrade2018_realistic_v21"
     },
 
     "flashggMETsFunction" : "runMETs2016",
+    "flashggMetFilters" :
+    {
+        "rerun_ecal_calib_filter" : true,
+        "data" :
+        [
+            "Flag_goodVertices",
+            "Flag_globalSuperTightHalo2016Filter",
+            "Flag_HBHENoiseFilter",
+            "Flag_HBHENoiseIsoFilter",
+            "Flag_EcalDeadCellTriggerPrimitiveFilter",
+            "Flag_BadPFMuonFilter",
+            "Flag_eeBadScFilter"
+        ],
+        "mc" :
+        [
+            "Flag_goodVertices",
+            "Flag_globalSuperTightHalo2016Filter",
+            "Flag_HBHENoiseFilter",
+            "Flag_HBHENoiseIsoFilter",
+            "Flag_EcalDeadCellTriggerPrimitiveFilter",
+            "Flag_BadPFMuonFilter"
+        ]
+    },
+
     "DeepJet" : "read",
 
     "flashggPhotons" :
@@ -25,29 +49,145 @@
     "TriggerPaths" :
     {
         ".*EGamma.*2018.*" :
-        [
-            "HLT_Diphoton30_22_R9Id_OR_IsoCaloId_AND_HE_R9Id_Mass90*",
-            "HLT_Diphoton30_22_R9Id_OR_IsoCaloId_AND_HE_R9Id_Mass95*",
-            "HLT_Diphoton30_18_R9IdL_AND_HE_AND_IsoCaloId_NoPixelVeto_Mass55*",
-            "HLT_Diphoton30_18_R9IdL_AND_HE_AND_IsoCaloId_NoPixelVeto*",
-            "HLT_Ele*_WPTight_Gsf_v*"
-        ],        
+        {
+	    "mainAnalysis" :
+	    [
+		"HLT_Diphoton30_22_R9Id_OR_IsoCaloId_AND_HE_R9Id_Mass90*",
+		"HLT_Diphoton30_22_R9Id_OR_IsoCaloId_AND_HE_R9Id_Mass95*"
+	    ],
+	    "lowMassAnalysis" :
+	    [
+		"HLT_Diphoton30_18_R9IdL_AND_HE_AND_IsoCaloId_NoPixelVeto_Mass55*",
+		"HLT_Diphoton30_18_R9IdL_AND_HE_AND_IsoCaloId_NoPixelVeto*"
+	    ],
+	    "tagAndProbe" :
+	    [
+		"HLT_Ele*_WPTight_Gsf_v*"
+	    ]
+        },
         ".*DoubleMuon.*2018.*" :
-        [
-            "HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_v*",
-            "HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_v*",
-            "HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_Mass3p8_v*",
-            "HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_Mass8_v*"
-        ]
+        {
+	    "ZmumuGamma" :
+	    [
+		"HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_v*",
+		"HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_v*",
+		"HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_Mass3p8_v*",
+		"HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_Mass8_v*"
+	    ]
+        }
     },
-    "flashggDiPhotonSystematics" : "flashggDiPhotonSystematics2018_cfi",
+    "flashggDiPhotonSystematics" : "flashggDiPhotonSystematics2018_Legacy_cfi.py",
 
-    
+
+    "sigmaM_M_decorr" : "flashgg/Taggers/data/diphoMVA_sigmaMoMdecorr_split_2018_Mgg100to180.root",
+
+    "flashggDiPhotonMVA" :
+    {
+        "weightFile" : "flashgg/Taggers/data/STXSmodels/legacyDiphoModelMerged.xml",
+        "version" : "xgb"
+    },
+
+    "flashggJetSystematics" :
+    {
+        "doHEMuncertainty" : true,
+        "textFileName" : "flashgg/Systematics/data/JEC/Regrouped_Autumn18_V19_MC_UncertaintySources_AK4PFchs.txt",
+        "listOfSources" : [
+                           "Absolute",
+                           "Absolute2018",
+                           "BBEC1",
+                           "BBEC12018",
+                           "EC2",
+                           "EC22018",
+                           "FlavorQCD",
+                           "HF",
+                           "HF2018",
+                           "RelativeBal",
+                           "RelativeSample2018"
+                          ]
+    },
+
+    "flashggVBFMVA" :
+    {
+        "weightFile" : "flashgg/Taggers/data/STXSmodels/dijetDataDrivenMerged.xml",
+        "jetID" : "Tight2018"
+    },
+
+    "flashggVHhadMVA" :
+    {
+        "weightFile" : "flashgg/Taggers/data/STXSmodels/vhHadDataDrivenMerged.xml",
+        "jetID" : "Tight2018"
+    },
+
+    "stageOneCombinedTag" :
+    {
+        "rawDiphoBounds" : [
+                             0.783, 0.701, 0.525,
+                             0.836, 0.791, 0.655,
+
+                             0.854, 0.794, 0.690,
+                             0.883, 0.841, 0.746,
+                             0.922, 0.885, 0.814,
+
+                             0.831, 0.761, 0.637,
+                             0.891, 0.867, 0.726,
+                             0.918, 0.893, 0.829,
+
+                             0.945, 0.882,
+                             0.924, 0.802,
+                             0.844,
+                             0.815,
+
+                             0.832,
+                             0.745,
+
+                             0.800, 0.779,
+                             0.790, 0.606,
+                             0.826, 0.650,
+                             0.774, 0.800,
+                             0.509, 0.918,
+
+                             0.829, 0.720
+                           ],
+        "rawDijetBounds" : [
+                             0.379, 0.279,
+                             0.410, 0.260,
+                             0.302, 0.137,
+                             0.611, 0.218,
+                             0.268, 0.051,
+
+                             0.599, 0.478
+                           ],
+        "rawGghBounds" : [
+                             0.565, 0.726,
+                             0.583, 0.919,
+                             0.928, 0.876,
+                             0.362, 0.742,
+                             0.756, 0.965,
+
+                             0.482, 0.319
+                           ],
+        "rawVhHadBounds" : [
+                             0.842,
+                             0.613
+                           ]
+    },
+
+
     "MUON_ID" : "Medium",
     "MUON_ISO" : "LooseRel",
 
-    "Ele_ID_eff_bin" : "binInfo2018",
+    "MUON_ID_JSON_FileName" : "flashgg/Systematics/data/Muon2018_RunABCD_SF_ID.json",
+    "MUON_ID_JSON_FileName_LowPt" : "flashgg/Systematics/data/Muon2018_RunABCD_SF_ID_lowPt.json",
+    "MUON_ISO_JSON_FileName" : "flashgg/Systematics/data/Muon2018_RunABCD_SF_ISO.json",
 
+    "MUON_ID_RefTracks" : "TrackerMuons",
+    "MUON_ID_RefTracks_LowPt" : "genTracks",
+
+
+    "Ele_ID_SF_FileName" : "flashgg/Systematics/data/combined_eleIDSFs_2018.json",
+    "Ele_ID_version" : "mvaEleID-Fall17-iso-V2-wp90",
+
+    "Ele_reco_SF_FileName" : "flashgg/Systematics/data/2018_reco-eff.json",
 
     "bTagSystematics" :
     {
@@ -67,14 +207,20 @@
 	"eta" : 2.5
     },
 
+    "mc2hessianCSV" : "PhysicsTools/HepMCCandAlgos/data/NNPDF30_lo_as_0130_hessian_60.csv",
+
     "bRegression" :
     {
         "weightFile" : "/src/flashgg/Taggers/data/DNN_models/breg_training_2018_v8.pb",
         "y_mean" : 1.0545977354049683,
         "y_std" : 0.27912887930870056,
-        "year" : 2018
+        "year" : 2018,
+        "useBRegressionJERsf" : false,
+        "JER_central" : 1.1,
+        "JER_up" : 0.1,
+        "JER_down" : -0.1
     },
-      "doubleHTag":
+    "doubleHTag":
     {
 	"jetID" : "Tight2018",
 	"weightsFile" : {
@@ -105,6 +251,83 @@
                              2.79300773e-01,   2.82007646e-01,   6.50499362e+01,   3.08319388e+01,
                              9.72514714e-01,   1.09188163e+00,   1.80664926e+00,   1.80460847e+00],
 	"ttHKiller_listmean" : [  1.04960120e+02,  -5.49804481e-03,   3.08285275e-02],
-	"ttHKiller_liststd" : [ 85.77034272,   1.03762195,   1.83170033] 
+	"ttHKiller_liststd" : [ 85.77034272,   1.03762195,   1.83170033]
+    },
+    "VBFdoubleHTag":
+    {
+        "jetID" : "Tight2018",
+        "weightsFile" : {
+            "with_Mjj" : "flashgg/Taggers/data/HHTagger/training_30_04_2020_vbfHHbbgg_C2V0_2018.weights.xml",
+            "wo_Mjj" : "flashgg/Taggers/data/HHTagger/training_30_04_2020_vbfHHbbgg_C2V0_2018.weights.xml"
+        },
+        "MVAFlatteningFileName" : {
+            "with_Mjj" : "flashgg/Taggers/data/HHTagger/cumulativeTrans_30_04_2020_vbfHHbbgg_C2V0_training_2018.root",
+            "wo_Mjj" : "flashgg/Taggers/data/HHTagger/cumulativeTrans_30_04_2020_vbfHHbbgg_C2V0_training_2018.root"
+        },
+        "weightsFileCAT0" : {
+                "with_Mjj" : "flashgg/Taggers/data/HHTagger/training_with_2018_12_06_2020_mixed_signal_MX_gt_500.weights.xml",
+                "wo_Mjj" : "flashgg/Taggers/data/HHTagger/training_with_2018_12_06_2020_mixed_signal_MX_gt_500.weights.xml"
+        },
+        "MVAFlatteningFileNameCAT0" : {
+                "with_Mjj" : "flashgg/Taggers/data/HHTagger/cumulativeTransformation_Total_preselection_diffNaming_2018_12_06_2020_MX_gt_500.root",
+                "wo_Mjj" : "flashgg/Taggers/data/HHTagger/cumulativeTransformation_Total_preselection_diffNaming_2018_12_06_2020_MX_gt_500.root"
+        },
+        "weightsFileCAT1" : {
+                "with_Mjj" : "flashgg/Taggers/data/HHTagger/training_with_2018_12_06_2020_mixed_signal_MX_lt_500.weights.xml",
+                "wo_Mjj" : "flashgg/Taggers/data/HHTagger/training_with_2018_12_06_2020_mixed_signal_MX_lt_500.weights.xml"
+        },
+        "MVAFlatteningFileNameCAT1" : {
+                "with_Mjj" : "flashgg/Taggers/data/HHTagger/cumulativeTransformation_Total_preselection_diffNaming_2018_12_06_2020_MX_lt_500.root",
+                "wo_Mjj" : "flashgg/Taggers/data/HHTagger/cumulativeTransformation_Total_preselection_diffNaming_2018_12_06_2020_MX_lt_500.root"
+        },
+        "MVAscalingValue" : 1.0,
+        "ttHWeightfile" : "flashgg/Taggers/data/ttHKiller/Keras2017_converted_allnode.pb",
+        "ttHKiller_mean" : [  3.22491144e+02,   7.22919780e+01,   1.49387571e-01,   4.94052483e-03,
+                              5.10246425e-04,   1.38947662e+00,   5.31453078e+00,   7.45455854e+00,
+                              1.35956692e+02,   7.06566234e+01,   3.71319449e+01,   6.74400372e+01,
+                              3.78045958e+01,   1.73739779e+02,   2.44105199e-02,   8.74739133e-02,
+                              -1.06521292e-02,  -8.08607645e-02,  -5.39241839e-03,  -3.57037140e-02,
+                              1.59510158e-01,   2.73751540e-02,   1.89251401e-02,  -4.07854484e-03,
+                              4.75087259e-01,   4.65906361e-01,   1.23640841e+02,   5.92089022e+01,
+                              -8.63826805e-03,  -4.54561747e-03,  -2.04075881e-02,   5.20315820e-03],
+        "ttHKiller_std" : [  2.23688125e+02,   6.14480046e+01,   1.89750669e+00,   1.84765326e+00,
+                             1.81706814e+00,   6.16140431e-01,   1.57790173e+00,   1.21559976e+01,
+                             3.18350560e+02,   5.51059043e+01,   2.27778847e+01,   5.34930606e+01,
+                             2.33020848e+01,   1.13925303e+02,   1.07162645e+00,   1.11756573e+00,
+                             1.06602334e+00,   1.05170943e+00,   1.03730169e+00,   1.79671005e+00,
+                             1.76463679e+00,   1.81416114e+00,   1.72905029e+00,   1.81772461e+00,
+                             2.79300773e-01,   2.82007646e-01,   6.50499362e+01,   3.08319388e+01,
+                             9.72514714e-01,   1.09188163e+00,   1.80664926e+00,   1.80460847e+00],
+        "ttHKiller_listmean" : [  1.04960120e+02,  -5.49804481e-03,   3.08285275e-02],
+        "ttHKiller_liststd" : [ 85.77034272,   1.03762195,   1.83170033]
+    },
+
+
+    "PhoIdInputCorrections":
+    {
+	"corrections_summary" : "flashgg/Taggers/data/PhoIdInputsCorrections/corrections_summary_2018.json",
+	"SS_variables" : ["f0 := pt",
+                          "f1 := superCluster.eta",
+                          "f2 := phi",
+                          "f3 := global.rho",
+                          "f4 := sieip",
+                          "f5 := s4",
+                          "f6 := full5x5_r9",
+                          "f7 := superCluster.phiWidth",
+                          "f8 := full5x5_sigmaIetaIeta",
+                          "f9 := superCluster.etaWidth"]
+    },
+
+    "L1Prefiring" :
+    {
+        "isRelevant" : false
+    },
+
+    "THQLeptonicTag":
+    {
+        "MVAweights_VsAllBkg" : "flashgg/Taggers/data/TMVA_THQLeptonicTag_tHq_Vs_NonPeakingBkg_BDT_18_v1.weights.xml",
+        "MVAweights_VsttH" : "flashgg/Taggers/data/TMVA_THQLeptonicTag_tHq_Vs_ttH_BDT.weights.xml",
+        "MVAThreshold_VsAllBkg" : 0.08,
+        "MVAThreshold_VsttH" : -0.06
     }
 }

--- a/MetaData/data/MetaConditions/Era2018_legacy_v1.json
+++ b/MetaData/data/MetaConditions/Era2018_legacy_v1.json
@@ -76,7 +76,7 @@
 	    ]
         }
     },
-    "flashggDiPhotonSystematics" : "flashggDiPhotonSystematics2018_Legacy_cfi.py",
+    "flashggDiPhotonSystematics" : "flashggDiPhotonSystematics2018_Legacy_cfi",
 
 
     "sigmaM_M_decorr" : "flashgg/Taggers/data/diphoMVA_sigmaMoMdecorr_split_2018_Mgg100to180.root",

--- a/MetaData/data/MetaConditions/Era2018_legacy_v1.json
+++ b/MetaData/data/MetaConditions/Era2018_legacy_v1.json
@@ -1,8 +1,8 @@
 {
     "globalTags" :
     {
-        "data" : "102X_dataRun2_v13",
-        "MC" : "102X_upgrade2018_realistic_v21"
+        "data" : "106X_dataRun2_v28",
+        "MC" : "106X_upgrade2018_realistic_v11_L1v1"
     },
 
     "flashggMETsFunction" : "runMETs2016",

--- a/MetaData/data/MetaConditions/Era2018_legacy_v1.json
+++ b/MetaData/data/MetaConditions/Era2018_legacy_v1.json
@@ -306,16 +306,18 @@
     "PhoIdInputCorrections":
     {
 	"corrections_summary" : "flashgg/Taggers/data/PhoIdInputsCorrections/corrections_summary_2018_Legacy.json",
-	"SS_variables" : ["f0 := pt",
-                          "f1 := superCluster.eta",
-                          "f2 := phi",
-                          "f3 := global.rho",
-                          "f4 := sieip",
-                          "f5 := s4",
-                          "f6 := full5x5_r9",
-                          "f7 := superCluster.phiWidth",
-                          "f8 := full5x5_sigmaIetaIeta",
-                          "f9 := superCluster.etaWidth"]
+	"SS_variables" : [
+        "f0 := pt",
+        "f1 := superCluster.eta",
+        "f2 := phi",
+        "f3 := global.rho",
+        "f4 := sieip",
+        "f5 := s4",
+        "f6 := full5x5_r9",
+        "f7 := superCluster.phiWidth",
+        "f8 := full5x5_sigmaIetaIeta",
+        "f9 := superCluster.etaWidth"
+        ]
     },
 
     "L1Prefiring" :

--- a/MetaData/data/MetaConditions/Era2018_legacy_v1.json
+++ b/MetaData/data/MetaConditions/Era2018_legacy_v1.json
@@ -305,7 +305,7 @@
 
     "PhoIdInputCorrections":
     {
-	"corrections_summary" : "flashgg/Taggers/data/PhoIdInputsCorrections/corrections_summary_2018.json",
+	"corrections_summary" : "flashgg/Taggers/data/PhoIdInputsCorrections/corrections_summary_2018_Legacy.json",
 	"SS_variables" : ["f0 := pt",
                           "f1 := superCluster.eta",
                           "f2 := phi",

--- a/MicroAOD/src/PhotonIdUtils.cc
+++ b/MicroAOD/src/PhotonIdUtils.cc
@@ -292,7 +292,7 @@ float PhotonIdUtils::computeMVAWrtVtx( /*edm::Ptr<flashgg::Photon>& photon,*/
     phoIdMva_ScEta_           = photon.superCluster()->eta();
     phoIdMva_rho_             = rho; // we don't want to add the event-based rho as flashgg::photon member
     phoIdMva_ESEffSigmaRR_    = photon.esEffSigmaRR();
-    phoIdMva_esEnovSCRawEn_   = photon.superCluster()->preshowerEnergy()/photon.superCluster()->rawEnergy();
+    phoIdMva_esEnovSCRawEn_   = photon.hasUserFloat("esEnergyOverSCRawEnergy") ? photon.userFloat("esEnergyOverSCRawEnergy") : photon.superCluster()->preshowerEnergy()/photon.superCluster()->rawEnergy();
         
     if( photon.isEB() )      { phoIdMva = phoIdMva_EB_; }
     else if( photon.isEE() ) { phoIdMva = phoIdMva_EE_; }

--- a/Systematics/python/flashggDiPhotonSystematics2018_Legacy_cfi.py
+++ b/Systematics/python/flashggDiPhotonSystematics2018_Legacy_cfi.py
@@ -1,0 +1,856 @@
+import FWCore.ParameterSet.Config as cms
+
+# No default. Latest is only in the EGM tool
+photonSmearBins = cms.PSet()
+photonScaleUncertBins = cms.PSet()
+
+mvaShiftBins = cms.PSet(
+    variables = cms.vstring("abs(superCluster.eta)"),
+    bins = cms.VPSet(
+                     cms.PSet( lowBounds = cms.vdouble(0.000), upBounds = cms.vdouble(999.), values = cms.vdouble( 0.0 ), uncertainties = cms.vdouble( 0.00 ))
+                     )
+    )
+
+# PR 1045
+preselBins = cms.PSet(
+    variables = cms.vstring("abs(superCluster.eta)","full5x5_r9"),
+    bins = cms.VPSet(
+        cms.PSet( lowBounds = cms.vdouble( 0.0, 0.0 ) , upBounds = cms.vdouble( 1.5, 0.85 ) , values = cms.vdouble( 0.998 ) , uncertainties = cms.vdouble( 0.005 )  ) ,
+        cms.PSet( lowBounds = cms.vdouble( 0.0, 0.85 ), upBounds = cms.vdouble( 1.5, 999. ) , values = cms.vdouble( 1.001 ) , uncertainties = cms.vdouble( 0.003 )  ) ,
+        cms.PSet( lowBounds = cms.vdouble( 1.5, 0.0 ) , upBounds = cms.vdouble( 6.0, 0.9  ) , values = cms.vdouble( 0.989 ) , uncertainties = cms.vdouble( 0.006 )  ) ,
+        cms.PSet( lowBounds = cms.vdouble( 1.5, 0.9 ) , upBounds = cms.vdouble( 6.0, 999. ) , values = cms.vdouble( 1.002 ) , uncertainties = cms.vdouble( 0.009 )  ) 
+        )
+    )
+
+#JTao: slide 34 of https://indico.cern.ch/event/850506/contributions/3606914/attachments/1927946/3192290/201910_Zmmg_RhoBugFixed.pdf with 2018 data and MC samples, with new shower-shape and isolation corrections applied and photon PT > 20 GeV
+electronVetoBins = cms.PSet(
+    variables = cms.vstring("abs(superCluster.eta)","full5x5_r9"),
+    bins = cms.VPSet(
+        cms.PSet( lowBounds = cms.vdouble( 0.0, 0.00 ) , upBounds = cms.vdouble( 1.5, 0.85 ) , values = cms.vdouble( 0.9819 ) , uncertainties = cms.vdouble( 0.0020 )  ) ,
+        cms.PSet( lowBounds = cms.vdouble( 0.0, 0.85 ) , upBounds = cms.vdouble( 1.5, 999. ) , values = cms.vdouble( 0.9931 ) , uncertainties = cms.vdouble( 0.0005 )  ) ,
+        cms.PSet( lowBounds = cms.vdouble( 1.5, 0.00 ) , upBounds = cms.vdouble( 6.0, 0.90 ) , values = cms.vdouble( 0.9680 ) , uncertainties = cms.vdouble( 0.0069 )  ) ,
+        cms.PSet( lowBounds = cms.vdouble( 1.5, 0.90 ) , upBounds = cms.vdouble( 6.0, 999. ) , values = cms.vdouble( 0.9785 ) , uncertainties = cms.vdouble( 0.0018 )  )
+        )
+    )
+
+
+# JMalcles - based on JTao SF + ttH efficiencies. calculated to preserve nTot ttH. 
+
+leadPixelSeedBins = cms.PSet(
+    variables = cms.vstring("abs(superCluster.eta)","full5x5_r9", "hasPixelSeed"),
+    bins = cms.VPSet(
+        # No Pixel Seed
+        cms.PSet( lowBounds = cms.vdouble( 0.0, 0.00, -0.1 ) , upBounds = cms.vdouble( 1.5, 0.85 , 0.1) , values = cms.vdouble(0.978 ) , uncertainties = cms.vdouble( -0.00401807 )  ) ,
+        cms.PSet( lowBounds = cms.vdouble( 0.0, 0.85, -0.1 ) , upBounds = cms.vdouble( 1.5, 999. , 0.1) , values = cms.vdouble(0.9824) , uncertainties = cms.vdouble( -0.00200421 )  ) ,
+        cms.PSet( lowBounds = cms.vdouble( 1.5, 0.00, -0.1 ) , upBounds = cms.vdouble( 6.0, 0.90 , 0.1) , values = cms.vdouble(0.9168 ) , uncertainties = cms.vdouble( -0.0224756 )  ) ,
+        cms.PSet( lowBounds = cms.vdouble( 1.5, 0.90 ,-0.1) , upBounds = cms.vdouble( 6.0, 999., 0.1) , values = cms.vdouble( 0.9403 ) , uncertainties = cms.vdouble(  -0.00631264  )  ),        
+        # Yes Pixel Seed
+        cms.PSet( lowBounds = cms.vdouble( 0.0, 0.00 ,0.9) , upBounds = cms.vdouble( 1.5, 0.85, 1.1 ) , values = cms.vdouble( 1.08876 ) , uncertainties = cms.vdouble( 0.0162106 )  ) ,
+        cms.PSet( lowBounds = cms.vdouble( 0.0, 0.85 ,0.9) , upBounds = cms.vdouble( 1.5, 999., 1.1 ) , values = cms.vdouble( 1.5961) , uncertainties = cms.vdouble( 0.0678807 )  ) ,
+        cms.PSet( lowBounds = cms.vdouble( 1.5, 0.00 ,0.9) , upBounds = cms.vdouble( 6.0, 0.90, 1.1 ) , values = cms.vdouble( 1.09763 ) , uncertainties = cms.vdouble( 0.0263745 )  ) ,
+        cms.PSet( lowBounds = cms.vdouble( 1.5, 0.90 ,0.9) , upBounds = cms.vdouble( 6.0, 999., 1.1 ) , values = cms.vdouble( 1.20264 ) , uncertainties = cms.vdouble(  0.0214274 )  )
+        )
+    )
+
+
+subleadPixelSeedBins = cms.PSet(
+    variables = cms.vstring("abs(superCluster.eta)","full5x5_r9", "hasPixelSeed"),
+    bins = cms.VPSet(
+        # No Pixel Seed
+        cms.PSet( lowBounds = cms.vdouble( 0.0, 0.00, -0.1 ) , upBounds = cms.vdouble( 1.5, 0.85 , 0.1) , values = cms.vdouble( 0.978  ) , uncertainties = cms.vdouble(  -0.00415083)  ) ,
+        cms.PSet( lowBounds = cms.vdouble( 0.0, 0.85, -0.1 ) , upBounds = cms.vdouble( 1.5, 999. , 0.1) , values = cms.vdouble( 0.9824 ) , uncertainties = cms.vdouble( -0.00280026 )  ) ,
+        cms.PSet( lowBounds = cms.vdouble( 1.5, 0.00, -0.1 ) , upBounds = cms.vdouble( 6.0, 0.90 , 0.1) , values = cms.vdouble( 0.9168 ) , uncertainties = cms.vdouble( -0.0225538  )  ) ,
+        cms.PSet( lowBounds = cms.vdouble( 1.5, 0.90 ,-0.1) , upBounds = cms.vdouble( 6.0, 999., 0.1) , values = cms.vdouble( 0.9403 ) , uncertainties = cms.vdouble( -0.00655045 )  ),        
+        # Yes Pixel Seed
+        cms.PSet( lowBounds = cms.vdouble( 0.0, 0.00 ,0.9) , upBounds = cms.vdouble( 1.5, 0.85, 1.1 ) , values = cms.vdouble( 1.13196) , uncertainties = cms.vdouble( 0.0248967 )  ) ,
+        cms.PSet( lowBounds = cms.vdouble( 0.0, 0.85 ,0.9) , upBounds = cms.vdouble( 1.5, 999., 1.1 ) , values = cms.vdouble( 1.61512 ) , uncertainties = cms.vdouble(  0.0978689 )  ) ,
+        cms.PSet( lowBounds = cms.vdouble( 1.5, 0.00 ,0.9) , upBounds = cms.vdouble( 6.0, 0.90, 1.1 ) , values = cms.vdouble( 1.10623 ) , uncertainties = cms.vdouble(  0.0287957 )  ) ,
+        cms.PSet( lowBounds = cms.vdouble( 1.5, 0.90 ,0.9) , upBounds = cms.vdouble( 6.0, 999., 1.1 ) , values = cms.vdouble( 1.20311 ) , uncertainties = cms.vdouble(  0.0222861 )  )
+        )
+    )
+
+# Based on the updated derivation by N. Schroeder for HIG-19-004. Re-evaluated in coarse Eta-R9 bins
+FNUFBins = cms.PSet(
+    variables = cms.vstring("abs(superCluster.eta)","full5x5_r9"),
+    bins = cms.VPSet(
+        cms.PSet( lowBounds = cms.vdouble( 0.0, 0.00 ) , upBounds = cms.vdouble( 1.5, 0.94 ) , values = cms.vdouble( 0. ) , uncertainties = cms.vdouble(  0.0007 )  ) ,
+        cms.PSet( lowBounds = cms.vdouble( 0.0, 0.94 ) , upBounds = cms.vdouble( 1.5, 999. ) , values = cms.vdouble( 0. ) , uncertainties = cms.vdouble(  0.0022 )  ) ,
+        cms.PSet( lowBounds = cms.vdouble( 1.5, 0.00 ) , upBounds = cms.vdouble( 6.0, 0.94 ) , values = cms.vdouble( 0. ) , uncertainties = cms.vdouble(  0.00005 )  ) ,
+        cms.PSet( lowBounds = cms.vdouble( 1.5, 0.94 ) , upBounds = cms.vdouble( 6.0, 999. ) , values = cms.vdouble( 0. ) , uncertainties = cms.vdouble(  0.00251 )  )
+        )
+    )
+
+# from Martina: https://indico.cern.ch/event/628676/contributions/2546615/attachments/1440085/2216643/20170405_martina_regrEchecksUpdate.pdf
+showerShapeBins = cms.PSet(
+    variables = cms.vstring("abs(superCluster.eta)","full5x5_r9"),
+    bins = cms.VPSet(
+        #EB low R9
+        cms.PSet( lowBounds = cms.vdouble( 0.0, 0.00 ) , upBounds = cms.vdouble( 1.0, 0.94 ) , values = cms.vdouble( 0. ) , uncertainties = cms.vdouble( -0.0001 )  ) ,
+        cms.PSet( lowBounds = cms.vdouble( 1.0, 0.00 ) , upBounds = cms.vdouble( 1.5, 0.94 ) , values = cms.vdouble( 0. ) , uncertainties = cms.vdouble(  0.0002 )  ) ,
+        #EB high R9
+        cms.PSet( lowBounds = cms.vdouble( 0.0, 0.94 ) , upBounds = cms.vdouble( 1.0, 999. ) , values = cms.vdouble( 0. ) , uncertainties = cms.vdouble( -0.0006 )  ) ,
+        cms.PSet( lowBounds = cms.vdouble( 1.0, 0.94 ) , upBounds = cms.vdouble( 1.5, 999. ) , values = cms.vdouble( 0. ) , uncertainties = cms.vdouble( -0.0011 )  ) ,
+        #EE low R9
+        cms.PSet( lowBounds = cms.vdouble( 1.5, 0.00 ) , upBounds = cms.vdouble( 2.0, 0.94 ) , values = cms.vdouble( 0. ) , uncertainties = cms.vdouble( 0.0015 )  ) ,
+        cms.PSet( lowBounds = cms.vdouble( 2.0, 0.00 ) , upBounds = cms.vdouble( 6.0, 0.94 ) , values = cms.vdouble( 0. ) , uncertainties = cms.vdouble( 0.0004 )  ) ,
+        #EE high R9
+        cms.PSet( lowBounds = cms.vdouble( 1.5, 0.94 ) , upBounds = cms.vdouble( 2.0, 999. ) , values = cms.vdouble( 0. ) , uncertainties = cms.vdouble( 0.0002 )  ) ,
+        cms.PSet( lowBounds = cms.vdouble( 2.0, 0.94 ) , upBounds = cms.vdouble( 6.0, 999. ) , values = cms.vdouble( 0. ) , uncertainties = cms.vdouble( 0.0003 )  ) 
+        )
+    )
+
+
+#for full 2018 (Era2018_RR-17Sep2018_v2-legacyRun2FullV2-v0, rereco A-D dataset).  Trigger scale factors for use without HLT applied in MC
+leadTriggerScaleBins = cms.PSet(
+    variables = cms.vstring("full5x5_r9","abs(superCluster.eta)","pt"),
+    bins = cms.VPSet(
+
+        #0 <eta < 1.5, R9<0.54 (cat 2 r9 turn-on bin)
+        cms.PSet(lowBounds = cms.vdouble(0.0,0.0,0.0), upBounds = cms.vdouble(0.54,1.5,35.0), values = cms.vdouble(0.8020693032), uncertainties = cms.vdouble(0.0108370679,0.0108370679)),
+        cms.PSet(lowBounds = cms.vdouble(0.0,0.0,35.0), upBounds = cms.vdouble(0.54,1.5,37.0), values = cms.vdouble(0.9155469694), uncertainties = cms.vdouble(0.0042798703,0.0042798703)),
+        cms.PSet(lowBounds = cms.vdouble(0.0,0.0,37.0), upBounds = cms.vdouble(0.54,1.5,40.0), values = cms.vdouble(0.9266209669), uncertainties = cms.vdouble(0.0020932481,0.0020932481)), 
+        cms.PSet(lowBounds = cms.vdouble(0.0,0.0,40.0), upBounds = cms.vdouble(0.54,1.5,45.0), values = cms.vdouble(0.9295708491), uncertainties = cms.vdouble(0.0012322936,0.0012322936)),
+        cms.PSet(lowBounds = cms.vdouble(0.0,0.0,45.0), upBounds = cms.vdouble(0.54,1.5,50.0), values = cms.vdouble(0.9303265907), uncertainties = cms.vdouble(0.0024324819,0.0024324819)),
+        cms.PSet(lowBounds = cms.vdouble(0.0,0.0,50.0), upBounds = cms.vdouble(0.54,1.5,60.0), values = cms.vdouble(0.9416725453), uncertainties = cms.vdouble(0.0057677517,0.0057677517)),
+        cms.PSet(lowBounds = cms.vdouble(0.0,0.0,60.0), upBounds = cms.vdouble(0.54,1.5,70.0), values = cms.vdouble(0.9503439663), uncertainties = cms.vdouble(0.0143137857,0.0143137857)),
+        cms.PSet(lowBounds = cms.vdouble(0.0,0.0,70.0), upBounds = cms.vdouble(0.54,1.5,90.0), values = cms.vdouble(0.9574423947), uncertainties = cms.vdouble(0.0120714856,0.0120714856)),
+        cms.PSet(lowBounds = cms.vdouble(0.0,0.0,90.0), upBounds = cms.vdouble(0.54,1.5,99999), values = cms.vdouble(0.9523387414), uncertainties = cms.vdouble(0.0267745254,0.0267745254)),
+
+        #0 <eta < 1.5, 0.54 < R9<0.85 (cat 2 r9 plateau-bin) 
+        cms.PSet(lowBounds = cms.vdouble(0.54,0.0,0.0), upBounds = cms.vdouble(0.85,1.5,35.0), values = cms.vdouble(0.8524002552), uncertainties = cms.vdouble(0.0010000000,0.0010000000)),
+        cms.PSet(lowBounds = cms.vdouble(0.54,0.0,35.0), upBounds = cms.vdouble(0.85,1.5,37.0), values = cms.vdouble(0.9476119412), uncertainties = cms.vdouble(0.0010000000,0.0010000000)),
+        cms.PSet(lowBounds = cms.vdouble(0.54,0.0,37.0), upBounds = cms.vdouble(0.85,1.5,40.0), values = cms.vdouble(0.9537999031), uncertainties = cms.vdouble(0.0010000000,0.0010000000)),
+        cms.PSet(lowBounds = cms.vdouble(0.54,0.0,40.0), upBounds = cms.vdouble(0.85,1.5,45.0), values = cms.vdouble(0.9606177455), uncertainties = cms.vdouble(0.0010000000,0.0010000000)),
+        cms.PSet(lowBounds = cms.vdouble(0.54,0.0,45.0), upBounds = cms.vdouble(0.85,1.5,50.0), values = cms.vdouble(0.9652220994), uncertainties = cms.vdouble(0.0010000000,0.0010000000)),
+        cms.PSet(lowBounds = cms.vdouble(0.54,0.0,50.0), upBounds = cms.vdouble(0.85,1.5,60.0), values = cms.vdouble(0.9677140340), uncertainties = cms.vdouble(0.0010000000,0.0010000000)),
+        cms.PSet(lowBounds = cms.vdouble(0.54,0.0,60.0), upBounds = cms.vdouble(0.85,1.5,70.0), values = cms.vdouble(0.9714560889), uncertainties = cms.vdouble(0.0012234955,0.0012234955)),
+        cms.PSet(lowBounds = cms.vdouble(0.54,0.0,70.0), upBounds = cms.vdouble(0.85,1.5,90.0), values = cms.vdouble(0.9792025583), uncertainties = cms.vdouble(0.0021872047,0.0021872047)),
+        cms.PSet(lowBounds = cms.vdouble(0.54,0.0,90.0), upBounds = cms.vdouble(0.85,1.5,99999), values = cms.vdouble(0.9846367363), uncertainties = cms.vdouble(0.0016488000,0.0016488000)),
+
+        #0 <eta < 1.5, R9>0.85 (cat 0)
+        cms.PSet(lowBounds = cms.vdouble(0.85,0.0,0.0), upBounds = cms.vdouble(999,1.5,35.0), values = cms.vdouble(0.8855419724), uncertainties = cms.vdouble(0.0010000000,0.0010000000)),
+        cms.PSet(lowBounds = cms.vdouble(0.85,0.0,35.0), upBounds = cms.vdouble(999,1.5,37.0), values = cms.vdouble(0.9599693694), uncertainties = cms.vdouble(0.0012218737,0.0012218737)),
+        cms.PSet(lowBounds = cms.vdouble(0.85,0.0,37.0), upBounds = cms.vdouble(999,1.5,40.0), values = cms.vdouble(0.9665558231), uncertainties = cms.vdouble(0.0010000000,0.0010000000)),
+        cms.PSet(lowBounds = cms.vdouble(0.85,0.0,40.0), upBounds = cms.vdouble(999,1.5,45.0), values = cms.vdouble(0.9729324583), uncertainties = cms.vdouble(0.0010000000,0.0010000000)),
+        cms.PSet(lowBounds = cms.vdouble(0.85,0.0,45.0), upBounds = cms.vdouble(999,1.5,50.0), values = cms.vdouble(0.9784734824), uncertainties = cms.vdouble(0.0010000000,0.0010000000)),
+        cms.PSet(lowBounds = cms.vdouble(0.85,0.0,50.0), upBounds = cms.vdouble(999,1.5,60.0), values = cms.vdouble(0.9806145301), uncertainties = cms.vdouble(0.0010000000,0.0010000000)),
+        cms.PSet(lowBounds = cms.vdouble(0.85,0.0,60.0), upBounds = cms.vdouble(999,1.5,70.0), values = cms.vdouble(0.9814731790), uncertainties = cms.vdouble(0.0010000000,0.0010000000)),
+        cms.PSet(lowBounds = cms.vdouble(0.85,0.0,70.0), upBounds = cms.vdouble(999,1.5,90.0), values = cms.vdouble(0.9830517669), uncertainties = cms.vdouble(0.0010000000,0.0010000000)),
+        cms.PSet(lowBounds = cms.vdouble(0.85,0.0,90.0), upBounds = cms.vdouble(999,1.5,99999), values = cms.vdouble(0.9903382393), uncertainties = cms.vdouble(0.0010000000,0.0010000000)),
+
+        #1.5 <eta <3, R9<0.84 (cat 3 r9 turn-on bin)
+        cms.PSet(lowBounds = cms.vdouble(0.0,1.5,0.0), upBounds = cms.vdouble(0.84,3.0,35.0), values = cms.vdouble(0.8656534670), uncertainties = cms.vdouble(0.0019334223,0.0019334223)),
+        cms.PSet(lowBounds = cms.vdouble(0.0,1.5,35.0), upBounds = cms.vdouble(0.84,3.0,37.0), values = cms.vdouble(0.9482903730), uncertainties = cms.vdouble(0.0014018856,0.0014018856)),
+        cms.PSet(lowBounds = cms.vdouble(0.0,1.5,37.0), upBounds = cms.vdouble(0.84,3.0,40.0), values = cms.vdouble(0.9560211271), uncertainties = cms.vdouble(0.0022246022,0.0022246022)),
+        cms.PSet(lowBounds = cms.vdouble(0.0,1.5,40.0), upBounds = cms.vdouble(0.84,3.0,45.0), values = cms.vdouble(0.9656682311), uncertainties = cms.vdouble(0.0010000000,0.0010000000)),
+        cms.PSet(lowBounds = cms.vdouble(0.0,1.5,45.0), upBounds = cms.vdouble(0.84,3.0,50.0), values = cms.vdouble(0.9714389718), uncertainties = cms.vdouble(0.0011571498,0.0011571498)),
+        cms.PSet(lowBounds = cms.vdouble(0.0,1.5,50.0), upBounds = cms.vdouble(0.84,3.0,60.0), values = cms.vdouble(0.9727868307), uncertainties = cms.vdouble(0.0027277860,0.0027277860)),
+        cms.PSet(lowBounds = cms.vdouble(0.0,1.5,60.0), upBounds = cms.vdouble(0.84,3.0,70.0), values = cms.vdouble(0.9716310829), uncertainties = cms.vdouble(0.0053509351,0.0053509351)),
+        cms.PSet(lowBounds = cms.vdouble(0.0,1.5,70.0), upBounds = cms.vdouble(0.84,3.0,90.0), values = cms.vdouble(0.9749593833), uncertainties = cms.vdouble(0.0043547018,0.0043547018)),
+        cms.PSet(lowBounds = cms.vdouble(0.,1.5,90.0), upBounds = cms.vdouble(0.84,3.0,999999), values = cms.vdouble(0.9781950680), uncertainties = cms.vdouble(0.0051854430,0.0051854430)),
+
+        #1.5 <eta <3, 0.84< R9<0.90 (cat 3 r9 plateau bin)
+        cms.PSet(lowBounds = cms.vdouble(0.84,1.5,0.0), upBounds = cms.vdouble(0.9,3.0,35.0), values = cms.vdouble(0.8790818182), uncertainties = cms.vdouble(0.0011724123,0.0011724123)),
+        cms.PSet(lowBounds = cms.vdouble(0.84,1.5,35.0), upBounds = cms.vdouble(0.9,3.0,37.0), values = cms.vdouble(0.9730292260), uncertainties = cms.vdouble(0.0010000000,0.0010000000)),
+        cms.PSet(lowBounds = cms.vdouble(0.84,1.5,37.0), upBounds = cms.vdouble(0.9,3.0,40.0), values = cms.vdouble(0.9788279858), uncertainties = cms.vdouble(0.0010000000,0.0010000000)),
+        cms.PSet(lowBounds = cms.vdouble(0.84,1.5,40.0), upBounds = cms.vdouble(0.9,3.0,45.0), values = cms.vdouble(0.9824542096), uncertainties = cms.vdouble(0.0010000000,0.0010000000)),
+        cms.PSet(lowBounds = cms.vdouble(0.84,1.5,45.0), upBounds = cms.vdouble(0.9,3.0,50.0), values = cms.vdouble(0.9841886360), uncertainties = cms.vdouble(0.0010000000,0.0010000000)),
+        cms.PSet(lowBounds = cms.vdouble(0.84,1.5,50.0), upBounds = cms.vdouble(0.9,3.0,60.0), values = cms.vdouble(0.9848402006), uncertainties = cms.vdouble(0.0011284238,0.0011284238)),
+        cms.PSet(lowBounds = cms.vdouble(0.84,1.5,60.0), upBounds = cms.vdouble(0.9,3.0,70.0), values = cms.vdouble(0.9875812187), uncertainties = cms.vdouble(0.0018108700,0.0018108700)),
+        cms.PSet(lowBounds = cms.vdouble(0.84,1.5,70.0), upBounds = cms.vdouble(0.9,3.0,90.0), values = cms.vdouble(0.9885875172), uncertainties = cms.vdouble(0.0016709154,0.0016709154)),
+        cms.PSet(lowBounds = cms.vdouble(0.84,1.5,90.0), upBounds = cms.vdouble(0.9,3.0,99999), values = cms.vdouble(0.9941926927), uncertainties = cms.vdouble(0.0014826775,0.0014826775)),
+       
+
+        #1.5 <eta <3, R9>0.90 (cat 1)
+        cms.PSet(lowBounds = cms.vdouble(0.9,1.5,0.0), upBounds = cms.vdouble(999,3.0,35.0), values = cms.vdouble(0.8425282382), uncertainties = cms.vdouble(0.0010416570,0.0010416570)),
+        cms.PSet(lowBounds = cms.vdouble(0.9,1.5,35.0), upBounds = cms.vdouble(999,3.0,37.0), values = cms.vdouble(0.9729130893), uncertainties = cms.vdouble(0.0010000000,0.0010000000)),
+        cms.PSet(lowBounds = cms.vdouble(0.9,1.5,37.0), upBounds = cms.vdouble(999,3.0,40.0), values = cms.vdouble(0.9781362068), uncertainties = cms.vdouble(0.0010000000,0.0010000000)),
+        cms.PSet(lowBounds = cms.vdouble(0.9,1.5,40.0), upBounds = cms.vdouble(999,3.0,45.0), values = cms.vdouble(0.9826974813), uncertainties = cms.vdouble(0.0010000000,0.0010000000)),
+        cms.PSet(lowBounds = cms.vdouble(0.9,1.5,45.0), upBounds = cms.vdouble(999,3.0,50.0), values = cms.vdouble(0.9858318192), uncertainties = cms.vdouble(0.0010000000,0.0010000000)),
+        cms.PSet(lowBounds = cms.vdouble(0.9,1.5,50.0), upBounds = cms.vdouble(999,3.0,60.0), values = cms.vdouble(0.9794794506), uncertainties = cms.vdouble(0.0010000000,0.0010000000)),
+        cms.PSet(lowBounds = cms.vdouble(0.9,1.5,60.0), upBounds = cms.vdouble(999,3.0,70.0), values = cms.vdouble(0.9925981035), uncertainties = cms.vdouble(0.0010298667,0.0010298667)),
+        cms.PSet(lowBounds = cms.vdouble(0.9,1.5,70.0), upBounds = cms.vdouble(999,3.0,90.0), values = cms.vdouble(0.9920874219), uncertainties = cms.vdouble(0.0010000000,0.0010000000)),
+        cms.PSet(lowBounds = cms.vdouble(0.9,1.5,90.0), upBounds = cms.vdouble(999,3.0,99999), values = cms.vdouble(0.9942726543), uncertainties = cms.vdouble(0.0010000000,0.0010000000)),
+        
+        cms.PSet(lowBounds = cms.vdouble(0.0,3.,0), upBounds = cms.vdouble(999,999,999999), values = cms.vdouble(1.), uncertainties = cms.vdouble(1.,1.))
+        )
+    )
+
+
+subleadTriggerScaleBins = cms.PSet(
+    variables = cms.vstring("full5x5_r9","abs(superCluster.eta)","pt"),
+    bins = cms.VPSet(
+      
+        #0 <eta < 1.5, R9<0.54 (cat 2 r9 turn-on bin)
+        cms.PSet(lowBounds = cms.vdouble(0.0,0.0,0.0), upBounds = cms.vdouble(0.54,1.5,28.0), values = cms.vdouble(0.8884153471), uncertainties = cms.vdouble(0.0035078397,0.0035078397)),
+        cms.PSet(lowBounds = cms.vdouble(0.0,0.0,28.0), upBounds = cms.vdouble(0.54,1.5,31.0), values = cms.vdouble(0.9517603567), uncertainties = cms.vdouble(0.0012683293,0.0012683293)),
+        cms.PSet(lowBounds = cms.vdouble(0.0,0.0,31.0), upBounds = cms.vdouble(0.54,1.5,35.0), values = cms.vdouble(0.9690496396), uncertainties = cms.vdouble(0.0014644761,0.0014644761)),
+        cms.PSet(lowBounds = cms.vdouble(0.0,0.0,35.0), upBounds = cms.vdouble(0.54,1.5,40.0), values = cms.vdouble(0.9717160162), uncertainties = cms.vdouble(0.0013420893,0.0013420893)),
+        cms.PSet(lowBounds = cms.vdouble(0.0,0.0,40.0), upBounds = cms.vdouble(0.54,1.5,45.0), values = cms.vdouble(0.9796815413), uncertainties = cms.vdouble(0.0010000000,0.0010000000)), 
+        cms.PSet(lowBounds = cms.vdouble(0.0,0.0,45.0), upBounds = cms.vdouble(0.54,1.5,50.0), values = cms.vdouble(0.9843574751), uncertainties = cms.vdouble(0.0019132259,0.0019132259)),
+        cms.PSet(lowBounds = cms.vdouble(0.0,0.0,50.0), upBounds = cms.vdouble(0.54,1.5,60.0), values = cms.vdouble(0.9844776733), uncertainties = cms.vdouble(0.0040644219,0.0040644219)),
+        cms.PSet(lowBounds = cms.vdouble(0.0,0.0,60.0), upBounds = cms.vdouble(0.54,1.5,70.0), values = cms.vdouble(0.9873999094), uncertainties = cms.vdouble(0.0053801091,0.0053801091)),
+        cms.PSet(lowBounds = cms.vdouble(0.0,0.0,70.0), upBounds = cms.vdouble(0.54,1.5,90.0), values = cms.vdouble(0.9933255120), uncertainties = cms.vdouble(0.0063638347,0.0063638347)),
+        cms.PSet(lowBounds = cms.vdouble(0.0,0.0,90.0), upBounds = cms.vdouble(0.54,1.5,999999), values = cms.vdouble(0.9804395842), uncertainties = cms.vdouble(0.0310825604,0.019560)),
+
+        #0 <eta < 1.5, 0.54<R9<0.85 (cat 2 r9 plateau bin)
+        cms.PSet(lowBounds = cms.vdouble(0.54,0.0,0.0), upBounds = cms.vdouble(0.85,1.5,28.0), values = cms.vdouble(0.9184639454), uncertainties = cms.vdouble(0.0010000000,0.0010000000)),
+        cms.PSet(lowBounds = cms.vdouble(0.54,0.0,28.0), upBounds = cms.vdouble(0.85,1.5,31.0), values = cms.vdouble(0.9950437401), uncertainties = cms.vdouble(0.0010000000,0.0010000000)),
+        cms.PSet(lowBounds = cms.vdouble(0.54,0.0,31.0), upBounds = cms.vdouble(0.85,1.5,35.0), values = cms.vdouble(0.9917999437), uncertainties = cms.vdouble(0.0010000000,0.0010000000)),
+        cms.PSet(lowBounds = cms.vdouble(0.54,0.0,35.0), upBounds = cms.vdouble(0.85,1.5,40.0), values = cms.vdouble(0.9939153322), uncertainties = cms.vdouble(0.0010000000,0.0010000000)),
+        cms.PSet(lowBounds = cms.vdouble(0.54,0.0,40.0), upBounds = cms.vdouble(0.85,1.5,45.0), values = cms.vdouble(0.9947390674), uncertainties = cms.vdouble(0.0010000000,0.0010000000)),
+        cms.PSet(lowBounds = cms.vdouble(0.54,0.0,45.0), upBounds = cms.vdouble(0.85,1.5,50.0), values = cms.vdouble(0.9945127334), uncertainties = cms.vdouble(0.0010000000,0.0010000000)),
+        cms.PSet(lowBounds = cms.vdouble(0.54,0.0,50.0), upBounds = cms.vdouble(0.85,1.5,60.0), values = cms.vdouble(0.9953081007), uncertainties = cms.vdouble(0.0010000000,0.0010000000)),
+        cms.PSet(lowBounds = cms.vdouble(0.54,0.0,60.0), upBounds = cms.vdouble(0.85,1.5,70.0), values = cms.vdouble(0.9968578311), uncertainties = cms.vdouble(0.0024445012,0.0024445012)),
+        cms.PSet(lowBounds = cms.vdouble(0.54,0.0,70.0), upBounds = cms.vdouble(0.85,1.5,90.0), values = cms.vdouble(0.9956645030), uncertainties = cms.vdouble(0.0010000000,0.0010000000)),
+        cms.PSet(lowBounds = cms.vdouble(0.54,0.0,90.0), upBounds = cms.vdouble(0.85,1.5,99999), values = cms.vdouble(0.9957331016), uncertainties = cms.vdouble(0.0010000000,0.0010000000)),
+
+        #0 <eta < 1.5, R9>0.85 (cat 0)
+        cms.PSet(lowBounds = cms.vdouble(0.85,0.0,0.0), upBounds = cms.vdouble(999,1.5,28.0), values = cms.vdouble(0.9482245748), uncertainties = cms.vdouble(0.0024089227,0.0024089227)),
+        cms.PSet(lowBounds = cms.vdouble(0.85,0.0,28.0), upBounds = cms.vdouble(999,1.5,31.0), values = cms.vdouble(0.9999020755), uncertainties = cms.vdouble(0.0010000000,0.0010000000)),
+        cms.PSet(lowBounds = cms.vdouble(0.85,0.0,31.0), upBounds = cms.vdouble(999,1.5,35.0), values = cms.vdouble(0.9999120130), uncertainties = cms.vdouble(0.0010000000,0.0010000000)),
+        cms.PSet(lowBounds = cms.vdouble(0.85,0.0,35.0), upBounds = cms.vdouble(999,1.5,40.0), values = cms.vdouble(0.9999573970), uncertainties = cms.vdouble(0.0026996598,0.0026996598)),
+        cms.PSet(lowBounds = cms.vdouble(0.85,0.0,40.0), upBounds = cms.vdouble(999,1.5,45.0), values = cms.vdouble(0.9999830622), uncertainties = cms.vdouble(0.0010000000,0.0010000000)),
+        cms.PSet(lowBounds = cms.vdouble(0.85,0.0,45.0), upBounds = cms.vdouble(999,1.5,50.0), values = cms.vdouble(0.9999880454), uncertainties = cms.vdouble(0.0010000000,0.0010000000)),
+        cms.PSet(lowBounds = cms.vdouble(0.85,0.0,50.0), upBounds = cms.vdouble(999,1.5,60.0), values = cms.vdouble(0.9999938661), uncertainties = cms.vdouble(0.0010000000,0.0010000000)),
+        cms.PSet(lowBounds = cms.vdouble(0.85,0.0,60.0), upBounds = cms.vdouble(999,1.5,70.0), values = cms.vdouble(0.9999867470), uncertainties = cms.vdouble(0.0010000000,0.0010000000)),
+        cms.PSet(lowBounds = cms.vdouble(0.85,0.0,70.0), upBounds = cms.vdouble(999,1.5,90.0),values = cms.vdouble(0.9999972153), uncertainties = cms.vdouble(0.0010000000,0.0010000000)),
+        cms.PSet(lowBounds = cms.vdouble(0.85,0.0,90.0), upBounds = cms.vdouble(999,1.5,999999), values = cms.vdouble(0.9999550063), uncertainties = cms.vdouble(0.0010000000,0.0010000000)),
+    
+        
+        #1.5 <eta < 3, R9<0.84 (cat 3 r9 turn-on bin)
+        cms.PSet(lowBounds = cms.vdouble(0.0,1.5,0.0), upBounds = cms.vdouble(0.84,3.0,28.0), values = cms.vdouble(0.9024458938), uncertainties = cms.vdouble(0.0028471768,0.0028471768)), 
+        cms.PSet(lowBounds = cms.vdouble(0.0,1.5,28.0), upBounds = cms.vdouble(0.84,3.0,31.0), values = cms.vdouble(0.9706150264), uncertainties = cms.vdouble(0.0046523365,0.0046523365)), 
+        cms.PSet(lowBounds = cms.vdouble(0.0,1.5,31.0), upBounds = cms.vdouble(0.84,3.0,35.0), values = cms.vdouble(0.9697381479), uncertainties = cms.vdouble(0.0034363710,0.0034363710)),
+        cms.PSet(lowBounds = cms.vdouble(0.0,1.5,35.0), upBounds = cms.vdouble(0.84,3.0,40.0), values = cms.vdouble(0.9723474700), uncertainties = cms.vdouble(0.0010000000,0.0010000000)),
+        cms.PSet(lowBounds = cms.vdouble(0.0,1.5,40.0), upBounds = cms.vdouble(0.84,3.0,45.0), values = cms.vdouble(0.9776980417), uncertainties = cms.vdouble(0.0010000000,0.0010000000)),
+        cms.PSet(lowBounds = cms.vdouble(0.0,1.5,45.0), upBounds = cms.vdouble(0.84,3.0,50.0), values = cms.vdouble(0.9796103567), uncertainties = cms.vdouble(0.0012977858,0.0012977858)),
+        cms.PSet(lowBounds = cms.vdouble(0.0,1.5,50.0), upBounds = cms.vdouble(0.84,3.0,60.0), values = cms.vdouble(0.9761773122), uncertainties = cms.vdouble(0.0028290744,0.0028290744)), 
+        cms.PSet(lowBounds = cms.vdouble(0.0,1.5,60.0), upBounds = cms.vdouble(0.84,3.0,70.0), values = cms.vdouble(0.9767940972), uncertainties = cms.vdouble(0.0038576930,0.0038576930)), 
+        cms.PSet(lowBounds = cms.vdouble(0.0,1.5,70.0), upBounds = cms.vdouble(0.84,3.0,90.0), values = cms.vdouble(0.9820266168), uncertainties = cms.vdouble(0.0037175753,0.0037175753)),
+        cms.PSet(lowBounds = cms.vdouble(0.0,1.5,90.0), upBounds = cms.vdouble(0.84,3.0,9999999), values = cms.vdouble(0.9786811223), uncertainties = cms.vdouble(0.0020066146,0.0020066146)),
+
+
+        #1.5 <eta < 3, 0.84<R9<0.9 (cat 3 r9 plateau bin)
+        cms.PSet(lowBounds = cms.vdouble(0.84,1.5,0.0), upBounds = cms.vdouble(0.9,3.0,28.0), values = cms.vdouble(0.9187774368), uncertainties = cms.vdouble(0.0016372591,0.0016372591)),
+        cms.PSet(lowBounds = cms.vdouble(0.84,1.5,28.0), upBounds = cms.vdouble(0.9,3.0,31.0), values = cms.vdouble(0.9912278169), uncertainties = cms.vdouble(0.0018807126,0.0018807126)),
+        cms.PSet(lowBounds = cms.vdouble(0.84,1.5,31.0), upBounds = cms.vdouble(0.9,3.0,35.0), values = cms.vdouble(0.9901680254), uncertainties = cms.vdouble(0.0010000000,0.0010000000)),
+        cms.PSet(lowBounds = cms.vdouble(0.84,1.5,35.0), upBounds = cms.vdouble(0.9,3.0,40.0), values = cms.vdouble(0.9928358746), uncertainties = cms.vdouble(0.0010000000,0.0010000000)),
+        cms.PSet(lowBounds = cms.vdouble(0.84,1.5,40.0), upBounds = cms.vdouble(0.9,3.0,45.0), values = cms.vdouble(0.9935834235), uncertainties = cms.vdouble(0.0010000000,0.0010000000)),
+        cms.PSet(lowBounds = cms.vdouble(0.84,1.5,45.0), upBounds = cms.vdouble(0.9,3.0,50.0), values = cms.vdouble(0.9935942765), uncertainties = cms.vdouble(0.0010000000,0.0010000000)),
+        cms.PSet(lowBounds = cms.vdouble(0.84,1.5,50.0), upBounds = cms.vdouble(0.9,3.0,60.0), values = cms.vdouble(0.9940966594), uncertainties = cms.vdouble(0.0010000000,0.0010000000)),
+        cms.PSet(lowBounds = cms.vdouble(0.84,1.5,60.0), upBounds = cms.vdouble(0.9,3.0,70.0), values = cms.vdouble(0.9944723732), uncertainties = cms.vdouble(0.0014841931,0.0014841931)),
+        cms.PSet(lowBounds = cms.vdouble(0.84,1.5,70.0), upBounds = cms.vdouble(0.9,3.0,90.0), values = cms.vdouble(0.9966527166), uncertainties = cms.vdouble(0.0010000000,0.0010000000)),
+        cms.PSet(lowBounds = cms.vdouble(0.84,1.5,90.0), upBounds = cms.vdouble(0.9,3.0,999999), values = cms.vdouble(0.9963826143), uncertainties = cms.vdouble(0.0013134571,0.0013134571)),
+
+
+        #1.5 <eta < 3, R9>0.9 (cat 1)
+        cms.PSet(lowBounds = cms.vdouble(0.9,1.5,0.0), upBounds = cms.vdouble(999,3.0,28.0), values = cms.vdouble(0.9126823457), uncertainties = cms.vdouble(0.0030246593,0.0030246593)), 
+        cms.PSet(lowBounds = cms.vdouble(0.9,1.5,28.0), upBounds = cms.vdouble(999,3.0,31.0), values = cms.vdouble(0.9997440713), uncertainties = cms.vdouble(0.0010000000,0.0010000000)), 
+        cms.PSet(lowBounds = cms.vdouble(0.9,1.5,31.0), upBounds = cms.vdouble(999,3.0,35.0), values = cms.vdouble(0.9996615281), uncertainties = cms.vdouble(0.0010000000,0.0010000000)), 
+        cms.PSet(lowBounds = cms.vdouble(0.9,1.5,35.0), upBounds = cms.vdouble(999,3.0,40.0), values = cms.vdouble(0.9997655760), uncertainties = cms.vdouble(0.0010000000,0.0010000000)), 
+        cms.PSet(lowBounds = cms.vdouble(0.9,1.5,40.0), upBounds = cms.vdouble(999,3.0,45.0), values = cms.vdouble(0.9998579409), uncertainties = cms.vdouble(0.0010000000,0.0010000000)), 
+        cms.PSet(lowBounds = cms.vdouble(0.9,1.5,45.0), upBounds = cms.vdouble(999,3.0,50.0), values = cms.vdouble(0.9998936352), uncertainties = cms.vdouble(0.0010000000,0.0010000000)), 
+        cms.PSet(lowBounds = cms.vdouble(0.9,1.5,50.0), upBounds = cms.vdouble(999,3.0,60.0), values = cms.vdouble(0.9998729705), uncertainties = cms.vdouble(0.0010000000,0.0010000000)), 
+        cms.PSet(lowBounds = cms.vdouble(0.9,1.5,60.0), upBounds = cms.vdouble(999,3.0,70.0), values = cms.vdouble(0.9997750397), uncertainties = cms.vdouble(0.0010000000,0.0010000000)), 
+        cms.PSet(lowBounds = cms.vdouble(0.9,1.5,70.0), upBounds = cms.vdouble(999,3.0,90.0), values = cms.vdouble(0.9999724487), uncertainties = cms.vdouble(0.0010000000,0.0010000000)), 
+        cms.PSet(lowBounds = cms.vdouble(0.9,1.5,90.0), upBounds = cms.vdouble(999,3.0,9999999), values = cms.vdouble(0.9999686824), uncertainties = cms.vdouble(0.0010000000,0.0010000000)),
+
+        cms.PSet(lowBounds = cms.vdouble(0.0,3.,0), upBounds = cms.vdouble(999,999,999999), values = cms.vdouble(1.), uncertainties = cms.vdouble(1.,1.))
+        )
+    )
+
+# from Arnab via Martina 10/03/2016
+looseMvaBins = cms.PSet(
+    variables = cms.vstring("abs(superCluster.eta)","full5x5_r9"),
+    bins = cms.VPSet(
+        cms.PSet( lowBounds = cms.vdouble( 0.0, 0.0  ) , upBounds = cms.vdouble( 1.5, 0.85  ) , values = cms.vdouble( 0.9999 ) , uncertainties = cms.vdouble( 0.0001 )  ) ,
+        cms.PSet( lowBounds = cms.vdouble( 0.0, 0.85 ) , upBounds = cms.vdouble( 1.5, 999.0 ) , values = cms.vdouble( 1.0003 ) , uncertainties = cms.vdouble( 0.0000 )  ) ,
+        cms.PSet( lowBounds = cms.vdouble( 1.5, 0.0  ) , upBounds = cms.vdouble( 6.0, 0.9   ) , values = cms.vdouble( 1.0003 ) , uncertainties = cms.vdouble( 0.0000 )  ) ,
+        cms.PSet( lowBounds = cms.vdouble( 1.5, 0.9  ) , upBounds = cms.vdouble( 6.0, 999.0 ) , values = cms.vdouble( 1.0004 ) , uncertainties = cms.vdouble( 0.0000 ) ) ) ) 
+
+# RELATIVE shift of sigmaE/E --> 0.05 corresponds to a shift of 5%
+sigmaEOverEShiftBins = cms.PSet(
+    variables = cms.vstring("abs(superCluster.eta)"),
+    bins = cms.VPSet(
+                     cms.PSet( lowBounds = cms.vdouble(0.000), upBounds = cms.vdouble(999.), values = cms.vdouble( 0.0 ), uncertainties = cms.vdouble( 0.05 ))
+                     )
+    )
+
+
+RVBins = cms.PSet(
+    variables = cms.vstring("pt"),
+    bins = cms.VPSet(
+        cms.PSet(lowBounds = cms.vdouble(0),   upBounds = cms.vdouble(5),   values = cms.vdouble(0.993565, 1.00664), uncertainties = cms.vdouble(0.0225433, 0.0225433, 0.023279, 0.023279)),
+        cms.PSet(lowBounds = cms.vdouble(5),   upBounds = cms.vdouble(10),  values = cms.vdouble(1.01856, 0.978069), uncertainties = cms.vdouble(0.0240601, 0.0240601, 0.0284297, 0.0284297)),
+        cms.PSet(lowBounds = cms.vdouble(10),  upBounds = cms.vdouble(15),  values = cms.vdouble(1.01375, 0.980025), uncertainties = cms.vdouble(0.0240097, 0.0240097, 0.0348869, 0.0348869)),
+        cms.PSet(lowBounds = cms.vdouble(15),  upBounds = cms.vdouble(20),  values = cms.vdouble(1.00379, 0.99301), uncertainties = cms.vdouble(0.02055, 0.02055, 0.0379198, 0.0379198)),
+        cms.PSet(lowBounds = cms.vdouble(20),  upBounds = cms.vdouble(30),  values = cms.vdouble(0.989918, 1.02713), uncertainties = cms.vdouble(0.0153448, 0.0153448, 0.0412937, 0.0412937)),
+        cms.PSet(lowBounds = cms.vdouble(30),  upBounds = cms.vdouble(40),  values = cms.vdouble(0.982182, 1.07812), uncertainties = cms.vdouble(0.0095869, 0.0095869, 0.0420487, 0.0420487)),
+        cms.PSet(lowBounds = cms.vdouble(40),  upBounds = cms.vdouble(50),  values = cms.vdouble(0.984574, 1.10344), uncertainties = cms.vdouble(0.00598576, 0.00598576, 0.0401913, 0.0401913)),
+        cms.PSet(lowBounds = cms.vdouble(50),  upBounds = cms.vdouble(60),  values = cms.vdouble(0.988021, 1.11469), uncertainties = cms.vdouble(0.00382511, 0.00382511, 0.0367491, 0.0367491)),
+        cms.PSet(lowBounds = cms.vdouble(60),  upBounds = cms.vdouble(80),  values = cms.vdouble(0.992915, 1.11058), uncertainties = cms.vdouble(0.00318309, 0.00318309, 0.0497911, 0.0497911)),
+        cms.PSet(lowBounds = cms.vdouble(80),  upBounds = cms.vdouble(100), values = cms.vdouble(0.996389, 1.08094), uncertainties = cms.vdouble(0.00186217, 0.00186217, 0.0419005, 0.0419005)),
+        cms.PSet(lowBounds = cms.vdouble(100), upBounds = cms.vdouble(140), values = cms.vdouble(0.998132, 1.0714), uncertainties = cms.vdouble(0.0010437, 0.0010437, 0.0401096, 0.0401096)),
+        cms.PSet(lowBounds = cms.vdouble(140), upBounds = cms.vdouble(200), values = cms.vdouble(0.997934, 1.12722), uncertainties = cms.vdouble(0.000736251, 0.000736251, 0.0467527, 0.0467527)),
+        cms.PSet(lowBounds = cms.vdouble(200), upBounds = cms.vdouble(400), values = cms.vdouble(0.998515, 1.17222), uncertainties = cms.vdouble(0.000719232, 0.000719232, 0.0862914, 0.0862914)),
+        # maximum energy beyond 7000 because of wonky DiPhotons in data
+        cms.PSet(lowBounds = cms.vdouble(400 ) , upBounds = cms.vdouble(999999999 ) , values = cms.vdouble(1,1              ) , uncertainties = cms.vdouble(0.,0.,0.,0.))       
+        )
+    )      
+ 
+RVBinsNvtx = cms.PSet(
+    variables = cms.vstring("nVert"),
+     bins = cms.VPSet(
+        cms.PSet(lowBounds = cms.vdouble(-0.5), upBounds = cms.vdouble(10.5), values = cms.vdouble(1.02898,0.828452), uncertainties = cms.vdouble(0.00155068,0.00155068,0.00918045,0.00918045)),
+        cms.PSet(lowBounds = cms.vdouble(10.5), upBounds = cms.vdouble(12.5), values = cms.vdouble(1.00775,0.960156), uncertainties = cms.vdouble(0.0013211,0.0013211,0.00679271,0.00679271)),
+        cms.PSet(lowBounds = cms.vdouble(12.5), upBounds = cms.vdouble(14.5), values = cms.vdouble(1.00406,0.980929), uncertainties = cms.vdouble(0.00113947,0.00113947,0.00535269,0.00535269)),
+        cms.PSet(lowBounds = cms.vdouble(14.5), upBounds = cms.vdouble(16.5), values = cms.vdouble(1.00159,0.992869), uncertainties = cms.vdouble(0.00109956,0.00109956,0.00493888,0.00493888)),
+        cms.PSet(lowBounds = cms.vdouble(16.5), upBounds = cms.vdouble(18.5), values = cms.vdouble(0.993201,1.02899), uncertainties = cms.vdouble(0.00112887,0.00112887,0.00481407,0.00481407)),
+        cms.PSet(lowBounds = cms.vdouble(18.5), upBounds = cms.vdouble(20.5), values = cms.vdouble(0.991425,1.03468), uncertainties = cms.vdouble(0.0012414,0.0012414,0.00502105,0.00502105)),
+        cms.PSet(lowBounds = cms.vdouble(20.5), upBounds = cms.vdouble(22.5), values = cms.vdouble(0.989716,1.03941), uncertainties = cms.vdouble(0.00142369,0.00142369,0.00545553,0.00545553)),
+        cms.PSet(lowBounds = cms.vdouble(22.5), upBounds = cms.vdouble(25.5), values = cms.vdouble(0.98674,1.04837), uncertainties = cms.vdouble(0.00147513,0.00147513,0.00538112,0.00538112)),
+        cms.PSet(lowBounds = cms.vdouble(25.5), upBounds = cms.vdouble(30.5), values = cms.vdouble(0.976922,1.07893), uncertainties = cms.vdouble(0.00188024,0.00188024,0.00643049,0.00643049)),
+        cms.PSet(lowBounds = cms.vdouble(30.5), upBounds = cms.vdouble(100.5), values = cms.vdouble(0.959731,1.13018), uncertainties = cms.vdouble(0.00440431,0.00440431,0.0142389,0.0142389)),
+        # just in case
+        cms.PSet(lowBounds = cms.vdouble(100.5 ) , upBounds = cms.vdouble(999999999 ) , values = cms.vdouble(1,1              ) , uncertainties = cms.vdouble(0.,0.,0.,0.))       
+        )
+    )     
+
+
+
+
+# Photon categoryscale [$\times 10^{-2}$]
+# central EB (eta<0.8) low r9  0.035
+# central EB (eta<0.8) high r9  0.033
+# intermediate EB (0.8 < eta < 1.0) low r9  0.058
+# intermediate EB (0.8 < eta < 1.0) high r9  0.12
+# outer EB (eta>1.0) low r9  0.22
+# outer EB (eta>1.0) high r9  0.34
+# EE low r9  0.22
+# EE high r9  0.34
+#
+# Copied from Run 1 values
+# https://twiki.cern.ch/twiki/bin/viewauth/CMS/HggLegacySystematicUncertainties#Upstream_material_electron_to_ph
+# NB these are comparable to other scale uncertainties
+materialBinsRun1 = cms.PSet(
+    variables = cms.vstring("abs(superCluster.eta)","full5x5_r9"),
+    bins = cms.VPSet(
+        cms.PSet( lowBounds = cms.vdouble( 0.0, 0.0  ), upBounds = cms.vdouble( 0.8, 0.94  ), values = cms.vdouble( 0. ), uncertainties = cms.vdouble( 0.00035 ) ),
+        cms.PSet( lowBounds = cms.vdouble( 0.0, 0.94 ), upBounds = cms.vdouble( 0.8, 999.0 ), values = cms.vdouble( 0. ), uncertainties = cms.vdouble( 0.00033 ) ),
+        cms.PSet( lowBounds = cms.vdouble( 0.8, 0.0  ), upBounds = cms.vdouble( 1.0, 0.94  ), values = cms.vdouble( 0. ), uncertainties = cms.vdouble( 0.00058 ) ),
+        cms.PSet( lowBounds = cms.vdouble( 0.8, 0.94 ), upBounds = cms.vdouble( 1.0, 999.0 ), values = cms.vdouble( 0. ), uncertainties = cms.vdouble( 0.0012 ) ),
+        cms.PSet( lowBounds = cms.vdouble( 1.0, 0.0  ), upBounds = cms.vdouble( 1.5, 0.94  ), values = cms.vdouble( 0. ), uncertainties = cms.vdouble( 0.0022 ) ),
+        cms.PSet( lowBounds = cms.vdouble( 1.0, 0.94 ), upBounds = cms.vdouble( 1.5, 999.0 ), values = cms.vdouble( 0. ), uncertainties = cms.vdouble( 0.0034 ) ),
+        cms.PSet( lowBounds = cms.vdouble( 1.5, 0.0  ), upBounds = cms.vdouble( 999., 0.94  ), values = cms.vdouble( 0. ), uncertainties = cms.vdouble( 0.0022 ) ),
+        cms.PSet( lowBounds = cms.vdouble( 1.5, 0.94 ), upBounds = cms.vdouble( 999., 999.0 ), values = cms.vdouble( 0. ), uncertainties = cms.vdouble( 0.0034 ) ),
+
+        )
+    )
+
+materialBinsICHEP = cms.PSet(
+    variables = cms.vstring("abs(superCluster.eta)","full5x5_r9"),
+    bins = cms.VPSet(
+        cms.PSet( lowBounds = cms.vdouble( 0.0, 0.0 ), upBounds = cms.vdouble( 1.5, 0.94 ), values = cms.vdouble( 0. ) , uncertainties = cms.vdouble( 0.00070 ) ),
+        cms.PSet( lowBounds = cms.vdouble( 0.0, 0.94 ), upBounds = cms.vdouble( 1.5, 999. ), values = cms.vdouble( 0. ), uncertainties = cms.vdouble( 0.00036 ) ),
+        cms.PSet( lowBounds = cms.vdouble( 1.5, 0.0 ), upBounds = cms.vdouble( 6.0, 0.94  ), values = cms.vdouble( 0. ), uncertainties = cms.vdouble( 0.00089 ) ),
+        cms.PSet( lowBounds = cms.vdouble( 1.5, 0.9 ), upBounds = cms.vdouble( 6.0, 999. ), values = cms.vdouble( 0. ), uncertainties = cms.vdouble( 0.00170 ) )
+        )
+    )
+
+# Moriond17 studies from https://indico.cern.ch/event/628619/contributions/2552389/attachments/1442921/2222173/MaterialStudy_10042017_v2.pdf
+#
+# All numbers for 5% material uncertainty (x10^-3)
+#
+# Category1:CentralBarrelandlowr9 (|eta|<1.0andr9<0.94)     0.455
+# Category2:CentralBarrelandhighr9(|eta|<1.0andr9>0.94)     0.233
+# Category3:OuterBarrelandlowr9 (1.0<|eta|<1.5andr9<0.94)   2.089
+# Category4:OuterBarrelandhighr9 (1.0<|eta|<1.5andr9>0.94)   N/A   (taken to be equal to cat3)
+# Category5:Endcapandlowr9 (|eta|>1.5andr9<0.94)            1.090
+# Category6:Endcapandhighr9 (|eta|>1.5andr9>0.94)           2.377
+
+materialBinsMoriond17 = cms.PSet(
+    variables = cms.vstring("abs(superCluster.eta)","full5x5_r9"),
+    bins = cms.VPSet(
+        cms.PSet( lowBounds = cms.vdouble( 0.0, 0.0  ), upBounds = cms.vdouble( 1.0, 0.94  ), values = cms.vdouble( 0. ),  uncertainties = cms.vdouble( 0.000455 ) ),
+        cms.PSet( lowBounds = cms.vdouble( 0.0, 0.94 ), upBounds = cms.vdouble( 1.0, 999.0 ), values = cms.vdouble( 0. ),  uncertainties = cms.vdouble( 0.000233 ) ),
+        cms.PSet( lowBounds = cms.vdouble( 1.0, 0.0  ), upBounds = cms.vdouble( 1.5, 0.94  ), values = cms.vdouble( 0. ),  uncertainties = cms.vdouble( 0.002089 ) ),
+        cms.PSet( lowBounds = cms.vdouble( 1.0, 0.94 ), upBounds = cms.vdouble( 1.5, 999.0 ), values = cms.vdouble( 0. ),  uncertainties = cms.vdouble( 0.002089 ) ),
+        cms.PSet( lowBounds = cms.vdouble( 1.5, 0.0  ), upBounds = cms.vdouble( 999., 0.94  ), values = cms.vdouble( 0. ), uncertainties = cms.vdouble( 0.001090 ) ),
+        cms.PSet( lowBounds = cms.vdouble( 1.5, 0.94 ), upBounds = cms.vdouble( 999., 999.0 ), values = cms.vdouble( 0. ), uncertainties = cms.vdouble( 0.002377 ) ),
+
+        )
+    )
+
+emptyBins = cms.PSet(
+    variables = cms.vstring("1"),
+    bins = cms.VPSet()
+    )
+
+emptySigma = cms.PSet(
+    firstVar = cms.vint32(),
+    secondVar = cms.vint32()
+)
+
+
+scalesAndSmearingsPrefix = cms.string("EgammaAnalysis/ElectronTools/data/ScalesSmearings/Run2018_29Sep2020_RunFineEtaR9Gain_oldFormat")
+#scalesAndSmearingsPrefixForSigmaEOverE = scalesAndSmearingsPrefix
+
+MCScaleHighR9EB = cms.PSet( PhotonMethodName = cms.string("FlashggPhotonScale"),
+          MethodName = cms.string("FlashggDiPhotonFromPhoton"),
+          Label = cms.string("MCScaleHighR9EB"),
+          NSigmas = cms.vint32(-1,1),
+          OverallRange = cms.string("full5x5_r9>0.94&&abs(superCluster.eta)<1.5"),
+          BinList = photonScaleUncertBins,
+          ApplyCentralValue = cms.bool(False),
+          Debug = cms.untracked.bool(False)
+          )
+
+MCScaleLowR9EB = cms.PSet( PhotonMethodName = cms.string("FlashggPhotonScale"),
+          MethodName = cms.string("FlashggDiPhotonFromPhoton"),
+          Label = cms.string("MCScaleLowR9EB"),
+          NSigmas = cms.vint32(-1,1),
+          OverallRange = cms.string("full5x5_r9<0.94&&abs(superCluster.eta)<1.5"),
+          BinList = photonScaleUncertBins,
+          ApplyCentralValue = cms.bool(False),
+          Debug = cms.untracked.bool(False)
+          )
+
+MCScaleHighR9EE = cms.PSet( PhotonMethodName = cms.string("FlashggPhotonScale"),
+          MethodName = cms.string("FlashggDiPhotonFromPhoton"),
+          Label = cms.string("MCScaleHighR9EE"),
+          NSigmas = cms.vint32(-1,1),
+          OverallRange = cms.string("full5x5_r9>0.94&&abs(superCluster.eta)>=1.5"),
+          BinList = photonScaleUncertBins,
+          ApplyCentralValue = cms.bool(False),
+          Debug = cms.untracked.bool(False)
+          )
+
+MCScaleLowR9EE = cms.PSet( PhotonMethodName = cms.string("FlashggPhotonScale"),
+          MethodName = cms.string("FlashggDiPhotonFromPhoton"),
+          Label = cms.string("MCScaleLowR9EE"),
+          NSigmas = cms.vint32(-1,1),
+          OverallRange = cms.string("full5x5_r9<0.94&&abs(superCluster.eta)>=1.5"),
+          BinList = photonScaleUncertBins,
+          ApplyCentralValue = cms.bool(False),
+          Debug = cms.untracked.bool(False)
+          )
+
+MaterialCentralBarrel = cms.PSet( PhotonMethodName = cms.string("FlashggPhotonScale"),
+          MethodName = cms.string("FlashggDiPhotonFromPhoton"),
+          Label = cms.string("MaterialCentralBarrel"),
+          NSigmas = cms.vint32(-1,1),
+          OverallRange = cms.string("abs(superCluster.eta)<1.0"),
+          BinList = materialBinsMoriond17,
+          ApplyCentralValue = cms.bool(False),
+          Debug = cms.untracked.bool(False)
+          )
+
+MaterialOuterBarrel = cms.PSet( PhotonMethodName = cms.string("FlashggPhotonScale"),
+          MethodName = cms.string("FlashggDiPhotonFromPhoton"),
+          Label = cms.string("MaterialOuterBarrel"),
+          NSigmas = cms.vint32(-1,1),
+          OverallRange = cms.string("abs(superCluster.eta)>=1.0&&abs(superCluster.eta)<1.5"),
+          BinList = materialBinsMoriond17,
+          ApplyCentralValue = cms.bool(False),
+          Debug = cms.untracked.bool(False)
+          )
+
+MaterialForward = cms.PSet( PhotonMethodName = cms.string("FlashggPhotonScale"),
+          MethodName = cms.string("FlashggDiPhotonFromPhoton"),
+          Label = cms.string("MaterialForward"),
+          NSigmas = cms.vint32(-1,1),
+          OverallRange = cms.string("abs(superCluster.eta)>=1.5"),
+          BinList = materialBinsMoriond17,
+          ApplyCentralValue = cms.bool(False),
+          Debug = cms.untracked.bool(False)
+          )
+
+FNUFEB = cms.PSet( PhotonMethodName = cms.string("FlashggPhotonScale"),
+          MethodName = cms.string("FlashggDiPhotonFromPhoton"),
+          Label = cms.string("FNUFEB"),
+          NSigmas = cms.vint32(-1,1),
+          OverallRange = cms.string("abs(superCluster.eta)<1.5"),
+          BinList = FNUFBins,
+          ApplyCentralValue = cms.bool(False),
+          Debug = cms.untracked.bool(False)
+          )
+
+FNUFEE = cms.PSet( PhotonMethodName = cms.string("FlashggPhotonScale"),
+          MethodName = cms.string("FlashggDiPhotonFromPhoton"),
+          Label = cms.string("FNUFEE"),
+          NSigmas = cms.vint32(-1,1),
+          OverallRange = cms.string("abs(superCluster.eta)>=1.5"),
+          BinList = FNUFBins,
+          ApplyCentralValue = cms.bool(False),
+          Debug = cms.untracked.bool(False)
+          )
+
+ShowerShapeHighR9EB = cms.PSet( PhotonMethodName = cms.string("FlashggPhotonScale"),
+          MethodName = cms.string("FlashggDiPhotonFromPhoton"),
+          Label = cms.string("ShowerShapeHighR9EB"),
+          NSigmas = cms.vint32(-1,1),
+          OverallRange = cms.string("full5x5_r9>0.94&&abs(superCluster.eta)<1.5"),
+          BinList = showerShapeBins,
+          ApplyCentralValue = cms.bool(False),
+          Debug = cms.untracked.bool(False)
+          )
+
+ShowerShapeHighR9EE = cms.PSet( PhotonMethodName = cms.string("FlashggPhotonScale"),
+          MethodName = cms.string("FlashggDiPhotonFromPhoton"),
+          Label = cms.string("ShowerShapeHighR9EE"),
+          NSigmas = cms.vint32(-1,1),
+          OverallRange = cms.string("full5x5_r9>0.94&&abs(superCluster.eta)>=1.5"),
+          BinList = showerShapeBins,
+          ApplyCentralValue = cms.bool(False),
+          Debug = cms.untracked.bool(False)
+          )
+
+ShowerShapeLowR9EB = cms.PSet( PhotonMethodName = cms.string("FlashggPhotonScale"),
+          MethodName = cms.string("FlashggDiPhotonFromPhoton"),
+          Label = cms.string("ShowerShapeLowR9EB"),
+          NSigmas = cms.vint32(-1,1),
+          OverallRange = cms.string("full5x5_r9<=0.94&&abs(superCluster.eta)<1.5"),
+          BinList = showerShapeBins,
+          ApplyCentralValue = cms.bool(False),
+          Debug = cms.untracked.bool(False)
+          )
+
+ShowerShapeLowR9EE = cms.PSet( PhotonMethodName = cms.string("FlashggPhotonScale"),
+          MethodName = cms.string("FlashggDiPhotonFromPhoton"),
+          Label = cms.string("ShowerShapeLowR9EE"),
+          NSigmas = cms.vint32(-1,1),
+          OverallRange = cms.string("full5x5_r9<=0.94&&abs(superCluster.eta)>=1.5"),
+          BinList = showerShapeBins,
+          ApplyCentralValue = cms.bool(False),
+          Debug = cms.untracked.bool(False)
+          )
+
+
+MCSmearHighR9EE = cms.PSet( PhotonMethodName = cms.string("FlashggPhotonSmearConstant"),
+          MethodName = cms.string("FlashggDiPhotonFromPhoton"),
+          Label = cms.string("MCSmearHighR9EE"),
+          NSigmas = cms.vint32(-1,1),
+          OverallRange = cms.string("full5x5_r9>0.94&&abs(superCluster.eta)>=1.5"),
+          BinList = photonSmearBins,
+          # has to match the labels embedded in the photon object as
+          # defined e.g. in flashgg/MicroAOD/python/flashggRandomizedPerPhotonDiPhotonProducer_cff.py
+          #           or in flashgg/MicroAOD/python/flashggRandomizedPhotonProducer_cff.py (if at MicroAOD prod.)
+          RandomLabel = cms.string("rnd_g_E"),
+          Debug = cms.untracked.bool(False),
+          ExaggerateShiftUp = cms.bool(False),
+          ApplyCentralValue = cms.bool(True)
+          )
+
+MCSmearLowR9EE = cms.PSet( PhotonMethodName = cms.string("FlashggPhotonSmearConstant"),
+          MethodName = cms.string("FlashggDiPhotonFromPhoton"),
+          Label = cms.string("MCSmearLowR9EE"),
+          NSigmas = cms.vint32(-1,1),
+          OverallRange = cms.string("full5x5_r9<0.94&&abs(superCluster.eta)>=1.5"),
+          BinList = photonSmearBins,
+          # has to match the labels embedded in the photon object as
+          # defined e.g. in flashgg/MicroAOD/python/flashggRandomizedPerPhotonDiPhotonProducer_cff.py
+          #           or in flashgg/MicroAOD/python/flashggRandomizedPhotonProducer_cff.py (if at MicroAOD prod.)
+          RandomLabel = cms.string("rnd_g_E"),
+          Debug = cms.untracked.bool(False),
+          ExaggerateShiftUp = cms.bool(False),
+          ApplyCentralValue = cms.bool(True)
+          )
+
+MCSmearHighR9EB = cms.PSet( PhotonMethodName = cms.string("FlashggPhotonSmearConstant"),
+          MethodName = cms.string("FlashggDiPhotonFromPhoton"),
+          Label = cms.string("MCSmearHighR9EB"),
+          NSigmas = cms.vint32(-1,1),
+          OverallRange = cms.string("full5x5_r9>0.94&&abs(superCluster.eta)<1.5"),
+          BinList = photonSmearBins,
+          # has to match the labels embedded in the photon object as
+          # defined e.g. in flashgg/MicroAOD/python/flashggRandomizedPerPhotonDiPhotonProducer_cff.py
+          #           or in flashgg/MicroAOD/python/flashggRandomizedPhotonProducer_cff.py (if at MicroAOD prod.)
+          RandomLabel = cms.string("rnd_g_E"),
+          Debug = cms.untracked.bool(False),
+          ExaggerateShiftUp = cms.bool(False),
+          ApplyCentralValue = cms.bool(True)
+          )
+
+MCSmearLowR9EB = cms.PSet( PhotonMethodName = cms.string("FlashggPhotonSmearConstant"),
+          MethodName = cms.string("FlashggDiPhotonFromPhoton"),
+          Label = cms.string("MCSmearLowR9EB"),
+          NSigmas = cms.vint32(-1,1),
+          OverallRange = cms.string("full5x5_r9<=0.94&&abs(superCluster.eta)<1.5"),
+          BinList = photonSmearBins,
+          # has to match the labels embedded in the photon object as
+          # defined e.g. in flashgg/MicroAOD/python/flashggRandomizedPerPhotonDiPhotonProducer_cff.py
+          #           or in flashgg/MicroAOD/python/flashggRandomizedPhotonProducer_cff.py (if at MicroAOD prod.)
+          RandomLabel = cms.string("rnd_g_E"),
+          Debug = cms.untracked.bool(False),
+          ExaggerateShiftUp = cms.bool(False),
+          ApplyCentralValue = cms.bool(True)
+          )
+
+MvaShift = cms.PSet( PhotonMethodName = cms.string("FlashggPhotonMvaTransform"),
+          MethodName = cms.string("FlashggDiPhotonFromPhoton"),
+          Label = cms.string("MvaShift"),
+          NSigmas = cms.vint32(-1,1),
+          OverallRange = cms.string("1"),
+          CorrectionFile = cms.FileInPath("flashgg/Systematics/data/SystematicsIDMVA_LegRunII_v1_2018.root"),
+          BinList = mvaShiftBins,
+          Debug = cms.untracked.bool(False),
+          ApplyCentralValue = cms.bool(False)
+          )
+
+PreselSF = cms.PSet( PhotonMethodName = cms.string("FlashggPhotonWeight"),
+          MethodName = cms.string("FlashggDiPhotonFromPhoton"),
+          Label = cms.string("PreselSF"),
+          NSigmas = cms.vint32(-1,1),
+          OverallRange = cms.string("1"),
+          BinList = preselBins,
+          Debug = cms.untracked.bool(False),
+          ApplyCentralValue = cms.bool(True)
+          )
+
+electronVetoSF = cms.PSet( PhotonMethodName = cms.string("FlashggPhotonWeight"),
+          MethodName = cms.string("FlashggDiPhotonFromPhoton"),
+          Label = cms.string("electronVetoSF"),
+          NSigmas = cms.vint32(-1,1),
+          OverallRange = cms.string("1"),
+          BinList = electronVetoBins,
+          Debug = cms.untracked.bool(False),
+          ApplyCentralValue = cms.bool(True)
+          )
+
+TriggerWeight = cms.PSet( PhotonMethodName = cms.string("FlashggPhotonWeight"),
+          MethodName = cms.string("FlashggDiPhotonFromPhoton"),
+          Label = cms.string("TriggerWeight"),
+          NSigmas = cms.vint32(-1,1),
+          OverallRange = cms.string("pt<99999"),
+          BinList = leadTriggerScaleBins,
+          BinList2 = subleadTriggerScaleBins,
+          Debug = cms.untracked.bool(False),
+          ApplyCentralValue = cms.bool(True)
+          )
+
+PixelSeedWeight = cms.PSet( PhotonMethodName = cms.string("FlashggPhotonWeight"),
+          MethodName = cms.string("FlashggDiPhotonFromPhoton"),
+          Label = cms.string("PixelSeedWeight"),
+          NSigmas = cms.vint32(-1,1),
+          OverallRange = cms.string("pt<99999"),
+          BinList = leadPixelSeedBins,
+          BinList2 = subleadPixelSeedBins,
+          Debug = cms.untracked.bool(False),
+          ApplyCentralValue = cms.bool(True)
+          )
+
+LooseMvaSF = cms.PSet( PhotonMethodName = cms.string("FlashggPhotonWeight"),
+          MethodName = cms.string("FlashggDiPhotonFromPhoton"),
+          Label = cms.string("LooseMvaSF"),
+          NSigmas = cms.vint32(-1,1),
+          OverallRange = cms.string("1"),
+          BinList = looseMvaBins,
+          Debug = cms.untracked.bool(False),
+          ApplyCentralValue = cms.bool(True)
+          )
+
+SigmaEOverEShift = cms.PSet( PhotonMethodName = cms.string("FlashggPhotonSigEOverEShift"),
+          MethodName = cms.string("FlashggDiPhotonFromPhoton"),
+          Label = cms.string("SigmaEOverEShift"),
+          NSigmas = cms.vint32(-1,1),
+          OverallRange = cms.string("1"),
+          BinList = sigmaEOverEShiftBins,
+          Debug = cms.untracked.bool(False),
+          ApplyCentralValue = cms.bool(False)
+          )
+
+SigmaEOverESmearing = cms.PSet( PhotonMethodName = cms.string("FlashggPhotonSigEoverESmearing"),
+          MethodName = cms.string("FlashggDiPhotonFromPhoton"),
+          Label = cms.string("SigmaEOverESmearing"),
+          NSigmas = cms.vint32(),
+          OverallRange = cms.string("1"),
+          BinList = photonSmearBins,
+          Debug = cms.untracked.bool(False),
+          ApplyCentralValue = cms.bool(True)
+          )
+
+SigmaEOverESmearing_EGM = cms.PSet( PhotonMethodName = cms.string("FlashggPhotonSigEoverESmearingEGMTool"),
+          MethodName = cms.string("FlashggDiPhotonFromPhoton"),
+          Label = cms.string("SigmaEOverESmearing"),
+          CorrectionFile = scalesAndSmearingsPrefix,
+          NSigmas = cms.vint32(),
+          OverallRange = cms.string("1"),
+          BinList = emptyBins,
+          Debug = cms.untracked.bool(False),
+          ExaggerateShiftUp = cms.bool(False),
+          ApplyCentralValue = cms.bool(True)
+          )
+
+FracRVWeight = cms.PSet( MethodName = cms.string("FlashggDiPhotonWeightFromFracRV"),
+          Label = cms.string("FracRVWeight"),
+          NSigmas = cms.vint32(-1,1),
+          OverallRange = cms.string("pt<99999"),
+          BinList = RVBins,
+          Debug = cms.untracked.bool(False),
+          ApplyCentralValue = cms.bool(True)
+          )
+
+FracRVNvtxWeight = cms.PSet( MethodName = cms.string("FlashggDiPhotonWeightFromFracRV"),
+          Label = cms.string("FracRVNvtxWeight"),
+          NSigmas = cms.vint32(-1,1),
+          OverallRange = cms.string("nVert<99999"),
+          BinList = RVBinsNvtx,
+          Debug = cms.untracked.bool(False),
+          ApplyCentralValue = cms.bool(True)
+          )
+
+MCSmearHighR9EE_EGM = cms.PSet( PhotonMethodName = cms.string("FlashggPhotonSmearStochasticEGMTool"),
+         MethodName = cms.string("FlashggDiPhotonFromPhoton2D"),
+         Label = cms.string("MCSmearHighR9EE"),
+         FirstParameterName = cms.string("Rho"),
+         SecondParameterName = cms.string("Phi"),
+         CorrectionFile = scalesAndSmearingsPrefix,
+         NSigmas = cms.PSet( firstVar = cms.vint32(1,-1,0,0),
+                            secondVar = cms.vint32(0,0,1,-1)),
+         OverallRange = cms.string("full5x5_r9>0.94&&abs(superCluster.eta)>=1.5"),
+         BinList = emptyBins,
+         # has to match the labels embedded in the photon object as
+         # defined e.g. in flashgg/MicroAOD/python/flashggRandomizedPerPhotonDiPhotonProducer_cff.py
+         #           or in flashgg/MicroAOD/python/flashggRandomizedPhotonProducer_cff.py (if at MicroAOD prod.)
+         RandomLabel = cms.string("rnd_g_E"),
+         Debug = cms.untracked.bool(False),
+         ExaggerateShiftUp = cms.bool(False),
+         ApplyCentralValue = cms.bool(True)
+         )
+
+MCSmearLowR9EE_EGM = cms.PSet( PhotonMethodName = cms.string("FlashggPhotonSmearStochasticEGMTool"),
+         MethodName = cms.string("FlashggDiPhotonFromPhoton2D"),
+         Label = cms.string("MCSmearLowR9EE"),
+         FirstParameterName = cms.string("Rho"),
+         SecondParameterName = cms.string("Phi"),
+         CorrectionFile = scalesAndSmearingsPrefix,
+         NSigmas = cms.PSet( firstVar = cms.vint32(1,-1,0,0),
+                            secondVar = cms.vint32(0,0,1,-1)),
+         OverallRange = cms.string("full5x5_r9<=0.94&&abs(superCluster.eta)>=1.5"),
+         BinList = emptyBins,
+         # has to match the labels embedded in the photon object as
+         # defined e.g. in flashgg/MicroAOD/python/flashggRandomizedPerPhotonDiPhotonProducer_cff.py
+         #           or in flashgg/MicroAOD/python/flashggRandomizedPhotonProducer_cff.py (if at MicroAOD prod.)
+         RandomLabel = cms.string("rnd_g_E"),
+         Debug = cms.untracked.bool(False),
+         ExaggerateShiftUp = cms.bool(False),
+         ApplyCentralValue = cms.bool(True)
+         )
+
+MCSmearHighR9EB_EGM = cms.PSet( PhotonMethodName = cms.string("FlashggPhotonSmearStochasticEGMTool"),
+         MethodName = cms.string("FlashggDiPhotonFromPhoton2D"),
+         Label = cms.string("MCSmearHighR9EB"),
+         FirstParameterName = cms.string("Rho"),
+         SecondParameterName = cms.string("Phi"),
+         CorrectionFile = scalesAndSmearingsPrefix,
+         NSigmas = cms.PSet( firstVar = cms.vint32(1,-1,0,0),
+                             secondVar = cms.vint32(0,0,1,-1)),
+         OverallRange = cms.string("full5x5_r9>0.94&&abs(superCluster.eta)<1.5"),
+         BinList = emptyBins,
+         # has to match the labels embedded in the photon object as
+         # defined e.g. in flashgg/MicroAOD/python/flashggRandomizedPerPhotonDiPhotonProducer_cff.py
+         #           or in flashgg/MicroAOD/python/flashggRandomizedPhotonProducer_cff.py (if at MicroAOD prod.)
+         RandomLabel = cms.string("rnd_g_E"),
+         Debug = cms.untracked.bool(False),
+         ExaggerateShiftUp = cms.bool(False),
+         ApplyCentralValue = cms.bool(True)
+         )
+
+MCSmearLowR9EB_EGM = cms.PSet( PhotonMethodName = cms.string("FlashggPhotonSmearStochasticEGMTool"),
+         MethodName = cms.string("FlashggDiPhotonFromPhoton2D"),
+         Label = cms.string("MCSmearLowR9EB"),
+         FirstParameterName = cms.string("Rho"),
+         SecondParameterName = cms.string("Phi"),
+         CorrectionFile = scalesAndSmearingsPrefix,
+         NSigmas = cms.PSet( firstVar = cms.vint32(1,-1,0,0),
+                            secondVar = cms.vint32(0,0,1,-1)),
+         OverallRange = cms.string("full5x5_r9<=0.94&&abs(superCluster.eta)<1.5"),
+         BinList = emptyBins,
+         # has to match the labels embedded in the photon object as
+         # defined e.g. in flashgg/MicroAOD/python/flashggRandomizedPerPhotonDiPhotonProducer_cff.py
+         #           or in flashgg/MicroAOD/python/flashggRandomizedPhotonProducer_cff.py (if at MicroAOD prod.)
+         RandomLabel = cms.string("rnd_g_E"),
+         Debug = cms.untracked.bool(False),
+         ExaggerateShiftUp = cms.bool(False),
+         ApplyCentralValue = cms.bool(True)
+         )
+
+MCScaleHighR9EB_EGM = cms.PSet( PhotonMethodName = cms.string("FlashggPhotonScaleEGMTool"),
+         MethodName = cms.string("FlashggDiPhotonFromPhoton"),
+         Label = cms.string("MCScaleHighR9EB"),
+         NSigmas = cms.vint32(-1,1),
+         OverallRange = cms.string("full5x5_r9>0.94&&abs(superCluster.eta)<1.5"),
+         BinList = emptyBins,
+         CorrectionFile = scalesAndSmearingsPrefix,
+         ApplyCentralValue = cms.bool(False),
+         UncertaintyBitMask = cms.string("011"),#cms.string("110"),
+         ExaggerateShiftUp = cms.bool(False),
+         Debug = cms.untracked.bool(False)
+         )
+
+MCScaleLowR9EB_EGM = cms.PSet( PhotonMethodName = cms.string("FlashggPhotonScaleEGMTool"),
+         MethodName = cms.string("FlashggDiPhotonFromPhoton"),
+         Label = cms.string("MCScaleLowR9EB"),
+         NSigmas = cms.vint32(-1,1),
+         OverallRange = cms.string("full5x5_r9<0.94&&abs(superCluster.eta)<1.5"),
+         BinList = emptyBins,
+         CorrectionFile = scalesAndSmearingsPrefix,
+         ApplyCentralValue = cms.bool(False),
+         UncertaintyBitMask = cms.string("011"),#cms.string("110"),
+         ExaggerateShiftUp = cms.bool(False),
+         Debug = cms.untracked.bool(False)
+         )
+
+MCScaleHighR9EE_EGM = cms.PSet( PhotonMethodName = cms.string("FlashggPhotonScaleEGMTool"),
+         MethodName = cms.string("FlashggDiPhotonFromPhoton"),
+         Label = cms.string("MCScaleHighR9EE"),
+         NSigmas = cms.vint32(-1,1),
+         OverallRange = cms.string("full5x5_r9>0.94&&abs(superCluster.eta)>=1.5"),
+         BinList = emptyBins,
+         CorrectionFile = scalesAndSmearingsPrefix,
+         ApplyCentralValue = cms.bool(False),
+         UncertaintyBitMask = cms.string("011"),#cms.string("110"),
+         ExaggerateShiftUp = cms.bool(False),
+         Debug = cms.untracked.bool(False)
+         )
+
+MCScaleLowR9EE_EGM = cms.PSet( PhotonMethodName = cms.string("FlashggPhotonScaleEGMTool"),
+         MethodName = cms.string("FlashggDiPhotonFromPhoton"),
+         Label = cms.string("MCScaleLowR9EE"),
+         NSigmas = cms.vint32(-1,1),
+         OverallRange = cms.string("full5x5_r9<0.94&&abs(superCluster.eta)>=1.5"),
+         BinList = emptyBins,
+         CorrectionFile = scalesAndSmearingsPrefix,
+         ApplyCentralValue = cms.bool(False),
+         UncertaintyBitMask = cms.string("011"),#cms.string("110"),
+         ExaggerateShiftUp = cms.bool(False),
+         Debug = cms.untracked.bool(False)
+         )
+
+MCScaleGain6EB_EGM = cms.PSet( PhotonMethodName = cms.string("FlashggPhotonScaleEGMTool"),
+         MethodName = cms.string("FlashggDiPhotonFromPhoton"),
+         Label = cms.string("MCScaleGain6EB"),
+         NSigmas = cms.vint32(-1,1),
+         OverallRange = cms.string("hasSwitchToGain6&&abs(superCluster.eta)<1.5"),
+         BinList = emptyBins,
+         CorrectionFile = scalesAndSmearingsPrefix,
+         ApplyCentralValue = cms.bool(False),
+         ExaggerateShiftUp = cms.bool(False),
+         UncertaintyBitMask = cms.string("100"),#cms.string("001"), # this should be a bit mask, don't know how to make it in python now
+         Debug = cms.untracked.bool(False)
+         )
+
+MCScaleGain1EB_EGM = cms.PSet( PhotonMethodName = cms.string("FlashggPhotonScaleEGMTool"),
+         MethodName = cms.string("FlashggDiPhotonFromPhoton"),
+         Label = cms.string("MCScaleGain1EB"),
+         NSigmas = cms.vint32(-1,1),
+         OverallRange = cms.string("hasSwitchToGain1&&abs(superCluster.eta)<1.5"),
+         BinList = emptyBins,
+         CorrectionFile = scalesAndSmearingsPrefix,
+         ApplyCentralValue = cms.bool(False),
+         ExaggerateShiftUp = cms.bool(False),
+         UncertaintyBitMask = cms.string("100"),#cms.string("001"), # this should be a bit mask, don't know how to make it in python now
+         Debug = cms.untracked.bool(False)
+         )
+

--- a/Systematics/python/flashggDiPhotonSystematics2018_Legacy_cfi.py
+++ b/Systematics/python/flashggDiPhotonSystematics2018_Legacy_cfi.py
@@ -592,7 +592,7 @@ MvaShift = cms.PSet( PhotonMethodName = cms.string("FlashggPhotonMvaTransform"),
           Label = cms.string("MvaShift"),
           NSigmas = cms.vint32(-1,1),
           OverallRange = cms.string("1"),
-          CorrectionFile = cms.FileInPath("flashgg/Systematics/data/SystematicsIDMVA_LegRunII_v1_2018.root"),
+          CorrectionFile = cms.FileInPath("flashgg/Systematics/data/SystematicsIDMVA_LegRunII_v1_UL2018.root"),
           BinList = mvaShiftBins,
           Debug = cms.untracked.bool(False),
           ApplyCentralValue = cms.bool(False)

--- a/Validation/python/tagAndProbeDumperConfig.py
+++ b/Validation/python/tagAndProbeDumperConfig.py
@@ -108,10 +108,13 @@ def getConfig(extended=False, dumpShowerShapes=False, dumpClusterShapes=False, d
                          "probePhoIso_uncorr            := ? getProbe.hasUserFloat('uncorr_pfPhoIso03') ? getProbe.userFloat('uncorr_pfPhoIso03') : -999",
                          "probeChIso03_uncorr           := ? getProbe.hasUserFloat('uncorr_pfChIso03') ? getProbe.userFloat('uncorr_pfChIso03') : -999",
                          "probeChIso03worst_uncorr      := ? getProbe.hasUserFloat('uncorr_pfChIsoWorst03') ? getProbe.userFloat('uncorr_pfChIsoWorst03') : -999",
+                         "probeesEnergyOverSCRawEnergy_uncorr      := ? getProbe.hasUserFloat('uncorr_esEnergyOverSCRawEnergy') ? getProbe.userFloat('uncorr_esEnergyOverSCRawEnergy') : -999",
                          "probePhoIdMVA_uncorr          := ? getProbe.hasUserFloat('original_phoId') ? getProbe.userFloat('original_phoId') : -999" ]
 
     probeCorrClVars = ["probePhiWidth := ? getProbe.hasUserFloat('phiWidth') ? getProbe.userFloat('phiWidth') : -999",
                        "probeEtaWidth := ? getProbe.hasUserFloat('etaWidth') ? getProbe.userFloat('etaWidth') : -999"]
+
+    probePreshower = ["probeesEnergyOverSCRawEnergy := ? getProbe.hasUserFloat('esEnergyOverSCRawEnergy') ? getProbe.userFloat('esEnergyOverSCRawEnergy') : -999"]
 
     singleEleVars = minSingleEleVars
     singleEleViewVars = minSingleEleViewVars
@@ -142,6 +145,8 @@ def getConfig(extended=False, dumpShowerShapes=False, dumpClusterShapes=False, d
 
     if trackClIsoCorrections:
         variables.extend(probeUncorrClIsos + probeCorrClVars)
+
+    variables.extend(probePreshower)
 
     return variables
 


### PR DESCRIPTION
The trained regressors for UL2018 are now available at
```/eos/cms/store/group/phys_higgs/cmshgg/flashgg-data/Taggers/data/PhoIdInputsCorrections/2018_Legacy```
and the summary can be found at 
```/eos/cms/store/group/phys_higgs/cmshgg/flashgg-data/Taggers/data/PhoIdInputsCorrections/corrections_summary_2018_Legacy.json```.
The path to the correct json file is thus updated in ```MetaData/data/MetaConditions/Era2018_legacy_v1.json```.

Please note that this PR shouldn't be merged until https://github.com/cms-analysis/flashgg/pull/1249 is merged as well.
The correct procedure would be to push 50f8feb1e4b2eef328a9db0c31b31804da310a1f to https://github.com/cms-analysis/flashgg/pull/1249, but since also 6cc65e994d605ded4154e43808fd50b3133c8d9f (which is already in master) is needed to correctly reproduce the results, it made more sense to cherry-pick fc1a59fc75195a225f54cf6b000ca7bb666f92e3 and 5896b9843c9af66ee0125d8fc90472e665a6a7d5 and add 50f8feb1e4b2eef328a9db0c31b31804da310a1f on top.
This should also cause less confusion at the moment of merging.

Feedback is needed from @simonepigazzini and/or @rchatter concerning whether or not including https://github.com/maxgalli/flashgg/commit/0618a9664bc9768c27d8bc17ebf606f48037cc79 since it was applied for the training.  
