### PR TITLE
Additional UL17 samples

### DIFF
--- a/MetaData/data/Era2017_legacy_v1/datasets_36.json
+++ b/MetaData/data/Era2017_legacy_v1/datasets_36.json
@@ -1,0 +1,4889 @@
+{
+    "/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/alesauva-UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2-8980ba169e8b72d53459e52844728ed8/USER": {
+        "dset_type": "mc", 
+        "files": [
+            {
+                "bad": false, 
+                "events": 7255, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_452.root", 
+                "nevents": 7255, 
+                "totEvents": 7255, 
+                "weights": 7255.0
+            }, 
+            {
+                "bad": false, 
+                "events": 7307, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_301.root", 
+                "nevents": 7307, 
+                "totEvents": 7307, 
+                "weights": 7307.0
+            }, 
+            {
+                "bad": false, 
+                "events": 14937, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_256.root", 
+                "nevents": 14937, 
+                "totEvents": 14937, 
+                "weights": 14937.0
+            }, 
+            {
+                "bad": false, 
+                "events": 16461, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_455.root", 
+                "nevents": 16461, 
+                "totEvents": 16461, 
+                "weights": 16461.0
+            }, 
+            {
+                "bad": false, 
+                "events": 7330, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_341.root", 
+                "nevents": 7330, 
+                "totEvents": 7330, 
+                "weights": 7330.0
+            }, 
+            {
+                "bad": false, 
+                "events": 7311, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_300.root", 
+                "nevents": 7311, 
+                "totEvents": 7311, 
+                "weights": 7311.0
+            }, 
+            {
+                "bad": false, 
+                "events": 17852, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_298.root", 
+                "nevents": 17852, 
+                "totEvents": 17852, 
+                "weights": 17852.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25149, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_206.root", 
+                "nevents": 25149, 
+                "totEvents": 25149, 
+                "weights": 25149.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24895, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_249.root", 
+                "nevents": 24895, 
+                "totEvents": 24895, 
+                "weights": 24895.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24638, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_263.root", 
+                "nevents": 24638, 
+                "totEvents": 24638, 
+                "weights": 24638.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25059, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_169.root", 
+                "nevents": 25059, 
+                "totEvents": 25059, 
+                "weights": 25059.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25035, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_551.root", 
+                "nevents": 25035, 
+                "totEvents": 25035, 
+                "weights": 25035.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24731, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_386.root", 
+                "nevents": 24731, 
+                "totEvents": 24731, 
+                "weights": 24731.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25015, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_531.root", 
+                "nevents": 25015, 
+                "totEvents": 25015, 
+                "weights": 25015.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24571, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_265.root", 
+                "nevents": 24571, 
+                "totEvents": 24571, 
+                "weights": 24571.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24934, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_270.root", 
+                "nevents": 24934, 
+                "totEvents": 24934, 
+                "weights": 24934.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24905, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_27.root", 
+                "nevents": 24905, 
+                "totEvents": 24905, 
+                "weights": 24905.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25212, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_533.root", 
+                "nevents": 25212, 
+                "totEvents": 25212, 
+                "weights": 25212.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24697, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_504.root", 
+                "nevents": 24697, 
+                "totEvents": 24697, 
+                "weights": 24697.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25038, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_67.root", 
+                "nevents": 25038, 
+                "totEvents": 25038, 
+                "weights": 25038.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25099, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_550.root", 
+                "nevents": 25099, 
+                "totEvents": 25099, 
+                "weights": 25099.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25024, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_251.root", 
+                "nevents": 25024, 
+                "totEvents": 25024, 
+                "weights": 25024.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25007, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_208.root", 
+                "nevents": 25007, 
+                "totEvents": 25007, 
+                "weights": 25007.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24778, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_116.root", 
+                "nevents": 24778, 
+                "totEvents": 24778, 
+                "weights": 24778.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25058, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_268.root", 
+                "nevents": 25058, 
+                "totEvents": 25058, 
+                "weights": 25058.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24900, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_484.root", 
+                "nevents": 24900, 
+                "totEvents": 24900, 
+                "weights": 24900.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24755, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_421.root", 
+                "nevents": 24755, 
+                "totEvents": 24755, 
+                "weights": 24755.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25164, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_493.root", 
+                "nevents": 25164, 
+                "totEvents": 25164, 
+                "weights": 25164.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25152, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_201.root", 
+                "nevents": 25152, 
+                "totEvents": 25152, 
+                "weights": 25152.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24888, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_246.root", 
+                "nevents": 24888, 
+                "totEvents": 24888, 
+                "weights": 24888.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25032, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_214.root", 
+                "nevents": 25032, 
+                "totEvents": 25032, 
+                "weights": 25032.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25043, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_165.root", 
+                "nevents": 25043, 
+                "totEvents": 25043, 
+                "weights": 25043.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24924, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_311.root", 
+                "nevents": 24924, 
+                "totEvents": 24924, 
+                "weights": 24924.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25145, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_147.root", 
+                "nevents": 25145, 
+                "totEvents": 25145, 
+                "weights": 25145.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24943, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_93.root", 
+                "nevents": 24943, 
+                "totEvents": 24943, 
+                "weights": 24943.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25100, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_174.root", 
+                "nevents": 25100, 
+                "totEvents": 25100, 
+                "weights": 25100.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24833, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_276.root", 
+                "nevents": 24833, 
+                "totEvents": 24833, 
+                "weights": 24833.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24824, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_66.root", 
+                "nevents": 24824, 
+                "totEvents": 24824, 
+                "weights": 24824.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25240, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_178.root", 
+                "nevents": 25240, 
+                "totEvents": 25240, 
+                "weights": 25240.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25262, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_517.root", 
+                "nevents": 25262, 
+                "totEvents": 25262, 
+                "weights": 25262.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25248, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_346.root", 
+                "nevents": 25248, 
+                "totEvents": 25248, 
+                "weights": 25248.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24956, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_94.root", 
+                "nevents": 24956, 
+                "totEvents": 24956, 
+                "weights": 24956.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25062, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_410.root", 
+                "nevents": 25062, 
+                "totEvents": 25062, 
+                "weights": 25062.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25061, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_562.root", 
+                "nevents": 25061, 
+                "totEvents": 25061, 
+                "weights": 25061.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25199, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_582.root", 
+                "nevents": 25199, 
+                "totEvents": 25199, 
+                "weights": 25199.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24939, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_522.root", 
+                "nevents": 24939, 
+                "totEvents": 24939, 
+                "weights": 24939.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25154, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_544.root", 
+                "nevents": 25154, 
+                "totEvents": 25154, 
+                "weights": 25154.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24699, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_440.root", 
+                "nevents": 24699, 
+                "totEvents": 24699, 
+                "weights": 24699.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25245, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_363.root", 
+                "nevents": 25245, 
+                "totEvents": 25245, 
+                "weights": 25245.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24709, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_131.root", 
+                "nevents": 24709, 
+                "totEvents": 24709, 
+                "weights": 24709.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25010, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_501.root", 
+                "nevents": 25010, 
+                "totEvents": 25010, 
+                "weights": 25010.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25178, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_605.root", 
+                "nevents": 25178, 
+                "totEvents": 25178, 
+                "weights": 25178.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24691, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_84.root", 
+                "nevents": 24691, 
+                "totEvents": 24691, 
+                "weights": 24691.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24967, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_245.root", 
+                "nevents": 24967, 
+                "totEvents": 24967, 
+                "weights": 24967.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25022, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_400.root", 
+                "nevents": 25022, 
+                "totEvents": 25022, 
+                "weights": 25022.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24958, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_417.root", 
+                "nevents": 24958, 
+                "totEvents": 24958, 
+                "weights": 24958.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24969, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_21.root", 
+                "nevents": 24969, 
+                "totEvents": 24969, 
+                "weights": 24969.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25163, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_563.root", 
+                "nevents": 25163, 
+                "totEvents": 25163, 
+                "weights": 25163.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25124, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_462.root", 
+                "nevents": 25124, 
+                "totEvents": 25124, 
+                "weights": 25124.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24902, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_19.root", 
+                "nevents": 24902, 
+                "totEvents": 24902, 
+                "weights": 24902.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24770, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_482.root", 
+                "nevents": 24770, 
+                "totEvents": 24770, 
+                "weights": 24770.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25090, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_36.root", 
+                "nevents": 25090, 
+                "totEvents": 25090, 
+                "weights": 25090.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25020, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_478.root", 
+                "nevents": 25020, 
+                "totEvents": 25020, 
+                "weights": 25020.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24915, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_136.root", 
+                "nevents": 24915, 
+                "totEvents": 24915, 
+                "weights": 24915.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25005, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_430.root", 
+                "nevents": 25005, 
+                "totEvents": 25005, 
+                "weights": 25005.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24960, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_290.root", 
+                "nevents": 24960, 
+                "totEvents": 24960, 
+                "weights": 24960.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25156, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_438.root", 
+                "nevents": 25156, 
+                "totEvents": 25156, 
+                "weights": 25156.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24732, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_125.root", 
+                "nevents": 24732, 
+                "totEvents": 24732, 
+                "weights": 24732.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25034, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_378.root", 
+                "nevents": 25034, 
+                "totEvents": 25034, 
+                "weights": 25034.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25219, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_427.root", 
+                "nevents": 25219, 
+                "totEvents": 25219, 
+                "weights": 25219.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25100, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_413.root", 
+                "nevents": 25100, 
+                "totEvents": 25100, 
+                "weights": 25100.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24932, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_443.root", 
+                "nevents": 24932, 
+                "totEvents": 24932, 
+                "weights": 24932.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25268, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_371.root", 
+                "nevents": 25268, 
+                "totEvents": 25268, 
+                "weights": 25268.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25049, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_135.root", 
+                "nevents": 25049, 
+                "totEvents": 25049, 
+                "weights": 25049.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25014, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_132.root", 
+                "nevents": 25014, 
+                "totEvents": 25014, 
+                "weights": 25014.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25009, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_331.root", 
+                "nevents": 25009, 
+                "totEvents": 25009, 
+                "weights": 25009.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25169, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_432.root", 
+                "nevents": 25169, 
+                "totEvents": 25169, 
+                "weights": 25169.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25016, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_126.root", 
+                "nevents": 25016, 
+                "totEvents": 25016, 
+                "weights": 25016.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24884, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_56.root", 
+                "nevents": 24884, 
+                "totEvents": 24884, 
+                "weights": 24884.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24756, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_367.root", 
+                "nevents": 24756, 
+                "totEvents": 24756, 
+                "weights": 24756.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24794, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_406.root", 
+                "nevents": 24794, 
+                "totEvents": 24794, 
+                "weights": 24794.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25117, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_392.root", 
+                "nevents": 25117, 
+                "totEvents": 25117, 
+                "weights": 25117.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24858, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_351.root", 
+                "nevents": 24858, 
+                "totEvents": 24858, 
+                "weights": 24858.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24858, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_388.root", 
+                "nevents": 24858, 
+                "totEvents": 24858, 
+                "weights": 24858.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25001, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_31.root", 
+                "nevents": 25001, 
+                "totEvents": 25001, 
+                "weights": 25001.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25021, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_137.root", 
+                "nevents": 25021, 
+                "totEvents": 25021, 
+                "weights": 25021.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25012, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_318.root", 
+                "nevents": 25012, 
+                "totEvents": 25012, 
+                "weights": 25012.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24814, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_449.root", 
+                "nevents": 24814, 
+                "totEvents": 24814, 
+                "weights": 24814.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25247, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_344.root", 
+                "nevents": 25247, 
+                "totEvents": 25247, 
+                "weights": 25247.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24949, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_437.root", 
+                "nevents": 24949, 
+                "totEvents": 24949, 
+                "weights": 24949.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25007, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_64.root", 
+                "nevents": 25007, 
+                "totEvents": 25007, 
+                "weights": 25007.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25136, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_404.root", 
+                "nevents": 25136, 
+                "totEvents": 25136, 
+                "weights": 25136.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24966, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_262.root", 
+                "nevents": 24966, 
+                "totEvents": 24966, 
+                "weights": 24966.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25019, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_362.root", 
+                "nevents": 25019, 
+                "totEvents": 25019, 
+                "weights": 25019.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24984, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_360.root", 
+                "nevents": 24984, 
+                "totEvents": 24984, 
+                "weights": 24984.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25137, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_317.root", 
+                "nevents": 25137, 
+                "totEvents": 25137, 
+                "weights": 25137.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24842, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_450.root", 
+                "nevents": 24842, 
+                "totEvents": 24842, 
+                "weights": 24842.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25012, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_419.root", 
+                "nevents": 25012, 
+                "totEvents": 25012, 
+                "weights": 25012.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25003, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_231.root", 
+                "nevents": 25003, 
+                "totEvents": 25003, 
+                "weights": 25003.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25018, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_535.root", 
+                "nevents": 25018, 
+                "totEvents": 25018, 
+                "weights": 25018.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24899, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_219.root", 
+                "nevents": 24899, 
+                "totEvents": 24899, 
+                "weights": 24899.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24973, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_138.root", 
+                "nevents": 24973, 
+                "totEvents": 24973, 
+                "weights": 24973.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24850, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_122.root", 
+                "nevents": 24850, 
+                "totEvents": 24850, 
+                "weights": 24850.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24789, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_514.root", 
+                "nevents": 24789, 
+                "totEvents": 24789, 
+                "weights": 24789.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25162, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_380.root", 
+                "nevents": 25162, 
+                "totEvents": 25162, 
+                "weights": 25162.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24893, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_557.root", 
+                "nevents": 24893, 
+                "totEvents": 24893, 
+                "weights": 24893.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25161, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_133.root", 
+                "nevents": 25161, 
+                "totEvents": 25161, 
+                "weights": 25161.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25020, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_418.root", 
+                "nevents": 25020, 
+                "totEvents": 25020, 
+                "weights": 25020.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24776, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_63.root", 
+                "nevents": 24776, 
+                "totEvents": 24776, 
+                "weights": 24776.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25104, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_213.root", 
+                "nevents": 25104, 
+                "totEvents": 25104, 
+                "weights": 25104.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24704, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_545.root", 
+                "nevents": 24704, 
+                "totEvents": 24704, 
+                "weights": 24704.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25230, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_238.root", 
+                "nevents": 25230, 
+                "totEvents": 25230, 
+                "weights": 25230.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24944, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_127.root", 
+                "nevents": 24944, 
+                "totEvents": 24944, 
+                "weights": 24944.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25033, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_129.root", 
+                "nevents": 25033, 
+                "totEvents": 25033, 
+                "weights": 25033.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25122, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_448.root", 
+                "nevents": 25122, 
+                "totEvents": 25122, 
+                "weights": 25122.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25066, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_409.root", 
+                "nevents": 25066, 
+                "totEvents": 25066, 
+                "weights": 25066.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24745, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_319.root", 
+                "nevents": 24745, 
+                "totEvents": 24745, 
+                "weights": 24745.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25169, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_379.root", 
+                "nevents": 25169, 
+                "totEvents": 25169, 
+                "weights": 25169.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25120, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_60.root", 
+                "nevents": 25120, 
+                "totEvents": 25120, 
+                "weights": 25120.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24859, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_416.root", 
+                "nevents": 24859, 
+                "totEvents": 24859, 
+                "weights": 24859.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25027, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_383.root", 
+                "nevents": 25027, 
+                "totEvents": 25027, 
+                "weights": 25027.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24910, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_306.root", 
+                "nevents": 24910, 
+                "totEvents": 24910, 
+                "weights": 24910.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25178, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_144.root", 
+                "nevents": 25178, 
+                "totEvents": 25178, 
+                "weights": 25178.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24803, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_525.root", 
+                "nevents": 24803, 
+                "totEvents": 24803, 
+                "weights": 24803.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24705, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_423.root", 
+                "nevents": 24705, 
+                "totEvents": 24705, 
+                "weights": 24705.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25226, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_433.root", 
+                "nevents": 25226, 
+                "totEvents": 25226, 
+                "weights": 25226.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25222, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_41.root", 
+                "nevents": 25222, 
+                "totEvents": 25222, 
+                "weights": 25222.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24881, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_608.root", 
+                "nevents": 24881, 
+                "totEvents": 24881, 
+                "weights": 24881.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24936, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_373.root", 
+                "nevents": 24936, 
+                "totEvents": 24936, 
+                "weights": 24936.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25140, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_604.root", 
+                "nevents": 25140, 
+                "totEvents": 25140, 
+                "weights": 25140.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24975, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_422.root", 
+                "nevents": 24975, 
+                "totEvents": 24975, 
+                "weights": 24975.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25005, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_414.root", 
+                "nevents": 25005, 
+                "totEvents": 25005, 
+                "weights": 25005.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25023, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_554.root", 
+                "nevents": 25023, 
+                "totEvents": 25023, 
+                "weights": 25023.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25286, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_395.root", 
+                "nevents": 25286, 
+                "totEvents": 25286, 
+                "weights": 25286.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24837, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_412.root", 
+                "nevents": 24837, 
+                "totEvents": 24837, 
+                "weights": 24837.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25024, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_324.root", 
+                "nevents": 25024, 
+                "totEvents": 25024, 
+                "weights": 25024.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24848, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_403.root", 
+                "nevents": 24848, 
+                "totEvents": 24848, 
+                "weights": 24848.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25036, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_286.root", 
+                "nevents": 25036, 
+                "totEvents": 25036, 
+                "weights": 25036.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24556, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_287.root", 
+                "nevents": 24556, 
+                "totEvents": 24556, 
+                "weights": 24556.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24838, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_394.root", 
+                "nevents": 24838, 
+                "totEvents": 24838, 
+                "weights": 24838.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24831, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_128.root", 
+                "nevents": 24831, 
+                "totEvents": 24831, 
+                "weights": 24831.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25025, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_488.root", 
+                "nevents": 25025, 
+                "totEvents": 25025, 
+                "weights": 25025.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25042, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_43.root", 
+                "nevents": 25042, 
+                "totEvents": 25042, 
+                "weights": 25042.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25185, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_420.root", 
+                "nevents": 25185, 
+                "totEvents": 25185, 
+                "weights": 25185.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24985, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_216.root", 
+                "nevents": 24985, 
+                "totEvents": 24985, 
+                "weights": 24985.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25122, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_407.root", 
+                "nevents": 25122, 
+                "totEvents": 25122, 
+                "weights": 25122.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25083, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_242.root", 
+                "nevents": 25083, 
+                "totEvents": 25083, 
+                "weights": 25083.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25092, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_358.root", 
+                "nevents": 25092, 
+                "totEvents": 25092, 
+                "weights": 25092.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25020, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_408.root", 
+                "nevents": 25020, 
+                "totEvents": 25020, 
+                "weights": 25020.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25053, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_402.root", 
+                "nevents": 25053, 
+                "totEvents": 25053, 
+                "weights": 25053.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24913, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_3.root", 
+                "nevents": 24913, 
+                "totEvents": 24913, 
+                "weights": 24913.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25110, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_509.root", 
+                "nevents": 25110, 
+                "totEvents": 25110, 
+                "weights": 25110.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25054, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_424.root", 
+                "nevents": 25054, 
+                "totEvents": 25054, 
+                "weights": 25054.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24890, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_130.root", 
+                "nevents": 24890, 
+                "totEvents": 24890, 
+                "weights": 24890.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25322, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_353.root", 
+                "nevents": 25322, 
+                "totEvents": 25322, 
+                "weights": 25322.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24570, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_435.root", 
+                "nevents": 24570, 
+                "totEvents": 24570, 
+                "weights": 24570.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25055, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_119.root", 
+                "nevents": 25055, 
+                "totEvents": 25055, 
+                "weights": 25055.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25023, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_357.root", 
+                "nevents": 25023, 
+                "totEvents": 25023, 
+                "weights": 25023.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25012, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_124.root", 
+                "nevents": 25012, 
+                "totEvents": 25012, 
+                "weights": 25012.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24880, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_345.root", 
+                "nevents": 24880, 
+                "totEvents": 24880, 
+                "weights": 24880.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25095, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_179.root", 
+                "nevents": 25095, 
+                "totEvents": 25095, 
+                "weights": 25095.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24882, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_558.root", 
+                "nevents": 24882, 
+                "totEvents": 24882, 
+                "weights": 24882.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24994, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_247.root", 
+                "nevents": 24994, 
+                "totEvents": 24994, 
+                "weights": 24994.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24861, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_104.root", 
+                "nevents": 24861, 
+                "totEvents": 24861, 
+                "weights": 24861.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24762, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_85.root", 
+                "nevents": 24762, 
+                "totEvents": 24762, 
+                "weights": 24762.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24705, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_271.root", 
+                "nevents": 24705, 
+                "totEvents": 24705, 
+                "weights": 24705.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24903, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_95.root", 
+                "nevents": 24903, 
+                "totEvents": 24903, 
+                "weights": 24903.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24867, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_105.root", 
+                "nevents": 24867, 
+                "totEvents": 24867, 
+                "weights": 24867.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25327, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_473.root", 
+                "nevents": 25327, 
+                "totEvents": 25327, 
+                "weights": 25327.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24655, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_280.root", 
+                "nevents": 24655, 
+                "totEvents": 24655, 
+                "weights": 24655.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25111, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_224.root", 
+                "nevents": 25111, 
+                "totEvents": 25111, 
+                "weights": 25111.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24978, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_296.root", 
+                "nevents": 24978, 
+                "totEvents": 24978, 
+                "weights": 24978.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24919, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_100.root", 
+                "nevents": 24919, 
+                "totEvents": 24919, 
+                "weights": 24919.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24811, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_269.root", 
+                "nevents": 24811, 
+                "totEvents": 24811, 
+                "weights": 24811.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24968, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_480.root", 
+                "nevents": 24968, 
+                "totEvents": 24968, 
+                "weights": 24968.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25112, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_283.root", 
+                "nevents": 25112, 
+                "totEvents": 25112, 
+                "weights": 25112.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24834, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_58.root", 
+                "nevents": 24834, 
+                "totEvents": 24834, 
+                "weights": 24834.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25059, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_44.root", 
+                "nevents": 25059, 
+                "totEvents": 25059, 
+                "weights": 25059.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24910, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_234.root", 
+                "nevents": 24910, 
+                "totEvents": 24910, 
+                "weights": 24910.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24919, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_267.root", 
+                "nevents": 24919, 
+                "totEvents": 24919, 
+                "weights": 24919.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24928, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_491.root", 
+                "nevents": 24928, 
+                "totEvents": 24928, 
+                "weights": 24928.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24822, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_26.root", 
+                "nevents": 24822, 
+                "totEvents": 24822, 
+                "weights": 24822.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25316, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_260.root", 
+                "nevents": 25316, 
+                "totEvents": 25316, 
+                "weights": 25316.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25100, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_505.root", 
+                "nevents": 25100, 
+                "totEvents": 25100, 
+                "weights": 25100.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24879, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_20.root", 
+                "nevents": 24879, 
+                "totEvents": 24879, 
+                "weights": 24879.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24917, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_528.root", 
+                "nevents": 24917, 
+                "totEvents": 24917, 
+                "weights": 24917.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24920, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_17.root", 
+                "nevents": 24920, 
+                "totEvents": 24920, 
+                "weights": 24920.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24954, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_460.root", 
+                "nevents": 24954, 
+                "totEvents": 24954, 
+                "weights": 24954.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25196, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_217.root", 
+                "nevents": 25196, 
+                "totEvents": 25196, 
+                "weights": 25196.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25068, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_15.root", 
+                "nevents": 25068, 
+                "totEvents": 25068, 
+                "weights": 25068.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24964, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_288.root", 
+                "nevents": 24964, 
+                "totEvents": 24964, 
+                "weights": 24964.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24876, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_366.root", 
+                "nevents": 24876, 
+                "totEvents": 24876, 
+                "weights": 24876.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24809, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_547.root", 
+                "nevents": 24809, 
+                "totEvents": 24809, 
+                "weights": 24809.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24752, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_568.root", 
+                "nevents": 24752, 
+                "totEvents": 24752, 
+                "weights": 24752.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25131, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_492.root", 
+                "nevents": 25131, 
+                "totEvents": 25131, 
+                "weights": 25131.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25220, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_193.root", 
+                "nevents": 25220, 
+                "totEvents": 25220, 
+                "weights": 25220.0
+            }, 
+            {
+                "bad": false, 
+                "events": 915, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_55.root", 
+                "nevents": 915, 
+                "totEvents": 915, 
+                "weights": 915.0
+            }, 
+            {
+                "bad": false, 
+                "events": 4509, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_339.root", 
+                "nevents": 4509, 
+                "totEvents": 4509, 
+                "weights": 4509.0
+            }, 
+            {
+                "bad": false, 
+                "events": 5080, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_337.root", 
+                "nevents": 5080, 
+                "totEvents": 5080, 
+                "weights": 5080.0
+            }, 
+            {
+                "bad": false, 
+                "events": 4688, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_336.root", 
+                "nevents": 4688, 
+                "totEvents": 4688, 
+                "weights": 4688.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25131, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_35.root", 
+                "nevents": 25131, 
+                "totEvents": 25131, 
+                "weights": 25131.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24887, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_82.root", 
+                "nevents": 24887, 
+                "totEvents": 24887, 
+                "weights": 24887.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25095, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_581.root", 
+                "nevents": 25095, 
+                "totEvents": 25095, 
+                "weights": 25095.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25293, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_312.root", 
+                "nevents": 25293, 
+                "totEvents": 25293, 
+                "weights": 25293.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24882, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_468.root", 
+                "nevents": 24882, 
+                "totEvents": 24882, 
+                "weights": 24882.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24860, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_338.root", 
+                "nevents": 24860, 
+                "totEvents": 24860, 
+                "weights": 24860.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24743, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_500.root", 
+                "nevents": 24743, 
+                "totEvents": 24743, 
+                "weights": 24743.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25033, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_399.root", 
+                "nevents": 25033, 
+                "totEvents": 25033, 
+                "weights": 25033.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24978, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_61.root", 
+                "nevents": 24978, 
+                "totEvents": 24978, 
+                "weights": 24978.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24827, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_59.root", 
+                "nevents": 24827, 
+                "totEvents": 24827, 
+                "weights": 24827.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24863, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_303.root", 
+                "nevents": 24863, 
+                "totEvents": 24863, 
+                "weights": 24863.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24824, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_150.root", 
+                "nevents": 24824, 
+                "totEvents": 24824, 
+                "weights": 24824.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25184, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_441.root", 
+                "nevents": 25184, 
+                "totEvents": 25184, 
+                "weights": 25184.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24984, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_309.root", 
+                "nevents": 24984, 
+                "totEvents": 24984, 
+                "weights": 24984.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25138, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_316.root", 
+                "nevents": 25138, 
+                "totEvents": 25138, 
+                "weights": 25138.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25193, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_175.root", 
+                "nevents": 25193, 
+                "totEvents": 25193, 
+                "weights": 25193.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24750, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_381.root", 
+                "nevents": 24750, 
+                "totEvents": 24750, 
+                "weights": 24750.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25187, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_207.root", 
+                "nevents": 25187, 
+                "totEvents": 25187, 
+                "weights": 25187.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24973, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_62.root", 
+                "nevents": 24973, 
+                "totEvents": 24973, 
+                "weights": 24973.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25165, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_485.root", 
+                "nevents": 25165, 
+                "totEvents": 25165, 
+                "weights": 25165.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24899, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_369.root", 
+                "nevents": 24899, 
+                "totEvents": 24899, 
+                "weights": 24899.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25090, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_349.root", 
+                "nevents": 25090, 
+                "totEvents": 25090, 
+                "weights": 25090.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25077, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_160.root", 
+                "nevents": 25077, 
+                "totEvents": 25077, 
+                "weights": 25077.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25009, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_230.root", 
+                "nevents": 25009, 
+                "totEvents": 25009, 
+                "weights": 25009.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25013, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_177.root", 
+                "nevents": 25013, 
+                "totEvents": 25013, 
+                "weights": 25013.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24924, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_180.root", 
+                "nevents": 24924, 
+                "totEvents": 24924, 
+                "weights": 24924.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24941, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_490.root", 
+                "nevents": 24941, 
+                "totEvents": 24941, 
+                "weights": 24941.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24911, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_226.root", 
+                "nevents": 24911, 
+                "totEvents": 24911, 
+                "weights": 24911.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24645, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_512.root", 
+                "nevents": 24645, 
+                "totEvents": 24645, 
+                "weights": 24645.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24908, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_304.root", 
+                "nevents": 24908, 
+                "totEvents": 24908, 
+                "weights": 24908.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25073, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_308.root", 
+                "nevents": 25073, 
+                "totEvents": 25073, 
+                "weights": 25073.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24754, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_255.root", 
+                "nevents": 24754, 
+                "totEvents": 24754, 
+                "weights": 24754.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25086, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_134.root", 
+                "nevents": 25086, 
+                "totEvents": 25086, 
+                "weights": 25086.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24603, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_313.root", 
+                "nevents": 24603, 
+                "totEvents": 24603, 
+                "weights": 24603.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24877, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_372.root", 
+                "nevents": 24877, 
+                "totEvents": 24877, 
+                "weights": 24877.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25253, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_343.root", 
+                "nevents": 25253, 
+                "totEvents": 25253, 
+                "weights": 25253.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24805, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_23.root", 
+                "nevents": 24805, 
+                "totEvents": 24805, 
+                "weights": 24805.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24823, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_22.root", 
+                "nevents": 24823, 
+                "totEvents": 24823, 
+                "weights": 24823.0
+            }, 
+            {
+                "bad": false, 
+                "events": 21291, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_334.root", 
+                "nevents": 21291, 
+                "totEvents": 21291, 
+                "weights": 21291.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24864, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_333.root", 
+                "nevents": 24864, 
+                "totEvents": 24864, 
+                "weights": 24864.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25020, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_510.root", 
+                "nevents": 25020, 
+                "totEvents": 25020, 
+                "weights": 25020.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24879, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_445.root", 
+                "nevents": 24879, 
+                "totEvents": 24879, 
+                "weights": 24879.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24934, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_197.root", 
+                "nevents": 24934, 
+                "totEvents": 24934, 
+                "weights": 24934.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24784, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_156.root", 
+                "nevents": 24784, 
+                "totEvents": 24784, 
+                "weights": 24784.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25051, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_359.root", 
+                "nevents": 25051, 
+                "totEvents": 25051, 
+                "weights": 25051.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24763, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_453.root", 
+                "nevents": 24763, 
+                "totEvents": 24763, 
+                "weights": 24763.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24944, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_375.root", 
+                "nevents": 24944, 
+                "totEvents": 24944, 
+                "weights": 24944.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24836, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_495.root", 
+                "nevents": 24836, 
+                "totEvents": 24836, 
+                "weights": 24836.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25135, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_559.root", 
+                "nevents": 25135, 
+                "totEvents": 25135, 
+                "weights": 25135.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25201, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_314.root", 
+                "nevents": 25201, 
+                "totEvents": 25201, 
+                "weights": 25201.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24938, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_540.root", 
+                "nevents": 24938, 
+                "totEvents": 24938, 
+                "weights": 24938.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25042, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_565.root", 
+                "nevents": 25042, 
+                "totEvents": 25042, 
+                "weights": 25042.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24885, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_471.root", 
+                "nevents": 24885, 
+                "totEvents": 24885, 
+                "weights": 24885.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25078, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_203.root", 
+                "nevents": 25078, 
+                "totEvents": 25078, 
+                "weights": 25078.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24862, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_155.root", 
+                "nevents": 24862, 
+                "totEvents": 24862, 
+                "weights": 24862.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25003, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_376.root", 
+                "nevents": 25003, 
+                "totEvents": 25003, 
+                "weights": 25003.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24983, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_583.root", 
+                "nevents": 24983, 
+                "totEvents": 24983, 
+                "weights": 24983.0
+            }, 
+            {
+                "bad": false, 
+                "events": 14617, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_299.root", 
+                "nevents": 14617, 
+                "totEvents": 14617, 
+                "weights": 14617.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25006, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_454.root", 
+                "nevents": 25006, 
+                "totEvents": 25006, 
+                "weights": 25006.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24806, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_16.root", 
+                "nevents": 24806, 
+                "totEvents": 24806, 
+                "weights": 24806.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_220.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 25000.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24900, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_520.root", 
+                "nevents": 24900, 
+                "totEvents": 24900, 
+                "weights": 24900.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24846, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_534.root", 
+                "nevents": 24846, 
+                "totEvents": 24846, 
+                "weights": 24846.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24588, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_521.root", 
+                "nevents": 24588, 
+                "totEvents": 24588, 
+                "weights": 24588.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24845, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_65.root", 
+                "nevents": 24845, 
+                "totEvents": 24845, 
+                "weights": 24845.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24653, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_355.root", 
+                "nevents": 24653, 
+                "totEvents": 24653, 
+                "weights": 24653.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24862, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_28.root", 
+                "nevents": 24862, 
+                "totEvents": 24862, 
+                "weights": 24862.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24918, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_171.root", 
+                "nevents": 24918, 
+                "totEvents": 24918, 
+                "weights": 24918.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25109, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_154.root", 
+                "nevents": 25109, 
+                "totEvents": 25109, 
+                "weights": 25109.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24889, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_537.root", 
+                "nevents": 24889, 
+                "totEvents": 24889, 
+                "weights": 24889.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24960, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_192.root", 
+                "nevents": 24960, 
+                "totEvents": 24960, 
+                "weights": 24960.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24943, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_356.root", 
+                "nevents": 24943, 
+                "totEvents": 24943, 
+                "weights": 24943.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24965, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_397.root", 
+                "nevents": 24965, 
+                "totEvents": 24965, 
+                "weights": 24965.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24832, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_466.root", 
+                "nevents": 24832, 
+                "totEvents": 24832, 
+                "weights": 24832.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25087, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_527.root", 
+                "nevents": 25087, 
+                "totEvents": 25087, 
+                "weights": 25087.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25024, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_457.root", 
+                "nevents": 25024, 
+                "totEvents": 25024, 
+                "weights": 25024.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25081, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_598.root", 
+                "nevents": 25081, 
+                "totEvents": 25081, 
+                "weights": 25081.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24826, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_539.root", 
+                "nevents": 24826, 
+                "totEvents": 24826, 
+                "weights": 24826.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24883, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_223.root", 
+                "nevents": 24883, 
+                "totEvents": 24883, 
+                "weights": 24883.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24963, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_253.root", 
+                "nevents": 24963, 
+                "totEvents": 24963, 
+                "weights": 24963.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25244, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_391.root", 
+                "nevents": 25244, 
+                "totEvents": 25244, 
+                "weights": 25244.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25092, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_523.root", 
+                "nevents": 25092, 
+                "totEvents": 25092, 
+                "weights": 25092.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24924, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_442.root", 
+                "nevents": 24924, 
+                "totEvents": 24924, 
+                "weights": 24924.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24824, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_99.root", 
+                "nevents": 24824, 
+                "totEvents": 24824, 
+                "weights": 24824.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24684, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_431.root", 
+                "nevents": 24684, 
+                "totEvents": 24684, 
+                "weights": 24684.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24942, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_561.root", 
+                "nevents": 24942, 
+                "totEvents": 24942, 
+                "weights": 24942.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24815, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_497.root", 
+                "nevents": 24815, 
+                "totEvents": 24815, 
+                "weights": 24815.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25114, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_609.root", 
+                "nevents": 25114, 
+                "totEvents": 25114, 
+                "weights": 25114.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25341, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_297.root", 
+                "nevents": 25341, 
+                "totEvents": 25341, 
+                "weights": 25341.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25019, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_570.root", 
+                "nevents": 25019, 
+                "totEvents": 25019, 
+                "weights": 25019.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24795, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_248.root", 
+                "nevents": 24795, 
+                "totEvents": 24795, 
+                "weights": 24795.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24803, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_8.root", 
+                "nevents": 24803, 
+                "totEvents": 24803, 
+                "weights": 24803.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24923, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_274.root", 
+                "nevents": 24923, 
+                "totEvents": 24923, 
+                "weights": 24923.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24925, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_370.root", 
+                "nevents": 24925, 
+                "totEvents": 24925, 
+                "weights": 24925.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24921, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_600.root", 
+                "nevents": 24921, 
+                "totEvents": 24921, 
+                "weights": 24921.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25100, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_24.root", 
+                "nevents": 25100, 
+                "totEvents": 25100, 
+                "weights": 25100.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24920, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_115.root", 
+                "nevents": 24920, 
+                "totEvents": 24920, 
+                "weights": 24920.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24895, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_9.root", 
+                "nevents": 24895, 
+                "totEvents": 24895, 
+                "weights": 24895.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24939, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_481.root", 
+                "nevents": 24939, 
+                "totEvents": 24939, 
+                "weights": 24939.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24624, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_227.root", 
+                "nevents": 24624, 
+                "totEvents": 24624, 
+                "weights": 24624.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25008, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_607.root", 
+                "nevents": 25008, 
+                "totEvents": 25008, 
+                "weights": 25008.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25177, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_516.root", 
+                "nevents": 25177, 
+                "totEvents": 25177, 
+                "weights": 25177.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25177, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_266.root", 
+                "nevents": 25177, 
+                "totEvents": 25177, 
+                "weights": 25177.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24992, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_475.root", 
+                "nevents": 24992, 
+                "totEvents": 24992, 
+                "weights": 24992.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25207, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_123.root", 
+                "nevents": 25207, 
+                "totEvents": 25207, 
+                "weights": 25207.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25110, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_571.root", 
+                "nevents": 25110, 
+                "totEvents": 25110, 
+                "weights": 25110.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25154, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_229.root", 
+                "nevents": 25154, 
+                "totEvents": 25154, 
+                "weights": 25154.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25385, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_239.root", 
+                "nevents": 25385, 
+                "totEvents": 25385, 
+                "weights": 25385.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24868, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_538.root", 
+                "nevents": 24868, 
+                "totEvents": 24868, 
+                "weights": 24868.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24997, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_240.root", 
+                "nevents": 24997, 
+                "totEvents": 24997, 
+                "weights": 24997.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25022, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_592.root", 
+                "nevents": 25022, 
+                "totEvents": 25022, 
+                "weights": 25022.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25142, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_401.root", 
+                "nevents": 25142, 
+                "totEvents": 25142, 
+                "weights": 25142.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24794, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_170.root", 
+                "nevents": 24794, 
+                "totEvents": 24794, 
+                "weights": 24794.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24989, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_543.root", 
+                "nevents": 24989, 
+                "totEvents": 24989, 
+                "weights": 24989.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25150, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_350.root", 
+                "nevents": 25150, 
+                "totEvents": 25150, 
+                "weights": 25150.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24691, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_536.root", 
+                "nevents": 24691, 
+                "totEvents": 24691, 
+                "weights": 24691.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24773, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_575.root", 
+                "nevents": 24773, 
+                "totEvents": 24773, 
+                "weights": 24773.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24791, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_222.root", 
+                "nevents": 24791, 
+                "totEvents": 24791, 
+                "weights": 24791.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24672, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_172.root", 
+                "nevents": 24672, 
+                "totEvents": 24672, 
+                "weights": 24672.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24842, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_555.root", 
+                "nevents": 24842, 
+                "totEvents": 24842, 
+                "weights": 24842.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24928, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_579.root", 
+                "nevents": 24928, 
+                "totEvents": 24928, 
+                "weights": 24928.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24881, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_502.root", 
+                "nevents": 24881, 
+                "totEvents": 24881, 
+                "weights": 24881.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24832, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_279.root", 
+                "nevents": 24832, 
+                "totEvents": 24832, 
+                "weights": 24832.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25016, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_323.root", 
+                "nevents": 25016, 
+                "totEvents": 25016, 
+                "weights": 25016.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24817, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_496.root", 
+                "nevents": 24817, 
+                "totEvents": 24817, 
+                "weights": 24817.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24878, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_321.root", 
+                "nevents": 24878, 
+                "totEvents": 24878, 
+                "weights": 24878.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24831, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_429.root", 
+                "nevents": 24831, 
+                "totEvents": 24831, 
+                "weights": 24831.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24805, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_158.root", 
+                "nevents": 24805, 
+                "totEvents": 24805, 
+                "weights": 24805.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25079, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_295.root", 
+                "nevents": 25079, 
+                "totEvents": 25079, 
+                "weights": 25079.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24988, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_596.root", 
+                "nevents": 24988, 
+                "totEvents": 24988, 
+                "weights": 24988.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25150, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_469.root", 
+                "nevents": 25150, 
+                "totEvents": 25150, 
+                "weights": 25150.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25228, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_7.root", 
+                "nevents": 25228, 
+                "totEvents": 25228, 
+                "weights": 25228.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24823, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_503.root", 
+                "nevents": 24823, 
+                "totEvents": 24823, 
+                "weights": 24823.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25045, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_352.root", 
+                "nevents": 25045, 
+                "totEvents": 25045, 
+                "weights": 25045.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24992, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_477.root", 
+                "nevents": 24992, 
+                "totEvents": 24992, 
+                "weights": 24992.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24804, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_589.root", 
+                "nevents": 24804, 
+                "totEvents": 24804, 
+                "weights": 24804.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24889, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_13.root", 
+                "nevents": 24889, 
+                "totEvents": 24889, 
+                "weights": 24889.0
+            }, 
+            {
+                "bad": false, 
+                "events": 21023, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_451.root", 
+                "nevents": 21023, 
+                "totEvents": 21023, 
+                "weights": 21023.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25056, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_574.root", 
+                "nevents": 25056, 
+                "totEvents": 25056, 
+                "weights": 25056.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25028, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_11.root", 
+                "nevents": 25028, 
+                "totEvents": 25028, 
+                "weights": 25028.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24844, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_194.root", 
+                "nevents": 24844, 
+                "totEvents": 24844, 
+                "weights": 24844.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25019, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_146.root", 
+                "nevents": 25019, 
+                "totEvents": 25019, 
+                "weights": 25019.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24315, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_396.root", 
+                "nevents": 24315, 
+                "totEvents": 24315, 
+                "weights": 24315.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24720, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_599.root", 
+                "nevents": 24720, 
+                "totEvents": 24720, 
+                "weights": 24720.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24812, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_157.root", 
+                "nevents": 24812, 
+                "totEvents": 24812, 
+                "weights": 24812.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24857, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_365.root", 
+                "nevents": 24857, 
+                "totEvents": 24857, 
+                "weights": 24857.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25171, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_572.root", 
+                "nevents": 25171, 
+                "totEvents": 25171, 
+                "weights": 25171.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25110, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_518.root", 
+                "nevents": 25110, 
+                "totEvents": 25110, 
+                "weights": 25110.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25185, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_384.root", 
+                "nevents": 25185, 
+                "totEvents": 25185, 
+                "weights": 25185.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25219, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_167.root", 
+                "nevents": 25219, 
+                "totEvents": 25219, 
+                "weights": 25219.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25063, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_330.root", 
+                "nevents": 25063, 
+                "totEvents": 25063, 
+                "weights": 25063.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24870, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_187.root", 
+                "nevents": 24870, 
+                "totEvents": 24870, 
+                "weights": 24870.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24912, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_254.root", 
+                "nevents": 24912, 
+                "totEvents": 24912, 
+                "weights": 24912.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25035, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_456.root", 
+                "nevents": 25035, 
+                "totEvents": 25035, 
+                "weights": 25035.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25089, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_382.root", 
+                "nevents": 25089, 
+                "totEvents": 25089, 
+                "weights": 25089.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25207, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_474.root", 
+                "nevents": 25207, 
+                "totEvents": 25207, 
+                "weights": 25207.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24833, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_25.root", 
+                "nevents": 24833, 
+                "totEvents": 24833, 
+                "weights": 24833.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24711, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_377.root", 
+                "nevents": 24711, 
+                "totEvents": 24711, 
+                "weights": 24711.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24987, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_348.root", 
+                "nevents": 24987, 
+                "totEvents": 24987, 
+                "weights": 24987.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24892, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_546.root", 
+                "nevents": 24892, 
+                "totEvents": 24892, 
+                "weights": 24892.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24790, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_148.root", 
+                "nevents": 24790, 
+                "totEvents": 24790, 
+                "weights": 24790.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24777, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_601.root", 
+                "nevents": 24777, 
+                "totEvents": 24777, 
+                "weights": 24777.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24745, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_541.root", 
+                "nevents": 24745, 
+                "totEvents": 24745, 
+                "weights": 24745.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25132, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_241.root", 
+                "nevents": 25132, 
+                "totEvents": 25132, 
+                "weights": 25132.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24757, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_228.root", 
+                "nevents": 24757, 
+                "totEvents": 24757, 
+                "weights": 24757.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24958, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_602.root", 
+                "nevents": 24958, 
+                "totEvents": 24958, 
+                "weights": 24958.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24873, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_275.root", 
+                "nevents": 24873, 
+                "totEvents": 24873, 
+                "weights": 24873.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24726, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_112.root", 
+                "nevents": 24726, 
+                "totEvents": 24726, 
+                "weights": 24726.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24820, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_305.root", 
+                "nevents": 24820, 
+                "totEvents": 24820, 
+                "weights": 24820.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24832, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_30.root", 
+                "nevents": 24832, 
+                "totEvents": 24832, 
+                "weights": 24832.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24936, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_205.root", 
+                "nevents": 24936, 
+                "totEvents": 24936, 
+                "weights": 24936.0
+            }, 
+            {
+                "bad": false, 
+                "events": 16540, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_610.root", 
+                "nevents": 16540, 
+                "totEvents": 16540, 
+                "weights": 16540.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24861, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_273.root", 
+                "nevents": 24861, 
+                "totEvents": 24861, 
+                "weights": 24861.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24807, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_444.root", 
+                "nevents": 24807, 
+                "totEvents": 24807, 
+                "weights": 24807.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25055, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_483.root", 
+                "nevents": 25055, 
+                "totEvents": 25055, 
+                "weights": 25055.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25049, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_498.root", 
+                "nevents": 25049, 
+                "totEvents": 25049, 
+                "weights": 25049.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24993, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_342.root", 
+                "nevents": 24993, 
+                "totEvents": 24993, 
+                "weights": 24993.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24870, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_236.root", 
+                "nevents": 24870, 
+                "totEvents": 24870, 
+                "weights": 24870.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24813, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_189.root", 
+                "nevents": 24813, 
+                "totEvents": 24813, 
+                "weights": 24813.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24942, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_368.root", 
+                "nevents": 24942, 
+                "totEvents": 24942, 
+                "weights": 24942.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24864, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_264.root", 
+                "nevents": 24864, 
+                "totEvents": 24864, 
+                "weights": 24864.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25018, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_18.root", 
+                "nevents": 25018, 
+                "totEvents": 25018, 
+                "weights": 25018.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25017, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_411.root", 
+                "nevents": 25017, 
+                "totEvents": 25017, 
+                "weights": 25017.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24855, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_548.root", 
+                "nevents": 24855, 
+                "totEvents": 24855, 
+                "weights": 24855.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24862, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_439.root", 
+                "nevents": 24862, 
+                "totEvents": 24862, 
+                "weights": 24862.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24907, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_225.root", 
+                "nevents": 24907, 
+                "totEvents": 24907, 
+                "weights": 24907.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25064, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_184.root", 
+                "nevents": 25064, 
+                "totEvents": 25064, 
+                "weights": 25064.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24879, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_291.root", 
+                "nevents": 24879, 
+                "totEvents": 24879, 
+                "weights": 24879.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24815, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_221.root", 
+                "nevents": 24815, 
+                "totEvents": 24815, 
+                "weights": 24815.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25146, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_161.root", 
+                "nevents": 25146, 
+                "totEvents": 25146, 
+                "weights": 25146.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24881, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_472.root", 
+                "nevents": 24881, 
+                "totEvents": 24881, 
+                "weights": 24881.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24981, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_326.root", 
+                "nevents": 24981, 
+                "totEvents": 24981, 
+                "weights": 24981.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25361, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_446.root", 
+                "nevents": 25361, 
+                "totEvents": 25361, 
+                "weights": 25361.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24947, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_139.root", 
+                "nevents": 24947, 
+                "totEvents": 24947, 
+                "weights": 24947.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25173, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_586.root", 
+                "nevents": 25173, 
+                "totEvents": 25173, 
+                "weights": 25173.0
+            }, 
+            {
+                "bad": false, 
+                "events": 23156, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_121.root", 
+                "nevents": 23156, 
+                "totEvents": 23156, 
+                "weights": 23156.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24945, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_511.root", 
+                "nevents": 24945, 
+                "totEvents": 24945, 
+                "weights": 24945.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24930, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_162.root", 
+                "nevents": 24930, 
+                "totEvents": 24930, 
+                "weights": 24930.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24849, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_6.root", 
+                "nevents": 24849, 
+                "totEvents": 24849, 
+                "weights": 24849.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25090, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_176.root", 
+                "nevents": 25090, 
+                "totEvents": 25090, 
+                "weights": 25090.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25249, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_494.root", 
+                "nevents": 25249, 
+                "totEvents": 25249, 
+                "weights": 25249.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24749, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_374.root", 
+                "nevents": 24749, 
+                "totEvents": 24749, 
+                "weights": 24749.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24928, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_393.root", 
+                "nevents": 24928, 
+                "totEvents": 24928, 
+                "weights": 24928.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24964, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_149.root", 
+                "nevents": 24964, 
+                "totEvents": 24964, 
+                "weights": 24964.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25079, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_261.root", 
+                "nevents": 25079, 
+                "totEvents": 25079, 
+                "weights": 25079.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24913, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_168.root", 
+                "nevents": 24913, 
+                "totEvents": 24913, 
+                "weights": 24913.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24972, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_524.root", 
+                "nevents": 24972, 
+                "totEvents": 24972, 
+                "weights": 24972.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24880, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_29.root", 
+                "nevents": 24880, 
+                "totEvents": 24880, 
+                "weights": 24880.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24896, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_114.root", 
+                "nevents": 24896, 
+                "totEvents": 24896, 
+                "weights": 24896.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25280, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_434.root", 
+                "nevents": 25280, 
+                "totEvents": 25280, 
+                "weights": 25280.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25045, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_118.root", 
+                "nevents": 25045, 
+                "totEvents": 25045, 
+                "weights": 25045.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24860, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_325.root", 
+                "nevents": 24860, 
+                "totEvents": 24860, 
+                "weights": 24860.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24986, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_327.root", 
+                "nevents": 24986, 
+                "totEvents": 24986, 
+                "weights": 24986.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24826, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_464.root", 
+                "nevents": 24826, 
+                "totEvents": 24826, 
+                "weights": 24826.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25071, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_499.root", 
+                "nevents": 25071, 
+                "totEvents": 25071, 
+                "weights": 25071.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25200, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_578.root", 
+                "nevents": 25200, 
+                "totEvents": 25200, 
+                "weights": 25200.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25216, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_272.root", 
+                "nevents": 25216, 
+                "totEvents": 25216, 
+                "weights": 25216.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24792, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_436.root", 
+                "nevents": 24792, 
+                "totEvents": 24792, 
+                "weights": 24792.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24614, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_542.root", 
+                "nevents": 24614, 
+                "totEvents": 24614, 
+                "weights": 24614.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25115, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_38.root", 
+                "nevents": 25115, 
+                "totEvents": 25115, 
+                "weights": 25115.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25082, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_315.root", 
+                "nevents": 25082, 
+                "totEvents": 25082, 
+                "weights": 25082.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25175, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_199.root", 
+                "nevents": 25175, 
+                "totEvents": 25175, 
+                "weights": 25175.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25069, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_585.root", 
+                "nevents": 25069, 
+                "totEvents": 25069, 
+                "weights": 25069.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24883, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_190.root", 
+                "nevents": 24883, 
+                "totEvents": 24883, 
+                "weights": 24883.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24607, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_508.root", 
+                "nevents": 24607, 
+                "totEvents": 24607, 
+                "weights": 24607.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25011, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_258.root", 
+                "nevents": 25011, 
+                "totEvents": 25011, 
+                "weights": 25011.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24954, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_320.root", 
+                "nevents": 24954, 
+                "totEvents": 24954, 
+                "weights": 24954.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25119, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_181.root", 
+                "nevents": 25119, 
+                "totEvents": 25119, 
+                "weights": 25119.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24988, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_458.root", 
+                "nevents": 24988, 
+                "totEvents": 24988, 
+                "weights": 24988.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24806, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_307.root", 
+                "nevents": 24806, 
+                "totEvents": 24806, 
+                "weights": 24806.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25162, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_385.root", 
+                "nevents": 25162, 
+                "totEvents": 25162, 
+                "weights": 25162.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24814, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_12.root", 
+                "nevents": 24814, 
+                "totEvents": 24814, 
+                "weights": 24814.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25141, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_347.root", 
+                "nevents": 25141, 
+                "totEvents": 25141, 
+                "weights": 25141.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24792, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_101.root", 
+                "nevents": 24792, 
+                "totEvents": 24792, 
+                "weights": 24792.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24621, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_530.root", 
+                "nevents": 24621, 
+                "totEvents": 24621, 
+                "weights": 24621.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25026, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_202.root", 
+                "nevents": 25026, 
+                "totEvents": 25026, 
+                "weights": 25026.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24983, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_513.root", 
+                "nevents": 24983, 
+                "totEvents": 24983, 
+                "weights": 24983.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25238, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_88.root", 
+                "nevents": 25238, 
+                "totEvents": 25238, 
+                "weights": 25238.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25017, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_569.root", 
+                "nevents": 25017, 
+                "totEvents": 25017, 
+                "weights": 25017.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25064, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_215.root", 
+                "nevents": 25064, 
+                "totEvents": 25064, 
+                "weights": 25064.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24980, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_588.root", 
+                "nevents": 24980, 
+                "totEvents": 24980, 
+                "weights": 24980.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25081, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_354.root", 
+                "nevents": 25081, 
+                "totEvents": 25081, 
+                "weights": 25081.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25057, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_390.root", 
+                "nevents": 25057, 
+                "totEvents": 25057, 
+                "weights": 25057.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24922, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_519.root", 
+                "nevents": 24922, 
+                "totEvents": 24922, 
+                "weights": 24922.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24932, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_250.root", 
+                "nevents": 24932, 
+                "totEvents": 24932, 
+                "weights": 24932.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24684, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_398.root", 
+                "nevents": 24684, 
+                "totEvents": 24684, 
+                "weights": 24684.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24834, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_218.root", 
+                "nevents": 24834, 
+                "totEvents": 24834, 
+                "weights": 24834.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24946, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_567.root", 
+                "nevents": 24946, 
+                "totEvents": 24946, 
+                "weights": 24946.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25031, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_110.root", 
+                "nevents": 25031, 
+                "totEvents": 25031, 
+                "weights": 25031.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25027, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_389.root", 
+                "nevents": 25027, 
+                "totEvents": 25027, 
+                "weights": 25027.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24972, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_140.root", 
+                "nevents": 24972, 
+                "totEvents": 24972, 
+                "weights": 24972.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25246, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_479.root", 
+                "nevents": 25246, 
+                "totEvents": 25246, 
+                "weights": 25246.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24982, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_5.root", 
+                "nevents": 24982, 
+                "totEvents": 24982, 
+                "weights": 24982.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24774, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_33.root", 
+                "nevents": 24774, 
+                "totEvents": 24774, 
+                "weights": 24774.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24951, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_463.root", 
+                "nevents": 24951, 
+                "totEvents": 24951, 
+                "weights": 24951.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24767, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_185.root", 
+                "nevents": 24767, 
+                "totEvents": 24767, 
+                "weights": 24767.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25226, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_182.root", 
+                "nevents": 25226, 
+                "totEvents": 25226, 
+                "weights": 25226.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25222, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_10.root", 
+                "nevents": 25222, 
+                "totEvents": 25222, 
+                "weights": 25222.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25188, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_166.root", 
+                "nevents": 25188, 
+                "totEvents": 25188, 
+                "weights": 25188.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24975, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_14.root", 
+                "nevents": 24975, 
+                "totEvents": 24975, 
+                "weights": 24975.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24962, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_526.root", 
+                "nevents": 24962, 
+                "totEvents": 24962, 
+                "weights": 24962.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25057, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_244.root", 
+                "nevents": 25057, 
+                "totEvents": 25057, 
+                "weights": 25057.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24944, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_200.root", 
+                "nevents": 24944, 
+                "totEvents": 24944, 
+                "weights": 24944.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24986, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_576.root", 
+                "nevents": 24986, 
+                "totEvents": 24986, 
+                "weights": 24986.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24857, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_86.root", 
+                "nevents": 24857, 
+                "totEvents": 24857, 
+                "weights": 24857.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24854, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_566.root", 
+                "nevents": 24854, 
+                "totEvents": 24854, 
+                "weights": 24854.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25024, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_40.root", 
+                "nevents": 25024, 
+                "totEvents": 25024, 
+                "weights": 25024.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_183.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 25000.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24931, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_387.root", 
+                "nevents": 24931, 
+                "totEvents": 24931, 
+                "weights": 24931.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24987, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_89.root", 
+                "nevents": 24987, 
+                "totEvents": 24987, 
+                "weights": 24987.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24986, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_103.root", 
+                "nevents": 24986, 
+                "totEvents": 24986, 
+                "weights": 24986.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25017, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_80.root", 
+                "nevents": 25017, 
+                "totEvents": 25017, 
+                "weights": 25017.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24820, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_310.root", 
+                "nevents": 24820, 
+                "totEvents": 24820, 
+                "weights": 24820.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25271, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_1.root", 
+                "nevents": 25271, 
+                "totEvents": 25271, 
+                "weights": 25271.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24756, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_529.root", 
+                "nevents": 24756, 
+                "totEvents": 24756, 
+                "weights": 24756.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24846, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_553.root", 
+                "nevents": 24846, 
+                "totEvents": 24846, 
+                "weights": 24846.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24729, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_447.root", 
+                "nevents": 24729, 
+                "totEvents": 24729, 
+                "weights": 24729.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25106, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_507.root", 
+                "nevents": 25106, 
+                "totEvents": 25106, 
+                "weights": 25106.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24786, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_322.root", 
+                "nevents": 24786, 
+                "totEvents": 24786, 
+                "weights": 24786.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25101, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_90.root", 
+                "nevents": 25101, 
+                "totEvents": 25101, 
+                "weights": 25101.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25122, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_83.root", 
+                "nevents": 25122, 
+                "totEvents": 25122, 
+                "weights": 25122.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24968, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_486.root", 
+                "nevents": 24968, 
+                "totEvents": 24968, 
+                "weights": 24968.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24938, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_191.root", 
+                "nevents": 24938, 
+                "totEvents": 24938, 
+                "weights": 24938.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24977, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_57.root", 
+                "nevents": 24977, 
+                "totEvents": 24977, 
+                "weights": 24977.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24819, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_204.root", 
+                "nevents": 24819, 
+                "totEvents": 24819, 
+                "weights": 24819.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25108, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_606.root", 
+                "nevents": 25108, 
+                "totEvents": 25108, 
+                "weights": 25108.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24867, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_590.root", 
+                "nevents": 24867, 
+                "totEvents": 24867, 
+                "weights": 24867.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25120, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_594.root", 
+                "nevents": 25120, 
+                "totEvents": 25120, 
+                "weights": 25120.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24755, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_506.root", 
+                "nevents": 24755, 
+                "totEvents": 24755, 
+                "weights": 24755.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25063, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_476.root", 
+                "nevents": 25063, 
+                "totEvents": 25063, 
+                "weights": 25063.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24626, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_198.root", 
+                "nevents": 24626, 
+                "totEvents": 24626, 
+                "weights": 24626.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24526, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_564.root", 
+                "nevents": 24526, 
+                "totEvents": 24526, 
+                "weights": 24526.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25036, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_211.root", 
+                "nevents": 25036, 
+                "totEvents": 25036, 
+                "weights": 25036.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25288, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_489.root", 
+                "nevents": 25288, 
+                "totEvents": 25288, 
+                "weights": 25288.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25067, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_259.root", 
+                "nevents": 25067, 
+                "totEvents": 25067, 
+                "weights": 25067.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24689, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_302.root", 
+                "nevents": 24689, 
+                "totEvents": 24689, 
+                "weights": 24689.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24869, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_425.root", 
+                "nevents": 24869, 
+                "totEvents": 24869, 
+                "weights": 24869.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24871, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_556.root", 
+                "nevents": 24871, 
+                "totEvents": 24871, 
+                "weights": 24871.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24777, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_243.root", 
+                "nevents": 24777, 
+                "totEvents": 24777, 
+                "weights": 24777.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25056, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_361.root", 
+                "nevents": 25056, 
+                "totEvents": 25056, 
+                "weights": 25056.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25267, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_487.root", 
+                "nevents": 25267, 
+                "totEvents": 25267, 
+                "weights": 25267.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24871, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_117.root", 
+                "nevents": 24871, 
+                "totEvents": 24871, 
+                "weights": 24871.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24868, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_188.root", 
+                "nevents": 24868, 
+                "totEvents": 24868, 
+                "weights": 24868.0
+            }, 
+            {
+                "bad": false, 
+                "events": 10152, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_340.root", 
+                "nevents": 10152, 
+                "totEvents": 10152, 
+                "weights": 10152.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24797, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_141.root", 
+                "nevents": 24797, 
+                "totEvents": 24797, 
+                "weights": 24797.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24769, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_2.root", 
+                "nevents": 24769, 
+                "totEvents": 24769, 
+                "weights": 24769.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24873, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_4.root", 
+                "nevents": 24873, 
+                "totEvents": 24873, 
+                "weights": 24873.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24757, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_285.root", 
+                "nevents": 24757, 
+                "totEvents": 24757, 
+                "weights": 24757.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24691, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_252.root", 
+                "nevents": 24691, 
+                "totEvents": 24691, 
+                "weights": 24691.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25026, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_292.root", 
+                "nevents": 25026, 
+                "totEvents": 25026, 
+                "weights": 25026.0
+            }, 
+            {
+                "bad": false, 
+                "events": 10940, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_465.root", 
+                "nevents": 10940, 
+                "totEvents": 10940, 
+                "weights": 10940.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24950, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_34.root", 
+                "nevents": 24950, 
+                "totEvents": 24950, 
+                "weights": 24950.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24743, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_68.root", 
+                "nevents": 24743, 
+                "totEvents": 24743, 
+                "weights": 24743.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24917, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_186.root", 
+                "nevents": 24917, 
+                "totEvents": 24917, 
+                "weights": 24917.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24903, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_289.root", 
+                "nevents": 24903, 
+                "totEvents": 24903, 
+                "weights": 24903.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24746, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_233.root", 
+                "nevents": 24746, 
+                "totEvents": 24746, 
+                "weights": 24746.0
+            }, 
+            {
+                "bad": false, 
+                "events": 15742, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_164.root", 
+                "nevents": 15742, 
+                "totEvents": 15742, 
+                "weights": 15742.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24994, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_42.root", 
+                "nevents": 24994, 
+                "totEvents": 24994, 
+                "weights": 24994.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25394, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_97.root", 
+                "nevents": 25394, 
+                "totEvents": 25394, 
+                "weights": 25394.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24983, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_143.root", 
+                "nevents": 24983, 
+                "totEvents": 24983, 
+                "weights": 24983.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24928, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_196.root", 
+                "nevents": 24928, 
+                "totEvents": 24928, 
+                "weights": 24928.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25152, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_235.root", 
+                "nevents": 25152, 
+                "totEvents": 25152, 
+                "weights": 25152.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25140, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_332.root", 
+                "nevents": 25140, 
+                "totEvents": 25140, 
+                "weights": 25140.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24912, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_329.root", 
+                "nevents": 24912, 
+                "totEvents": 24912, 
+                "weights": 24912.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_210.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 25000.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25108, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_142.root", 
+                "nevents": 25108, 
+                "totEvents": 25108, 
+                "weights": 25108.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24971, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_145.root", 
+                "nevents": 24971, 
+                "totEvents": 24971, 
+                "weights": 24971.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24985, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_212.root", 
+                "nevents": 24985, 
+                "totEvents": 24985, 
+                "weights": 24985.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25173, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_257.root", 
+                "nevents": 25173, 
+                "totEvents": 25173, 
+                "weights": 25173.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24848, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_232.root", 
+                "nevents": 24848, 
+                "totEvents": 24848, 
+                "weights": 24848.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25074, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_328.root", 
+                "nevents": 25074, 
+                "totEvents": 25074, 
+                "weights": 25074.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25343, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_195.root", 
+                "nevents": 25343, 
+                "totEvents": 25343, 
+                "weights": 25343.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24891, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_96.root", 
+                "nevents": 24891, 
+                "totEvents": 24891, 
+                "weights": 24891.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24947, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_120.root", 
+                "nevents": 24947, 
+                "totEvents": 24947, 
+                "weights": 24947.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24971, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_159.root", 
+                "nevents": 24971, 
+                "totEvents": 24971, 
+                "weights": 24971.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24928, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_151.root", 
+                "nevents": 24928, 
+                "totEvents": 24928, 
+                "weights": 24928.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25054, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_294.root", 
+                "nevents": 25054, 
+                "totEvents": 25054, 
+                "weights": 25054.0
+            }, 
+            {
+                "bad": false, 
+                "events": 13565, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_597.root", 
+                "nevents": 13565, 
+                "totEvents": 13565, 
+                "weights": 13565.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24910, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_284.root", 
+                "nevents": 24910, 
+                "totEvents": 24910, 
+                "weights": 24910.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24998, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_281.root", 
+                "nevents": 24998, 
+                "totEvents": 24998, 
+                "weights": 24998.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24738, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_603.root", 
+                "nevents": 24738, 
+                "totEvents": 24738, 
+                "weights": 24738.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24907, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_278.root", 
+                "nevents": 24907, 
+                "totEvents": 24907, 
+                "weights": 24907.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25016, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_277.root", 
+                "nevents": 25016, 
+                "totEvents": 25016, 
+                "weights": 25016.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25001, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_98.root", 
+                "nevents": 25001, 
+                "totEvents": 25001, 
+                "weights": 25001.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25131, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_46.root", 
+                "nevents": 25131, 
+                "totEvents": 25131, 
+                "weights": 25131.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24977, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_106.root", 
+                "nevents": 24977, 
+                "totEvents": 24977, 
+                "weights": 24977.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24982, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_74.root", 
+                "nevents": 24982, 
+                "totEvents": 24982, 
+                "weights": 24982.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24831, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_461.root", 
+                "nevents": 24831, 
+                "totEvents": 24831, 
+                "weights": 24831.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24941, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_87.root", 
+                "nevents": 24941, 
+                "totEvents": 24941, 
+                "weights": 24941.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25068, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_49.root", 
+                "nevents": 25068, 
+                "totEvents": 25068, 
+                "weights": 25068.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24880, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_111.root", 
+                "nevents": 24880, 
+                "totEvents": 24880, 
+                "weights": 24880.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25031, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_102.root", 
+                "nevents": 25031, 
+                "totEvents": 25031, 
+                "weights": 25031.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24811, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_92.root", 
+                "nevents": 24811, 
+                "totEvents": 24811, 
+                "weights": 24811.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24825, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_580.root", 
+                "nevents": 24825, 
+                "totEvents": 24825, 
+                "weights": 24825.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24791, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_76.root", 
+                "nevents": 24791, 
+                "totEvents": 24791, 
+                "weights": 24791.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25186, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_48.root", 
+                "nevents": 25186, 
+                "totEvents": 25186, 
+                "weights": 25186.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24855, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_70.root", 
+                "nevents": 24855, 
+                "totEvents": 24855, 
+                "weights": 24855.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24911, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_109.root", 
+                "nevents": 24911, 
+                "totEvents": 24911, 
+                "weights": 24911.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25037, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_364.root", 
+                "nevents": 25037, 
+                "totEvents": 25037, 
+                "weights": 25037.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25218, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_75.root", 
+                "nevents": 25218, 
+                "totEvents": 25218, 
+                "weights": 25218.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24899, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_584.root", 
+                "nevents": 24899, 
+                "totEvents": 24899, 
+                "weights": 24899.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24992, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_552.root", 
+                "nevents": 24992, 
+                "totEvents": 24992, 
+                "weights": 24992.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25047, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_107.root", 
+                "nevents": 25047, 
+                "totEvents": 25047, 
+                "weights": 25047.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24991, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_45.root", 
+                "nevents": 24991, 
+                "totEvents": 24991, 
+                "weights": 24991.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24821, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_79.root", 
+                "nevents": 24821, 
+                "totEvents": 24821, 
+                "weights": 24821.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25014, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_405.root", 
+                "nevents": 25014, 
+                "totEvents": 25014, 
+                "weights": 25014.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24951, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_415.root", 
+                "nevents": 24951, 
+                "totEvents": 24951, 
+                "weights": 24951.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24794, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_587.root", 
+                "nevents": 24794, 
+                "totEvents": 24794, 
+                "weights": 24794.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24979, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_593.root", 
+                "nevents": 24979, 
+                "totEvents": 24979, 
+                "weights": 24979.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25136, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_113.root", 
+                "nevents": 25136, 
+                "totEvents": 25136, 
+                "weights": 25136.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25006, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_428.root", 
+                "nevents": 25006, 
+                "totEvents": 25006, 
+                "weights": 25006.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25085, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_577.root", 
+                "nevents": 25085, 
+                "totEvents": 25085, 
+                "weights": 25085.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25020, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_549.root", 
+                "nevents": 25020, 
+                "totEvents": 25020, 
+                "weights": 25020.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25136, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_515.root", 
+                "nevents": 25136, 
+                "totEvents": 25136, 
+                "weights": 25136.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25074, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_69.root", 
+                "nevents": 25074, 
+                "totEvents": 25074, 
+                "weights": 25074.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25134, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_595.root", 
+                "nevents": 25134, 
+                "totEvents": 25134, 
+                "weights": 25134.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25189, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_91.root", 
+                "nevents": 25189, 
+                "totEvents": 25189, 
+                "weights": 25189.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24850, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_71.root", 
+                "nevents": 24850, 
+                "totEvents": 24850, 
+                "weights": 24850.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24928, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_335.root", 
+                "nevents": 24928, 
+                "totEvents": 24928, 
+                "weights": 24928.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25045, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_78.root", 
+                "nevents": 25045, 
+                "totEvents": 25045, 
+                "weights": 25045.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25101, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_560.root", 
+                "nevents": 25101, 
+                "totEvents": 25101, 
+                "weights": 25101.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25100, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_108.root", 
+                "nevents": 25100, 
+                "totEvents": 25100, 
+                "weights": 25100.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25027, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_467.root", 
+                "nevents": 25027, 
+                "totEvents": 25027, 
+                "weights": 25027.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24681, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_72.root", 
+                "nevents": 24681, 
+                "totEvents": 24681, 
+                "weights": 24681.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24888, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_153.root", 
+                "nevents": 24888, 
+                "totEvents": 24888, 
+                "weights": 24888.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25014, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_81.root", 
+                "nevents": 25014, 
+                "totEvents": 25014, 
+                "weights": 25014.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24864, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_73.root", 
+                "nevents": 24864, 
+                "totEvents": 24864, 
+                "weights": 24864.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24837, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_459.root", 
+                "nevents": 24837, 
+                "totEvents": 24837, 
+                "weights": 24837.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25054, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_51.root", 
+                "nevents": 25054, 
+                "totEvents": 25054, 
+                "weights": 25054.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25169, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_50.root", 
+                "nevents": 25169, 
+                "totEvents": 25169, 
+                "weights": 25169.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24757, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_282.root", 
+                "nevents": 24757, 
+                "totEvents": 24757, 
+                "weights": 24757.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25117, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_39.root", 
+                "nevents": 25117, 
+                "totEvents": 25117, 
+                "weights": 25117.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25059, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_152.root", 
+                "nevents": 25059, 
+                "totEvents": 25059, 
+                "weights": 25059.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25243, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_532.root", 
+                "nevents": 25243, 
+                "totEvents": 25243, 
+                "weights": 25243.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24856, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_163.root", 
+                "nevents": 24856, 
+                "totEvents": 24856, 
+                "weights": 24856.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25059, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_470.root", 
+                "nevents": 25059, 
+                "totEvents": 25059, 
+                "weights": 25059.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24948, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_53.root", 
+                "nevents": 24948, 
+                "totEvents": 24948, 
+                "weights": 24948.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24776, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_52.root", 
+                "nevents": 24776, 
+                "totEvents": 24776, 
+                "weights": 24776.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24907, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_573.root", 
+                "nevents": 24907, 
+                "totEvents": 24907, 
+                "weights": 24907.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25132, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_77.root", 
+                "nevents": 25132, 
+                "totEvents": 25132, 
+                "weights": 25132.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24898, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_426.root", 
+                "nevents": 24898, 
+                "totEvents": 24898, 
+                "weights": 24898.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24754, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_54.root", 
+                "nevents": 24754, 
+                "totEvents": 24754, 
+                "weights": 24754.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25011, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_591.root", 
+                "nevents": 25011, 
+                "totEvents": 25011, 
+                "weights": 25011.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25176, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_209.root", 
+                "nevents": 25176, 
+                "totEvents": 25176, 
+                "weights": 25176.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25079, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_237.root", 
+                "nevents": 25079, 
+                "totEvents": 25079, 
+                "weights": 25079.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24812, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_32.root", 
+                "nevents": 24812, 
+                "totEvents": 24812, 
+                "weights": 24812.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24957, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_293.root", 
+                "nevents": 24957, 
+                "totEvents": 24957, 
+                "weights": 24957.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25042, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_37.root", 
+                "nevents": 25042, 
+                "totEvents": 25042, 
+                "weights": 25042.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25086, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_47.root", 
+                "nevents": 25086, 
+                "totEvents": 25086, 
+                "weights": 25086.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25034, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-30to50_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_140911/0000/myMicroAODOutputFile_173.root", 
+                "nevents": 25034, 
+                "totEvents": 25034, 
+                "weights": 25034.0
+            }
+        ], 
+        "parent_n_units": 14971725, 
+        "vetted": true
+    }
+}

--- a/MetaData/data/Era2017_legacy_v1/datasets_37.json
+++ b/MetaData/data/Era2017_legacy_v1/datasets_37.json
@@ -1,0 +1,4753 @@
+{
+    "/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/alesauva-UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2-8980ba169e8b72d53459e52844728ed8/USER": {
+        "dset_type": "mc", 
+        "files": [
+            {
+                "bad": false, 
+                "events": 24956, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_62.root", 
+                "nevents": 24956, 
+                "totEvents": 24956, 
+                "weights": 24956.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25182, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_134.root", 
+                "nevents": 25182, 
+                "totEvents": 25182, 
+                "weights": 25182.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25017, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_583.root", 
+                "nevents": 25017, 
+                "totEvents": 25017, 
+                "weights": 25017.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25265, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_288.root", 
+                "nevents": 25265, 
+                "totEvents": 25265, 
+                "weights": 25265.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24993, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_381.root", 
+                "nevents": 24993, 
+                "totEvents": 24993, 
+                "weights": 24993.001953125
+            }, 
+            {
+                "bad": false, 
+                "events": 24755, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_223.root", 
+                "nevents": 24755, 
+                "totEvents": 24755, 
+                "weights": 24755.02734375
+            }, 
+            {
+                "bad": false, 
+                "events": 25160, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_306.root", 
+                "nevents": 25160, 
+                "totEvents": 25160, 
+                "weights": 25160.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25166, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_66.root", 
+                "nevents": 25166, 
+                "totEvents": 25166, 
+                "weights": 25166.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24942, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_508.root", 
+                "nevents": 24942, 
+                "totEvents": 24942, 
+                "weights": 24942.052734375
+            }, 
+            {
+                "bad": false, 
+                "events": 24981, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_535.root", 
+                "nevents": 24981, 
+                "totEvents": 24981, 
+                "weights": 24981.060546875
+            }, 
+            {
+                "bad": false, 
+                "events": 25094, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_456.root", 
+                "nevents": 25094, 
+                "totEvents": 25094, 
+                "weights": 25094.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24894, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_59.root", 
+                "nevents": 24894, 
+                "totEvents": 24894, 
+                "weights": 24894.0390625
+            }, 
+            {
+                "bad": false, 
+                "events": 24923, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_537.root", 
+                "nevents": 24923, 
+                "totEvents": 24923, 
+                "weights": 24923.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24954, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_451.root", 
+                "nevents": 24954, 
+                "totEvents": 24954, 
+                "weights": 24954.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25281, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_552.root", 
+                "nevents": 25281, 
+                "totEvents": 25281, 
+                "weights": 25281.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25106, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_477.root", 
+                "nevents": 25106, 
+                "totEvents": 25106, 
+                "weights": 25106.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25073, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_102.root", 
+                "nevents": 25073, 
+                "totEvents": 25073, 
+                "weights": 25073.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25261, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_145.root", 
+                "nevents": 25261, 
+                "totEvents": 25261, 
+                "weights": 25261.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25372, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_19.root", 
+                "nevents": 25372, 
+                "totEvents": 25372, 
+                "weights": 25372.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24947, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_341.root", 
+                "nevents": 24947, 
+                "totEvents": 24947, 
+                "weights": 24947.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25106, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_382.root", 
+                "nevents": 25106, 
+                "totEvents": 25106, 
+                "weights": 25106.046875
+            }, 
+            {
+                "bad": false, 
+                "events": 24807, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_200.root", 
+                "nevents": 24807, 
+                "totEvents": 24807, 
+                "weights": 24807.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25220, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_262.root", 
+                "nevents": 25220, 
+                "totEvents": 25220, 
+                "weights": 25220.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25148, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_452.root", 
+                "nevents": 25148, 
+                "totEvents": 25148, 
+                "weights": 25148.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25072, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_22.root", 
+                "nevents": 25072, 
+                "totEvents": 25072, 
+                "weights": 25072.00390625
+            }, 
+            {
+                "bad": false, 
+                "events": 25081, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_464.root", 
+                "nevents": 25081, 
+                "totEvents": 25081, 
+                "weights": 25081.044921875
+            }, 
+            {
+                "bad": false, 
+                "events": 25121, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_33.root", 
+                "nevents": 25121, 
+                "totEvents": 25121, 
+                "weights": 25121.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24933, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_429.root", 
+                "nevents": 24933, 
+                "totEvents": 24933, 
+                "weights": 24933.06640625
+            }, 
+            {
+                "bad": false, 
+                "events": 25196, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_213.root", 
+                "nevents": 25196, 
+                "totEvents": 25196, 
+                "weights": 25196.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24854, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_278.root", 
+                "nevents": 24854, 
+                "totEvents": 24854, 
+                "weights": 24854.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24792, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_498.root", 
+                "nevents": 24792, 
+                "totEvents": 24792, 
+                "weights": 24792.078125
+            }, 
+            {
+                "bad": false, 
+                "events": 24841, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_254.root", 
+                "nevents": 24841, 
+                "totEvents": 24841, 
+                "weights": 24841.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24723, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_369.root", 
+                "nevents": 24723, 
+                "totEvents": 24723, 
+                "weights": 24723.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25043, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_156.root", 
+                "nevents": 25043, 
+                "totEvents": 25043, 
+                "weights": 25043.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24940, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_545.root", 
+                "nevents": 24940, 
+                "totEvents": 24940, 
+                "weights": 24940.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25185, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_468.root", 
+                "nevents": 25185, 
+                "totEvents": 25185, 
+                "weights": 25185.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24945, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_419.root", 
+                "nevents": 24945, 
+                "totEvents": 24945, 
+                "weights": 24945.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24938, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_228.root", 
+                "nevents": 24938, 
+                "totEvents": 24938, 
+                "weights": 24938.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24839, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_539.root", 
+                "nevents": 24839, 
+                "totEvents": 24839, 
+                "weights": 24839.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25037, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_286.root", 
+                "nevents": 25037, 
+                "totEvents": 25037, 
+                "weights": 25037.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25121, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_58.root", 
+                "nevents": 25121, 
+                "totEvents": 25121, 
+                "weights": 25121.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25009, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_294.root", 
+                "nevents": 25009, 
+                "totEvents": 25009, 
+                "weights": 25009.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25108, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_222.root", 
+                "nevents": 25108, 
+                "totEvents": 25108, 
+                "weights": 25108.05859375
+            }, 
+            {
+                "bad": false, 
+                "events": 25138, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_226.root", 
+                "nevents": 25138, 
+                "totEvents": 25138, 
+                "weights": 25138.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25095, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_216.root", 
+                "nevents": 25095, 
+                "totEvents": 25095, 
+                "weights": 25095.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24976, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_129.root", 
+                "nevents": 24976, 
+                "totEvents": 24976, 
+                "weights": 24976.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25075, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_144.root", 
+                "nevents": 25075, 
+                "totEvents": 25075, 
+                "weights": 25075.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24910, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_453.root", 
+                "nevents": 24910, 
+                "totEvents": 24910, 
+                "weights": 24910.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25094, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_153.root", 
+                "nevents": 25094, 
+                "totEvents": 25094, 
+                "weights": 25094.0
+            }, 
+            {
+                "bad": false, 
+                "events": 1186, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_108.root", 
+                "nevents": 1186, 
+                "totEvents": 1186, 
+                "weights": 1186.0
+            }, 
+            {
+                "bad": false, 
+                "events": 1062, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_3.root", 
+                "nevents": 1062, 
+                "totEvents": 1062, 
+                "weights": 1062.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24823, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_352.root", 
+                "nevents": 24823, 
+                "totEvents": 24823, 
+                "weights": 24823.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25049, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_523.root", 
+                "nevents": 25049, 
+                "totEvents": 25049, 
+                "weights": 25049.01953125
+            }, 
+            {
+                "bad": false, 
+                "events": 24812, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_231.root", 
+                "nevents": 24812, 
+                "totEvents": 24812, 
+                "weights": 24812.029296875
+            }, 
+            {
+                "bad": false, 
+                "events": 25327, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_409.root", 
+                "nevents": 25327, 
+                "totEvents": 25327, 
+                "weights": 25327.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24850, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_387.root", 
+                "nevents": 24850, 
+                "totEvents": 24850, 
+                "weights": 24850.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25023, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_516.root", 
+                "nevents": 25023, 
+                "totEvents": 25023, 
+                "weights": 25023.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24826, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_538.root", 
+                "nevents": 24826, 
+                "totEvents": 24826, 
+                "weights": 24826.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24926, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_38.root", 
+                "nevents": 24926, 
+                "totEvents": 24926, 
+                "weights": 24926.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24755, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_233.root", 
+                "nevents": 24755, 
+                "totEvents": 24755, 
+                "weights": 24755.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24832, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_315.root", 
+                "nevents": 24832, 
+                "totEvents": 24832, 
+                "weights": 24832.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24847, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_149.root", 
+                "nevents": 24847, 
+                "totEvents": 24847, 
+                "weights": 24847.07421875
+            }, 
+            {
+                "bad": false, 
+                "events": 24978, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_126.root", 
+                "nevents": 24978, 
+                "totEvents": 24978, 
+                "weights": 24978.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25190, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_432.root", 
+                "nevents": 25190, 
+                "totEvents": 25190, 
+                "weights": 25190.01171875
+            }, 
+            {
+                "bad": false, 
+                "events": 25225, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_264.root", 
+                "nevents": 25225, 
+                "totEvents": 25225, 
+                "weights": 25225.01953125
+            }, 
+            {
+                "bad": false, 
+                "events": 24740, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_394.root", 
+                "nevents": 24740, 
+                "totEvents": 24740, 
+                "weights": 24740.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25132, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_510.root", 
+                "nevents": 25132, 
+                "totEvents": 25132, 
+                "weights": 25132.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24723, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_150.root", 
+                "nevents": 24723, 
+                "totEvents": 24723, 
+                "weights": 24723.005859375
+            }, 
+            {
+                "bad": false, 
+                "events": 25164, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_309.root", 
+                "nevents": 25164, 
+                "totEvents": 25164, 
+                "weights": 25164.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25008, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_566.root", 
+                "nevents": 25008, 
+                "totEvents": 25008, 
+                "weights": 25008.068359375
+            }, 
+            {
+                "bad": false, 
+                "events": 25142, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_12.root", 
+                "nevents": 25142, 
+                "totEvents": 25142, 
+                "weights": 25142.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24888, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_214.root", 
+                "nevents": 24888, 
+                "totEvents": 24888, 
+                "weights": 24888.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25070, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_125.root", 
+                "nevents": 25070, 
+                "totEvents": 25070, 
+                "weights": 25070.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25220, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_366.root", 
+                "nevents": 25220, 
+                "totEvents": 25220, 
+                "weights": 25220.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25019, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_590.root", 
+                "nevents": 25019, 
+                "totEvents": 25019, 
+                "weights": 25019.0703125
+            }, 
+            {
+                "bad": false, 
+                "events": 24777, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_487.root", 
+                "nevents": 24777, 
+                "totEvents": 24777, 
+                "weights": 24777.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24610, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_206.root", 
+                "nevents": 24610, 
+                "totEvents": 24610, 
+                "weights": 24610.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25062, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_522.root", 
+                "nevents": 25062, 
+                "totEvents": 25062, 
+                "weights": 25062.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24916, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_560.root", 
+                "nevents": 24916, 
+                "totEvents": 24916, 
+                "weights": 24916.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24810, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_349.root", 
+                "nevents": 24810, 
+                "totEvents": 24810, 
+                "weights": 24810.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24938, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_259.root", 
+                "nevents": 24938, 
+                "totEvents": 24938, 
+                "weights": 24938.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25045, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_427.root", 
+                "nevents": 25045, 
+                "totEvents": 25045, 
+                "weights": 25045.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25009, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_400.root", 
+                "nevents": 25009, 
+                "totEvents": 25009, 
+                "weights": 25009.056640625
+            }, 
+            {
+                "bad": false, 
+                "events": 25087, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_354.root", 
+                "nevents": 25087, 
+                "totEvents": 25087, 
+                "weights": 25087.07421875
+            }, 
+            {
+                "bad": false, 
+                "events": 24958, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_155.root", 
+                "nevents": 24958, 
+                "totEvents": 24958, 
+                "weights": 24958.0
+            }, 
+            {
+                "bad": false, 
+                "events": 14431, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_438.root", 
+                "nevents": 14431, 
+                "totEvents": 14431, 
+                "weights": 14431.0
+            }, 
+            {
+                "bad": false, 
+                "events": 13052, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_574.root", 
+                "nevents": 13052, 
+                "totEvents": 13052, 
+                "weights": 13052.05859375
+            }, 
+            {
+                "bad": false, 
+                "events": 6696, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_253.root", 
+                "nevents": 6696, 
+                "totEvents": 6696, 
+                "weights": 6696.0185546875
+            }, 
+            {
+                "bad": false, 
+                "events": 16198, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_593.root", 
+                "nevents": 16198, 
+                "totEvents": 16198, 
+                "weights": 16198.0517578125
+            }, 
+            {
+                "bad": false, 
+                "events": 24546, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_358.root", 
+                "nevents": 24546, 
+                "totEvents": 24546, 
+                "weights": 24546.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24928, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_26.root", 
+                "nevents": 24928, 
+                "totEvents": 24928, 
+                "weights": 24928.001953125
+            }, 
+            {
+                "bad": false, 
+                "events": 25033, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_378.root", 
+                "nevents": 25033, 
+                "totEvents": 25033, 
+                "weights": 25033.048828125
+            }, 
+            {
+                "bad": false, 
+                "events": 24934, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_10.root", 
+                "nevents": 24934, 
+                "totEvents": 24934, 
+                "weights": 24934.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25179, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_370.root", 
+                "nevents": 25179, 
+                "totEvents": 25179, 
+                "weights": 25179.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25208, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_365.root", 
+                "nevents": 25208, 
+                "totEvents": 25208, 
+                "weights": 25208.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24829, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_519.root", 
+                "nevents": 24829, 
+                "totEvents": 24829, 
+                "weights": 24829.0
+            }, 
+            {
+                "bad": false, 
+                "events": 2879, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_483.root", 
+                "nevents": 2879, 
+                "totEvents": 2879, 
+                "weights": 2879.0
+            }, 
+            {
+                "bad": false, 
+                "events": 14705, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_518.root", 
+                "nevents": 14705, 
+                "totEvents": 14705, 
+                "weights": 14705.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25110, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_437.root", 
+                "nevents": 25110, 
+                "totEvents": 25110, 
+                "weights": 25110.044921875
+            }, 
+            {
+                "bad": false, 
+                "events": 24998, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_287.root", 
+                "nevents": 24998, 
+                "totEvents": 24998, 
+                "weights": 24998.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24755, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_39.root", 
+                "nevents": 24755, 
+                "totEvents": 24755, 
+                "weights": 24755.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24900, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_89.root", 
+                "nevents": 24900, 
+                "totEvents": 24900, 
+                "weights": 24900.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24894, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_179.root", 
+                "nevents": 24894, 
+                "totEvents": 24894, 
+                "weights": 24894.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24780, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_118.root", 
+                "nevents": 24780, 
+                "totEvents": 24780, 
+                "weights": 24780.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25418, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_197.root", 
+                "nevents": 25418, 
+                "totEvents": 25418, 
+                "weights": 25418.01171875
+            }, 
+            {
+                "bad": false, 
+                "events": 24857, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_136.root", 
+                "nevents": 24857, 
+                "totEvents": 24857, 
+                "weights": 24857.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24885, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_47.root", 
+                "nevents": 24885, 
+                "totEvents": 24885, 
+                "weights": 24885.03515625
+            }, 
+            {
+                "bad": false, 
+                "events": 24536, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_36.root", 
+                "nevents": 24536, 
+                "totEvents": 24536, 
+                "weights": 24536.0
+            }, 
+            {
+                "bad": false, 
+                "events": 20626, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_484.root", 
+                "nevents": 20626, 
+                "totEvents": 20626, 
+                "weights": 20626.06640625
+            }, 
+            {
+                "bad": false, 
+                "events": 24860, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_267.root", 
+                "nevents": 24860, 
+                "totEvents": 24860, 
+                "weights": 24860.015625
+            }, 
+            {
+                "bad": false, 
+                "events": 24953, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_53.root", 
+                "nevents": 24953, 
+                "totEvents": 24953, 
+                "weights": 24953.029296875
+            }, 
+            {
+                "bad": false, 
+                "events": 25044, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_133.root", 
+                "nevents": 25044, 
+                "totEvents": 25044, 
+                "weights": 25044.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24886, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_96.root", 
+                "nevents": 24886, 
+                "totEvents": 24886, 
+                "weights": 24886.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25011, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_204.root", 
+                "nevents": 25011, 
+                "totEvents": 25011, 
+                "weights": 25011.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24855, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_42.root", 
+                "nevents": 24855, 
+                "totEvents": 24855, 
+                "weights": 24855.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25134, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_113.root", 
+                "nevents": 25134, 
+                "totEvents": 25134, 
+                "weights": 25134.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24926, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_16.root", 
+                "nevents": 24926, 
+                "totEvents": 24926, 
+                "weights": 24926.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24626, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_297.root", 
+                "nevents": 24626, 
+                "totEvents": 24626, 
+                "weights": 24626.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24946, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_556.root", 
+                "nevents": 24946, 
+                "totEvents": 24946, 
+                "weights": 24946.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24871, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_393.root", 
+                "nevents": 24871, 
+                "totEvents": 24871, 
+                "weights": 24871.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25166, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_212.root", 
+                "nevents": 25166, 
+                "totEvents": 25166, 
+                "weights": 25166.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24905, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_339.root", 
+                "nevents": 24905, 
+                "totEvents": 24905, 
+                "weights": 24905.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24830, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_218.root", 
+                "nevents": 24830, 
+                "totEvents": 24830, 
+                "weights": 24830.0078125
+            }, 
+            {
+                "bad": false, 
+                "events": 25154, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_217.root", 
+                "nevents": 25154, 
+                "totEvents": 25154, 
+                "weights": 25154.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25164, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_543.root", 
+                "nevents": 25164, 
+                "totEvents": 25164, 
+                "weights": 25164.041015625
+            }, 
+            {
+                "bad": false, 
+                "events": 25076, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_323.root", 
+                "nevents": 25076, 
+                "totEvents": 25076, 
+                "weights": 25076.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24867, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_474.root", 
+                "nevents": 24867, 
+                "totEvents": 24867, 
+                "weights": 24867.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25192, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_139.root", 
+                "nevents": 25192, 
+                "totEvents": 25192, 
+                "weights": 25192.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24748, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_272.root", 
+                "nevents": 24748, 
+                "totEvents": 24748, 
+                "weights": 24748.021484375
+            }, 
+            {
+                "bad": false, 
+                "events": 25026, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_463.root", 
+                "nevents": 25026, 
+                "totEvents": 25026, 
+                "weights": 25026.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24923, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_385.root", 
+                "nevents": 24923, 
+                "totEvents": 24923, 
+                "weights": 24923.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24822, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_548.root", 
+                "nevents": 24822, 
+                "totEvents": 24822, 
+                "weights": 24822.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25146, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_371.root", 
+                "nevents": 25146, 
+                "totEvents": 25146, 
+                "weights": 25146.033203125
+            }, 
+            {
+                "bad": false, 
+                "events": 25101, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_439.root", 
+                "nevents": 25101, 
+                "totEvents": 25101, 
+                "weights": 25101.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24917, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_478.root", 
+                "nevents": 24917, 
+                "totEvents": 24917, 
+                "weights": 24917.021484375
+            }, 
+            {
+                "bad": false, 
+                "events": 25073, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_362.root", 
+                "nevents": 25073, 
+                "totEvents": 25073, 
+                "weights": 25073.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24755, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_448.root", 
+                "nevents": 24755, 
+                "totEvents": 24755, 
+                "weights": 24755.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24710, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_499.root", 
+                "nevents": 24710, 
+                "totEvents": 24710, 
+                "weights": 24710.00390625
+            }, 
+            {
+                "bad": false, 
+                "events": 25011, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_312.root", 
+                "nevents": 25011, 
+                "totEvents": 25011, 
+                "weights": 25011.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24912, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_555.root", 
+                "nevents": 24912, 
+                "totEvents": 24912, 
+                "weights": 24912.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25088, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_301.root", 
+                "nevents": 25088, 
+                "totEvents": 25088, 
+                "weights": 25088.0625
+            }, 
+            {
+                "bad": false, 
+                "events": 17304, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_403.root", 
+                "nevents": 17304, 
+                "totEvents": 17304, 
+                "weights": 17304.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25047, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_189.root", 
+                "nevents": 25047, 
+                "totEvents": 25047, 
+                "weights": 25047.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24944, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_175.root", 
+                "nevents": 24944, 
+                "totEvents": 24944, 
+                "weights": 24944.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25198, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_201.root", 
+                "nevents": 25198, 
+                "totEvents": 25198, 
+                "weights": 25198.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24921, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_109.root", 
+                "nevents": 24921, 
+                "totEvents": 24921, 
+                "weights": 24921.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24982, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_177.root", 
+                "nevents": 24982, 
+                "totEvents": 24982, 
+                "weights": 24982.0234375
+            }, 
+            {
+                "bad": false, 
+                "events": 25138, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_187.root", 
+                "nevents": 25138, 
+                "totEvents": 25138, 
+                "weights": 25138.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24828, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_94.root", 
+                "nevents": 24828, 
+                "totEvents": 24828, 
+                "weights": 24828.05859375
+            }, 
+            {
+                "bad": false, 
+                "events": 24942, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_251.root", 
+                "nevents": 24942, 
+                "totEvents": 24942, 
+                "weights": 24942.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24981, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_182.root", 
+                "nevents": 24981, 
+                "totEvents": 24981, 
+                "weights": 24981.04296875
+            }, 
+            {
+                "bad": false, 
+                "events": 25160, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_122.root", 
+                "nevents": 25160, 
+                "totEvents": 25160, 
+                "weights": 25160.044921875
+            }, 
+            {
+                "bad": false, 
+                "events": 24977, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_95.root", 
+                "nevents": 24977, 
+                "totEvents": 24977, 
+                "weights": 24977.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24936, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_27.root", 
+                "nevents": 24936, 
+                "totEvents": 24936, 
+                "weights": 24936.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25099, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_436.root", 
+                "nevents": 25099, 
+                "totEvents": 25099, 
+                "weights": 25099.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25053, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_193.root", 
+                "nevents": 25053, 
+                "totEvents": 25053, 
+                "weights": 25053.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24885, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_123.root", 
+                "nevents": 24885, 
+                "totEvents": 24885, 
+                "weights": 24885.0234375
+            }, 
+            {
+                "bad": false, 
+                "events": 24905, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_120.root", 
+                "nevents": 24905, 
+                "totEvents": 24905, 
+                "weights": 24905.015625
+            }, 
+            {
+                "bad": false, 
+                "events": 25133, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_199.root", 
+                "nevents": 25133, 
+                "totEvents": 25133, 
+                "weights": 25133.005859375
+            }, 
+            {
+                "bad": false, 
+                "events": 24898, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_85.root", 
+                "nevents": 24898, 
+                "totEvents": 24898, 
+                "weights": 24898.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24883, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_274.root", 
+                "nevents": 24883, 
+                "totEvents": 24883, 
+                "weights": 24883.01171875
+            }, 
+            {
+                "bad": false, 
+                "events": 24812, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_191.root", 
+                "nevents": 24812, 
+                "totEvents": 24812, 
+                "weights": 24812.021484375
+            }, 
+            {
+                "bad": false, 
+                "events": 24847, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_348.root", 
+                "nevents": 24847, 
+                "totEvents": 24847, 
+                "weights": 24847.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24940, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_289.root", 
+                "nevents": 24940, 
+                "totEvents": 24940, 
+                "weights": 24940.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25216, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_471.root", 
+                "nevents": 25216, 
+                "totEvents": 25216, 
+                "weights": 25216.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24864, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_547.root", 
+                "nevents": 24864, 
+                "totEvents": 24864, 
+                "weights": 24864.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25130, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_337.root", 
+                "nevents": 25130, 
+                "totEvents": 25130, 
+                "weights": 25130.0078125
+            }, 
+            {
+                "bad": false, 
+                "events": 24938, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_296.root", 
+                "nevents": 24938, 
+                "totEvents": 24938, 
+                "weights": 24938.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24900, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_405.root", 
+                "nevents": 24900, 
+                "totEvents": 24900, 
+                "weights": 24900.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25009, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_30.root", 
+                "nevents": 25009, 
+                "totEvents": 25009, 
+                "weights": 25009.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24893, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_420.root", 
+                "nevents": 24893, 
+                "totEvents": 24893, 
+                "weights": 24893.015625
+            }, 
+            {
+                "bad": false, 
+                "events": 25218, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_373.root", 
+                "nevents": 25218, 
+                "totEvents": 25218, 
+                "weights": 25218.013671875
+            }, 
+            {
+                "bad": false, 
+                "events": 25032, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_446.root", 
+                "nevents": 25032, 
+                "totEvents": 25032, 
+                "weights": 25032.01171875
+            }, 
+            {
+                "bad": false, 
+                "events": 24873, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_440.root", 
+                "nevents": 24873, 
+                "totEvents": 24873, 
+                "weights": 24873.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24929, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_551.root", 
+                "nevents": 24929, 
+                "totEvents": 24929, 
+                "weights": 24929.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24906, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_458.root", 
+                "nevents": 24906, 
+                "totEvents": 24906, 
+                "weights": 24906.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25180, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_398.root", 
+                "nevents": 25180, 
+                "totEvents": 25180, 
+                "weights": 25180.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25179, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_473.root", 
+                "nevents": 25179, 
+                "totEvents": 25179, 
+                "weights": 25179.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24941, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_572.root", 
+                "nevents": 24941, 
+                "totEvents": 24941, 
+                "weights": 24941.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25025, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_491.root", 
+                "nevents": 25025, 
+                "totEvents": 25025, 
+                "weights": 25025.0546875
+            }, 
+            {
+                "bad": false, 
+                "events": 24798, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_546.root", 
+                "nevents": 24798, 
+                "totEvents": 24798, 
+                "weights": 24798.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24956, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_32.root", 
+                "nevents": 24956, 
+                "totEvents": 24956, 
+                "weights": 24956.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25002, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_305.root", 
+                "nevents": 25002, 
+                "totEvents": 25002, 
+                "weights": 25002.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24715, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_481.root", 
+                "nevents": 24715, 
+                "totEvents": 24715, 
+                "weights": 24715.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24723, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_101.root", 
+                "nevents": 24723, 
+                "totEvents": 24723, 
+                "weights": 24723.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24950, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_314.root", 
+                "nevents": 24950, 
+                "totEvents": 24950, 
+                "weights": 24950.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24653, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_364.root", 
+                "nevents": 24653, 
+                "totEvents": 24653, 
+                "weights": 24653.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24965, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_533.root", 
+                "nevents": 24965, 
+                "totEvents": 24965, 
+                "weights": 24965.05078125
+            }, 
+            {
+                "bad": false, 
+                "events": 25174, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_31.root", 
+                "nevents": 25174, 
+                "totEvents": 25174, 
+                "weights": 25174.025390625
+            }, 
+            {
+                "bad": false, 
+                "events": 25194, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_78.root", 
+                "nevents": 25194, 
+                "totEvents": 25194, 
+                "weights": 25194.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25137, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_176.root", 
+                "nevents": 25137, 
+                "totEvents": 25137, 
+                "weights": 25137.0
+            }, 
+            {
+                "bad": false, 
+                "events": 20855, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_434.root", 
+                "nevents": 20855, 
+                "totEvents": 20855, 
+                "weights": 20855.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25035, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_76.root", 
+                "nevents": 25035, 
+                "totEvents": 25035, 
+                "weights": 25035.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25466, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_536.root", 
+                "nevents": 25466, 
+                "totEvents": 25466, 
+                "weights": 25466.00390625
+            }, 
+            {
+                "bad": false, 
+                "events": 24941, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_257.root", 
+                "nevents": 24941, 
+                "totEvents": 24941, 
+                "weights": 24941.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25026, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_282.root", 
+                "nevents": 25026, 
+                "totEvents": 25026, 
+                "weights": 25026.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24936, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_486.root", 
+                "nevents": 24936, 
+                "totEvents": 24936, 
+                "weights": 24936.05859375
+            }, 
+            {
+                "bad": false, 
+                "events": 25353, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_140.root", 
+                "nevents": 25353, 
+                "totEvents": 25353, 
+                "weights": 25353.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24929, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_246.root", 
+                "nevents": 24929, 
+                "totEvents": 24929, 
+                "weights": 24929.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24632, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_110.root", 
+                "nevents": 24632, 
+                "totEvents": 24632, 
+                "weights": 24632.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25261, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_119.root", 
+                "nevents": 25261, 
+                "totEvents": 25261, 
+                "weights": 25261.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24922, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_184.root", 
+                "nevents": 24922, 
+                "totEvents": 24922, 
+                "weights": 24922.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25185, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_239.root", 
+                "nevents": 25185, 
+                "totEvents": 25185, 
+                "weights": 25185.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25052, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_562.root", 
+                "nevents": 25052, 
+                "totEvents": 25052, 
+                "weights": 25052.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25105, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_28.root", 
+                "nevents": 25105, 
+                "totEvents": 25105, 
+                "weights": 25105.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24880, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_169.root", 
+                "nevents": 24880, 
+                "totEvents": 24880, 
+                "weights": 24880.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24977, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_534.root", 
+                "nevents": 24977, 
+                "totEvents": 24977, 
+                "weights": 24977.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25016, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_307.root", 
+                "nevents": 25016, 
+                "totEvents": 25016, 
+                "weights": 25016.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25010, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_416.root", 
+                "nevents": 25010, 
+                "totEvents": 25010, 
+                "weights": 25010.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24963, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_334.root", 
+                "nevents": 24963, 
+                "totEvents": 24963, 
+                "weights": 24963.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24908, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_295.root", 
+                "nevents": 24908, 
+                "totEvents": 24908, 
+                "weights": 24908.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24934, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_497.root", 
+                "nevents": 24934, 
+                "totEvents": 24934, 
+                "weights": 24934.01171875
+            }, 
+            {
+                "bad": false, 
+                "events": 25193, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_455.root", 
+                "nevents": 25193, 
+                "totEvents": 25193, 
+                "weights": 25193.05078125
+            }, 
+            {
+                "bad": false, 
+                "events": 25026, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_331.root", 
+                "nevents": 25026, 
+                "totEvents": 25026, 
+                "weights": 25026.146484375
+            }, 
+            {
+                "bad": false, 
+                "events": 25054, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_462.root", 
+                "nevents": 25054, 
+                "totEvents": 25054, 
+                "weights": 25054.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25342, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_559.root", 
+                "nevents": 25342, 
+                "totEvents": 25342, 
+                "weights": 25342.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24997, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_488.root", 
+                "nevents": 24997, 
+                "totEvents": 24997, 
+                "weights": 24997.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24961, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_342.root", 
+                "nevents": 24961, 
+                "totEvents": 24961, 
+                "weights": 24961.01171875
+            }, 
+            {
+                "bad": false, 
+                "events": 24980, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_402.root", 
+                "nevents": 24980, 
+                "totEvents": 24980, 
+                "weights": 24980.01953125
+            }, 
+            {
+                "bad": false, 
+                "events": 25079, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_558.root", 
+                "nevents": 25079, 
+                "totEvents": 25079, 
+                "weights": 25079.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25286, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_550.root", 
+                "nevents": 25286, 
+                "totEvents": 25286, 
+                "weights": 25286.068359375
+            }, 
+            {
+                "bad": false, 
+                "events": 25168, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_549.root", 
+                "nevents": 25168, 
+                "totEvents": 25168, 
+                "weights": 25168.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25040, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_388.root", 
+                "nevents": 25040, 
+                "totEvents": 25040, 
+                "weights": 25040.00390625
+            }, 
+            {
+                "bad": false, 
+                "events": 24869, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_63.root", 
+                "nevents": 24869, 
+                "totEvents": 24869, 
+                "weights": 24869.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24693, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_592.root", 
+                "nevents": 24693, 
+                "totEvents": 24693, 
+                "weights": 24693.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24922, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_250.root", 
+                "nevents": 24922, 
+                "totEvents": 24922, 
+                "weights": 24922.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25162, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_351.root", 
+                "nevents": 25162, 
+                "totEvents": 25162, 
+                "weights": 25162.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24963, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_467.root", 
+                "nevents": 24963, 
+                "totEvents": 24963, 
+                "weights": 24963.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24913, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_40.root", 
+                "nevents": 24913, 
+                "totEvents": 24913, 
+                "weights": 24913.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24977, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_128.root", 
+                "nevents": 24977, 
+                "totEvents": 24977, 
+                "weights": 24977.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25179, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_520.root", 
+                "nevents": 25179, 
+                "totEvents": 25179, 
+                "weights": 25179.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24890, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_183.root", 
+                "nevents": 24890, 
+                "totEvents": 24890, 
+                "weights": 24890.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25104, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_203.root", 
+                "nevents": 25104, 
+                "totEvents": 25104, 
+                "weights": 25104.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24727, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_580.root", 
+                "nevents": 24727, 
+                "totEvents": 24727, 
+                "weights": 24727.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24705, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_48.root", 
+                "nevents": 24705, 
+                "totEvents": 24705, 
+                "weights": 24705.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25146, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_93.root", 
+                "nevents": 25146, 
+                "totEvents": 25146, 
+                "weights": 25146.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25106, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_143.root", 
+                "nevents": 25106, 
+                "totEvents": 25106, 
+                "weights": 25106.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24948, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_6.root", 
+                "nevents": 24948, 
+                "totEvents": 24948, 
+                "weights": 24948.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25069, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_271.root", 
+                "nevents": 25069, 
+                "totEvents": 25069, 
+                "weights": 25069.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25079, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_87.root", 
+                "nevents": 25079, 
+                "totEvents": 25079, 
+                "weights": 25079.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25154, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_107.root", 
+                "nevents": 25154, 
+                "totEvents": 25154, 
+                "weights": 25154.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25196, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_45.root", 
+                "nevents": 25196, 
+                "totEvents": 25196, 
+                "weights": 25196.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24786, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_170.root", 
+                "nevents": 24786, 
+                "totEvents": 24786, 
+                "weights": 24786.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24975, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_54.root", 
+                "nevents": 24975, 
+                "totEvents": 24975, 
+                "weights": 24975.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25378, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_56.root", 
+                "nevents": 25378, 
+                "totEvents": 25378, 
+                "weights": 25378.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25193, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_115.root", 
+                "nevents": 25193, 
+                "totEvents": 25193, 
+                "weights": 25193.01953125
+            }, 
+            {
+                "bad": false, 
+                "events": 24782, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_575.root", 
+                "nevents": 24782, 
+                "totEvents": 24782, 
+                "weights": 24782.03515625
+            }, 
+            {
+                "bad": false, 
+                "events": 24778, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_281.root", 
+                "nevents": 24778, 
+                "totEvents": 24778, 
+                "weights": 24778.052734375
+            }, 
+            {
+                "bad": false, 
+                "events": 25044, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_173.root", 
+                "nevents": 25044, 
+                "totEvents": 25044, 
+                "weights": 25044.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24809, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_163.root", 
+                "nevents": 24809, 
+                "totEvents": 24809, 
+                "weights": 24809.0390625
+            }, 
+            {
+                "bad": false, 
+                "events": 24785, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_166.root", 
+                "nevents": 24785, 
+                "totEvents": 24785, 
+                "weights": 24785.0625
+            }, 
+            {
+                "bad": false, 
+                "events": 24877, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_237.root", 
+                "nevents": 24877, 
+                "totEvents": 24877, 
+                "weights": 24877.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24803, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_268.root", 
+                "nevents": 24803, 
+                "totEvents": 24803, 
+                "weights": 24803.029296875
+            }, 
+            {
+                "bad": false, 
+                "events": 25118, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_311.root", 
+                "nevents": 25118, 
+                "totEvents": 25118, 
+                "weights": 25118.044921875
+            }, 
+            {
+                "bad": false, 
+                "events": 24955, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_524.root", 
+                "nevents": 24955, 
+                "totEvents": 24955, 
+                "weights": 24955.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25112, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_504.root", 
+                "nevents": 25112, 
+                "totEvents": 25112, 
+                "weights": 25112.11328125
+            }, 
+            {
+                "bad": false, 
+                "events": 25138, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_103.root", 
+                "nevents": 25138, 
+                "totEvents": 25138, 
+                "weights": 25138.076171875
+            }, 
+            {
+                "bad": false, 
+                "events": 25011, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_51.root", 
+                "nevents": 25011, 
+                "totEvents": 25011, 
+                "weights": 25011.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24937, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_249.root", 
+                "nevents": 24937, 
+                "totEvents": 24937, 
+                "weights": 24937.06640625
+            }, 
+            {
+                "bad": false, 
+                "events": 25174, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_17.root", 
+                "nevents": 25174, 
+                "totEvents": 25174, 
+                "weights": 25174.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24942, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_181.root", 
+                "nevents": 24942, 
+                "totEvents": 24942, 
+                "weights": 24942.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24831, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_195.root", 
+                "nevents": 24831, 
+                "totEvents": 24831, 
+                "weights": 24831.09765625
+            }, 
+            {
+                "bad": false, 
+                "events": 24887, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_557.root", 
+                "nevents": 24887, 
+                "totEvents": 24887, 
+                "weights": 24887.0234375
+            }, 
+            {
+                "bad": false, 
+                "events": 24891, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_554.root", 
+                "nevents": 24891, 
+                "totEvents": 24891, 
+                "weights": 24891.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24941, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_328.root", 
+                "nevents": 24941, 
+                "totEvents": 24941, 
+                "weights": 24941.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24788, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_353.root", 
+                "nevents": 24788, 
+                "totEvents": 24788, 
+                "weights": 24788.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24843, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_540.root", 
+                "nevents": 24843, 
+                "totEvents": 24843, 
+                "weights": 24843.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25109, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_346.root", 
+                "nevents": 25109, 
+                "totEvents": 25109, 
+                "weights": 25109.0390625
+            }, 
+            {
+                "bad": false, 
+                "events": 24826, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_161.root", 
+                "nevents": 24826, 
+                "totEvents": 24826, 
+                "weights": 24826.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24834, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_7.root", 
+                "nevents": 24834, 
+                "totEvents": 24834, 
+                "weights": 24834.029296875
+            }, 
+            {
+                "bad": false, 
+                "events": 25270, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_333.root", 
+                "nevents": 25270, 
+                "totEvents": 25270, 
+                "weights": 25270.03515625
+            }, 
+            {
+                "bad": false, 
+                "events": 24922, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_245.root", 
+                "nevents": 24922, 
+                "totEvents": 24922, 
+                "weights": 24922.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24901, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_360.root", 
+                "nevents": 24901, 
+                "totEvents": 24901, 
+                "weights": 24901.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24958, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_135.root", 
+                "nevents": 24958, 
+                "totEvents": 24958, 
+                "weights": 24958.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24986, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_544.root", 
+                "nevents": 24986, 
+                "totEvents": 24986, 
+                "weights": 24986.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24805, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_581.root", 
+                "nevents": 24805, 
+                "totEvents": 24805, 
+                "weights": 24805.033203125
+            }, 
+            {
+                "bad": false, 
+                "events": 25219, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_588.root", 
+                "nevents": 25219, 
+                "totEvents": 25219, 
+                "weights": 25219.02734375
+            }, 
+            {
+                "bad": false, 
+                "events": 25006, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_361.root", 
+                "nevents": 25006, 
+                "totEvents": 25006, 
+                "weights": 25006.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24996, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_37.root", 
+                "nevents": 24996, 
+                "totEvents": 24996, 
+                "weights": 24996.091796875
+            }, 
+            {
+                "bad": false, 
+                "events": 25287, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_260.root", 
+                "nevents": 25287, 
+                "totEvents": 25287, 
+                "weights": 25287.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24995, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_298.root", 
+                "nevents": 24995, 
+                "totEvents": 24995, 
+                "weights": 24995.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24993, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_541.root", 
+                "nevents": 24993, 
+                "totEvents": 24993, 
+                "weights": 24993.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24952, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_417.root", 
+                "nevents": 24952, 
+                "totEvents": 24952, 
+                "weights": 24952.015625
+            }, 
+            {
+                "bad": false, 
+                "events": 24987, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_9.root", 
+                "nevents": 24987, 
+                "totEvents": 24987, 
+                "weights": 24987.041015625
+            }, 
+            {
+                "bad": false, 
+                "events": 24849, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_244.root", 
+                "nevents": 24849, 
+                "totEvents": 24849, 
+                "weights": 24849.0078125
+            }, 
+            {
+                "bad": false, 
+                "events": 25117, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_116.root", 
+                "nevents": 25117, 
+                "totEvents": 25117, 
+                "weights": 25117.0
+            }, 
+            {
+                "bad": false, 
+                "events": 19367, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_391.root", 
+                "nevents": 19367, 
+                "totEvents": 19367, 
+                "weights": 19367.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24819, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_585.root", 
+                "nevents": 24819, 
+                "totEvents": 24819, 
+                "weights": 24819.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24977, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_14.root", 
+                "nevents": 24977, 
+                "totEvents": 24977, 
+                "weights": 24977.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25257, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_375.root", 
+                "nevents": 25257, 
+                "totEvents": 25257, 
+                "weights": 25257.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25045, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_174.root", 
+                "nevents": 25045, 
+                "totEvents": 25045, 
+                "weights": 25045.01953125
+            }, 
+            {
+                "bad": false, 
+                "events": 24787, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_576.root", 
+                "nevents": 24787, 
+                "totEvents": 24787, 
+                "weights": 24787.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25056, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_98.root", 
+                "nevents": 25056, 
+                "totEvents": 25056, 
+                "weights": 25056.05859375
+            }, 
+            {
+                "bad": false, 
+                "events": 24982, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_443.root", 
+                "nevents": 24982, 
+                "totEvents": 24982, 
+                "weights": 24982.025390625
+            }, 
+            {
+                "bad": false, 
+                "events": 25105, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_542.root", 
+                "nevents": 25105, 
+                "totEvents": 25105, 
+                "weights": 25105.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24923, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_470.root", 
+                "nevents": 24923, 
+                "totEvents": 24923, 
+                "weights": 24923.052734375
+            }, 
+            {
+                "bad": false, 
+                "events": 24759, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_553.root", 
+                "nevents": 24759, 
+                "totEvents": 24759, 
+                "weights": 24759.04296875
+            }, 
+            {
+                "bad": false, 
+                "events": 25137, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_461.root", 
+                "nevents": 25137, 
+                "totEvents": 25137, 
+                "weights": 25137.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24940, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_356.root", 
+                "nevents": 24940, 
+                "totEvents": 24940, 
+                "weights": 24940.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25002, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_423.root", 
+                "nevents": 25002, 
+                "totEvents": 25002, 
+                "weights": 25002.0078125
+            }, 
+            {
+                "bad": false, 
+                "events": 24997, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_326.root", 
+                "nevents": 24997, 
+                "totEvents": 24997, 
+                "weights": 24997.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24836, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_433.root", 
+                "nevents": 24836, 
+                "totEvents": 24836, 
+                "weights": 24836.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25005, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_236.root", 
+                "nevents": 25005, 
+                "totEvents": 25005, 
+                "weights": 25005.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24886, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_92.root", 
+                "nevents": 24886, 
+                "totEvents": 24886, 
+                "weights": 24886.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25038, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_422.root", 
+                "nevents": 25038, 
+                "totEvents": 25038, 
+                "weights": 25038.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25006, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_57.root", 
+                "nevents": 25006, 
+                "totEvents": 25006, 
+                "weights": 25006.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24739, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_82.root", 
+                "nevents": 24739, 
+                "totEvents": 24739, 
+                "weights": 24739.0546875
+            }, 
+            {
+                "bad": false, 
+                "events": 24861, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_112.root", 
+                "nevents": 24861, 
+                "totEvents": 24861, 
+                "weights": 24861.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25069, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_202.root", 
+                "nevents": 25069, 
+                "totEvents": 25069, 
+                "weights": 25069.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24921, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_397.root", 
+                "nevents": 24921, 
+                "totEvents": 24921, 
+                "weights": 24921.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24845, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_284.root", 
+                "nevents": 24845, 
+                "totEvents": 24845, 
+                "weights": 24845.02734375
+            }, 
+            {
+                "bad": false, 
+                "events": 24970, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_77.root", 
+                "nevents": 24970, 
+                "totEvents": 24970, 
+                "weights": 24970.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25095, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_509.root", 
+                "nevents": 25095, 
+                "totEvents": 25095, 
+                "weights": 25095.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25297, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_505.root", 
+                "nevents": 25297, 
+                "totEvents": 25297, 
+                "weights": 25297.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25025, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_503.root", 
+                "nevents": 25025, 
+                "totEvents": 25025, 
+                "weights": 25025.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24767, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_396.root", 
+                "nevents": 24767, 
+                "totEvents": 24767, 
+                "weights": 24767.0078125
+            }, 
+            {
+                "bad": false, 
+                "events": 25033, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_15.root", 
+                "nevents": 25033, 
+                "totEvents": 25033, 
+                "weights": 25033.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25021, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_18.root", 
+                "nevents": 25021, 
+                "totEvents": 25021, 
+                "weights": 25021.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25059, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_528.root", 
+                "nevents": 25059, 
+                "totEvents": 25059, 
+                "weights": 25059.017578125
+            }, 
+            {
+                "bad": false, 
+                "events": 25164, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_252.root", 
+                "nevents": 25164, 
+                "totEvents": 25164, 
+                "weights": 25164.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25136, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_529.root", 
+                "nevents": 25136, 
+                "totEvents": 25136, 
+                "weights": 25136.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24943, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_530.root", 
+                "nevents": 24943, 
+                "totEvents": 24943, 
+                "weights": 24943.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25090, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_124.root", 
+                "nevents": 25090, 
+                "totEvents": 25090, 
+                "weights": 25090.00390625
+            }, 
+            {
+                "bad": false, 
+                "events": 24936, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_280.root", 
+                "nevents": 24936, 
+                "totEvents": 24936, 
+                "weights": 24936.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24946, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_279.root", 
+                "nevents": 24946, 
+                "totEvents": 24946, 
+                "weights": 24946.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24862, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_502.root", 
+                "nevents": 24862, 
+                "totEvents": 24862, 
+                "weights": 24862.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24881, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_586.root", 
+                "nevents": 24881, 
+                "totEvents": 24881, 
+                "weights": 24881.029296875
+            }, 
+            {
+                "bad": false, 
+                "events": 24973, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_266.root", 
+                "nevents": 24973, 
+                "totEvents": 24973, 
+                "weights": 24973.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24993, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_359.root", 
+                "nevents": 24993, 
+                "totEvents": 24993, 
+                "weights": 24993.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24837, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_367.root", 
+                "nevents": 24837, 
+                "totEvents": 24837, 
+                "weights": 24837.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24931, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_137.root", 
+                "nevents": 24931, 
+                "totEvents": 24931, 
+                "weights": 24931.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25185, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_517.root", 
+                "nevents": 25185, 
+                "totEvents": 25185, 
+                "weights": 25185.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25129, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_1.root", 
+                "nevents": 25129, 
+                "totEvents": 25129, 
+                "weights": 25129.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24864, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_41.root", 
+                "nevents": 24864, 
+                "totEvents": 24864, 
+                "weights": 24864.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24945, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_372.root", 
+                "nevents": 24945, 
+                "totEvents": 24945, 
+                "weights": 24945.087890625
+            }, 
+            {
+                "bad": false, 
+                "events": 25154, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_344.root", 
+                "nevents": 25154, 
+                "totEvents": 25154, 
+                "weights": 25154.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25119, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_241.root", 
+                "nevents": 25119, 
+                "totEvents": 25119, 
+                "weights": 25119.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24640, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_374.root", 
+                "nevents": 24640, 
+                "totEvents": 24640, 
+                "weights": 24640.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25031, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_159.root", 
+                "nevents": 25031, 
+                "totEvents": 25031, 
+                "weights": 25031.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25115, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_317.root", 
+                "nevents": 25115, 
+                "totEvents": 25115, 
+                "weights": 25115.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25060, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_185.root", 
+                "nevents": 25060, 
+                "totEvents": 25060, 
+                "weights": 25060.0703125
+            }, 
+            {
+                "bad": false, 
+                "events": 24797, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_127.root", 
+                "nevents": 24797, 
+                "totEvents": 24797, 
+                "weights": 24797.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24978, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_256.root", 
+                "nevents": 24978, 
+                "totEvents": 24978, 
+                "weights": 24978.048828125
+            }, 
+            {
+                "bad": false, 
+                "events": 25173, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_186.root", 
+                "nevents": 25173, 
+                "totEvents": 25173, 
+                "weights": 25173.015625
+            }, 
+            {
+                "bad": false, 
+                "events": 24784, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_168.root", 
+                "nevents": 24784, 
+                "totEvents": 24784, 
+                "weights": 24784.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25080, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_67.root", 
+                "nevents": 25080, 
+                "totEvents": 25080, 
+                "weights": 25080.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25199, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_573.root", 
+                "nevents": 25199, 
+                "totEvents": 25199, 
+                "weights": 25199.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25029, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_501.root", 
+                "nevents": 25029, 
+                "totEvents": 25029, 
+                "weights": 25029.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24869, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_332.root", 
+                "nevents": 24869, 
+                "totEvents": 24869, 
+                "weights": 24869.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24943, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_25.root", 
+                "nevents": 24943, 
+                "totEvents": 24943, 
+                "weights": 24943.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25071, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_151.root", 
+                "nevents": 25071, 
+                "totEvents": 25071, 
+                "weights": 25071.080078125
+            }, 
+            {
+                "bad": false, 
+                "events": 25042, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_20.root", 
+                "nevents": 25042, 
+                "totEvents": 25042, 
+                "weights": 25042.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25057, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_384.root", 
+                "nevents": 25057, 
+                "totEvents": 25057, 
+                "weights": 25057.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24852, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_188.root", 
+                "nevents": 24852, 
+                "totEvents": 24852, 
+                "weights": 24852.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24761, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_363.root", 
+                "nevents": 24761, 
+                "totEvents": 24761, 
+                "weights": 24761.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24862, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_192.root", 
+                "nevents": 24862, 
+                "totEvents": 24862, 
+                "weights": 24862.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25203, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_413.root", 
+                "nevents": 25203, 
+                "totEvents": 25203, 
+                "weights": 25203.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24952, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_285.root", 
+                "nevents": 24952, 
+                "totEvents": 24952, 
+                "weights": 24952.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25273, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_171.root", 
+                "nevents": 25273, 
+                "totEvents": 25273, 
+                "weights": 25273.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25012, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_527.root", 
+                "nevents": 25012, 
+                "totEvents": 25012, 
+                "weights": 25012.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24694, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_104.root", 
+                "nevents": 24694, 
+                "totEvents": 24694, 
+                "weights": 24694.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25342, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_180.root", 
+                "nevents": 25342, 
+                "totEvents": 25342, 
+                "weights": 25342.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25051, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_29.root", 
+                "nevents": 25051, 
+                "totEvents": 25051, 
+                "weights": 25051.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25100, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_343.root", 
+                "nevents": 25100, 
+                "totEvents": 25100, 
+                "weights": 25100.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25300, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_61.root", 
+                "nevents": 25300, 
+                "totEvents": 25300, 
+                "weights": 25300.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24913, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_568.root", 
+                "nevents": 24913, 
+                "totEvents": 24913, 
+                "weights": 24913.041015625
+            }, 
+            {
+                "bad": false, 
+                "events": 25058, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_215.root", 
+                "nevents": 25058, 
+                "totEvents": 25058, 
+                "weights": 25058.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24975, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_565.root", 
+                "nevents": 24975, 
+                "totEvents": 24975, 
+                "weights": 24975.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25051, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_435.root", 
+                "nevents": 25051, 
+                "totEvents": 25051, 
+                "weights": 25051.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25109, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_72.root", 
+                "nevents": 25109, 
+                "totEvents": 25109, 
+                "weights": 25109.029296875
+            }, 
+            {
+                "bad": false, 
+                "events": 25012, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_444.root", 
+                "nevents": 25012, 
+                "totEvents": 25012, 
+                "weights": 25012.015625
+            }, 
+            {
+                "bad": false, 
+                "events": 25004, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_308.root", 
+                "nevents": 25004, 
+                "totEvents": 25004, 
+                "weights": 25004.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24989, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_493.root", 
+                "nevents": 24989, 
+                "totEvents": 24989, 
+                "weights": 24989.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24921, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_160.root", 
+                "nevents": 24921, 
+                "totEvents": 24921, 
+                "weights": 24921.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24979, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_460.root", 
+                "nevents": 24979, 
+                "totEvents": 24979, 
+                "weights": 24979.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24969, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_292.root", 
+                "nevents": 24969, 
+                "totEvents": 24969, 
+                "weights": 24969.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24785, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_412.root", 
+                "nevents": 24785, 
+                "totEvents": 24785, 
+                "weights": 24785.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24966, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_80.root", 
+                "nevents": 24966, 
+                "totEvents": 24966, 
+                "weights": 24966.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24908, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_512.root", 
+                "nevents": 24908, 
+                "totEvents": 24908, 
+                "weights": 24908.0546875
+            }, 
+            {
+                "bad": false, 
+                "events": 25062, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_564.root", 
+                "nevents": 25062, 
+                "totEvents": 25062, 
+                "weights": 25062.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24937, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_327.root", 
+                "nevents": 24937, 
+                "totEvents": 24937, 
+                "weights": 24937.09765625
+            }, 
+            {
+                "bad": false, 
+                "events": 24934, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_418.root", 
+                "nevents": 24934, 
+                "totEvents": 24934, 
+                "weights": 24934.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24829, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_377.root", 
+                "nevents": 24829, 
+                "totEvents": 24829, 
+                "weights": 24829.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24899, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_2.root", 
+                "nevents": 24899, 
+                "totEvents": 24899, 
+                "weights": 24899.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24547, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_219.root", 
+                "nevents": 24547, 
+                "totEvents": 24547, 
+                "weights": 24547.0078125
+            }, 
+            {
+                "bad": false, 
+                "events": 25306, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_74.root", 
+                "nevents": 25306, 
+                "totEvents": 25306, 
+                "weights": 25306.0390625
+            }, 
+            {
+                "bad": false, 
+                "events": 24957, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_485.root", 
+                "nevents": 24957, 
+                "totEvents": 24957, 
+                "weights": 24957.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25165, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_91.root", 
+                "nevents": 25165, 
+                "totEvents": 25165, 
+                "weights": 25165.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25227, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_178.root", 
+                "nevents": 25227, 
+                "totEvents": 25227, 
+                "weights": 25227.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25107, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_569.root", 
+                "nevents": 25107, 
+                "totEvents": 25107, 
+                "weights": 25107.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24760, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_83.root", 
+                "nevents": 24760, 
+                "totEvents": 24760, 
+                "weights": 24760.044921875
+            }, 
+            {
+                "bad": false, 
+                "events": 25115, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_5.root", 
+                "nevents": 25115, 
+                "totEvents": 25115, 
+                "weights": 25115.021484375
+            }, 
+            {
+                "bad": false, 
+                "events": 24819, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_247.root", 
+                "nevents": 24819, 
+                "totEvents": 24819, 
+                "weights": 24819.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25135, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_65.root", 
+                "nevents": 25135, 
+                "totEvents": 25135, 
+                "weights": 25135.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24662, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_587.root", 
+                "nevents": 24662, 
+                "totEvents": 24662, 
+                "weights": 24662.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24822, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_454.root", 
+                "nevents": 24822, 
+                "totEvents": 24822, 
+                "weights": 24822.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24862, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_211.root", 
+                "nevents": 24862, 
+                "totEvents": 24862, 
+                "weights": 24862.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25306, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_21.root", 
+                "nevents": 25306, 
+                "totEvents": 25306, 
+                "weights": 25306.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24978, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_490.root", 
+                "nevents": 24978, 
+                "totEvents": 24978, 
+                "weights": 24978.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24967, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_86.root", 
+                "nevents": 24967, 
+                "totEvents": 24967, 
+                "weights": 24967.068359375
+            }, 
+            {
+                "bad": false, 
+                "events": 25166, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_238.root", 
+                "nevents": 25166, 
+                "totEvents": 25166, 
+                "weights": 25166.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24783, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_513.root", 
+                "nevents": 24783, 
+                "totEvents": 24783, 
+                "weights": 24783.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25093, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_494.root", 
+                "nevents": 25093, 
+                "totEvents": 25093, 
+                "weights": 25093.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25177, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_350.root", 
+                "nevents": 25177, 
+                "totEvents": 25177, 
+                "weights": 25177.0234375
+            }, 
+            {
+                "bad": false, 
+                "events": 24777, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_300.root", 
+                "nevents": 24777, 
+                "totEvents": 24777, 
+                "weights": 24777.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25115, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_532.root", 
+                "nevents": 25115, 
+                "totEvents": 25115, 
+                "weights": 25115.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25063, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_511.root", 
+                "nevents": 25063, 
+                "totEvents": 25063, 
+                "weights": 25063.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24938, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_172.root", 
+                "nevents": 24938, 
+                "totEvents": 24938, 
+                "weights": 24938.017578125
+            }, 
+            {
+                "bad": false, 
+                "events": 24793, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_489.root", 
+                "nevents": 24793, 
+                "totEvents": 24793, 
+                "weights": 24793.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24720, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_35.root", 
+                "nevents": 24720, 
+                "totEvents": 24720, 
+                "weights": 24720.01953125
+            }, 
+            {
+                "bad": false, 
+                "events": 24819, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_23.root", 
+                "nevents": 24819, 
+                "totEvents": 24819, 
+                "weights": 24819.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24987, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_589.root", 
+                "nevents": 24987, 
+                "totEvents": 24987, 
+                "weights": 24987.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24903, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_221.root", 
+                "nevents": 24903, 
+                "totEvents": 24903, 
+                "weights": 24903.015625
+            }, 
+            {
+                "bad": false, 
+                "events": 24754, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_582.root", 
+                "nevents": 24754, 
+                "totEvents": 24754, 
+                "weights": 24754.01953125
+            }, 
+            {
+                "bad": false, 
+                "events": 24775, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_421.root", 
+                "nevents": 24775, 
+                "totEvents": 24775, 
+                "weights": 24775.04296875
+            }, 
+            {
+                "bad": false, 
+                "events": 25072, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_411.root", 
+                "nevents": 25072, 
+                "totEvents": 25072, 
+                "weights": 25072.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24928, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_49.root", 
+                "nevents": 24928, 
+                "totEvents": 24928, 
+                "weights": 24928.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24933, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_495.root", 
+                "nevents": 24933, 
+                "totEvents": 24933, 
+                "weights": 24933.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25197, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_121.root", 
+                "nevents": 25197, 
+                "totEvents": 25197, 
+                "weights": 25197.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24949, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_275.root", 
+                "nevents": 24949, 
+                "totEvents": 24949, 
+                "weights": 24949.0078125
+            }, 
+            {
+                "bad": false, 
+                "events": 24885, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_248.root", 
+                "nevents": 24885, 
+                "totEvents": 24885, 
+                "weights": 24885.078125
+            }, 
+            {
+                "bad": false, 
+                "events": 24879, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_207.root", 
+                "nevents": 24879, 
+                "totEvents": 24879, 
+                "weights": 24879.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25113, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_376.root", 
+                "nevents": 25113, 
+                "totEvents": 25113, 
+                "weights": 25113.025390625
+            }, 
+            {
+                "bad": false, 
+                "events": 24903, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_243.root", 
+                "nevents": 24903, 
+                "totEvents": 24903, 
+                "weights": 24903.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25018, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_496.root", 
+                "nevents": 25018, 
+                "totEvents": 25018, 
+                "weights": 25018.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24986, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_368.root", 
+                "nevents": 24986, 
+                "totEvents": 24986, 
+                "weights": 24986.0078125
+            }, 
+            {
+                "bad": false, 
+                "events": 25289, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_60.root", 
+                "nevents": 25289, 
+                "totEvents": 25289, 
+                "weights": 25289.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25199, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_242.root", 
+                "nevents": 25199, 
+                "totEvents": 25199, 
+                "weights": 25199.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24776, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_340.root", 
+                "nevents": 24776, 
+                "totEvents": 24776, 
+                "weights": 24776.154296875
+            }, 
+            {
+                "bad": false, 
+                "events": 25268, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_276.root", 
+                "nevents": 25268, 
+                "totEvents": 25268, 
+                "weights": 25268.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24877, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_205.root", 
+                "nevents": 24877, 
+                "totEvents": 24877, 
+                "weights": 24877.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24863, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_428.root", 
+                "nevents": 24863, 
+                "totEvents": 24863, 
+                "weights": 24863.001953125
+            }, 
+            {
+                "bad": false, 
+                "events": 25019, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_515.root", 
+                "nevents": 25019, 
+                "totEvents": 25019, 
+                "weights": 25019.056640625
+            }, 
+            {
+                "bad": false, 
+                "events": 25164, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_138.root", 
+                "nevents": 25164, 
+                "totEvents": 25164, 
+                "weights": 25164.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25217, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_270.root", 
+                "nevents": 25217, 
+                "totEvents": 25217, 
+                "weights": 25217.0546875
+            }, 
+            {
+                "bad": false, 
+                "events": 25009, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_190.root", 
+                "nevents": 25009, 
+                "totEvents": 25009, 
+                "weights": 25009.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24863, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_141.root", 
+                "nevents": 24863, 
+                "totEvents": 24863, 
+                "weights": 24863.0
+            }, 
+            {
+                "bad": false, 
+                "events": 23950, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_261.root", 
+                "nevents": 23950, 
+                "totEvents": 23950, 
+                "weights": 23950.0078125
+            }, 
+            {
+                "bad": false, 
+                "events": 25165, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_313.root", 
+                "nevents": 25165, 
+                "totEvents": 25165, 
+                "weights": 25165.05859375
+            }, 
+            {
+                "bad": false, 
+                "events": 24654, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_209.root", 
+                "nevents": 24654, 
+                "totEvents": 24654, 
+                "weights": 24654.0078125
+            }, 
+            {
+                "bad": false, 
+                "events": 24644, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_158.root", 
+                "nevents": 24644, 
+                "totEvents": 24644, 
+                "weights": 24644.046875
+            }, 
+            {
+                "bad": false, 
+                "events": 24833, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_383.root", 
+                "nevents": 24833, 
+                "totEvents": 24833, 
+                "weights": 24833.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25116, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_571.root", 
+                "nevents": 25116, 
+                "totEvents": 25116, 
+                "weights": 25116.01171875
+            }, 
+            {
+                "bad": false, 
+                "events": 24956, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_88.root", 
+                "nevents": 24956, 
+                "totEvents": 24956, 
+                "weights": 24956.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24889, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_234.root", 
+                "nevents": 24889, 
+                "totEvents": 24889, 
+                "weights": 24889.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25096, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_44.root", 
+                "nevents": 25096, 
+                "totEvents": 25096, 
+                "weights": 25096.015625
+            }, 
+            {
+                "bad": false, 
+                "events": 24830, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_50.root", 
+                "nevents": 24830, 
+                "totEvents": 24830, 
+                "weights": 24830.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25054, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_90.root", 
+                "nevents": 25054, 
+                "totEvents": 25054, 
+                "weights": 25054.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24610, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_415.root", 
+                "nevents": 24610, 
+                "totEvents": 24610, 
+                "weights": 24610.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25190, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_514.root", 
+                "nevents": 25190, 
+                "totEvents": 25190, 
+                "weights": 25190.0546875
+            }, 
+            {
+                "bad": false, 
+                "events": 24982, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_431.root", 
+                "nevents": 24982, 
+                "totEvents": 24982, 
+                "weights": 24982.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25062, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_401.root", 
+                "nevents": 25062, 
+                "totEvents": 25062, 
+                "weights": 25062.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24698, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_70.root", 
+                "nevents": 24698, 
+                "totEvents": 24698, 
+                "weights": 24698.0078125
+            }, 
+            {
+                "bad": false, 
+                "events": 24829, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_525.root", 
+                "nevents": 24829, 
+                "totEvents": 24829, 
+                "weights": 24829.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25259, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_329.root", 
+                "nevents": 25259, 
+                "totEvents": 25259, 
+                "weights": 25259.078125
+            }, 
+            {
+                "bad": false, 
+                "events": 24773, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_277.root", 
+                "nevents": 24773, 
+                "totEvents": 24773, 
+                "weights": 24773.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24969, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_106.root", 
+                "nevents": 24969, 
+                "totEvents": 24969, 
+                "weights": 24969.0234375
+            }, 
+            {
+                "bad": false, 
+                "events": 25348, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_302.root", 
+                "nevents": 25348, 
+                "totEvents": 25348, 
+                "weights": 25348.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25049, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_447.root", 
+                "nevents": 25049, 
+                "totEvents": 25049, 
+                "weights": 25049.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24836, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_345.root", 
+                "nevents": 24836, 
+                "totEvents": 24836, 
+                "weights": 24836.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25104, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_321.root", 
+                "nevents": 25104, 
+                "totEvents": 25104, 
+                "weights": 25104.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24808, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_224.root", 
+                "nevents": 24808, 
+                "totEvents": 24808, 
+                "weights": 24808.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24754, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_84.root", 
+                "nevents": 24754, 
+                "totEvents": 24754, 
+                "weights": 24754.056640625
+            }, 
+            {
+                "bad": false, 
+                "events": 24792, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_303.root", 
+                "nevents": 24792, 
+                "totEvents": 24792, 
+                "weights": 24792.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25263, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_410.root", 
+                "nevents": 25263, 
+                "totEvents": 25263, 
+                "weights": 25263.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24458, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_310.root", 
+                "nevents": 24458, 
+                "totEvents": 24458, 
+                "weights": 24458.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25164, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_142.root", 
+                "nevents": 25164, 
+                "totEvents": 25164, 
+                "weights": 25164.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24941, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_386.root", 
+                "nevents": 24941, 
+                "totEvents": 24941, 
+                "weights": 24941.02734375
+            }, 
+            {
+                "bad": false, 
+                "events": 25108, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_472.root", 
+                "nevents": 25108, 
+                "totEvents": 25108, 
+                "weights": 25108.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24716, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_100.root", 
+                "nevents": 24716, 
+                "totEvents": 24716, 
+                "weights": 24716.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25247, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_475.root", 
+                "nevents": 25247, 
+                "totEvents": 25247, 
+                "weights": 25247.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24841, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_424.root", 
+                "nevents": 24841, 
+                "totEvents": 24841, 
+                "weights": 24841.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25040, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_450.root", 
+                "nevents": 25040, 
+                "totEvents": 25040, 
+                "weights": 25040.013671875
+            }, 
+            {
+                "bad": false, 
+                "events": 25039, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_466.root", 
+                "nevents": 25039, 
+                "totEvents": 25039, 
+                "weights": 25039.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24996, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_480.root", 
+                "nevents": 24996, 
+                "totEvents": 24996, 
+                "weights": 24996.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25086, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_24.root", 
+                "nevents": 25086, 
+                "totEvents": 25086, 
+                "weights": 25086.041015625
+            }, 
+            {
+                "bad": false, 
+                "events": 25110, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_563.root", 
+                "nevents": 25110, 
+                "totEvents": 25110, 
+                "weights": 25110.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25038, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_52.root", 
+                "nevents": 25038, 
+                "totEvents": 25038, 
+                "weights": 25038.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25011, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_291.root", 
+                "nevents": 25011, 
+                "totEvents": 25011, 
+                "weights": 25011.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24970, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_232.root", 
+                "nevents": 24970, 
+                "totEvents": 24970, 
+                "weights": 24970.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25116, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_220.root", 
+                "nevents": 25116, 
+                "totEvents": 25116, 
+                "weights": 25116.04296875
+            }, 
+            {
+                "bad": false, 
+                "events": 25060, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_235.root", 
+                "nevents": 25060, 
+                "totEvents": 25060, 
+                "weights": 25060.046875
+            }, 
+            {
+                "bad": false, 
+                "events": 24832, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_392.root", 
+                "nevents": 24832, 
+                "totEvents": 24832, 
+                "weights": 24832.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24945, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_390.root", 
+                "nevents": 24945, 
+                "totEvents": 24945, 
+                "weights": 24945.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25039, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_69.root", 
+                "nevents": 25039, 
+                "totEvents": 25039, 
+                "weights": 25039.009765625
+            }, 
+            {
+                "bad": false, 
+                "events": 25003, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_570.root", 
+                "nevents": 25003, 
+                "totEvents": 25003, 
+                "weights": 25003.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24820, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_4.root", 
+                "nevents": 24820, 
+                "totEvents": 24820, 
+                "weights": 24820.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24904, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_269.root", 
+                "nevents": 24904, 
+                "totEvents": 24904, 
+                "weights": 24904.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25013, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_240.root", 
+                "nevents": 25013, 
+                "totEvents": 25013, 
+                "weights": 25013.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24914, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_335.root", 
+                "nevents": 24914, 
+                "totEvents": 24914, 
+                "weights": 24914.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25365, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_258.root", 
+                "nevents": 25365, 
+                "totEvents": 25365, 
+                "weights": 25365.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24964, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_579.root", 
+                "nevents": 24964, 
+                "totEvents": 24964, 
+                "weights": 24964.029296875
+            }, 
+            {
+                "bad": false, 
+                "events": 24941, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_208.root", 
+                "nevents": 24941, 
+                "totEvents": 24941, 
+                "weights": 24941.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25002, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_316.root", 
+                "nevents": 25002, 
+                "totEvents": 25002, 
+                "weights": 25002.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25181, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_304.root", 
+                "nevents": 25181, 
+                "totEvents": 25181, 
+                "weights": 25181.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24749, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_425.root", 
+                "nevents": 24749, 
+                "totEvents": 24749, 
+                "weights": 24749.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25161, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_395.root", 
+                "nevents": 25161, 
+                "totEvents": 25161, 
+                "weights": 25161.03515625
+            }, 
+            {
+                "bad": false, 
+                "events": 24823, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_146.root", 
+                "nevents": 24823, 
+                "totEvents": 24823, 
+                "weights": 24823.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25368, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_79.root", 
+                "nevents": 25368, 
+                "totEvents": 25368, 
+                "weights": 25368.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25042, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_318.root", 
+                "nevents": 25042, 
+                "totEvents": 25042, 
+                "weights": 25042.060546875
+            }, 
+            {
+                "bad": false, 
+                "events": 24949, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_507.root", 
+                "nevents": 24949, 
+                "totEvents": 24949, 
+                "weights": 24949.07421875
+            }, 
+            {
+                "bad": false, 
+                "events": 25154, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_577.root", 
+                "nevents": 25154, 
+                "totEvents": 25154, 
+                "weights": 25154.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24984, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_99.root", 
+                "nevents": 24984, 
+                "totEvents": 24984, 
+                "weights": 24984.05859375
+            }, 
+            {
+                "bad": false, 
+                "events": 24864, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_445.root", 
+                "nevents": 24864, 
+                "totEvents": 24864, 
+                "weights": 24864.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24873, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_380.root", 
+                "nevents": 24873, 
+                "totEvents": 24873, 
+                "weights": 24873.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24656, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_459.root", 
+                "nevents": 24656, 
+                "totEvents": 24656, 
+                "weights": 24656.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24855, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_263.root", 
+                "nevents": 24855, 
+                "totEvents": 24855, 
+                "weights": 24855.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25036, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_357.root", 
+                "nevents": 25036, 
+                "totEvents": 25036, 
+                "weights": 25036.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25230, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_430.root", 
+                "nevents": 25230, 
+                "totEvents": 25230, 
+                "weights": 25230.005859375
+            }, 
+            {
+                "bad": false, 
+                "events": 24988, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_408.root", 
+                "nevents": 24988, 
+                "totEvents": 24988, 
+                "weights": 24988.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24977, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_71.root", 
+                "nevents": 24977, 
+                "totEvents": 24977, 
+                "weights": 24977.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25010, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_324.root", 
+                "nevents": 25010, 
+                "totEvents": 25010, 
+                "weights": 25010.0234375
+            }, 
+            {
+                "bad": false, 
+                "events": 25089, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_561.root", 
+                "nevents": 25089, 
+                "totEvents": 25089, 
+                "weights": 25089.03515625
+            }, 
+            {
+                "bad": false, 
+                "events": 25012, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_73.root", 
+                "nevents": 25012, 
+                "totEvents": 25012, 
+                "weights": 25012.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25084, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_492.root", 
+                "nevents": 25084, 
+                "totEvents": 25084, 
+                "weights": 25084.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24847, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_476.root", 
+                "nevents": 24847, 
+                "totEvents": 24847, 
+                "weights": 24847.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25115, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_154.root", 
+                "nevents": 25115, 
+                "totEvents": 25115, 
+                "weights": 25115.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25058, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_336.root", 
+                "nevents": 25058, 
+                "totEvents": 25058, 
+                "weights": 25058.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25017, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_194.root", 
+                "nevents": 25017, 
+                "totEvents": 25017, 
+                "weights": 25017.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25111, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_389.root", 
+                "nevents": 25111, 
+                "totEvents": 25111, 
+                "weights": 25111.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25139, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_526.root", 
+                "nevents": 25139, 
+                "totEvents": 25139, 
+                "weights": 25139.01171875
+            }, 
+            {
+                "bad": false, 
+                "events": 24973, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_196.root", 
+                "nevents": 24973, 
+                "totEvents": 24973, 
+                "weights": 24973.0078125
+            }, 
+            {
+                "bad": false, 
+                "events": 24887, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_457.root", 
+                "nevents": 24887, 
+                "totEvents": 24887, 
+                "weights": 24887.04296875
+            }, 
+            {
+                "bad": false, 
+                "events": 25159, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_469.root", 
+                "nevents": 25159, 
+                "totEvents": 25159, 
+                "weights": 25159.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24743, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_167.root", 
+                "nevents": 24743, 
+                "totEvents": 24743, 
+                "weights": 24743.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24884, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_319.root", 
+                "nevents": 24884, 
+                "totEvents": 24884, 
+                "weights": 24884.0234375
+            }, 
+            {
+                "bad": false, 
+                "events": 25228, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_531.root", 
+                "nevents": 25228, 
+                "totEvents": 25228, 
+                "weights": 25228.05859375
+            }, 
+            {
+                "bad": false, 
+                "events": 25070, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_68.root", 
+                "nevents": 25070, 
+                "totEvents": 25070, 
+                "weights": 25070.0546875
+            }, 
+            {
+                "bad": false, 
+                "events": 24742, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_230.root", 
+                "nevents": 24742, 
+                "totEvents": 24742, 
+                "weights": 24742.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25017, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_407.root", 
+                "nevents": 25017, 
+                "totEvents": 25017, 
+                "weights": 25017.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24925, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_8.root", 
+                "nevents": 24925, 
+                "totEvents": 24925, 
+                "weights": 24925.02734375
+            }, 
+            {
+                "bad": false, 
+                "events": 25036, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_299.root", 
+                "nevents": 25036, 
+                "totEvents": 25036, 
+                "weights": 25036.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25003, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_157.root", 
+                "nevents": 25003, 
+                "totEvents": 25003, 
+                "weights": 25003.03515625
+            }, 
+            {
+                "bad": false, 
+                "events": 25187, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_13.root", 
+                "nevents": 25187, 
+                "totEvents": 25187, 
+                "weights": 25187.009765625
+            }, 
+            {
+                "bad": false, 
+                "events": 25189, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_399.root", 
+                "nevents": 25189, 
+                "totEvents": 25189, 
+                "weights": 25189.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24951, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_55.root", 
+                "nevents": 24951, 
+                "totEvents": 24951, 
+                "weights": 24951.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25009, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_465.root", 
+                "nevents": 25009, 
+                "totEvents": 25009, 
+                "weights": 25009.025390625
+            }, 
+            {
+                "bad": false, 
+                "events": 24708, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_567.root", 
+                "nevents": 24708, 
+                "totEvents": 24708, 
+                "weights": 24708.04296875
+            }, 
+            {
+                "bad": false, 
+                "events": 25161, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_227.root", 
+                "nevents": 25161, 
+                "totEvents": 25161, 
+                "weights": 25161.041015625
+            }, 
+            {
+                "bad": false, 
+                "events": 24831, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_131.root", 
+                "nevents": 24831, 
+                "totEvents": 24831, 
+                "weights": 24831.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24930, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_75.root", 
+                "nevents": 24930, 
+                "totEvents": 24930, 
+                "weights": 24930.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24738, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_11.root", 
+                "nevents": 24738, 
+                "totEvents": 24738, 
+                "weights": 24738.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24945, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_482.root", 
+                "nevents": 24945, 
+                "totEvents": 24945, 
+                "weights": 24945.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25056, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_283.root", 
+                "nevents": 25056, 
+                "totEvents": 25056, 
+                "weights": 25056.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25172, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_578.root", 
+                "nevents": 25172, 
+                "totEvents": 25172, 
+                "weights": 25172.119140625
+            }, 
+            {
+                "bad": false, 
+                "events": 24918, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_130.root", 
+                "nevents": 24918, 
+                "totEvents": 24918, 
+                "weights": 24918.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24812, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_290.root", 
+                "nevents": 24812, 
+                "totEvents": 24812, 
+                "weights": 24812.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25054, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_442.root", 
+                "nevents": 25054, 
+                "totEvents": 25054, 
+                "weights": 25054.025390625
+            }, 
+            {
+                "bad": false, 
+                "events": 25050, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_164.root", 
+                "nevents": 25050, 
+                "totEvents": 25050, 
+                "weights": 25050.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25137, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_355.root", 
+                "nevents": 25137, 
+                "totEvents": 25137, 
+                "weights": 25137.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24965, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_265.root", 
+                "nevents": 24965, 
+                "totEvents": 24965, 
+                "weights": 24965.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24881, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_162.root", 
+                "nevents": 24881, 
+                "totEvents": 24881, 
+                "weights": 24881.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24948, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_229.root", 
+                "nevents": 24948, 
+                "totEvents": 24948, 
+                "weights": 24948.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25145, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_500.root", 
+                "nevents": 25145, 
+                "totEvents": 25145, 
+                "weights": 25145.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24792, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_255.root", 
+                "nevents": 24792, 
+                "totEvents": 24792, 
+                "weights": 24792.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25136, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_449.root", 
+                "nevents": 25136, 
+                "totEvents": 25136, 
+                "weights": 25136.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24902, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_414.root", 
+                "nevents": 24902, 
+                "totEvents": 24902, 
+                "weights": 24902.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24983, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_97.root", 
+                "nevents": 24983, 
+                "totEvents": 24983, 
+                "weights": 24983.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24975, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_338.root", 
+                "nevents": 24975, 
+                "totEvents": 24975, 
+                "weights": 24975.01171875
+            }, 
+            {
+                "bad": false, 
+                "events": 25097, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_43.root", 
+                "nevents": 25097, 
+                "totEvents": 25097, 
+                "weights": 25097.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25046, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_293.root", 
+                "nevents": 25046, 
+                "totEvents": 25046, 
+                "weights": 25046.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25011, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_132.root", 
+                "nevents": 25011, 
+                "totEvents": 25011, 
+                "weights": 25011.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24904, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_147.root", 
+                "nevents": 24904, 
+                "totEvents": 24904, 
+                "weights": 24904.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24795, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_148.root", 
+                "nevents": 24795, 
+                "totEvents": 24795, 
+                "weights": 24795.056640625
+            }, 
+            {
+                "bad": false, 
+                "events": 25012, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_591.root", 
+                "nevents": 25012, 
+                "totEvents": 25012, 
+                "weights": 25012.05078125
+            }, 
+            {
+                "bad": false, 
+                "events": 24891, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_64.root", 
+                "nevents": 24891, 
+                "totEvents": 24891, 
+                "weights": 24891.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24804, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_81.root", 
+                "nevents": 24804, 
+                "totEvents": 24804, 
+                "weights": 24804.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25300, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_441.root", 
+                "nevents": 25300, 
+                "totEvents": 25300, 
+                "weights": 25300.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25090, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_34.root", 
+                "nevents": 25090, 
+                "totEvents": 25090, 
+                "weights": 25090.09765625
+            }, 
+            {
+                "bad": false, 
+                "events": 24773, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_322.root", 
+                "nevents": 24773, 
+                "totEvents": 24773, 
+                "weights": 24773.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24792, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_46.root", 
+                "nevents": 24792, 
+                "totEvents": 24792, 
+                "weights": 24792.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25147, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_111.root", 
+                "nevents": 25147, 
+                "totEvents": 25147, 
+                "weights": 25147.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24712, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_584.root", 
+                "nevents": 24712, 
+                "totEvents": 24712, 
+                "weights": 24712.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24948, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_165.root", 
+                "nevents": 24948, 
+                "totEvents": 24948, 
+                "weights": 24948.0
+            }, 
+            {
+                "bad": false, 
+                "events": 20654, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_406.root", 
+                "nevents": 20654, 
+                "totEvents": 20654, 
+                "weights": 20654.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25161, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_320.root", 
+                "nevents": 25161, 
+                "totEvents": 25161, 
+                "weights": 25161.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25013, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_426.root", 
+                "nevents": 25013, 
+                "totEvents": 25013, 
+                "weights": 25013.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25149, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_273.root", 
+                "nevents": 25149, 
+                "totEvents": 25149, 
+                "weights": 25149.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25123, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_506.root", 
+                "nevents": 25123, 
+                "totEvents": 25123, 
+                "weights": 25123.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25045, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_117.root", 
+                "nevents": 25045, 
+                "totEvents": 25045, 
+                "weights": 25045.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24739, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_347.root", 
+                "nevents": 24739, 
+                "totEvents": 24739, 
+                "weights": 24739.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25254, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_114.root", 
+                "nevents": 25254, 
+                "totEvents": 25254, 
+                "weights": 25254.0078125
+            }, 
+            {
+                "bad": false, 
+                "events": 25041, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_325.root", 
+                "nevents": 25041, 
+                "totEvents": 25041, 
+                "weights": 25041.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24840, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_210.root", 
+                "nevents": 24840, 
+                "totEvents": 24840, 
+                "weights": 24840.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24851, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_225.root", 
+                "nevents": 24851, 
+                "totEvents": 24851, 
+                "weights": 24851.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24863, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_152.root", 
+                "nevents": 24863, 
+                "totEvents": 24863, 
+                "weights": 24863.033203125
+            }, 
+            {
+                "bad": false, 
+                "events": 24887, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_198.root", 
+                "nevents": 24887, 
+                "totEvents": 24887, 
+                "weights": 24887.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25111, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_404.root", 
+                "nevents": 25111, 
+                "totEvents": 25111, 
+                "weights": 25111.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25154, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_330.root", 
+                "nevents": 25154, 
+                "totEvents": 25154, 
+                "weights": 25154.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25197, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_105.root", 
+                "nevents": 25197, 
+                "totEvents": 25197, 
+                "weights": 25197.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24904, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_379.root", 
+                "nevents": 24904, 
+                "totEvents": 24904, 
+                "weights": 24904.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24939, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_521.root", 
+                "nevents": 24939, 
+                "totEvents": 24939, 
+                "weights": 24939.0078125
+            }, 
+            {
+                "bad": false, 
+                "events": 25139, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV_pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/210113_134144/0000/myMicroAODOutputFile_479.root", 
+                "nevents": 25139, 
+                "totEvents": 25139, 
+                "weights": 25139.0
+            }
+        ], 
+        "parent_n_units": 14660675, 
+        "vetted": true
+    }
+}

--- a/MetaData/data/Era2017_legacy_v1/datasets_38.json
+++ b/MetaData/data/Era2017_legacy_v1/datasets_38.json
@@ -1,0 +1,7559 @@
+{
+    "/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/alesauva-UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1-8980ba169e8b72d53459e52844728ed8/USER": {
+        "dset_type": "mc", 
+        "files": [
+            {
+                "bad": false, 
+                "events": 25073, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_82.root", 
+                "nevents": 25073, 
+                "totEvents": 25073, 
+                "weights": 25073.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24971, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_87.root", 
+                "nevents": 24971, 
+                "totEvents": 24971, 
+                "weights": 24971.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24994, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_80.root", 
+                "nevents": 24994, 
+                "totEvents": 24994, 
+                "weights": 24994.0
+            }, 
+            {
+                "bad": false, 
+                "events": 8156, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_76.root", 
+                "nevents": 8156, 
+                "totEvents": 8156, 
+                "weights": 8156.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24932, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_89.root", 
+                "nevents": 24932, 
+                "totEvents": 24932, 
+                "weights": 24932.0
+            }, 
+            {
+                "bad": false, 
+                "events": 2307, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_408.root", 
+                "nevents": 2307, 
+                "totEvents": 2307, 
+                "weights": 2307.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25066, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_299.root", 
+                "nevents": 25066, 
+                "totEvents": 25066, 
+                "weights": 25066.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24718, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_145.root", 
+                "nevents": 24718, 
+                "totEvents": 24718, 
+                "weights": 24718.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24916, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_199.root", 
+                "nevents": 24916, 
+                "totEvents": 24916, 
+                "weights": 24916.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24804, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_168.root", 
+                "nevents": 24804, 
+                "totEvents": 24804, 
+                "weights": 24804.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25365, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_93.root", 
+                "nevents": 25365, 
+                "totEvents": 25365, 
+                "weights": 25365.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24918, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_109.root", 
+                "nevents": 24918, 
+                "totEvents": 24918, 
+                "weights": 24918.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25064, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_163.root", 
+                "nevents": 25064, 
+                "totEvents": 25064, 
+                "weights": 25064.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25188, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_97.root", 
+                "nevents": 25188, 
+                "totEvents": 25188, 
+                "weights": 25188.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24809, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_135.root", 
+                "nevents": 24809, 
+                "totEvents": 24809, 
+                "weights": 24809.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24883, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_276.root", 
+                "nevents": 24883, 
+                "totEvents": 24883, 
+                "weights": 24883.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25208, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_100.root", 
+                "nevents": 25208, 
+                "totEvents": 25208, 
+                "weights": 25208.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24570, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_322.root", 
+                "nevents": 24570, 
+                "totEvents": 24570, 
+                "weights": 24570.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25235, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_346.root", 
+                "nevents": 25235, 
+                "totEvents": 25235, 
+                "weights": 25235.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24962, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_103.root", 
+                "nevents": 24962, 
+                "totEvents": 24962, 
+                "weights": 24962.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24996, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_48.root", 
+                "nevents": 24996, 
+                "totEvents": 24996, 
+                "weights": 24996.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24875, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_219.root", 
+                "nevents": 24875, 
+                "totEvents": 24875, 
+                "weights": 24875.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24815, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_352.root", 
+                "nevents": 24815, 
+                "totEvents": 24815, 
+                "weights": 24815.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25116, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_167.root", 
+                "nevents": 25116, 
+                "totEvents": 25116, 
+                "weights": 25116.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24838, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_372.root", 
+                "nevents": 24838, 
+                "totEvents": 24838, 
+                "weights": 24838.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25036, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_96.root", 
+                "nevents": 25036, 
+                "totEvents": 25036, 
+                "weights": 25036.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24854, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_10.root", 
+                "nevents": 24854, 
+                "totEvents": 24854, 
+                "weights": 24854.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24906, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_362.root", 
+                "nevents": 24906, 
+                "totEvents": 24906, 
+                "weights": 24906.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24822, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_165.root", 
+                "nevents": 24822, 
+                "totEvents": 24822, 
+                "weights": 24822.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24935, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_192.root", 
+                "nevents": 24935, 
+                "totEvents": 24935, 
+                "weights": 24935.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24666, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_405.root", 
+                "nevents": 24666, 
+                "totEvents": 24666, 
+                "weights": 24666.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24867, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_331.root", 
+                "nevents": 24867, 
+                "totEvents": 24867, 
+                "weights": 24867.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25159, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_303.root", 
+                "nevents": 25159, 
+                "totEvents": 25159, 
+                "weights": 25159.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24979, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_49.root", 
+                "nevents": 24979, 
+                "totEvents": 24979, 
+                "weights": 24979.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25092, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_111.root", 
+                "nevents": 25092, 
+                "totEvents": 25092, 
+                "weights": 25092.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25073, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_34.root", 
+                "nevents": 25073, 
+                "totEvents": 25073, 
+                "weights": 25073.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24991, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_50.root", 
+                "nevents": 24991, 
+                "totEvents": 24991, 
+                "weights": 24991.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25027, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_14.root", 
+                "nevents": 25027, 
+                "totEvents": 25027, 
+                "weights": 25027.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24849, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_181.root", 
+                "nevents": 24849, 
+                "totEvents": 24849, 
+                "weights": 24849.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24955, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_75.root", 
+                "nevents": 24955, 
+                "totEvents": 24955, 
+                "weights": 24955.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24921, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_307.root", 
+                "nevents": 24921, 
+                "totEvents": 24921, 
+                "weights": 24921.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24976, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_170.root", 
+                "nevents": 24976, 
+                "totEvents": 24976, 
+                "weights": 24976.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25291, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_351.root", 
+                "nevents": 25291, 
+                "totEvents": 25291, 
+                "weights": 25291.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25096, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_90.root", 
+                "nevents": 25096, 
+                "totEvents": 25096, 
+                "weights": 25096.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25106, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_190.root", 
+                "nevents": 25106, 
+                "totEvents": 25106, 
+                "weights": 25106.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25032, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_16.root", 
+                "nevents": 25032, 
+                "totEvents": 25032, 
+                "weights": 25032.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24838, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_43.root", 
+                "nevents": 24838, 
+                "totEvents": 24838, 
+                "weights": 24838.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25053, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_305.root", 
+                "nevents": 25053, 
+                "totEvents": 25053, 
+                "weights": 25053.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24910, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_45.root", 
+                "nevents": 24910, 
+                "totEvents": 24910, 
+                "weights": 24910.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25139, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_134.root", 
+                "nevents": 25139, 
+                "totEvents": 25139, 
+                "weights": 25139.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24822, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_172.root", 
+                "nevents": 24822, 
+                "totEvents": 24822, 
+                "weights": 24822.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25089, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_66.root", 
+                "nevents": 25089, 
+                "totEvents": 25089, 
+                "weights": 25089.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25106, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_250.root", 
+                "nevents": 25106, 
+                "totEvents": 25106, 
+                "weights": 25106.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24819, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_209.root", 
+                "nevents": 24819, 
+                "totEvents": 24819, 
+                "weights": 24819.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24992, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_242.root", 
+                "nevents": 24992, 
+                "totEvents": 24992, 
+                "weights": 24992.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25064, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_329.root", 
+                "nevents": 25064, 
+                "totEvents": 25064, 
+                "weights": 25064.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25152, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_270.root", 
+                "nevents": 25152, 
+                "totEvents": 25152, 
+                "weights": 25152.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25104, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_23.root", 
+                "nevents": 25104, 
+                "totEvents": 25104, 
+                "weights": 25104.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24818, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_366.root", 
+                "nevents": 24818, 
+                "totEvents": 24818, 
+                "weights": 24818.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24738, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_396.root", 
+                "nevents": 24738, 
+                "totEvents": 24738, 
+                "weights": 24738.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25255, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_291.root", 
+                "nevents": 25255, 
+                "totEvents": 25255, 
+                "weights": 25255.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24753, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_59.root", 
+                "nevents": 24753, 
+                "totEvents": 24753, 
+                "weights": 24753.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25188, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_86.root", 
+                "nevents": 25188, 
+                "totEvents": 25188, 
+                "weights": 25188.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25049, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_293.root", 
+                "nevents": 25049, 
+                "totEvents": 25049, 
+                "weights": 25049.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25008, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_245.root", 
+                "nevents": 25008, 
+                "totEvents": 25008, 
+                "weights": 25008.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24870, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_363.root", 
+                "nevents": 24870, 
+                "totEvents": 24870, 
+                "weights": 24870.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24967, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_84.root", 
+                "nevents": 24967, 
+                "totEvents": 24967, 
+                "weights": 24967.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24894, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_389.root", 
+                "nevents": 24894, 
+                "totEvents": 24894, 
+                "weights": 24894.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24828, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_369.root", 
+                "nevents": 24828, 
+                "totEvents": 24828, 
+                "weights": 24828.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24926, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_336.root", 
+                "nevents": 24926, 
+                "totEvents": 24926, 
+                "weights": 24926.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24999, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_391.root", 
+                "nevents": 24999, 
+                "totEvents": 24999, 
+                "weights": 24999.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25137, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_116.root", 
+                "nevents": 25137, 
+                "totEvents": 25137, 
+                "weights": 25137.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24868, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_280.root", 
+                "nevents": 24868, 
+                "totEvents": 24868, 
+                "weights": 24868.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24641, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_357.root", 
+                "nevents": 24641, 
+                "totEvents": 24641, 
+                "weights": 24641.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25024, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_326.root", 
+                "nevents": 25024, 
+                "totEvents": 25024, 
+                "weights": 25024.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24726, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_126.root", 
+                "nevents": 24726, 
+                "totEvents": 24726, 
+                "weights": 24726.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25025, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_333.root", 
+                "nevents": 25025, 
+                "totEvents": 25025, 
+                "weights": 25025.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24998, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_259.root", 
+                "nevents": 24998, 
+                "totEvents": 24998, 
+                "weights": 24998.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24979, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_381.root", 
+                "nevents": 24979, 
+                "totEvents": 24979, 
+                "weights": 24979.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24902, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_323.root", 
+                "nevents": 24902, 
+                "totEvents": 24902, 
+                "weights": 24902.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25001, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_289.root", 
+                "nevents": 25001, 
+                "totEvents": 25001, 
+                "weights": 25001.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24904, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_127.root", 
+                "nevents": 24904, 
+                "totEvents": 24904, 
+                "weights": 24904.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24977, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_78.root", 
+                "nevents": 24977, 
+                "totEvents": 24977, 
+                "weights": 24977.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25122, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_85.root", 
+                "nevents": 25122, 
+                "totEvents": 25122, 
+                "weights": 25122.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25208, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_390.root", 
+                "nevents": 25208, 
+                "totEvents": 25208, 
+                "weights": 25208.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24947, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_207.root", 
+                "nevents": 24947, 
+                "totEvents": 24947, 
+                "weights": 24947.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24988, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_136.root", 
+                "nevents": 24988, 
+                "totEvents": 24988, 
+                "weights": 24988.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24928, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_398.root", 
+                "nevents": 24928, 
+                "totEvents": 24928, 
+                "weights": 24928.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24992, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_17.root", 
+                "nevents": 24992, 
+                "totEvents": 24992, 
+                "weights": 24992.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24813, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_274.root", 
+                "nevents": 24813, 
+                "totEvents": 24813, 
+                "weights": 24813.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25185, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_230.root", 
+                "nevents": 25185, 
+                "totEvents": 25185, 
+                "weights": 25185.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24941, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_339.root", 
+                "nevents": 24941, 
+                "totEvents": 24941, 
+                "weights": 24941.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25083, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_285.root", 
+                "nevents": 25083, 
+                "totEvents": 25083, 
+                "weights": 25083.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24950, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_132.root", 
+                "nevents": 24950, 
+                "totEvents": 24950, 
+                "weights": 24950.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25061, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_290.root", 
+                "nevents": 25061, 
+                "totEvents": 25061, 
+                "weights": 25061.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24895, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_137.root", 
+                "nevents": 24895, 
+                "totEvents": 24895, 
+                "weights": 24895.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24973, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_83.root", 
+                "nevents": 24973, 
+                "totEvents": 24973, 
+                "weights": 24973.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25107, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_154.root", 
+                "nevents": 25107, 
+                "totEvents": 25107, 
+                "weights": 25107.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24991, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_221.root", 
+                "nevents": 24991, 
+                "totEvents": 24991, 
+                "weights": 24991.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24843, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_64.root", 
+                "nevents": 24843, 
+                "totEvents": 24843, 
+                "weights": 24843.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25005, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_302.root", 
+                "nevents": 25005, 
+                "totEvents": 25005, 
+                "weights": 25005.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25078, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_267.root", 
+                "nevents": 25078, 
+                "totEvents": 25078, 
+                "weights": 25078.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24854, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_173.root", 
+                "nevents": 24854, 
+                "totEvents": 24854, 
+                "weights": 24854.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24942, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_380.root", 
+                "nevents": 24942, 
+                "totEvents": 24942, 
+                "weights": 24942.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24957, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_248.root", 
+                "nevents": 24957, 
+                "totEvents": 24957, 
+                "weights": 24957.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25195, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_265.root", 
+                "nevents": 25195, 
+                "totEvents": 25195, 
+                "weights": 25195.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24717, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_353.root", 
+                "nevents": 24717, 
+                "totEvents": 24717, 
+                "weights": 24717.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25271, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_28.root", 
+                "nevents": 25271, 
+                "totEvents": 25271, 
+                "weights": 25271.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25136, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_249.root", 
+                "nevents": 25136, 
+                "totEvents": 25136, 
+                "weights": 25136.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24979, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_361.root", 
+                "nevents": 24979, 
+                "totEvents": 24979, 
+                "weights": 24979.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25035, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_22.root", 
+                "nevents": 25035, 
+                "totEvents": 25035, 
+                "weights": 25035.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24683, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_282.root", 
+                "nevents": 24683, 
+                "totEvents": 24683, 
+                "weights": 24683.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25210, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_387.root", 
+                "nevents": 25210, 
+                "totEvents": 25210, 
+                "weights": 25210.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24918, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_53.root", 
+                "nevents": 24918, 
+                "totEvents": 24918, 
+                "weights": 24918.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25030, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_345.root", 
+                "nevents": 25030, 
+                "totEvents": 25030, 
+                "weights": 25030.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24643, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_359.root", 
+                "nevents": 24643, 
+                "totEvents": 24643, 
+                "weights": 24643.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25098, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_71.root", 
+                "nevents": 25098, 
+                "totEvents": 25098, 
+                "weights": 25098.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24994, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_348.root", 
+                "nevents": 24994, 
+                "totEvents": 24994, 
+                "weights": 24994.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25009, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_35.root", 
+                "nevents": 25009, 
+                "totEvents": 25009, 
+                "weights": 25009.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25167, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_198.root", 
+                "nevents": 25167, 
+                "totEvents": 25167, 
+                "weights": 25167.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25228, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_374.root", 
+                "nevents": 25228, 
+                "totEvents": 25228, 
+                "weights": 25228.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24856, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_364.root", 
+                "nevents": 24856, 
+                "totEvents": 24856, 
+                "weights": 24856.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24937, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_159.root", 
+                "nevents": 24937, 
+                "totEvents": 24937, 
+                "weights": 24937.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24862, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_286.root", 
+                "nevents": 24862, 
+                "totEvents": 24862, 
+                "weights": 24862.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24989, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_268.root", 
+                "nevents": 24989, 
+                "totEvents": 24989, 
+                "weights": 24989.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24846, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_146.root", 
+                "nevents": 24846, 
+                "totEvents": 24846, 
+                "weights": 24846.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24844, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_385.root", 
+                "nevents": 24844, 
+                "totEvents": 24844, 
+                "weights": 24844.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25033, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_324.root", 
+                "nevents": 25033, 
+                "totEvents": 25033, 
+                "weights": 25033.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24842, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_284.root", 
+                "nevents": 24842, 
+                "totEvents": 24842, 
+                "weights": 24842.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24931, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_148.root", 
+                "nevents": 24931, 
+                "totEvents": 24931, 
+                "weights": 24931.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25010, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_397.root", 
+                "nevents": 25010, 
+                "totEvents": 25010, 
+                "weights": 25010.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24845, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_355.root", 
+                "nevents": 24845, 
+                "totEvents": 24845, 
+                "weights": 24845.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24953, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_246.root", 
+                "nevents": 24953, 
+                "totEvents": 24953, 
+                "weights": 24953.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24934, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_349.root", 
+                "nevents": 24934, 
+                "totEvents": 24934, 
+                "weights": 24934.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24738, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_393.root", 
+                "nevents": 24738, 
+                "totEvents": 24738, 
+                "weights": 24738.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24922, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_386.root", 
+                "nevents": 24922, 
+                "totEvents": 24922, 
+                "weights": 24922.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24972, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_373.root", 
+                "nevents": 24972, 
+                "totEvents": 24972, 
+                "weights": 24972.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25065, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_226.root", 
+                "nevents": 25065, 
+                "totEvents": 25065, 
+                "weights": 25065.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24924, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_40.root", 
+                "nevents": 24924, 
+                "totEvents": 24924, 
+                "weights": 24924.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25010, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_354.root", 
+                "nevents": 25010, 
+                "totEvents": 25010, 
+                "weights": 25010.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25207, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_340.root", 
+                "nevents": 25207, 
+                "totEvents": 25207, 
+                "weights": 25207.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25006, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_164.root", 
+                "nevents": 25006, 
+                "totEvents": 25006, 
+                "weights": 25006.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24926, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_41.root", 
+                "nevents": 24926, 
+                "totEvents": 24926, 
+                "weights": 24926.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24861, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_296.root", 
+                "nevents": 24861, 
+                "totEvents": 24861, 
+                "weights": 24861.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24944, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_68.root", 
+                "nevents": 24944, 
+                "totEvents": 24944, 
+                "weights": 24944.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25005, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_310.root", 
+                "nevents": 25005, 
+                "totEvents": 25005, 
+                "weights": 25005.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25104, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_278.root", 
+                "nevents": 25104, 
+                "totEvents": 25104, 
+                "weights": 25104.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24968, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_407.root", 
+                "nevents": 24968, 
+                "totEvents": 24968, 
+                "weights": 24968.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25059, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_311.root", 
+                "nevents": 25059, 
+                "totEvents": 25059, 
+                "weights": 25059.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24817, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_99.root", 
+                "nevents": 24817, 
+                "totEvents": 24817, 
+                "weights": 24817.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25166, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_149.root", 
+                "nevents": 25166, 
+                "totEvents": 25166, 
+                "weights": 25166.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24790, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_399.root", 
+                "nevents": 24790, 
+                "totEvents": 24790, 
+                "weights": 24790.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24902, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_195.root", 
+                "nevents": 24902, 
+                "totEvents": 24902, 
+                "weights": 24902.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25009, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_233.root", 
+                "nevents": 25009, 
+                "totEvents": 25009, 
+                "weights": 25009.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24982, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_19.root", 
+                "nevents": 24982, 
+                "totEvents": 24982, 
+                "weights": 24982.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24722, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_204.root", 
+                "nevents": 24722, 
+                "totEvents": 24722, 
+                "weights": 24722.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24806, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_341.root", 
+                "nevents": 24806, 
+                "totEvents": 24806, 
+                "weights": 24806.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25019, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_243.root", 
+                "nevents": 25019, 
+                "totEvents": 25019, 
+                "weights": 25019.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25222, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_133.root", 
+                "nevents": 25222, 
+                "totEvents": 25222, 
+                "weights": 25222.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25043, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_288.root", 
+                "nevents": 25043, 
+                "totEvents": 25043, 
+                "weights": 25043.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24969, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_12.root", 
+                "nevents": 24969, 
+                "totEvents": 24969, 
+                "weights": 24969.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25045, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_153.root", 
+                "nevents": 25045, 
+                "totEvents": 25045, 
+                "weights": 25045.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24712, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_253.root", 
+                "nevents": 24712, 
+                "totEvents": 24712, 
+                "weights": 24712.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24729, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_27.root", 
+                "nevents": 24729, 
+                "totEvents": 24729, 
+                "weights": 24729.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24911, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_222.root", 
+                "nevents": 24911, 
+                "totEvents": 24911, 
+                "weights": 24911.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25165, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_272.root", 
+                "nevents": 25165, 
+                "totEvents": 25165, 
+                "weights": 25165.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25072, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_371.root", 
+                "nevents": 25072, 
+                "totEvents": 25072, 
+                "weights": 25072.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25104, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_271.root", 
+                "nevents": 25104, 
+                "totEvents": 25104, 
+                "weights": 25104.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25009, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_335.root", 
+                "nevents": 25009, 
+                "totEvents": 25009, 
+                "weights": 25009.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24932, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_240.root", 
+                "nevents": 24932, 
+                "totEvents": 24932, 
+                "weights": 24932.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24916, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_244.root", 
+                "nevents": 24916, 
+                "totEvents": 24916, 
+                "weights": 24916.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25137, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_143.root", 
+                "nevents": 25137, 
+                "totEvents": 25137, 
+                "weights": 25137.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25034, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_183.root", 
+                "nevents": 25034, 
+                "totEvents": 25034, 
+                "weights": 25034.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24961, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_269.root", 
+                "nevents": 24961, 
+                "totEvents": 24961, 
+                "weights": 24961.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24925, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_55.root", 
+                "nevents": 24925, 
+                "totEvents": 24925, 
+                "weights": 24925.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25094, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_258.root", 
+                "nevents": 25094, 
+                "totEvents": 25094, 
+                "weights": 25094.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24960, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_395.root", 
+                "nevents": 24960, 
+                "totEvents": 24960, 
+                "weights": 24960.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25022, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_238.root", 
+                "nevents": 25022, 
+                "totEvents": 25022, 
+                "weights": 25022.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24710, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_257.root", 
+                "nevents": 24710, 
+                "totEvents": 24710, 
+                "weights": 24710.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24818, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_171.root", 
+                "nevents": 24818, 
+                "totEvents": 24818, 
+                "weights": 24818.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24898, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_256.root", 
+                "nevents": 24898, 
+                "totEvents": 24898, 
+                "weights": 24898.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24692, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_61.root", 
+                "nevents": 24692, 
+                "totEvents": 24692, 
+                "weights": 24692.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24691, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_38.root", 
+                "nevents": 24691, 
+                "totEvents": 24691, 
+                "weights": 24691.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24962, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_343.root", 
+                "nevents": 24962, 
+                "totEvents": 24962, 
+                "weights": 24962.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24853, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_338.root", 
+                "nevents": 24853, 
+                "totEvents": 24853, 
+                "weights": 24853.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24925, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_382.root", 
+                "nevents": 24925, 
+                "totEvents": 24925, 
+                "weights": 24925.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24847, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_384.root", 
+                "nevents": 24847, 
+                "totEvents": 24847, 
+                "weights": 24847.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24913, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_18.root", 
+                "nevents": 24913, 
+                "totEvents": 24913, 
+                "weights": 24913.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25167, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_169.root", 
+                "nevents": 25167, 
+                "totEvents": 25167, 
+                "weights": 25167.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24774, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_294.root", 
+                "nevents": 24774, 
+                "totEvents": 24774, 
+                "weights": 24774.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24946, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_193.root", 
+                "nevents": 24946, 
+                "totEvents": 24946, 
+                "weights": 24946.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24653, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_29.root", 
+                "nevents": 24653, 
+                "totEvents": 24653, 
+                "weights": 24653.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24833, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_62.root", 
+                "nevents": 24833, 
+                "totEvents": 24833, 
+                "weights": 24833.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25022, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_74.root", 
+                "nevents": 25022, 
+                "totEvents": 25022, 
+                "weights": 25022.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24697, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_327.root", 
+                "nevents": 24697, 
+                "totEvents": 24697, 
+                "weights": 24697.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25024, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_404.root", 
+                "nevents": 25024, 
+                "totEvents": 25024, 
+                "weights": 25024.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24804, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_313.root", 
+                "nevents": 24804, 
+                "totEvents": 24804, 
+                "weights": 24804.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25214, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_334.root", 
+                "nevents": 25214, 
+                "totEvents": 25214, 
+                "weights": 25214.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25083, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_234.root", 
+                "nevents": 25083, 
+                "totEvents": 25083, 
+                "weights": 25083.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25208, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_51.root", 
+                "nevents": 25208, 
+                "totEvents": 25208, 
+                "weights": 25208.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25105, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_215.root", 
+                "nevents": 25105, 
+                "totEvents": 25105, 
+                "weights": 25105.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24797, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_220.root", 
+                "nevents": 24797, 
+                "totEvents": 24797, 
+                "weights": 24797.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25010, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_72.root", 
+                "nevents": 25010, 
+                "totEvents": 25010, 
+                "weights": 25010.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24896, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_312.root", 
+                "nevents": 24896, 
+                "totEvents": 24896, 
+                "weights": 24896.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24960, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_21.root", 
+                "nevents": 24960, 
+                "totEvents": 24960, 
+                "weights": 24960.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24960, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_92.root", 
+                "nevents": 24960, 
+                "totEvents": 24960, 
+                "weights": 24960.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24998, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_263.root", 
+                "nevents": 24998, 
+                "totEvents": 24998, 
+                "weights": 24998.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25190, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_356.root", 
+                "nevents": 25190, 
+                "totEvents": 25190, 
+                "weights": 25190.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24930, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_229.root", 
+                "nevents": 24930, 
+                "totEvents": 24930, 
+                "weights": 24930.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25054, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_394.root", 
+                "nevents": 25054, 
+                "totEvents": 25054, 
+                "weights": 25054.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25086, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_388.root", 
+                "nevents": 25086, 
+                "totEvents": 25086, 
+                "weights": 25086.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25036, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_231.root", 
+                "nevents": 25036, 
+                "totEvents": 25036, 
+                "weights": 25036.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24993, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_252.root", 
+                "nevents": 24993, 
+                "totEvents": 24993, 
+                "weights": 24993.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24971, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_401.root", 
+                "nevents": 24971, 
+                "totEvents": 24971, 
+                "weights": 24971.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24942, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_304.root", 
+                "nevents": 24942, 
+                "totEvents": 24942, 
+                "weights": 24942.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24845, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_217.root", 
+                "nevents": 24845, 
+                "totEvents": 24845, 
+                "weights": 24845.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24888, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_406.root", 
+                "nevents": 24888, 
+                "totEvents": 24888, 
+                "weights": 24888.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24880, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_42.root", 
+                "nevents": 24880, 
+                "totEvents": 24880, 
+                "weights": 24880.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25015, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_13.root", 
+                "nevents": 25015, 
+                "totEvents": 25015, 
+                "weights": 25015.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24693, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_175.root", 
+                "nevents": 24693, 
+                "totEvents": 24693, 
+                "weights": 24693.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24957, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_281.root", 
+                "nevents": 24957, 
+                "totEvents": 24957, 
+                "weights": 24957.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24933, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_273.root", 
+                "nevents": 24933, 
+                "totEvents": 24933, 
+                "weights": 24933.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24886, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_189.root", 
+                "nevents": 24886, 
+                "totEvents": 24886, 
+                "weights": 24886.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25041, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_151.root", 
+                "nevents": 25041, 
+                "totEvents": 25041, 
+                "weights": 25041.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25075, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_150.root", 
+                "nevents": 25075, 
+                "totEvents": 25075, 
+                "weights": 25075.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25094, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_30.root", 
+                "nevents": 25094, 
+                "totEvents": 25094, 
+                "weights": 25094.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24879, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_56.root", 
+                "nevents": 24879, 
+                "totEvents": 24879, 
+                "weights": 24879.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24970, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_365.root", 
+                "nevents": 24970, 
+                "totEvents": 24970, 
+                "weights": 24970.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25148, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_287.root", 
+                "nevents": 25148, 
+                "totEvents": 25148, 
+                "weights": 25148.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24742, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_210.root", 
+                "nevents": 24742, 
+                "totEvents": 24742, 
+                "weights": 24742.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25022, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_383.root", 
+                "nevents": 25022, 
+                "totEvents": 25022, 
+                "weights": 25022.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24970, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_176.root", 
+                "nevents": 24970, 
+                "totEvents": 24970, 
+                "weights": 24970.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24952, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_201.root", 
+                "nevents": 24952, 
+                "totEvents": 24952, 
+                "weights": 24952.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24951, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_11.root", 
+                "nevents": 24951, 
+                "totEvents": 24951, 
+                "weights": 24951.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25075, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_65.root", 
+                "nevents": 25075, 
+                "totEvents": 25075, 
+                "weights": 25075.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25076, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_213.root", 
+                "nevents": 25076, 
+                "totEvents": 25076, 
+                "weights": 25076.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25190, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_32.root", 
+                "nevents": 25190, 
+                "totEvents": 25190, 
+                "weights": 25190.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24989, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_63.root", 
+                "nevents": 24989, 
+                "totEvents": 24989, 
+                "weights": 24989.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25064, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_58.root", 
+                "nevents": 25064, 
+                "totEvents": 25064, 
+                "weights": 25064.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24924, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_370.root", 
+                "nevents": 24924, 
+                "totEvents": 24924, 
+                "weights": 24924.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25127, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_24.root", 
+                "nevents": 25127, 
+                "totEvents": 25127, 
+                "weights": 25127.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25116, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_31.root", 
+                "nevents": 25116, 
+                "totEvents": 25116, 
+                "weights": 25116.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25016, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_283.root", 
+                "nevents": 25016, 
+                "totEvents": 25016, 
+                "weights": 25016.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24874, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_277.root", 
+                "nevents": 24874, 
+                "totEvents": 24874, 
+                "weights": 24874.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24912, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_376.root", 
+                "nevents": 24912, 
+                "totEvents": 24912, 
+                "weights": 24912.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25039, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_131.root", 
+                "nevents": 25039, 
+                "totEvents": 25039, 
+                "weights": 25039.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24859, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_262.root", 
+                "nevents": 24859, 
+                "totEvents": 24859, 
+                "weights": 24859.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24890, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_208.root", 
+                "nevents": 24890, 
+                "totEvents": 24890, 
+                "weights": 24890.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25067, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_350.root", 
+                "nevents": 25067, 
+                "totEvents": 25067, 
+                "weights": 25067.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24792, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_188.root", 
+                "nevents": 24792, 
+                "totEvents": 24792, 
+                "weights": 24792.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25087, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_344.root", 
+                "nevents": 25087, 
+                "totEvents": 25087, 
+                "weights": 25087.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24824, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_260.root", 
+                "nevents": 24824, 
+                "totEvents": 24824, 
+                "weights": 24824.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24920, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_295.root", 
+                "nevents": 24920, 
+                "totEvents": 24920, 
+                "weights": 24920.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24995, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_6.root", 
+                "nevents": 24995, 
+                "totEvents": 24995, 
+                "weights": 24995.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24759, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_26.root", 
+                "nevents": 24759, 
+                "totEvents": 24759, 
+                "weights": 24759.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24929, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_33.root", 
+                "nevents": 24929, 
+                "totEvents": 24929, 
+                "weights": 24929.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24845, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_141.root", 
+                "nevents": 24845, 
+                "totEvents": 24845, 
+                "weights": 24845.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24764, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_203.root", 
+                "nevents": 24764, 
+                "totEvents": 24764, 
+                "weights": 24764.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25134, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_166.root", 
+                "nevents": 25134, 
+                "totEvents": 25134, 
+                "weights": 25134.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25127, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_104.root", 
+                "nevents": 25127, 
+                "totEvents": 25127, 
+                "weights": 25127.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25106, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_261.root", 
+                "nevents": 25106, 
+                "totEvents": 25106, 
+                "weights": 25106.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24889, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_130.root", 
+                "nevents": 24889, 
+                "totEvents": 24889, 
+                "weights": 24889.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24698, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_330.root", 
+                "nevents": 24698, 
+                "totEvents": 24698, 
+                "weights": 24698.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25008, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_247.root", 
+                "nevents": 25008, 
+                "totEvents": 25008, 
+                "weights": 25008.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24809, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_235.root", 
+                "nevents": 24809, 
+                "totEvents": 24809, 
+                "weights": 24809.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24999, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_177.root", 
+                "nevents": 24999, 
+                "totEvents": 24999, 
+                "weights": 24999.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24916, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_187.root", 
+                "nevents": 24916, 
+                "totEvents": 24916, 
+                "weights": 24916.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24729, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_185.root", 
+                "nevents": 24729, 
+                "totEvents": 24729, 
+                "weights": 24729.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25063, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_292.root", 
+                "nevents": 25063, 
+                "totEvents": 25063, 
+                "weights": 25063.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24861, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_160.root", 
+                "nevents": 24861, 
+                "totEvents": 24861, 
+                "weights": 24861.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25113, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_140.root", 
+                "nevents": 25113, 
+                "totEvents": 25113, 
+                "weights": 25113.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25027, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_178.root", 
+                "nevents": 25027, 
+                "totEvents": 25027, 
+                "weights": 25027.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25151, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_44.root", 
+                "nevents": 25151, 
+                "totEvents": 25151, 
+                "weights": 25151.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24968, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_95.root", 
+                "nevents": 24968, 
+                "totEvents": 24968, 
+                "weights": 24968.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24941, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_20.root", 
+                "nevents": 24941, 
+                "totEvents": 24941, 
+                "weights": 24941.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24878, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_254.root", 
+                "nevents": 24878, 
+                "totEvents": 24878, 
+                "weights": 24878.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24974, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_54.root", 
+                "nevents": 24974, 
+                "totEvents": 24974, 
+                "weights": 24974.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24921, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_197.root", 
+                "nevents": 24921, 
+                "totEvents": 24921, 
+                "weights": 24921.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25058, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_227.root", 
+                "nevents": 25058, 
+                "totEvents": 25058, 
+                "weights": 25058.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25101, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_228.root", 
+                "nevents": 25101, 
+                "totEvents": 25101, 
+                "weights": 25101.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24914, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_46.root", 
+                "nevents": 24914, 
+                "totEvents": 24914, 
+                "weights": 24914.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25265, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_7.root", 
+                "nevents": 25265, 
+                "totEvents": 25265, 
+                "weights": 25265.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24984, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_156.root", 
+                "nevents": 24984, 
+                "totEvents": 24984, 
+                "weights": 24984.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24940, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_60.root", 
+                "nevents": 24940, 
+                "totEvents": 24940, 
+                "weights": 24940.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24925, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_162.root", 
+                "nevents": 24925, 
+                "totEvents": 24925, 
+                "weights": 24925.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24987, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_279.root", 
+                "nevents": 24987, 
+                "totEvents": 24987, 
+                "weights": 24987.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24978, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_8.root", 
+                "nevents": 24978, 
+                "totEvents": 24978, 
+                "weights": 24978.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24986, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_37.root", 
+                "nevents": 24986, 
+                "totEvents": 24986, 
+                "weights": 24986.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24968, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_157.root", 
+                "nevents": 24968, 
+                "totEvents": 24968, 
+                "weights": 24968.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24969, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_264.root", 
+                "nevents": 24969, 
+                "totEvents": 24969, 
+                "weights": 24969.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25044, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_225.root", 
+                "nevents": 25044, 
+                "totEvents": 25044, 
+                "weights": 25044.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25096, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_223.root", 
+                "nevents": 25096, 
+                "totEvents": 25096, 
+                "weights": 25096.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25183, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_360.root", 
+                "nevents": 25183, 
+                "totEvents": 25183, 
+                "weights": 25183.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25014, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_306.root", 
+                "nevents": 25014, 
+                "totEvents": 25014, 
+                "weights": 25014.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25211, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_328.root", 
+                "nevents": 25211, 
+                "totEvents": 25211, 
+                "weights": 25211.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24857, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_52.root", 
+                "nevents": 24857, 
+                "totEvents": 24857, 
+                "weights": 24857.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25088, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_211.root", 
+                "nevents": 25088, 
+                "totEvents": 25088, 
+                "weights": 25088.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25152, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_184.root", 
+                "nevents": 25152, 
+                "totEvents": 25152, 
+                "weights": 25152.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24953, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_297.root", 
+                "nevents": 24953, 
+                "totEvents": 24953, 
+                "weights": 24953.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24924, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_206.root", 
+                "nevents": 24924, 
+                "totEvents": 24924, 
+                "weights": 24924.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24855, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_347.root", 
+                "nevents": 24855, 
+                "totEvents": 24855, 
+                "weights": 24855.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25025, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_337.root", 
+                "nevents": 25025, 
+                "totEvents": 25025, 
+                "weights": 25025.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24881, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_79.root", 
+                "nevents": 24881, 
+                "totEvents": 24881, 
+                "weights": 24881.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24777, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_25.root", 
+                "nevents": 24777, 
+                "totEvents": 24777, 
+                "weights": 24777.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24840, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_224.root", 
+                "nevents": 24840, 
+                "totEvents": 24840, 
+                "weights": 24840.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25179, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_128.root", 
+                "nevents": 25179, 
+                "totEvents": 25179, 
+                "weights": 25179.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25097, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_77.root", 
+                "nevents": 25097, 
+                "totEvents": 25097, 
+                "weights": 25097.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25060, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_180.root", 
+                "nevents": 25060, 
+                "totEvents": 25060, 
+                "weights": 25060.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24973, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_232.root", 
+                "nevents": 24973, 
+                "totEvents": 24973, 
+                "weights": 24973.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24950, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_266.root", 
+                "nevents": 24950, 
+                "totEvents": 24950, 
+                "weights": 24950.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25019, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_392.root", 
+                "nevents": 25019, 
+                "totEvents": 25019, 
+                "weights": 25019.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25081, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_81.root", 
+                "nevents": 25081, 
+                "totEvents": 25081, 
+                "weights": 25081.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24739, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_15.root", 
+                "nevents": 24739, 
+                "totEvents": 24739, 
+                "weights": 24739.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24745, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_174.root", 
+                "nevents": 24745, 
+                "totEvents": 24745, 
+                "weights": 24745.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24684, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_378.root", 
+                "nevents": 24684, 
+                "totEvents": 24684, 
+                "weights": 24684.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25032, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_105.root", 
+                "nevents": 25032, 
+                "totEvents": 25032, 
+                "weights": 25032.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24902, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_251.root", 
+                "nevents": 24902, 
+                "totEvents": 24902, 
+                "weights": 24902.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25120, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_194.root", 
+                "nevents": 25120, 
+                "totEvents": 25120, 
+                "weights": 25120.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24991, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_255.root", 
+                "nevents": 24991, 
+                "totEvents": 24991, 
+                "weights": 24991.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25003, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_139.root", 
+                "nevents": 25003, 
+                "totEvents": 25003, 
+                "weights": 25003.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24942, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_158.root", 
+                "nevents": 24942, 
+                "totEvents": 24942, 
+                "weights": 24942.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25028, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_298.root", 
+                "nevents": 25028, 
+                "totEvents": 25028, 
+                "weights": 25028.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24843, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_218.root", 
+                "nevents": 24843, 
+                "totEvents": 24843, 
+                "weights": 24843.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24900, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_375.root", 
+                "nevents": 24900, 
+                "totEvents": 24900, 
+                "weights": 24900.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24817, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_205.root", 
+                "nevents": 24817, 
+                "totEvents": 24817, 
+                "weights": 24817.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24830, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_236.root", 
+                "nevents": 24830, 
+                "totEvents": 24830, 
+                "weights": 24830.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25258, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_179.root", 
+                "nevents": 25258, 
+                "totEvents": 25258, 
+                "weights": 25258.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24863, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_196.root", 
+                "nevents": 24863, 
+                "totEvents": 24863, 
+                "weights": 24863.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25035, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_191.root", 
+                "nevents": 25035, 
+                "totEvents": 25035, 
+                "weights": 25035.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25097, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_152.root", 
+                "nevents": 25097, 
+                "totEvents": 25097, 
+                "weights": 25097.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24930, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_212.root", 
+                "nevents": 24930, 
+                "totEvents": 24930, 
+                "weights": 24930.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25048, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_214.root", 
+                "nevents": 25048, 
+                "totEvents": 25048, 
+                "weights": 25048.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24810, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_400.root", 
+                "nevents": 24810, 
+                "totEvents": 24810, 
+                "weights": 24810.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24899, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_275.root", 
+                "nevents": 24899, 
+                "totEvents": 24899, 
+                "weights": 24899.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24888, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_88.root", 
+                "nevents": 24888, 
+                "totEvents": 24888, 
+                "weights": 24888.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24960, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_182.root", 
+                "nevents": 24960, 
+                "totEvents": 24960, 
+                "weights": 24960.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24866, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_91.root", 
+                "nevents": 24866, 
+                "totEvents": 24866, 
+                "weights": 24866.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25093, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_106.root", 
+                "nevents": 25093, 
+                "totEvents": 25093, 
+                "weights": 25093.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25023, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_321.root", 
+                "nevents": 25023, 
+                "totEvents": 25023, 
+                "weights": 25023.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24986, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_47.root", 
+                "nevents": 24986, 
+                "totEvents": 24986, 
+                "weights": 24986.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24660, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_300.root", 
+                "nevents": 24660, 
+                "totEvents": 24660, 
+                "weights": 24660.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25053, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_358.root", 
+                "nevents": 25053, 
+                "totEvents": 25053, 
+                "weights": 25053.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24957, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_309.root", 
+                "nevents": 24957, 
+                "totEvents": 24957, 
+                "weights": 24957.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24799, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_308.root", 
+                "nevents": 24799, 
+                "totEvents": 24799, 
+                "weights": 24799.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25041, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_94.root", 
+                "nevents": 25041, 
+                "totEvents": 25041, 
+                "weights": 25041.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25112, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_70.root", 
+                "nevents": 25112, 
+                "totEvents": 25112, 
+                "weights": 25112.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24859, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_125.root", 
+                "nevents": 24859, 
+                "totEvents": 24859, 
+                "weights": 24859.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25005, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_144.root", 
+                "nevents": 25005, 
+                "totEvents": 25005, 
+                "weights": 25005.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24948, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_241.root", 
+                "nevents": 24948, 
+                "totEvents": 24948, 
+                "weights": 24948.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25092, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_161.root", 
+                "nevents": 25092, 
+                "totEvents": 25092, 
+                "weights": 25092.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24822, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_301.root", 
+                "nevents": 24822, 
+                "totEvents": 24822, 
+                "weights": 24822.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24914, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_9.root", 
+                "nevents": 24914, 
+                "totEvents": 24914, 
+                "weights": 24914.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24937, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_39.root", 
+                "nevents": 24937, 
+                "totEvents": 24937, 
+                "weights": 24937.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25093, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_237.root", 
+                "nevents": 25093, 
+                "totEvents": 25093, 
+                "weights": 25093.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25123, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_342.root", 
+                "nevents": 25123, 
+                "totEvents": 25123, 
+                "weights": 25123.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24850, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_403.root", 
+                "nevents": 24850, 
+                "totEvents": 24850, 
+                "weights": 24850.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25016, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_202.root", 
+                "nevents": 25016, 
+                "totEvents": 25016, 
+                "weights": 25016.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24982, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_200.root", 
+                "nevents": 24982, 
+                "totEvents": 24982, 
+                "weights": 24982.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24991, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_155.root", 
+                "nevents": 24991, 
+                "totEvents": 24991, 
+                "weights": 24991.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25203, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_377.root", 
+                "nevents": 25203, 
+                "totEvents": 25203, 
+                "weights": 25203.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24647, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_239.root", 
+                "nevents": 24647, 
+                "totEvents": 24647, 
+                "weights": 24647.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24798, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_216.root", 
+                "nevents": 24798, 
+                "totEvents": 24798, 
+                "weights": 24798.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24867, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_67.root", 
+                "nevents": 24867, 
+                "totEvents": 24867, 
+                "weights": 24867.0
+            }, 
+            {
+                "bad": false, 
+                "events": 13131, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_129.root", 
+                "nevents": 13131, 
+                "totEvents": 13131, 
+                "weights": 13131.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24995, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_5.root", 
+                "nevents": 24995, 
+                "totEvents": 24995, 
+                "weights": 24995.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24982, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_186.root", 
+                "nevents": 24982, 
+                "totEvents": 24982, 
+                "weights": 24982.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25135, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_332.root", 
+                "nevents": 25135, 
+                "totEvents": 25135, 
+                "weights": 25135.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25009, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_368.root", 
+                "nevents": 25009, 
+                "totEvents": 25009, 
+                "weights": 25009.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24946, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_1.root", 
+                "nevents": 24946, 
+                "totEvents": 24946, 
+                "weights": 24946.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24890, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_319.root", 
+                "nevents": 24890, 
+                "totEvents": 24890, 
+                "weights": 24890.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24881, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_101.root", 
+                "nevents": 24881, 
+                "totEvents": 24881, 
+                "weights": 24881.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24874, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_120.root", 
+                "nevents": 24874, 
+                "totEvents": 24874, 
+                "weights": 24874.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25104, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_118.root", 
+                "nevents": 25104, 
+                "totEvents": 25104, 
+                "weights": 25104.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24642, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_115.root", 
+                "nevents": 24642, 
+                "totEvents": 24642, 
+                "weights": 24642.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25154, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_119.root", 
+                "nevents": 25154, 
+                "totEvents": 25154, 
+                "weights": 25154.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24927, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_121.root", 
+                "nevents": 24927, 
+                "totEvents": 24927, 
+                "weights": 24927.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25245, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_325.root", 
+                "nevents": 25245, 
+                "totEvents": 25245, 
+                "weights": 25245.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25016, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_108.root", 
+                "nevents": 25016, 
+                "totEvents": 25016, 
+                "weights": 25016.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25053, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_112.root", 
+                "nevents": 25053, 
+                "totEvents": 25053, 
+                "weights": 25053.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25026, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_379.root", 
+                "nevents": 25026, 
+                "totEvents": 25026, 
+                "weights": 25026.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24810, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_124.root", 
+                "nevents": 24810, 
+                "totEvents": 24810, 
+                "weights": 24810.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25219, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_3.root", 
+                "nevents": 25219, 
+                "totEvents": 25219, 
+                "weights": 25219.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24983, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_107.root", 
+                "nevents": 24983, 
+                "totEvents": 24983, 
+                "weights": 24983.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25023, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_318.root", 
+                "nevents": 25023, 
+                "totEvents": 25023, 
+                "weights": 25023.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24791, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_317.root", 
+                "nevents": 24791, 
+                "totEvents": 24791, 
+                "weights": 24791.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25067, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_320.root", 
+                "nevents": 25067, 
+                "totEvents": 25067, 
+                "weights": 25067.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24882, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_117.root", 
+                "nevents": 24882, 
+                "totEvents": 24882, 
+                "weights": 24882.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25042, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_147.root", 
+                "nevents": 25042, 
+                "totEvents": 25042, 
+                "weights": 25042.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25064, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_314.root", 
+                "nevents": 25064, 
+                "totEvents": 25064, 
+                "weights": 25064.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24969, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_122.root", 
+                "nevents": 24969, 
+                "totEvents": 24969, 
+                "weights": 24969.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24994, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_102.root", 
+                "nevents": 24994, 
+                "totEvents": 24994, 
+                "weights": 24994.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24905, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_110.root", 
+                "nevents": 24905, 
+                "totEvents": 24905, 
+                "weights": 24905.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25027, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_114.root", 
+                "nevents": 25027, 
+                "totEvents": 25027, 
+                "weights": 25027.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25010, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_69.root", 
+                "nevents": 25010, 
+                "totEvents": 25010, 
+                "weights": 25010.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24993, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_138.root", 
+                "nevents": 24993, 
+                "totEvents": 24993, 
+                "weights": 24993.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25124, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_36.root", 
+                "nevents": 25124, 
+                "totEvents": 25124, 
+                "weights": 25124.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24728, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_4.root", 
+                "nevents": 24728, 
+                "totEvents": 24728, 
+                "weights": 24728.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24960, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_98.root", 
+                "nevents": 24960, 
+                "totEvents": 24960, 
+                "weights": 24960.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25003, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_73.root", 
+                "nevents": 25003, 
+                "totEvents": 25003, 
+                "weights": 25003.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24722, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_315.root", 
+                "nevents": 24722, 
+                "totEvents": 24722, 
+                "weights": 24722.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24910, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_367.root", 
+                "nevents": 24910, 
+                "totEvents": 24910, 
+                "weights": 24910.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24922, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_2.root", 
+                "nevents": 24922, 
+                "totEvents": 24922, 
+                "weights": 24922.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24796, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_123.root", 
+                "nevents": 24796, 
+                "totEvents": 24796, 
+                "weights": 24796.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25188, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_316.root", 
+                "nevents": 25188, 
+                "totEvents": 25188, 
+                "weights": 25188.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24916, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_113.root", 
+                "nevents": 24916, 
+                "totEvents": 24916, 
+                "weights": 24916.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24896, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_57.root", 
+                "nevents": 24896, 
+                "totEvents": 24896, 
+                "weights": 24896.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24938, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_142.root", 
+                "nevents": 24938, 
+                "totEvents": 24938, 
+                "weights": 24938.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24833, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-4cores5k_106X_mc2017_realistic_v6-v1/210202_132253/0000/myMicroAODOutputFile_402.root", 
+                "nevents": 24833, 
+                "totEvents": 24833, 
+                "weights": 24833.0
+            }
+        ], 
+        "parent_n_units": null, 
+        "vetted": true
+    }, 
+    "/GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/alesauva-UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1-8980ba169e8b72d53459e52844728ed8/USER": {
+        "dset_type": "mc", 
+        "files": [
+            {
+                "bad": false, 
+                "events": 25080, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_133757/0000/myMicroAODOutputFile_18.root", 
+                "nevents": 25080, 
+                "totEvents": 25080, 
+                "weights": 25080.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24927, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_133757/0000/myMicroAODOutputFile_6.root", 
+                "nevents": 24927, 
+                "totEvents": 24927, 
+                "weights": 24927.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25101, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_133757/0000/myMicroAODOutputFile_2.root", 
+                "nevents": 25101, 
+                "totEvents": 25101, 
+                "weights": 25101.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25030, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_133757/0000/myMicroAODOutputFile_88.root", 
+                "nevents": 25030, 
+                "totEvents": 25030, 
+                "weights": 25030.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24931, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_133757/0000/myMicroAODOutputFile_29.root", 
+                "nevents": 24931, 
+                "totEvents": 24931, 
+                "weights": 24931.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25237, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_133757/0000/myMicroAODOutputFile_78.root", 
+                "nevents": 25237, 
+                "totEvents": 25237, 
+                "weights": 25237.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24988, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_133757/0000/myMicroAODOutputFile_126.root", 
+                "nevents": 24988, 
+                "totEvents": 24988, 
+                "weights": 24988.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24976, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_133757/0000/myMicroAODOutputFile_28.root", 
+                "nevents": 24976, 
+                "totEvents": 24976, 
+                "weights": 24976.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25023, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_133757/0000/myMicroAODOutputFile_87.root", 
+                "nevents": 25023, 
+                "totEvents": 25023, 
+                "weights": 25023.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24905, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_133757/0000/myMicroAODOutputFile_46.root", 
+                "nevents": 24905, 
+                "totEvents": 24905, 
+                "weights": 24905.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25166, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_133757/0000/myMicroAODOutputFile_114.root", 
+                "nevents": 25166, 
+                "totEvents": 25166, 
+                "weights": 25166.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24861, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_133757/0000/myMicroAODOutputFile_102.root", 
+                "nevents": 24861, 
+                "totEvents": 24861, 
+                "weights": 24861.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24684, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_133757/0000/myMicroAODOutputFile_35.root", 
+                "nevents": 24684, 
+                "totEvents": 24684, 
+                "weights": 24684.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25115, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_133757/0000/myMicroAODOutputFile_65.root", 
+                "nevents": 25115, 
+                "totEvents": 25115, 
+                "weights": 25115.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25091, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_133757/0000/myMicroAODOutputFile_56.root", 
+                "nevents": 25091, 
+                "totEvents": 25091, 
+                "weights": 25091.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24960, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_133757/0000/myMicroAODOutputFile_40.root", 
+                "nevents": 24960, 
+                "totEvents": 24960, 
+                "weights": 24960.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24891, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_133757/0000/myMicroAODOutputFile_33.root", 
+                "nevents": 24891, 
+                "totEvents": 24891, 
+                "weights": 24891.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24673, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_133757/0000/myMicroAODOutputFile_103.root", 
+                "nevents": 24673, 
+                "totEvents": 24673, 
+                "weights": 24673.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24919, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_133757/0000/myMicroAODOutputFile_106.root", 
+                "nevents": 24919, 
+                "totEvents": 24919, 
+                "weights": 24919.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24779, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_133757/0000/myMicroAODOutputFile_75.root", 
+                "nevents": 24779, 
+                "totEvents": 24779, 
+                "weights": 24779.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24864, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_133757/0000/myMicroAODOutputFile_44.root", 
+                "nevents": 24864, 
+                "totEvents": 24864, 
+                "weights": 24864.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24662, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_133757/0000/myMicroAODOutputFile_76.root", 
+                "nevents": 24662, 
+                "totEvents": 24662, 
+                "weights": 24662.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24739, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_133757/0000/myMicroAODOutputFile_107.root", 
+                "nevents": 24739, 
+                "totEvents": 24739, 
+                "weights": 24739.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24671, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_133757/0000/myMicroAODOutputFile_83.root", 
+                "nevents": 24671, 
+                "totEvents": 24671, 
+                "weights": 24671.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24854, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_133757/0000/myMicroAODOutputFile_127.root", 
+                "nevents": 24854, 
+                "totEvents": 24854, 
+                "weights": 24854.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25079, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_133757/0000/myMicroAODOutputFile_138.root", 
+                "nevents": 25079, 
+                "totEvents": 25079, 
+                "weights": 25079.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25040, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_133757/0000/myMicroAODOutputFile_52.root", 
+                "nevents": 25040, 
+                "totEvents": 25040, 
+                "weights": 25040.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25005, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_133757/0000/myMicroAODOutputFile_116.root", 
+                "nevents": 25005, 
+                "totEvents": 25005, 
+                "weights": 25005.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25112, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_133757/0000/myMicroAODOutputFile_55.root", 
+                "nevents": 25112, 
+                "totEvents": 25112, 
+                "weights": 25112.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24644, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_133757/0000/myMicroAODOutputFile_51.root", 
+                "nevents": 24644, 
+                "totEvents": 24644, 
+                "weights": 24644.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24922, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_133757/0000/myMicroAODOutputFile_3.root", 
+                "nevents": 24922, 
+                "totEvents": 24922, 
+                "weights": 24922.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24753, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_133757/0000/myMicroAODOutputFile_7.root", 
+                "nevents": 24753, 
+                "totEvents": 24753, 
+                "weights": 24753.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24925, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_133757/0000/myMicroAODOutputFile_24.root", 
+                "nevents": 24925, 
+                "totEvents": 24925, 
+                "weights": 24925.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24828, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_133757/0000/myMicroAODOutputFile_48.root", 
+                "nevents": 24828, 
+                "totEvents": 24828, 
+                "weights": 24828.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24868, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_133757/0000/myMicroAODOutputFile_70.root", 
+                "nevents": 24868, 
+                "totEvents": 24868, 
+                "weights": 24868.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25193, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_133757/0000/myMicroAODOutputFile_14.root", 
+                "nevents": 25193, 
+                "totEvents": 25193, 
+                "weights": 25193.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24866, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_133757/0000/myMicroAODOutputFile_22.root", 
+                "nevents": 24866, 
+                "totEvents": 24866, 
+                "weights": 24866.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24872, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_133757/0000/myMicroAODOutputFile_72.root", 
+                "nevents": 24872, 
+                "totEvents": 24872, 
+                "weights": 24872.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24995, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_133757/0000/myMicroAODOutputFile_113.root", 
+                "nevents": 24995, 
+                "totEvents": 24995, 
+                "weights": 24995.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25203, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_133757/0000/myMicroAODOutputFile_71.root", 
+                "nevents": 25203, 
+                "totEvents": 25203, 
+                "weights": 25203.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25036, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_133757/0000/myMicroAODOutputFile_27.root", 
+                "nevents": 25036, 
+                "totEvents": 25036, 
+                "weights": 25036.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24707, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_133757/0000/myMicroAODOutputFile_63.root", 
+                "nevents": 24707, 
+                "totEvents": 24707, 
+                "weights": 24707.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25151, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_133757/0000/myMicroAODOutputFile_31.root", 
+                "nevents": 25151, 
+                "totEvents": 25151, 
+                "weights": 25151.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24932, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_133757/0000/myMicroAODOutputFile_15.root", 
+                "nevents": 24932, 
+                "totEvents": 24932, 
+                "weights": 24932.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25052, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_133757/0000/myMicroAODOutputFile_21.root", 
+                "nevents": 25052, 
+                "totEvents": 25052, 
+                "weights": 25052.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25132, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_133757/0000/myMicroAODOutputFile_84.root", 
+                "nevents": 25132, 
+                "totEvents": 25132, 
+                "weights": 25132.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25160, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_133757/0000/myMicroAODOutputFile_111.root", 
+                "nevents": 25160, 
+                "totEvents": 25160, 
+                "weights": 25160.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24963, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_133757/0000/myMicroAODOutputFile_19.root", 
+                "nevents": 24963, 
+                "totEvents": 24963, 
+                "weights": 24963.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25178, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_133757/0000/myMicroAODOutputFile_25.root", 
+                "nevents": 25178, 
+                "totEvents": 25178, 
+                "weights": 25178.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25109, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_133757/0000/myMicroAODOutputFile_94.root", 
+                "nevents": 25109, 
+                "totEvents": 25109, 
+                "weights": 25109.0
+            }, 
+            {
+                "bad": false, 
+                "events": 19770, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_133757/0000/myMicroAODOutputFile_8.root", 
+                "nevents": 19770, 
+                "totEvents": 19770, 
+                "weights": 19770.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24952, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_133757/0000/myMicroAODOutputFile_79.root", 
+                "nevents": 24952, 
+                "totEvents": 24952, 
+                "weights": 24952.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25002, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_133757/0000/myMicroAODOutputFile_119.root", 
+                "nevents": 25002, 
+                "totEvents": 25002, 
+                "weights": 25002.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24983, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_133757/0000/myMicroAODOutputFile_101.root", 
+                "nevents": 24983, 
+                "totEvents": 24983, 
+                "weights": 24983.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24881, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_133757/0000/myMicroAODOutputFile_50.root", 
+                "nevents": 24881, 
+                "totEvents": 24881, 
+                "weights": 24881.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25010, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_133757/0000/myMicroAODOutputFile_64.root", 
+                "nevents": 25010, 
+                "totEvents": 25010, 
+                "weights": 25010.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25218, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_133757/0000/myMicroAODOutputFile_62.root", 
+                "nevents": 25218, 
+                "totEvents": 25218, 
+                "weights": 25218.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24821, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_133757/0000/myMicroAODOutputFile_69.root", 
+                "nevents": 24821, 
+                "totEvents": 24821, 
+                "weights": 24821.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24902, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_133757/0000/myMicroAODOutputFile_60.root", 
+                "nevents": 24902, 
+                "totEvents": 24902, 
+                "weights": 24902.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24975, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_133757/0000/myMicroAODOutputFile_110.root", 
+                "nevents": 24975, 
+                "totEvents": 24975, 
+                "weights": 24975.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24906, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_133757/0000/myMicroAODOutputFile_36.root", 
+                "nevents": 24906, 
+                "totEvents": 24906, 
+                "weights": 24906.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24937, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_133757/0000/myMicroAODOutputFile_43.root", 
+                "nevents": 24937, 
+                "totEvents": 24937, 
+                "weights": 24937.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25316, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_133757/0000/myMicroAODOutputFile_67.root", 
+                "nevents": 25316, 
+                "totEvents": 25316, 
+                "weights": 25316.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25035, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_133757/0000/myMicroAODOutputFile_97.root", 
+                "nevents": 25035, 
+                "totEvents": 25035, 
+                "weights": 25035.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25053, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_133757/0000/myMicroAODOutputFile_96.root", 
+                "nevents": 25053, 
+                "totEvents": 25053, 
+                "weights": 25053.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24915, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_133757/0000/myMicroAODOutputFile_145.root", 
+                "nevents": 24915, 
+                "totEvents": 24915, 
+                "weights": 24915.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25063, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_133757/0000/myMicroAODOutputFile_109.root", 
+                "nevents": 25063, 
+                "totEvents": 25063, 
+                "weights": 25063.0
+            }, 
+            {
+                "bad": false, 
+                "events": 18654, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_133757/0000/myMicroAODOutputFile_161.root", 
+                "nevents": 18654, 
+                "totEvents": 18654, 
+                "weights": 18654.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_133757/0000/myMicroAODOutputFile_90.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 25000.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24755, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_133757/0000/myMicroAODOutputFile_120.root", 
+                "nevents": 24755, 
+                "totEvents": 24755, 
+                "weights": 24755.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25001, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_133757/0000/myMicroAODOutputFile_58.root", 
+                "nevents": 25001, 
+                "totEvents": 25001, 
+                "weights": 25001.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24898, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_133757/0000/myMicroAODOutputFile_135.root", 
+                "nevents": 24898, 
+                "totEvents": 24898, 
+                "weights": 24898.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24986, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_133757/0000/myMicroAODOutputFile_34.root", 
+                "nevents": 24986, 
+                "totEvents": 24986, 
+                "weights": 24986.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24842, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_133757/0000/myMicroAODOutputFile_59.root", 
+                "nevents": 24842, 
+                "totEvents": 24842, 
+                "weights": 24842.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24997, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_133757/0000/myMicroAODOutputFile_80.root", 
+                "nevents": 24997, 
+                "totEvents": 24997, 
+                "weights": 24997.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24939, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_133757/0000/myMicroAODOutputFile_112.root", 
+                "nevents": 24939, 
+                "totEvents": 24939, 
+                "weights": 24939.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25126, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_133757/0000/myMicroAODOutputFile_140.root", 
+                "nevents": 25126, 
+                "totEvents": 25126, 
+                "weights": 25126.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25038, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_133757/0000/myMicroAODOutputFile_148.root", 
+                "nevents": 25038, 
+                "totEvents": 25038, 
+                "weights": 25038.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24873, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_133757/0000/myMicroAODOutputFile_105.root", 
+                "nevents": 24873, 
+                "totEvents": 24873, 
+                "weights": 24873.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24925, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_133757/0000/myMicroAODOutputFile_42.root", 
+                "nevents": 24925, 
+                "totEvents": 24925, 
+                "weights": 24925.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25127, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_133757/0000/myMicroAODOutputFile_152.root", 
+                "nevents": 25127, 
+                "totEvents": 25127, 
+                "weights": 25127.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25026, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_133757/0000/myMicroAODOutputFile_95.root", 
+                "nevents": 25026, 
+                "totEvents": 25026, 
+                "weights": 25026.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24987, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_133757/0000/myMicroAODOutputFile_38.root", 
+                "nevents": 24987, 
+                "totEvents": 24987, 
+                "weights": 24987.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25041, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_133757/0000/myMicroAODOutputFile_68.root", 
+                "nevents": 25041, 
+                "totEvents": 25041, 
+                "weights": 25041.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24917, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_133757/0000/myMicroAODOutputFile_23.root", 
+                "nevents": 24917, 
+                "totEvents": 24917, 
+                "weights": 24917.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24961, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_133757/0000/myMicroAODOutputFile_54.root", 
+                "nevents": 24961, 
+                "totEvents": 24961, 
+                "weights": 24961.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25034, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_133757/0000/myMicroAODOutputFile_47.root", 
+                "nevents": 25034, 
+                "totEvents": 25034, 
+                "weights": 25034.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24871, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_133757/0000/myMicroAODOutputFile_73.root", 
+                "nevents": 24871, 
+                "totEvents": 24871, 
+                "weights": 24871.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25299, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_133757/0000/myMicroAODOutputFile_1.root", 
+                "nevents": 25299, 
+                "totEvents": 25299, 
+                "weights": 25299.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24965, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_133757/0000/myMicroAODOutputFile_45.root", 
+                "nevents": 24965, 
+                "totEvents": 24965, 
+                "weights": 24965.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25081, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_133757/0000/myMicroAODOutputFile_77.root", 
+                "nevents": 25081, 
+                "totEvents": 25081, 
+                "weights": 25081.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25095, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_133757/0000/myMicroAODOutputFile_100.root", 
+                "nevents": 25095, 
+                "totEvents": 25095, 
+                "weights": 25095.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25090, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_133757/0000/myMicroAODOutputFile_53.root", 
+                "nevents": 25090, 
+                "totEvents": 25090, 
+                "weights": 25090.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25066, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_133757/0000/myMicroAODOutputFile_41.root", 
+                "nevents": 25066, 
+                "totEvents": 25066, 
+                "weights": 25066.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24943, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_133757/0000/myMicroAODOutputFile_159.root", 
+                "nevents": 24943, 
+                "totEvents": 24943, 
+                "weights": 24943.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25214, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_133757/0000/myMicroAODOutputFile_11.root", 
+                "nevents": 25214, 
+                "totEvents": 25214, 
+                "weights": 25214.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24893, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_133757/0000/myMicroAODOutputFile_49.root", 
+                "nevents": 24893, 
+                "totEvents": 24893, 
+                "weights": 24893.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25114, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_133757/0000/myMicroAODOutputFile_12.root", 
+                "nevents": 25114, 
+                "totEvents": 25114, 
+                "weights": 25114.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25154, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_133757/0000/myMicroAODOutputFile_117.root", 
+                "nevents": 25154, 
+                "totEvents": 25154, 
+                "weights": 25154.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25116, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_133757/0000/myMicroAODOutputFile_37.root", 
+                "nevents": 25116, 
+                "totEvents": 25116, 
+                "weights": 25116.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24913, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_133757/0000/myMicroAODOutputFile_104.root", 
+                "nevents": 24913, 
+                "totEvents": 24913, 
+                "weights": 24913.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24993, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_133757/0000/myMicroAODOutputFile_66.root", 
+                "nevents": 24993, 
+                "totEvents": 24993, 
+                "weights": 24993.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25034, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_133757/0000/myMicroAODOutputFile_99.root", 
+                "nevents": 25034, 
+                "totEvents": 25034, 
+                "weights": 25034.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25067, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_133757/0000/myMicroAODOutputFile_5.root", 
+                "nevents": 25067, 
+                "totEvents": 25067, 
+                "weights": 25067.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24934, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_133757/0000/myMicroAODOutputFile_9.root", 
+                "nevents": 24934, 
+                "totEvents": 24934, 
+                "weights": 24934.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24902, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_133757/0000/myMicroAODOutputFile_86.root", 
+                "nevents": 24902, 
+                "totEvents": 24902, 
+                "weights": 24902.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24915, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_133757/0000/myMicroAODOutputFile_10.root", 
+                "nevents": 24915, 
+                "totEvents": 24915, 
+                "weights": 24915.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25067, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_133757/0000/myMicroAODOutputFile_57.root", 
+                "nevents": 25067, 
+                "totEvents": 25067, 
+                "weights": 25067.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25082, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_133757/0000/myMicroAODOutputFile_82.root", 
+                "nevents": 25082, 
+                "totEvents": 25082, 
+                "weights": 25082.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24922, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_133757/0000/myMicroAODOutputFile_128.root", 
+                "nevents": 24922, 
+                "totEvents": 24922, 
+                "weights": 24922.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24860, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_133757/0000/myMicroAODOutputFile_150.root", 
+                "nevents": 24860, 
+                "totEvents": 24860, 
+                "weights": 24860.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24834, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_133757/0000/myMicroAODOutputFile_146.root", 
+                "nevents": 24834, 
+                "totEvents": 24834, 
+                "weights": 24834.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25052, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_133757/0000/myMicroAODOutputFile_108.root", 
+                "nevents": 25052, 
+                "totEvents": 25052, 
+                "weights": 25052.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24948, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_133757/0000/myMicroAODOutputFile_61.root", 
+                "nevents": 24948, 
+                "totEvents": 24948, 
+                "weights": 24948.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24972, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_133757/0000/myMicroAODOutputFile_39.root", 
+                "nevents": 24972, 
+                "totEvents": 24972, 
+                "weights": 24972.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24821, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_133757/0000/myMicroAODOutputFile_20.root", 
+                "nevents": 24821, 
+                "totEvents": 24821, 
+                "weights": 24821.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25087, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_133757/0000/myMicroAODOutputFile_17.root", 
+                "nevents": 25087, 
+                "totEvents": 25087, 
+                "weights": 25087.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24908, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_133757/0000/myMicroAODOutputFile_13.root", 
+                "nevents": 24908, 
+                "totEvents": 24908, 
+                "weights": 24908.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24765, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_133757/0000/myMicroAODOutputFile_4.root", 
+                "nevents": 24765, 
+                "totEvents": 24765, 
+                "weights": 24765.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24976, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_133757/0000/myMicroAODOutputFile_26.root", 
+                "nevents": 24976, 
+                "totEvents": 24976, 
+                "weights": 24976.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24797, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_133757/0000/myMicroAODOutputFile_142.root", 
+                "nevents": 24797, 
+                "totEvents": 24797, 
+                "weights": 24797.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24888, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_133757/0000/myMicroAODOutputFile_144.root", 
+                "nevents": 24888, 
+                "totEvents": 24888, 
+                "weights": 24888.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25037, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_133757/0000/myMicroAODOutputFile_93.root", 
+                "nevents": 25037, 
+                "totEvents": 25037, 
+                "weights": 25037.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24848, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_133757/0000/myMicroAODOutputFile_157.root", 
+                "nevents": 24848, 
+                "totEvents": 24848, 
+                "weights": 24848.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25007, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_133757/0000/myMicroAODOutputFile_125.root", 
+                "nevents": 25007, 
+                "totEvents": 25007, 
+                "weights": 25007.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24837, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_133757/0000/myMicroAODOutputFile_118.root", 
+                "nevents": 24837, 
+                "totEvents": 24837, 
+                "weights": 24837.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25127, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_133757/0000/myMicroAODOutputFile_98.root", 
+                "nevents": 25127, 
+                "totEvents": 25127, 
+                "weights": 25127.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24833, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_133757/0000/myMicroAODOutputFile_16.root", 
+                "nevents": 24833, 
+                "totEvents": 24833, 
+                "weights": 24833.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25091, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_133757/0000/myMicroAODOutputFile_131.root", 
+                "nevents": 25091, 
+                "totEvents": 25091, 
+                "weights": 25091.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25032, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_133757/0000/myMicroAODOutputFile_141.root", 
+                "nevents": 25032, 
+                "totEvents": 25032, 
+                "weights": 25032.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24950, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_133757/0000/myMicroAODOutputFile_74.root", 
+                "nevents": 24950, 
+                "totEvents": 24950, 
+                "weights": 24950.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24880, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_133757/0000/myMicroAODOutputFile_133.root", 
+                "nevents": 24880, 
+                "totEvents": 24880, 
+                "weights": 24880.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25125, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_133757/0000/myMicroAODOutputFile_121.root", 
+                "nevents": 25125, 
+                "totEvents": 25125, 
+                "weights": 25125.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25082, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_133757/0000/myMicroAODOutputFile_134.root", 
+                "nevents": 25082, 
+                "totEvents": 25082, 
+                "weights": 25082.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25088, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_133757/0000/myMicroAODOutputFile_30.root", 
+                "nevents": 25088, 
+                "totEvents": 25088, 
+                "weights": 25088.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24829, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_133757/0000/myMicroAODOutputFile_153.root", 
+                "nevents": 24829, 
+                "totEvents": 24829, 
+                "weights": 24829.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24827, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_133757/0000/myMicroAODOutputFile_160.root", 
+                "nevents": 24827, 
+                "totEvents": 24827, 
+                "weights": 24827.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25150, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_133757/0000/myMicroAODOutputFile_154.root", 
+                "nevents": 25150, 
+                "totEvents": 25150, 
+                "weights": 25150.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25058, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_133757/0000/myMicroAODOutputFile_155.root", 
+                "nevents": 25058, 
+                "totEvents": 25058, 
+                "weights": 25058.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24773, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_133757/0000/myMicroAODOutputFile_123.root", 
+                "nevents": 24773, 
+                "totEvents": 24773, 
+                "weights": 24773.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24925, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_133757/0000/myMicroAODOutputFile_89.root", 
+                "nevents": 24925, 
+                "totEvents": 24925, 
+                "weights": 24925.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24870, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_133757/0000/myMicroAODOutputFile_158.root", 
+                "nevents": 24870, 
+                "totEvents": 24870, 
+                "weights": 24870.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25012, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_133757/0000/myMicroAODOutputFile_130.root", 
+                "nevents": 25012, 
+                "totEvents": 25012, 
+                "weights": 25012.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24902, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_133757/0000/myMicroAODOutputFile_136.root", 
+                "nevents": 24902, 
+                "totEvents": 24902, 
+                "weights": 24902.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25179, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_133757/0000/myMicroAODOutputFile_115.root", 
+                "nevents": 25179, 
+                "totEvents": 25179, 
+                "weights": 25179.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25088, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_133757/0000/myMicroAODOutputFile_149.root", 
+                "nevents": 25088, 
+                "totEvents": 25088, 
+                "weights": 25088.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24985, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_133757/0000/myMicroAODOutputFile_156.root", 
+                "nevents": 24985, 
+                "totEvents": 24985, 
+                "weights": 24985.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25147, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_133757/0000/myMicroAODOutputFile_91.root", 
+                "nevents": 25147, 
+                "totEvents": 25147, 
+                "weights": 25147.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25177, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_133757/0000/myMicroAODOutputFile_143.root", 
+                "nevents": 25177, 
+                "totEvents": 25177, 
+                "weights": 25177.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24723, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_133757/0000/myMicroAODOutputFile_151.root", 
+                "nevents": 24723, 
+                "totEvents": 24723, 
+                "weights": 24723.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24609, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_133757/0000/myMicroAODOutputFile_137.root", 
+                "nevents": 24609, 
+                "totEvents": 24609, 
+                "weights": 24609.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25142, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_133757/0000/myMicroAODOutputFile_139.root", 
+                "nevents": 25142, 
+                "totEvents": 25142, 
+                "weights": 25142.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25084, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_133757/0000/myMicroAODOutputFile_129.root", 
+                "nevents": 25084, 
+                "totEvents": 25084, 
+                "weights": 25084.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25217, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_133757/0000/myMicroAODOutputFile_147.root", 
+                "nevents": 25217, 
+                "totEvents": 25217, 
+                "weights": 25217.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25177, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_133757/0000/myMicroAODOutputFile_85.root", 
+                "nevents": 25177, 
+                "totEvents": 25177, 
+                "weights": 25177.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25209, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_133757/0000/myMicroAODOutputFile_81.root", 
+                "nevents": 25209, 
+                "totEvents": 25209, 
+                "weights": 25209.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25066, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_133757/0000/myMicroAODOutputFile_132.root", 
+                "nevents": 25066, 
+                "totEvents": 25066, 
+                "weights": 25066.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25037, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_133757/0000/myMicroAODOutputFile_124.root", 
+                "nevents": 25037, 
+                "totEvents": 25037, 
+                "weights": 25037.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25056, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_133757/0000/myMicroAODOutputFile_92.root", 
+                "nevents": 25056, 
+                "totEvents": 25056, 
+                "weights": 25056.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25159, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_133757/0000/myMicroAODOutputFile_32.root", 
+                "nevents": 25159, 
+                "totEvents": 25159, 
+                "weights": 25159.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25060, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_133757/0000/myMicroAODOutputFile_122.root", 
+                "nevents": 25060, 
+                "totEvents": 25060, 
+                "weights": 25060.0
+            }
+        ], 
+        "parent_n_units": 4010754, 
+        "vetted": true
+    }, 
+    "/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/alesauva-UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1-8980ba169e8b72d53459e52844728ed8/USER": {
+        "dset_type": "mc", 
+        "files": [
+            {
+                "bad": false, 
+                "events": 24782, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_239.root", 
+                "nevents": 24782, 
+                "totEvents": 24782, 
+                "weights": 24782.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25052, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_345.root", 
+                "nevents": 25052, 
+                "totEvents": 25052, 
+                "weights": 25052.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24944, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_300.root", 
+                "nevents": 24944, 
+                "totEvents": 24944, 
+                "weights": 24944.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24888, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_236.root", 
+                "nevents": 24888, 
+                "totEvents": 24888, 
+                "weights": 24888.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24845, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_240.root", 
+                "nevents": 24845, 
+                "totEvents": 24845, 
+                "weights": 24845.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25064, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_341.root", 
+                "nevents": 25064, 
+                "totEvents": 25064, 
+                "weights": 25064.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25245, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_123.root", 
+                "nevents": 25245, 
+                "totEvents": 25245, 
+                "weights": 25245.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24918, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_14.root", 
+                "nevents": 24918, 
+                "totEvents": 24918, 
+                "weights": 24918.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24738, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_321.root", 
+                "nevents": 24738, 
+                "totEvents": 24738, 
+                "weights": 24738.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24796, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_207.root", 
+                "nevents": 24796, 
+                "totEvents": 24796, 
+                "weights": 24796.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24830, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_11.root", 
+                "nevents": 24830, 
+                "totEvents": 24830, 
+                "weights": 24830.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24808, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_50.root", 
+                "nevents": 24808, 
+                "totEvents": 24808, 
+                "weights": 24808.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25092, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_355.root", 
+                "nevents": 25092, 
+                "totEvents": 25092, 
+                "weights": 25092.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25251, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_307.root", 
+                "nevents": 25251, 
+                "totEvents": 25251, 
+                "weights": 25251.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25023, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_323.root", 
+                "nevents": 25023, 
+                "totEvents": 25023, 
+                "weights": 25023.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24881, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_24.root", 
+                "nevents": 24881, 
+                "totEvents": 24881, 
+                "weights": 24881.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24771, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_4.root", 
+                "nevents": 24771, 
+                "totEvents": 24771, 
+                "weights": 24771.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24774, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_18.root", 
+                "nevents": 24774, 
+                "totEvents": 24774, 
+                "weights": 24774.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24894, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_372.root", 
+                "nevents": 24894, 
+                "totEvents": 24894, 
+                "weights": 24894.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24817, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_201.root", 
+                "nevents": 24817, 
+                "totEvents": 24817, 
+                "weights": 24817.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24899, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_73.root", 
+                "nevents": 24899, 
+                "totEvents": 24899, 
+                "weights": 24899.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25030, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_148.root", 
+                "nevents": 25030, 
+                "totEvents": 25030, 
+                "weights": 25030.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25045, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_8.root", 
+                "nevents": 25045, 
+                "totEvents": 25045, 
+                "weights": 25045.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24739, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_12.root", 
+                "nevents": 24739, 
+                "totEvents": 24739, 
+                "weights": 24739.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24814, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_213.root", 
+                "nevents": 24814, 
+                "totEvents": 24814, 
+                "weights": 24814.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25043, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_265.root", 
+                "nevents": 25043, 
+                "totEvents": 25043, 
+                "weights": 25043.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24888, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_59.root", 
+                "nevents": 24888, 
+                "totEvents": 24888, 
+                "weights": 24888.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24978, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_7.root", 
+                "nevents": 24978, 
+                "totEvents": 24978, 
+                "weights": 24978.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25246, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_147.root", 
+                "nevents": 25246, 
+                "totEvents": 25246, 
+                "weights": 25246.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24897, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_326.root", 
+                "nevents": 24897, 
+                "totEvents": 24897, 
+                "weights": 24897.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25075, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_200.root", 
+                "nevents": 25075, 
+                "totEvents": 25075, 
+                "weights": 25075.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24900, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_353.root", 
+                "nevents": 24900, 
+                "totEvents": 24900, 
+                "weights": 24900.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24715, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_362.root", 
+                "nevents": 24715, 
+                "totEvents": 24715, 
+                "weights": 24715.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24924, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_186.root", 
+                "nevents": 24924, 
+                "totEvents": 24924, 
+                "weights": 24924.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24928, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_216.root", 
+                "nevents": 24928, 
+                "totEvents": 24928, 
+                "weights": 24928.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24708, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_214.root", 
+                "nevents": 24708, 
+                "totEvents": 24708, 
+                "weights": 24708.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25047, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_183.root", 
+                "nevents": 25047, 
+                "totEvents": 25047, 
+                "weights": 25047.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24920, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_366.root", 
+                "nevents": 24920, 
+                "totEvents": 24920, 
+                "weights": 24920.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24900, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_332.root", 
+                "nevents": 24900, 
+                "totEvents": 24900, 
+                "weights": 24900.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24728, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_319.root", 
+                "nevents": 24728, 
+                "totEvents": 24728, 
+                "weights": 24728.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24985, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_115.root", 
+                "nevents": 24985, 
+                "totEvents": 24985, 
+                "weights": 24985.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25156, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_331.root", 
+                "nevents": 25156, 
+                "totEvents": 25156, 
+                "weights": 25156.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25022, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_257.root", 
+                "nevents": 25022, 
+                "totEvents": 25022, 
+                "weights": 25022.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24952, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_259.root", 
+                "nevents": 24952, 
+                "totEvents": 24952, 
+                "weights": 24952.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25002, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_295.root", 
+                "nevents": 25002, 
+                "totEvents": 25002, 
+                "weights": 25002.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24987, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_38.root", 
+                "nevents": 24987, 
+                "totEvents": 24987, 
+                "weights": 24987.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25060, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_248.root", 
+                "nevents": 25060, 
+                "totEvents": 25060, 
+                "weights": 25060.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25130, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_78.root", 
+                "nevents": 25130, 
+                "totEvents": 25130, 
+                "weights": 25130.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25128, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_19.root", 
+                "nevents": 25128, 
+                "totEvents": 25128, 
+                "weights": 25128.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25142, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_352.root", 
+                "nevents": 25142, 
+                "totEvents": 25142, 
+                "weights": 25142.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24974, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_33.root", 
+                "nevents": 24974, 
+                "totEvents": 24974, 
+                "weights": 24974.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25127, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_190.root", 
+                "nevents": 25127, 
+                "totEvents": 25127, 
+                "weights": 25127.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24886, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_226.root", 
+                "nevents": 24886, 
+                "totEvents": 24886, 
+                "weights": 24886.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25070, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_271.root", 
+                "nevents": 25070, 
+                "totEvents": 25070, 
+                "weights": 25070.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25041, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_29.root", 
+                "nevents": 25041, 
+                "totEvents": 25041, 
+                "weights": 25041.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24781, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_179.root", 
+                "nevents": 24781, 
+                "totEvents": 24781, 
+                "weights": 24781.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24795, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_86.root", 
+                "nevents": 24795, 
+                "totEvents": 24795, 
+                "weights": 24795.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24950, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_63.root", 
+                "nevents": 24950, 
+                "totEvents": 24950, 
+                "weights": 24950.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24734, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_75.root", 
+                "nevents": 24734, 
+                "totEvents": 24734, 
+                "weights": 24734.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25168, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_97.root", 
+                "nevents": 25168, 
+                "totEvents": 25168, 
+                "weights": 25168.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24719, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_100.root", 
+                "nevents": 24719, 
+                "totEvents": 24719, 
+                "weights": 24719.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24949, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_85.root", 
+                "nevents": 24949, 
+                "totEvents": 24949, 
+                "weights": 24949.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24706, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_138.root", 
+                "nevents": 24706, 
+                "totEvents": 24706, 
+                "weights": 24706.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24804, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_58.root", 
+                "nevents": 24804, 
+                "totEvents": 24804, 
+                "weights": 24804.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24894, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_106.root", 
+                "nevents": 24894, 
+                "totEvents": 24894, 
+                "weights": 24894.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25108, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_128.root", 
+                "nevents": 25108, 
+                "totEvents": 25108, 
+                "weights": 25108.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24958, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_135.root", 
+                "nevents": 24958, 
+                "totEvents": 24958, 
+                "weights": 24958.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25181, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_136.root", 
+                "nevents": 25181, 
+                "totEvents": 25181, 
+                "weights": 25181.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24928, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_66.root", 
+                "nevents": 24928, 
+                "totEvents": 24928, 
+                "weights": 24928.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25195, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_150.root", 
+                "nevents": 25195, 
+                "totEvents": 25195, 
+                "weights": 25195.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24859, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_48.root", 
+                "nevents": 24859, 
+                "totEvents": 24859, 
+                "weights": 24859.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24813, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_121.root", 
+                "nevents": 24813, 
+                "totEvents": 24813, 
+                "weights": 24813.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25039, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_104.root", 
+                "nevents": 25039, 
+                "totEvents": 25039, 
+                "weights": 25039.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25160, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_108.root", 
+                "nevents": 25160, 
+                "totEvents": 25160, 
+                "weights": 25160.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24844, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_81.root", 
+                "nevents": 24844, 
+                "totEvents": 24844, 
+                "weights": 24844.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25129, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_127.root", 
+                "nevents": 25129, 
+                "totEvents": 25129, 
+                "weights": 25129.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24924, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_130.root", 
+                "nevents": 24924, 
+                "totEvents": 24924, 
+                "weights": 24924.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24883, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_64.root", 
+                "nevents": 24883, 
+                "totEvents": 24883, 
+                "weights": 24883.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24983, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_118.root", 
+                "nevents": 24983, 
+                "totEvents": 24983, 
+                "weights": 24983.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24811, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_247.root", 
+                "nevents": 24811, 
+                "totEvents": 24811, 
+                "weights": 24811.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25039, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_79.root", 
+                "nevents": 25039, 
+                "totEvents": 25039, 
+                "weights": 25039.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25065, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_152.root", 
+                "nevents": 25065, 
+                "totEvents": 25065, 
+                "weights": 25065.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25072, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_103.root", 
+                "nevents": 25072, 
+                "totEvents": 25072, 
+                "weights": 25072.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24924, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_256.root", 
+                "nevents": 24924, 
+                "totEvents": 24924, 
+                "weights": 24924.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24992, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_163.root", 
+                "nevents": 24992, 
+                "totEvents": 24992, 
+                "weights": 24992.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25224, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_102.root", 
+                "nevents": 25224, 
+                "totEvents": 25224, 
+                "weights": 25224.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24841, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_161.root", 
+                "nevents": 24841, 
+                "totEvents": 24841, 
+                "weights": 24841.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25075, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_89.root", 
+                "nevents": 25075, 
+                "totEvents": 25075, 
+                "weights": 25075.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24981, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_347.root", 
+                "nevents": 24981, 
+                "totEvents": 24981, 
+                "weights": 24981.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24903, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_88.root", 
+                "nevents": 24903, 
+                "totEvents": 24903, 
+                "weights": 24903.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25036, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_219.root", 
+                "nevents": 25036, 
+                "totEvents": 25036, 
+                "weights": 25036.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25154, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_72.root", 
+                "nevents": 25154, 
+                "totEvents": 25154, 
+                "weights": 25154.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25022, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_158.root", 
+                "nevents": 25022, 
+                "totEvents": 25022, 
+                "weights": 25022.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24809, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_131.root", 
+                "nevents": 24809, 
+                "totEvents": 24809, 
+                "weights": 24809.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25040, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_173.root", 
+                "nevents": 25040, 
+                "totEvents": 25040, 
+                "weights": 25040.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25004, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_54.root", 
+                "nevents": 25004, 
+                "totEvents": 25004, 
+                "weights": 25004.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25105, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_94.root", 
+                "nevents": 25105, 
+                "totEvents": 25105, 
+                "weights": 25105.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24994, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_90.root", 
+                "nevents": 24994, 
+                "totEvents": 24994, 
+                "weights": 24994.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25020, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_134.root", 
+                "nevents": 25020, 
+                "totEvents": 25020, 
+                "weights": 25020.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24742, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_92.root", 
+                "nevents": 24742, 
+                "totEvents": 24742, 
+                "weights": 24742.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24917, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_170.root", 
+                "nevents": 24917, 
+                "totEvents": 24917, 
+                "weights": 24917.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24967, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_149.root", 
+                "nevents": 24967, 
+                "totEvents": 24967, 
+                "weights": 24967.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25026, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_191.root", 
+                "nevents": 25026, 
+                "totEvents": 25026, 
+                "weights": 25026.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24792, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_165.root", 
+                "nevents": 24792, 
+                "totEvents": 24792, 
+                "weights": 24792.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25099, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_111.root", 
+                "nevents": 25099, 
+                "totEvents": 25099, 
+                "weights": 25099.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25177, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_143.root", 
+                "nevents": 25177, 
+                "totEvents": 25177, 
+                "weights": 25177.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24799, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_116.root", 
+                "nevents": 24799, 
+                "totEvents": 24799, 
+                "weights": 24799.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25065, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_52.root", 
+                "nevents": 25065, 
+                "totEvents": 25065, 
+                "weights": 25065.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24809, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_139.root", 
+                "nevents": 24809, 
+                "totEvents": 24809, 
+                "weights": 24809.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24699, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_62.root", 
+                "nevents": 24699, 
+                "totEvents": 24699, 
+                "weights": 24699.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24966, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_162.root", 
+                "nevents": 24966, 
+                "totEvents": 24966, 
+                "weights": 24966.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24998, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_112.root", 
+                "nevents": 24998, 
+                "totEvents": 24998, 
+                "weights": 24998.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24844, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_6.root", 
+                "nevents": 24844, 
+                "totEvents": 24844, 
+                "weights": 24844.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25061, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_310.root", 
+                "nevents": 25061, 
+                "totEvents": 25061, 
+                "weights": 25061.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25260, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_95.root", 
+                "nevents": 25260, 
+                "totEvents": 25260, 
+                "weights": 25260.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24954, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_57.root", 
+                "nevents": 24954, 
+                "totEvents": 24954, 
+                "weights": 24954.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24881, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_137.root", 
+                "nevents": 24881, 
+                "totEvents": 24881, 
+                "weights": 24881.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24771, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_205.root", 
+                "nevents": 24771, 
+                "totEvents": 24771, 
+                "weights": 24771.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25260, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_188.root", 
+                "nevents": 25260, 
+                "totEvents": 25260, 
+                "weights": 25260.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24887, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_133.root", 
+                "nevents": 24887, 
+                "totEvents": 24887, 
+                "weights": 24887.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25017, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_145.root", 
+                "nevents": 25017, 
+                "totEvents": 25017, 
+                "weights": 25017.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24814, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_69.root", 
+                "nevents": 24814, 
+                "totEvents": 24814, 
+                "weights": 24814.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25228, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_227.root", 
+                "nevents": 25228, 
+                "totEvents": 25228, 
+                "weights": 25228.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25204, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_222.root", 
+                "nevents": 25204, 
+                "totEvents": 25204, 
+                "weights": 25204.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24977, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_87.root", 
+                "nevents": 24977, 
+                "totEvents": 24977, 
+                "weights": 24977.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24961, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_296.root", 
+                "nevents": 24961, 
+                "totEvents": 24961, 
+                "weights": 24961.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24833, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_360.root", 
+                "nevents": 24833, 
+                "totEvents": 24833, 
+                "weights": 24833.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24886, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_154.root", 
+                "nevents": 24886, 
+                "totEvents": 24886, 
+                "weights": 24886.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24925, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_174.root", 
+                "nevents": 24925, 
+                "totEvents": 24925, 
+                "weights": 24925.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24985, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_164.root", 
+                "nevents": 24985, 
+                "totEvents": 24985, 
+                "weights": 24985.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24774, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_37.root", 
+                "nevents": 24774, 
+                "totEvents": 24774, 
+                "weights": 24774.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25024, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_312.root", 
+                "nevents": 25024, 
+                "totEvents": 25024, 
+                "weights": 25024.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24454, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_47.root", 
+                "nevents": 24454, 
+                "totEvents": 24454, 
+                "weights": 24454.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24870, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_168.root", 
+                "nevents": 24870, 
+                "totEvents": 24870, 
+                "weights": 24870.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24911, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_176.root", 
+                "nevents": 24911, 
+                "totEvents": 24911, 
+                "weights": 24911.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24966, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_182.root", 
+                "nevents": 24966, 
+                "totEvents": 24966, 
+                "weights": 24966.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24767, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_202.root", 
+                "nevents": 24767, 
+                "totEvents": 24767, 
+                "weights": 24767.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24916, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_129.root", 
+                "nevents": 24916, 
+                "totEvents": 24916, 
+                "weights": 24916.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25171, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_60.root", 
+                "nevents": 25171, 
+                "totEvents": 25171, 
+                "weights": 25171.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24935, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_67.root", 
+                "nevents": 24935, 
+                "totEvents": 24935, 
+                "weights": 24935.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24700, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_68.root", 
+                "nevents": 24700, 
+                "totEvents": 24700, 
+                "weights": 24700.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24694, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_167.root", 
+                "nevents": 24694, 
+                "totEvents": 24694, 
+                "weights": 24694.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24795, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_217.root", 
+                "nevents": 24795, 
+                "totEvents": 24795, 
+                "weights": 24795.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25165, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_249.root", 
+                "nevents": 25165, 
+                "totEvents": 25165, 
+                "weights": 25165.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24737, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_39.root", 
+                "nevents": 24737, 
+                "totEvents": 24737, 
+                "weights": 24737.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24953, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_223.root", 
+                "nevents": 24953, 
+                "totEvents": 24953, 
+                "weights": 24953.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24923, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_140.root", 
+                "nevents": 24923, 
+                "totEvents": 24923, 
+                "weights": 24923.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25175, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_99.root", 
+                "nevents": 25175, 
+                "totEvents": 25175, 
+                "weights": 25175.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24952, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_93.root", 
+                "nevents": 24952, 
+                "totEvents": 24952, 
+                "weights": 24952.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25028, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_266.root", 
+                "nevents": 25028, 
+                "totEvents": 25028, 
+                "weights": 25028.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24831, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_114.root", 
+                "nevents": 24831, 
+                "totEvents": 24831, 
+                "weights": 24831.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24925, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_262.root", 
+                "nevents": 24925, 
+                "totEvents": 24925, 
+                "weights": 24925.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24988, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_194.root", 
+                "nevents": 24988, 
+                "totEvents": 24988, 
+                "weights": 24988.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25129, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_13.root", 
+                "nevents": 25129, 
+                "totEvents": 25129, 
+                "weights": 25129.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25028, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_364.root", 
+                "nevents": 25028, 
+                "totEvents": 25028, 
+                "weights": 25028.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25024, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_268.root", 
+                "nevents": 25024, 
+                "totEvents": 25024, 
+                "weights": 25024.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24841, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_141.root", 
+                "nevents": 24841, 
+                "totEvents": 24841, 
+                "weights": 24841.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25125, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_287.root", 
+                "nevents": 25125, 
+                "totEvents": 25125, 
+                "weights": 25125.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25246, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_122.root", 
+                "nevents": 25246, 
+                "totEvents": 25246, 
+                "weights": 25246.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24849, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_28.root", 
+                "nevents": 24849, 
+                "totEvents": 24849, 
+                "weights": 24849.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24921, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_373.root", 
+                "nevents": 24921, 
+                "totEvents": 24921, 
+                "weights": 24921.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25050, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_215.root", 
+                "nevents": 25050, 
+                "totEvents": 25050, 
+                "weights": 25050.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25174, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_204.root", 
+                "nevents": 25174, 
+                "totEvents": 25174, 
+                "weights": 25174.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24986, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_32.root", 
+                "nevents": 24986, 
+                "totEvents": 24986, 
+                "weights": 24986.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24935, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_316.root", 
+                "nevents": 24935, 
+                "totEvents": 24935, 
+                "weights": 24935.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25208, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_53.root", 
+                "nevents": 25208, 
+                "totEvents": 25208, 
+                "weights": 25208.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25118, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_224.root", 
+                "nevents": 25118, 
+                "totEvents": 25118, 
+                "weights": 25118.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25147, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_357.root", 
+                "nevents": 25147, 
+                "totEvents": 25147, 
+                "weights": 25147.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25015, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_171.root", 
+                "nevents": 25015, 
+                "totEvents": 25015, 
+                "weights": 25015.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24911, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_153.root", 
+                "nevents": 24911, 
+                "totEvents": 24911, 
+                "weights": 24911.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25156, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_349.root", 
+                "nevents": 25156, 
+                "totEvents": 25156, 
+                "weights": 25156.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24913, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_35.root", 
+                "nevents": 24913, 
+                "totEvents": 24913, 
+                "weights": 24913.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25028, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_228.root", 
+                "nevents": 25028, 
+                "totEvents": 25028, 
+                "weights": 25028.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24949, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_246.root", 
+                "nevents": 24949, 
+                "totEvents": 24949, 
+                "weights": 24949.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25136, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_177.root", 
+                "nevents": 25136, 
+                "totEvents": 25136, 
+                "weights": 25136.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24667, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_20.root", 
+                "nevents": 24667, 
+                "totEvents": 24667, 
+                "weights": 24667.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24921, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_27.root", 
+                "nevents": 24921, 
+                "totEvents": 24921, 
+                "weights": 24921.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24800, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_306.root", 
+                "nevents": 24800, 
+                "totEvents": 24800, 
+                "weights": 24800.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24978, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_203.root", 
+                "nevents": 24978, 
+                "totEvents": 24978, 
+                "weights": 24978.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25320, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_46.root", 
+                "nevents": 25320, 
+                "totEvents": 25320, 
+                "weights": 25320.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24949, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_51.root", 
+                "nevents": 24949, 
+                "totEvents": 24949, 
+                "weights": 24949.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25080, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_1.root", 
+                "nevents": 25080, 
+                "totEvents": 25080, 
+                "weights": 25080.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25076, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_120.root", 
+                "nevents": 25076, 
+                "totEvents": 25076, 
+                "weights": 25076.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25127, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_71.root", 
+                "nevents": 25127, 
+                "totEvents": 25127, 
+                "weights": 25127.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24928, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_126.root", 
+                "nevents": 24928, 
+                "totEvents": 24928, 
+                "weights": 24928.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25168, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_255.root", 
+                "nevents": 25168, 
+                "totEvents": 25168, 
+                "weights": 25168.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25096, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_30.root", 
+                "nevents": 25096, 
+                "totEvents": 25096, 
+                "weights": 25096.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24935, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_193.root", 
+                "nevents": 24935, 
+                "totEvents": 24935, 
+                "weights": 24935.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24694, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_253.root", 
+                "nevents": 24694, 
+                "totEvents": 24694, 
+                "weights": 24694.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25098, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_175.root", 
+                "nevents": 25098, 
+                "totEvents": 25098, 
+                "weights": 25098.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24761, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_184.root", 
+                "nevents": 24761, 
+                "totEvents": 24761, 
+                "weights": 24761.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24899, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_21.root", 
+                "nevents": 24899, 
+                "totEvents": 24899, 
+                "weights": 24899.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25007, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_354.root", 
+                "nevents": 25007, 
+                "totEvents": 25007, 
+                "weights": 25007.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24843, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_189.root", 
+                "nevents": 24843, 
+                "totEvents": 24843, 
+                "weights": 24843.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24920, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_55.root", 
+                "nevents": 24920, 
+                "totEvents": 24920, 
+                "weights": 24920.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24868, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_166.root", 
+                "nevents": 24868, 
+                "totEvents": 24868, 
+                "weights": 24868.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25042, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_178.root", 
+                "nevents": 25042, 
+                "totEvents": 25042, 
+                "weights": 25042.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24994, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_169.root", 
+                "nevents": 24994, 
+                "totEvents": 24994, 
+                "weights": 24994.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25048, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_17.root", 
+                "nevents": 25048, 
+                "totEvents": 25048, 
+                "weights": 25048.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24971, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_105.root", 
+                "nevents": 24971, 
+                "totEvents": 24971, 
+                "weights": 24971.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25015, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_180.root", 
+                "nevents": 25015, 
+                "totEvents": 25015, 
+                "weights": 25015.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24925, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_267.root", 
+                "nevents": 24925, 
+                "totEvents": 24925, 
+                "weights": 24925.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24868, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_212.root", 
+                "nevents": 24868, 
+                "totEvents": 24868, 
+                "weights": 24868.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24748, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_209.root", 
+                "nevents": 24748, 
+                "totEvents": 24748, 
+                "weights": 24748.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25055, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_172.root", 
+                "nevents": 25055, 
+                "totEvents": 25055, 
+                "weights": 25055.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24943, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_113.root", 
+                "nevents": 24943, 
+                "totEvents": 24943, 
+                "weights": 24943.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25232, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_251.root", 
+                "nevents": 25232, 
+                "totEvents": 25232, 
+                "weights": 25232.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24811, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_270.root", 
+                "nevents": 24811, 
+                "totEvents": 24811, 
+                "weights": 24811.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24979, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_15.root", 
+                "nevents": 24979, 
+                "totEvents": 24979, 
+                "weights": 24979.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25118, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_151.root", 
+                "nevents": 25118, 
+                "totEvents": 25118, 
+                "weights": 25118.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25015, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_159.root", 
+                "nevents": 25015, 
+                "totEvents": 25015, 
+                "weights": 25015.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25028, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_313.root", 
+                "nevents": 25028, 
+                "totEvents": 25028, 
+                "weights": 25028.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24818, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_196.root", 
+                "nevents": 24818, 
+                "totEvents": 24818, 
+                "weights": 24818.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24886, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_250.root", 
+                "nevents": 24886, 
+                "totEvents": 24886, 
+                "weights": 24886.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25039, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_315.root", 
+                "nevents": 25039, 
+                "totEvents": 25039, 
+                "weights": 25039.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24930, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_252.root", 
+                "nevents": 24930, 
+                "totEvents": 24930, 
+                "weights": 24930.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25129, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_261.root", 
+                "nevents": 25129, 
+                "totEvents": 25129, 
+                "weights": 25129.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24974, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_74.root", 
+                "nevents": 24974, 
+                "totEvents": 24974, 
+                "weights": 24974.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25235, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_22.root", 
+                "nevents": 25235, 
+                "totEvents": 25235, 
+                "weights": 25235.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24805, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_254.root", 
+                "nevents": 24805, 
+                "totEvents": 24805, 
+                "weights": 24805.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24824, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_84.root", 
+                "nevents": 24824, 
+                "totEvents": 24824, 
+                "weights": 24824.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24801, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_61.root", 
+                "nevents": 24801, 
+                "totEvents": 24801, 
+                "weights": 24801.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24944, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_225.root", 
+                "nevents": 24944, 
+                "totEvents": 24944, 
+                "weights": 24944.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24900, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_329.root", 
+                "nevents": 24900, 
+                "totEvents": 24900, 
+                "weights": 24900.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25007, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_258.root", 
+                "nevents": 25007, 
+                "totEvents": 25007, 
+                "weights": 25007.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24848, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_192.root", 
+                "nevents": 24848, 
+                "totEvents": 24848, 
+                "weights": 24848.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24915, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_370.root", 
+                "nevents": 24915, 
+                "totEvents": 24915, 
+                "weights": 24915.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24999, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_303.root", 
+                "nevents": 24999, 
+                "totEvents": 24999, 
+                "weights": 24999.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24958, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_317.root", 
+                "nevents": 24958, 
+                "totEvents": 24958, 
+                "weights": 24958.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25305, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_125.root", 
+                "nevents": 25305, 
+                "totEvents": 25305, 
+                "weights": 25305.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25019, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_117.root", 
+                "nevents": 25019, 
+                "totEvents": 25019, 
+                "weights": 25019.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24950, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_142.root", 
+                "nevents": 24950, 
+                "totEvents": 24950, 
+                "weights": 24950.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25128, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_185.root", 
+                "nevents": 25128, 
+                "totEvents": 25128, 
+                "weights": 25128.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24887, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_335.root", 
+                "nevents": 24887, 
+                "totEvents": 24887, 
+                "weights": 24887.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25011, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_187.root", 
+                "nevents": 25011, 
+                "totEvents": 25011, 
+                "weights": 25011.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24862, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_101.root", 
+                "nevents": 24862, 
+                "totEvents": 24862, 
+                "weights": 24862.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24963, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_243.root", 
+                "nevents": 24963, 
+                "totEvents": 24963, 
+                "weights": 24963.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24761, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_198.root", 
+                "nevents": 24761, 
+                "totEvents": 24761, 
+                "weights": 24761.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24931, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_23.root", 
+                "nevents": 24931, 
+                "totEvents": 24931, 
+                "weights": 24931.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24943, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_314.root", 
+                "nevents": 24943, 
+                "totEvents": 24943, 
+                "weights": 24943.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25073, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_70.root", 
+                "nevents": 25073, 
+                "totEvents": 25073, 
+                "weights": 25073.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24988, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_26.root", 
+                "nevents": 24988, 
+                "totEvents": 24988, 
+                "weights": 24988.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24983, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_241.root", 
+                "nevents": 24983, 
+                "totEvents": 24983, 
+                "weights": 24983.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25019, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_292.root", 
+                "nevents": 25019, 
+                "totEvents": 25019, 
+                "weights": 25019.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25145, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_244.root", 
+                "nevents": 25145, 
+                "totEvents": 25145, 
+                "weights": 25145.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25111, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_343.root", 
+                "nevents": 25111, 
+                "totEvents": 25111, 
+                "weights": 25111.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24854, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_260.root", 
+                "nevents": 24854, 
+                "totEvents": 24854, 
+                "weights": 24854.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24940, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_40.root", 
+                "nevents": 24940, 
+                "totEvents": 24940, 
+                "weights": 24940.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25018, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_195.root", 
+                "nevents": 25018, 
+                "totEvents": 25018, 
+                "weights": 25018.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25022, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_361.root", 
+                "nevents": 25022, 
+                "totEvents": 25022, 
+                "weights": 25022.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24749, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_3.root", 
+                "nevents": 24749, 
+                "totEvents": 24749, 
+                "weights": 24749.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24980, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_365.root", 
+                "nevents": 24980, 
+                "totEvents": 24980, 
+                "weights": 24980.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25024, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_96.root", 
+                "nevents": 25024, 
+                "totEvents": 25024, 
+                "weights": 25024.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24846, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_160.root", 
+                "nevents": 24846, 
+                "totEvents": 24846, 
+                "weights": 24846.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24977, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_211.root", 
+                "nevents": 24977, 
+                "totEvents": 24977, 
+                "weights": 24977.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24957, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_65.root", 
+                "nevents": 24957, 
+                "totEvents": 24957, 
+                "weights": 24957.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24811, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_330.root", 
+                "nevents": 24811, 
+                "totEvents": 24811, 
+                "weights": 24811.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24850, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_146.root", 
+                "nevents": 24850, 
+                "totEvents": 24850, 
+                "weights": 24850.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24833, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_98.root", 
+                "nevents": 24833, 
+                "totEvents": 24833, 
+                "weights": 24833.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24617, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_124.root", 
+                "nevents": 24617, 
+                "totEvents": 24617, 
+                "weights": 24617.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25277, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_10.root", 
+                "nevents": 25277, 
+                "totEvents": 25277, 
+                "weights": 25277.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24986, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_230.root", 
+                "nevents": 24986, 
+                "totEvents": 24986, 
+                "weights": 24986.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25378, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_91.root", 
+                "nevents": 25378, 
+                "totEvents": 25378, 
+                "weights": 25378.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24996, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_308.root", 
+                "nevents": 24996, 
+                "totEvents": 24996, 
+                "weights": 24996.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24992, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_237.root", 
+                "nevents": 24992, 
+                "totEvents": 24992, 
+                "weights": 24992.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24814, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_144.root", 
+                "nevents": 24814, 
+                "totEvents": 24814, 
+                "weights": 24814.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24806, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_132.root", 
+                "nevents": 24806, 
+                "totEvents": 24806, 
+                "weights": 24806.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24850, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_290.root", 
+                "nevents": 24850, 
+                "totEvents": 24850, 
+                "weights": 24850.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24970, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_56.root", 
+                "nevents": 24970, 
+                "totEvents": 24970, 
+                "weights": 24970.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24893, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_220.root", 
+                "nevents": 24893, 
+                "totEvents": 24893, 
+                "weights": 24893.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24968, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_76.root", 
+                "nevents": 24968, 
+                "totEvents": 24968, 
+                "weights": 24968.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24851, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_272.root", 
+                "nevents": 24851, 
+                "totEvents": 24851, 
+                "weights": 24851.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24602, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_25.root", 
+                "nevents": 24602, 
+                "totEvents": 24602, 
+                "weights": 24602.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24945, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_245.root", 
+                "nevents": 24945, 
+                "totEvents": 24945, 
+                "weights": 24945.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24839, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_285.root", 
+                "nevents": 24839, 
+                "totEvents": 24839, 
+                "weights": 24839.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25050, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_109.root", 
+                "nevents": 25050, 
+                "totEvents": 25050, 
+                "weights": 25050.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25024, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_328.root", 
+                "nevents": 25024, 
+                "totEvents": 25024, 
+                "weights": 25024.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25110, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_311.root", 
+                "nevents": 25110, 
+                "totEvents": 25110, 
+                "weights": 25110.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24901, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_322.root", 
+                "nevents": 24901, 
+                "totEvents": 24901, 
+                "weights": 24901.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24882, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_297.root", 
+                "nevents": 24882, 
+                "totEvents": 24882, 
+                "weights": 24882.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24958, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_338.root", 
+                "nevents": 24958, 
+                "totEvents": 24958, 
+                "weights": 24958.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24953, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_293.root", 
+                "nevents": 24953, 
+                "totEvents": 24953, 
+                "weights": 24953.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25052, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_324.root", 
+                "nevents": 25052, 
+                "totEvents": 25052, 
+                "weights": 25052.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24975, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_301.root", 
+                "nevents": 24975, 
+                "totEvents": 24975, 
+                "weights": 24975.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25037, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_333.root", 
+                "nevents": 25037, 
+                "totEvents": 25037, 
+                "weights": 25037.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25159, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_282.root", 
+                "nevents": 25159, 
+                "totEvents": 25159, 
+                "weights": 25159.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25006, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_110.root", 
+                "nevents": 25006, 
+                "totEvents": 25006, 
+                "weights": 25006.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24996, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_302.root", 
+                "nevents": 24996, 
+                "totEvents": 24996, 
+                "weights": 24996.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25003, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_42.root", 
+                "nevents": 25003, 
+                "totEvents": 25003, 
+                "weights": 25003.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25055, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_305.root", 
+                "nevents": 25055, 
+                "totEvents": 25055, 
+                "weights": 25055.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25108, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_273.root", 
+                "nevents": 25108, 
+                "totEvents": 25108, 
+                "weights": 25108.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24742, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_233.root", 
+                "nevents": 24742, 
+                "totEvents": 24742, 
+                "weights": 24742.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24996, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_309.root", 
+                "nevents": 24996, 
+                "totEvents": 24996, 
+                "weights": 24996.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24673, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_325.root", 
+                "nevents": 24673, 
+                "totEvents": 24673, 
+                "weights": 24673.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25026, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_359.root", 
+                "nevents": 25026, 
+                "totEvents": 25026, 
+                "weights": 25026.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24855, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_363.root", 
+                "nevents": 24855, 
+                "totEvents": 24855, 
+                "weights": 24855.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24832, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_340.root", 
+                "nevents": 24832, 
+                "totEvents": 24832, 
+                "weights": 24832.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24981, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_334.root", 
+                "nevents": 24981, 
+                "totEvents": 24981, 
+                "weights": 24981.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24924, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_348.root", 
+                "nevents": 24924, 
+                "totEvents": 24924, 
+                "weights": 24924.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24980, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_234.root", 
+                "nevents": 24980, 
+                "totEvents": 24980, 
+                "weights": 24980.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25011, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_181.root", 
+                "nevents": 25011, 
+                "totEvents": 25011, 
+                "weights": 25011.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24738, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_34.root", 
+                "nevents": 24738, 
+                "totEvents": 24738, 
+                "weights": 24738.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24974, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_155.root", 
+                "nevents": 24974, 
+                "totEvents": 24974, 
+                "weights": 24974.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25034, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_371.root", 
+                "nevents": 25034, 
+                "totEvents": 25034, 
+                "weights": 25034.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24762, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_358.root", 
+                "nevents": 24762, 
+                "totEvents": 24762, 
+                "weights": 24762.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24893, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_80.root", 
+                "nevents": 24893, 
+                "totEvents": 24893, 
+                "weights": 24893.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25039, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_283.root", 
+                "nevents": 25039, 
+                "totEvents": 25039, 
+                "weights": 25039.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24697, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_286.root", 
+                "nevents": 24697, 
+                "totEvents": 24697, 
+                "weights": 24697.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24935, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_369.root", 
+                "nevents": 24935, 
+                "totEvents": 24935, 
+                "weights": 24935.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24798, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_235.root", 
+                "nevents": 24798, 
+                "totEvents": 24798, 
+                "weights": 24798.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24972, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_238.root", 
+                "nevents": 24972, 
+                "totEvents": 24972, 
+                "weights": 24972.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25019, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_289.root", 
+                "nevents": 25019, 
+                "totEvents": 25019, 
+                "weights": 25019.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24818, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_346.root", 
+                "nevents": 24818, 
+                "totEvents": 24818, 
+                "weights": 24818.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24740, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_339.root", 
+                "nevents": 24740, 
+                "totEvents": 24740, 
+                "weights": 24740.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25054, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_320.root", 
+                "nevents": 25054, 
+                "totEvents": 25054, 
+                "weights": 25054.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24640, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_279.root", 
+                "nevents": 24640, 
+                "totEvents": 24640, 
+                "weights": 24640.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24781, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_299.root", 
+                "nevents": 24781, 
+                "totEvents": 24781, 
+                "weights": 24781.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24967, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_336.root", 
+                "nevents": 24967, 
+                "totEvents": 24967, 
+                "weights": 24967.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25117, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_337.root", 
+                "nevents": 25117, 
+                "totEvents": 25117, 
+                "weights": 25117.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24984, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_2.root", 
+                "nevents": 24984, 
+                "totEvents": 24984, 
+                "weights": 24984.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24788, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_263.root", 
+                "nevents": 24788, 
+                "totEvents": 24788, 
+                "weights": 24788.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25019, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_284.root", 
+                "nevents": 25019, 
+                "totEvents": 25019, 
+                "weights": 25019.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24977, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_298.root", 
+                "nevents": 24977, 
+                "totEvents": 24977, 
+                "weights": 24977.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24974, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_344.root", 
+                "nevents": 24974, 
+                "totEvents": 24974, 
+                "weights": 24974.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24989, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_281.root", 
+                "nevents": 24989, 
+                "totEvents": 24989, 
+                "weights": 24989.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25135, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_304.root", 
+                "nevents": 25135, 
+                "totEvents": 25135, 
+                "weights": 25135.0
+            }, 
+            {
+                "bad": false, 
+                "events": 11674, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_374.root", 
+                "nevents": 11674, 
+                "totEvents": 11674, 
+                "weights": 11674.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24703, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_83.root", 
+                "nevents": 24703, 
+                "totEvents": 24703, 
+                "weights": 24703.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25026, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_229.root", 
+                "nevents": 25026, 
+                "totEvents": 25026, 
+                "weights": 25026.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24850, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_199.root", 
+                "nevents": 24850, 
+                "totEvents": 24850, 
+                "weights": 24850.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25036, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_291.root", 
+                "nevents": 25036, 
+                "totEvents": 25036, 
+                "weights": 25036.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24869, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_232.root", 
+                "nevents": 24869, 
+                "totEvents": 24869, 
+                "weights": 24869.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24960, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_45.root", 
+                "nevents": 24960, 
+                "totEvents": 24960, 
+                "weights": 24960.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24717, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_278.root", 
+                "nevents": 24717, 
+                "totEvents": 24717, 
+                "weights": 24717.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25058, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_208.root", 
+                "nevents": 25058, 
+                "totEvents": 25058, 
+                "weights": 25058.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25109, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_157.root", 
+                "nevents": 25109, 
+                "totEvents": 25109, 
+                "weights": 25109.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24799, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_221.root", 
+                "nevents": 24799, 
+                "totEvents": 24799, 
+                "weights": 24799.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24998, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_318.root", 
+                "nevents": 24998, 
+                "totEvents": 24998, 
+                "weights": 24998.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25074, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_327.root", 
+                "nevents": 25074, 
+                "totEvents": 25074, 
+                "weights": 25074.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24995, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_350.root", 
+                "nevents": 24995, 
+                "totEvents": 24995, 
+                "weights": 24995.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25054, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_342.root", 
+                "nevents": 25054, 
+                "totEvents": 25054, 
+                "weights": 25054.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25060, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_280.root", 
+                "nevents": 25060, 
+                "totEvents": 25060, 
+                "weights": 25060.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25038, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_351.root", 
+                "nevents": 25038, 
+                "totEvents": 25038, 
+                "weights": 25038.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24907, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_288.root", 
+                "nevents": 24907, 
+                "totEvents": 24907, 
+                "weights": 24907.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24952, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_41.root", 
+                "nevents": 24952, 
+                "totEvents": 24952, 
+                "weights": 24952.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24961, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_269.root", 
+                "nevents": 24961, 
+                "totEvents": 24961, 
+                "weights": 24961.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25006, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_5.root", 
+                "nevents": 25006, 
+                "totEvents": 25006, 
+                "weights": 25006.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24882, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_43.root", 
+                "nevents": 24882, 
+                "totEvents": 24882, 
+                "weights": 24882.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24981, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_49.root", 
+                "nevents": 24981, 
+                "totEvents": 24981, 
+                "weights": 24981.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24956, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_264.root", 
+                "nevents": 24956, 
+                "totEvents": 24956, 
+                "weights": 24956.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25140, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_274.root", 
+                "nevents": 25140, 
+                "totEvents": 25140, 
+                "weights": 25140.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24952, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_277.root", 
+                "nevents": 24952, 
+                "totEvents": 24952, 
+                "weights": 24952.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24991, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_197.root", 
+                "nevents": 24991, 
+                "totEvents": 24991, 
+                "weights": 24991.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25042, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_107.root", 
+                "nevents": 25042, 
+                "totEvents": 25042, 
+                "weights": 25042.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25299, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_206.root", 
+                "nevents": 25299, 
+                "totEvents": 25299, 
+                "weights": 25299.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25138, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_210.root", 
+                "nevents": 25138, 
+                "totEvents": 25138, 
+                "weights": 25138.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24878, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_16.root", 
+                "nevents": 24878, 
+                "totEvents": 24878, 
+                "weights": 24878.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24972, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_294.root", 
+                "nevents": 24972, 
+                "totEvents": 24972, 
+                "weights": 24972.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24798, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_218.root", 
+                "nevents": 24798, 
+                "totEvents": 24798, 
+                "weights": 24798.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25185, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_368.root", 
+                "nevents": 25185, 
+                "totEvents": 25185, 
+                "weights": 25185.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25158, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_367.root", 
+                "nevents": 25158, 
+                "totEvents": 25158, 
+                "weights": 25158.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24882, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_36.root", 
+                "nevents": 24882, 
+                "totEvents": 24882, 
+                "weights": 24882.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24882, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_31.root", 
+                "nevents": 24882, 
+                "totEvents": 24882, 
+                "weights": 24882.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25065, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_156.root", 
+                "nevents": 25065, 
+                "totEvents": 25065, 
+                "weights": 25065.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24891, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_77.root", 
+                "nevents": 24891, 
+                "totEvents": 24891, 
+                "weights": 24891.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24855, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_44.root", 
+                "nevents": 24855, 
+                "totEvents": 24855, 
+                "weights": 24855.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25011, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_275.root", 
+                "nevents": 25011, 
+                "totEvents": 25011, 
+                "weights": 25011.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24690, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_242.root", 
+                "nevents": 24690, 
+                "totEvents": 24690, 
+                "weights": 24690.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24607, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_276.root", 
+                "nevents": 24607, 
+                "totEvents": 24607, 
+                "weights": 24607.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25073, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_356.root", 
+                "nevents": 25073, 
+                "totEvents": 25073, 
+                "weights": 25073.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25018, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_231.root", 
+                "nevents": 25018, 
+                "totEvents": 25018, 
+                "weights": 25018.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25037, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_82.root", 
+                "nevents": 25037, 
+                "totEvents": 25037, 
+                "weights": 25037.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24993, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_134947/0000/myMicroAODOutputFile_9.root", 
+                "nevents": 24993, 
+                "totEvents": 24993, 
+                "weights": 24993.0
+            }
+        ], 
+        "parent_n_units": 9321218, 
+        "vetted": true
+    }
+}

--- a/MetaData/data/Era2017_legacy_v1/datasets_39.json
+++ b/MetaData/data/Era2017_legacy_v1/datasets_39.json
@@ -1,0 +1,6791 @@
+{
+    "/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/alesauva-UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1-8980ba169e8b72d53459e52844728ed8/USER": {
+        "dset_type": "mc", 
+        "files": [
+            {
+                "bad": false, 
+                "events": 25268, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_372.root", 
+                "nevents": 25268, 
+                "totEvents": 25268, 
+                "weights": 25268.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25061, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_480.root", 
+                "nevents": 25061, 
+                "totEvents": 25061, 
+                "weights": 25061.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24970, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_265.root", 
+                "nevents": 24970, 
+                "totEvents": 24970, 
+                "weights": 24970.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25079, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_155.root", 
+                "nevents": 25079, 
+                "totEvents": 25079, 
+                "weights": 25079.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24779, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_205.root", 
+                "nevents": 24779, 
+                "totEvents": 24779, 
+                "weights": 24779.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24996, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_103.root", 
+                "nevents": 24996, 
+                "totEvents": 24996, 
+                "weights": 24996.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24859, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_170.root", 
+                "nevents": 24859, 
+                "totEvents": 24859, 
+                "weights": 24859.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25039, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_183.root", 
+                "nevents": 25039, 
+                "totEvents": 25039, 
+                "weights": 25039.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25125, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_32.root", 
+                "nevents": 25125, 
+                "totEvents": 25125, 
+                "weights": 25125.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25346, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_173.root", 
+                "nevents": 25346, 
+                "totEvents": 25346, 
+                "weights": 25346.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25009, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_138.root", 
+                "nevents": 25009, 
+                "totEvents": 25009, 
+                "weights": 25009.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25144, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_13.root", 
+                "nevents": 25144, 
+                "totEvents": 25144, 
+                "weights": 25144.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24766, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_307.root", 
+                "nevents": 24766, 
+                "totEvents": 24766, 
+                "weights": 24766.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24795, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_238.root", 
+                "nevents": 24795, 
+                "totEvents": 24795, 
+                "weights": 24795.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24689, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_188.root", 
+                "nevents": 24689, 
+                "totEvents": 24689, 
+                "weights": 24689.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25017, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_106.root", 
+                "nevents": 25017, 
+                "totEvents": 25017, 
+                "weights": 25017.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25142, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_177.root", 
+                "nevents": 25142, 
+                "totEvents": 25142, 
+                "weights": 25142.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25334, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_192.root", 
+                "nevents": 25334, 
+                "totEvents": 25334, 
+                "weights": 25334.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24974, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_171.root", 
+                "nevents": 24974, 
+                "totEvents": 24974, 
+                "weights": 24974.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24734, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_206.root", 
+                "nevents": 24734, 
+                "totEvents": 24734, 
+                "weights": 24734.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25185, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_208.root", 
+                "nevents": 25185, 
+                "totEvents": 25185, 
+                "weights": 25185.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24716, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_190.root", 
+                "nevents": 24716, 
+                "totEvents": 24716, 
+                "weights": 24716.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25152, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_180.root", 
+                "nevents": 25152, 
+                "totEvents": 25152, 
+                "weights": 25152.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24849, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_101.root", 
+                "nevents": 24849, 
+                "totEvents": 24849, 
+                "weights": 24849.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24914, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_266.root", 
+                "nevents": 24914, 
+                "totEvents": 24914, 
+                "weights": 24914.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25093, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_258.root", 
+                "nevents": 25093, 
+                "totEvents": 25093, 
+                "weights": 25093.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24887, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_326.root", 
+                "nevents": 24887, 
+                "totEvents": 24887, 
+                "weights": 24887.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25055, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_490.root", 
+                "nevents": 25055, 
+                "totEvents": 25055, 
+                "weights": 25055.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25305, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_306.root", 
+                "nevents": 25305, 
+                "totEvents": 25305, 
+                "weights": 25305.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24825, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_107.root", 
+                "nevents": 24825, 
+                "totEvents": 24825, 
+                "weights": 24825.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24974, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_202.root", 
+                "nevents": 24974, 
+                "totEvents": 24974, 
+                "weights": 24974.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24909, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_278.root", 
+                "nevents": 24909, 
+                "totEvents": 24909, 
+                "weights": 24909.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25129, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_287.root", 
+                "nevents": 25129, 
+                "totEvents": 25129, 
+                "weights": 25129.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24991, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_362.root", 
+                "nevents": 24991, 
+                "totEvents": 24991, 
+                "weights": 24991.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24994, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_332.root", 
+                "nevents": 24994, 
+                "totEvents": 24994, 
+                "weights": 24994.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25076, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_161.root", 
+                "nevents": 25076, 
+                "totEvents": 25076, 
+                "weights": 25076.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25060, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_178.root", 
+                "nevents": 25060, 
+                "totEvents": 25060, 
+                "weights": 25060.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25052, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_319.root", 
+                "nevents": 25052, 
+                "totEvents": 25052, 
+                "weights": 25052.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24883, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_172.root", 
+                "nevents": 24883, 
+                "totEvents": 24883, 
+                "weights": 24883.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24714, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_197.root", 
+                "nevents": 24714, 
+                "totEvents": 24714, 
+                "weights": 24714.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24963, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_485.root", 
+                "nevents": 24963, 
+                "totEvents": 24963, 
+                "weights": 24963.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25085, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_204.root", 
+                "nevents": 25085, 
+                "totEvents": 25085, 
+                "weights": 25085.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_342.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 25000.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25170, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_458.root", 
+                "nevents": 25170, 
+                "totEvents": 25170, 
+                "weights": 25170.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25069, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_310.root", 
+                "nevents": 25069, 
+                "totEvents": 25069, 
+                "weights": 25069.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25030, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_365.root", 
+                "nevents": 25030, 
+                "totEvents": 25030, 
+                "weights": 25030.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25117, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_303.root", 
+                "nevents": 25117, 
+                "totEvents": 25117, 
+                "weights": 25117.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25044, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_301.root", 
+                "nevents": 25044, 
+                "totEvents": 25044, 
+                "weights": 25044.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24872, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_191.root", 
+                "nevents": 24872, 
+                "totEvents": 24872, 
+                "weights": 24872.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25001, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_361.root", 
+                "nevents": 25001, 
+                "totEvents": 25001, 
+                "weights": 25001.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24893, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_341.root", 
+                "nevents": 24893, 
+                "totEvents": 24893, 
+                "weights": 24893.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24973, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_369.root", 
+                "nevents": 24973, 
+                "totEvents": 24973, 
+                "weights": 24973.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25033, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_181.root", 
+                "nevents": 25033, 
+                "totEvents": 25033, 
+                "weights": 25033.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25001, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_353.root", 
+                "nevents": 25001, 
+                "totEvents": 25001, 
+                "weights": 25001.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25295, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_288.root", 
+                "nevents": 25295, 
+                "totEvents": 25295, 
+                "weights": 25295.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25040, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_152.root", 
+                "nevents": 25040, 
+                "totEvents": 25040, 
+                "weights": 25040.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24942, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_295.root", 
+                "nevents": 24942, 
+                "totEvents": 24942, 
+                "weights": 24942.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25141, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_174.root", 
+                "nevents": 25141, 
+                "totEvents": 25141, 
+                "weights": 25141.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24976, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_122.root", 
+                "nevents": 24976, 
+                "totEvents": 24976, 
+                "weights": 24976.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24641, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_312.root", 
+                "nevents": 24641, 
+                "totEvents": 24641, 
+                "weights": 24641.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24948, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_473.root", 
+                "nevents": 24948, 
+                "totEvents": 24948, 
+                "weights": 24948.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25019, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_182.root", 
+                "nevents": 25019, 
+                "totEvents": 25019, 
+                "weights": 25019.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24588, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_237.root", 
+                "nevents": 24588, 
+                "totEvents": 24588, 
+                "weights": 24588.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25106, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_277.root", 
+                "nevents": 25106, 
+                "totEvents": 25106, 
+                "weights": 25106.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24830, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_253.root", 
+                "nevents": 24830, 
+                "totEvents": 24830, 
+                "weights": 24830.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24886, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_368.root", 
+                "nevents": 24886, 
+                "totEvents": 24886, 
+                "weights": 24886.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25121, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_120.root", 
+                "nevents": 25121, 
+                "totEvents": 25121, 
+                "weights": 25121.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25083, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_239.root", 
+                "nevents": 25083, 
+                "totEvents": 25083, 
+                "weights": 25083.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25067, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_355.root", 
+                "nevents": 25067, 
+                "totEvents": 25067, 
+                "weights": 25067.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25153, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_336.root", 
+                "nevents": 25153, 
+                "totEvents": 25153, 
+                "weights": 25153.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25124, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_298.root", 
+                "nevents": 25124, 
+                "totEvents": 25124, 
+                "weights": 25124.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24891, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_261.root", 
+                "nevents": 24891, 
+                "totEvents": 24891, 
+                "weights": 24891.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25246, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_459.root", 
+                "nevents": 25246, 
+                "totEvents": 25246, 
+                "weights": 25246.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24943, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_276.root", 
+                "nevents": 24943, 
+                "totEvents": 24943, 
+                "weights": 24943.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25201, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_339.root", 
+                "nevents": 25201, 
+                "totEvents": 25201, 
+                "weights": 25201.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25135, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_309.root", 
+                "nevents": 25135, 
+                "totEvents": 25135, 
+                "weights": 25135.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24858, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_248.root", 
+                "nevents": 24858, 
+                "totEvents": 24858, 
+                "weights": 24858.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25062, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_111.root", 
+                "nevents": 25062, 
+                "totEvents": 25062, 
+                "weights": 25062.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25010, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_267.root", 
+                "nevents": 25010, 
+                "totEvents": 25010, 
+                "weights": 25010.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24816, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_245.root", 
+                "nevents": 24816, 
+                "totEvents": 24816, 
+                "weights": 24816.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24991, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_456.root", 
+                "nevents": 24991, 
+                "totEvents": 24991, 
+                "weights": 24991.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25128, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_387.root", 
+                "nevents": 25128, 
+                "totEvents": 25128, 
+                "weights": 25128.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24932, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_448.root", 
+                "nevents": 24932, 
+                "totEvents": 24932, 
+                "weights": 24932.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24997, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_189.root", 
+                "nevents": 24997, 
+                "totEvents": 24997, 
+                "weights": 24997.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24919, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_200.root", 
+                "nevents": 24919, 
+                "totEvents": 24919, 
+                "weights": 24919.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25100, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_322.root", 
+                "nevents": 25100, 
+                "totEvents": 25100, 
+                "weights": 25100.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25335, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_324.root", 
+                "nevents": 25335, 
+                "totEvents": 25335, 
+                "weights": 25335.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25124, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_48.root", 
+                "nevents": 25124, 
+                "totEvents": 25124, 
+                "weights": 25124.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24913, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_446.root", 
+                "nevents": 24913, 
+                "totEvents": 24913, 
+                "weights": 24913.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24869, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_127.root", 
+                "nevents": 24869, 
+                "totEvents": 24869, 
+                "weights": 24869.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25059, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_215.root", 
+                "nevents": 25059, 
+                "totEvents": 25059, 
+                "weights": 25059.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24976, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_279.root", 
+                "nevents": 24976, 
+                "totEvents": 24976, 
+                "weights": 24976.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25215, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_230.root", 
+                "nevents": 25215, 
+                "totEvents": 25215, 
+                "weights": 25215.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24765, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_479.root", 
+                "nevents": 24765, 
+                "totEvents": 24765, 
+                "weights": 24765.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24924, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_207.root", 
+                "nevents": 24924, 
+                "totEvents": 24924, 
+                "weights": 24924.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24737, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_308.root", 
+                "nevents": 24737, 
+                "totEvents": 24737, 
+                "weights": 24737.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24949, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_330.root", 
+                "nevents": 24949, 
+                "totEvents": 24949, 
+                "weights": 24949.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25072, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_299.root", 
+                "nevents": 25072, 
+                "totEvents": 25072, 
+                "weights": 25072.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25234, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_100.root", 
+                "nevents": 25234, 
+                "totEvents": 25234, 
+                "weights": 25234.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24988, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_240.root", 
+                "nevents": 24988, 
+                "totEvents": 24988, 
+                "weights": 24988.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25015, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_481.root", 
+                "nevents": 25015, 
+                "totEvents": 25015, 
+                "weights": 25015.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24913, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_433.root", 
+                "nevents": 24913, 
+                "totEvents": 24913, 
+                "weights": 24913.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24921, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_431.root", 
+                "nevents": 24921, 
+                "totEvents": 24921, 
+                "weights": 24921.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24999, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_370.root", 
+                "nevents": 24999, 
+                "totEvents": 24999, 
+                "weights": 24999.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25075, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_555.root", 
+                "nevents": 25075, 
+                "totEvents": 25075, 
+                "weights": 25075.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24885, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_53.root", 
+                "nevents": 24885, 
+                "totEvents": 24885, 
+                "weights": 24885.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24853, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_379.root", 
+                "nevents": 24853, 
+                "totEvents": 24853, 
+                "weights": 24853.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24950, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_357.root", 
+                "nevents": 24950, 
+                "totEvents": 24950, 
+                "weights": 24950.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24743, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_388.root", 
+                "nevents": 24743, 
+                "totEvents": 24743, 
+                "weights": 24743.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24970, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_610.root", 
+                "nevents": 24970, 
+                "totEvents": 24970, 
+                "weights": 24970.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24995, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_635.root", 
+                "nevents": 24995, 
+                "totEvents": 24995, 
+                "weights": 24995.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24944, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_4.root", 
+                "nevents": 24944, 
+                "totEvents": 24944, 
+                "weights": 24944.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24793, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_631.root", 
+                "nevents": 24793, 
+                "totEvents": 24793, 
+                "weights": 24793.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25136, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_499.root", 
+                "nevents": 25136, 
+                "totEvents": 25136, 
+                "weights": 25136.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24799, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_26.root", 
+                "nevents": 24799, 
+                "totEvents": 24799, 
+                "weights": 24799.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24780, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_623.root", 
+                "nevents": 24780, 
+                "totEvents": 24780, 
+                "weights": 24780.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25093, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_6.root", 
+                "nevents": 25093, 
+                "totEvents": 25093, 
+                "weights": 25093.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24990, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_622.root", 
+                "nevents": 24990, 
+                "totEvents": 24990, 
+                "weights": 24990.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25048, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_350.root", 
+                "nevents": 25048, 
+                "totEvents": 25048, 
+                "weights": 25048.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25116, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_643.root", 
+                "nevents": 25116, 
+                "totEvents": 25116, 
+                "weights": 25116.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24980, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_415.root", 
+                "nevents": 24980, 
+                "totEvents": 24980, 
+                "weights": 24980.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25030, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_496.root", 
+                "nevents": 25030, 
+                "totEvents": 25030, 
+                "weights": 25030.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25062, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_333.root", 
+                "nevents": 25062, 
+                "totEvents": 25062, 
+                "weights": 25062.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24859, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_98.root", 
+                "nevents": 24859, 
+                "totEvents": 24859, 
+                "weights": 24859.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24992, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_144.root", 
+                "nevents": 24992, 
+                "totEvents": 24992, 
+                "weights": 24992.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24801, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_92.root", 
+                "nevents": 24801, 
+                "totEvents": 24801, 
+                "weights": 24801.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24868, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_641.root", 
+                "nevents": 24868, 
+                "totEvents": 24868, 
+                "weights": 24868.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24990, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_118.root", 
+                "nevents": 24990, 
+                "totEvents": 24990, 
+                "weights": 24990.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24965, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_343.root", 
+                "nevents": 24965, 
+                "totEvents": 24965, 
+                "weights": 24965.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24932, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_328.root", 
+                "nevents": 24932, 
+                "totEvents": 24932, 
+                "weights": 24932.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24965, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_614.root", 
+                "nevents": 24965, 
+                "totEvents": 24965, 
+                "weights": 24965.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25036, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_30.root", 
+                "nevents": 25036, 
+                "totEvents": 25036, 
+                "weights": 25036.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25126, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_389.root", 
+                "nevents": 25126, 
+                "totEvents": 25126, 
+                "weights": 25126.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25057, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_390.root", 
+                "nevents": 25057, 
+                "totEvents": 25057, 
+                "weights": 25057.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24965, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_176.root", 
+                "nevents": 24965, 
+                "totEvents": 24965, 
+                "weights": 24965.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25158, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_402.root", 
+                "nevents": 25158, 
+                "totEvents": 25158, 
+                "weights": 25158.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25172, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_656.root", 
+                "nevents": 25172, 
+                "totEvents": 25172, 
+                "weights": 25172.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25002, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_520.root", 
+                "nevents": 25002, 
+                "totEvents": 25002, 
+                "weights": 25002.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24833, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_116.root", 
+                "nevents": 24833, 
+                "totEvents": 24833, 
+                "weights": 24833.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25239, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_454.root", 
+                "nevents": 25239, 
+                "totEvents": 25239, 
+                "weights": 25239.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25091, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_47.root", 
+                "nevents": 25091, 
+                "totEvents": 25091, 
+                "weights": 25091.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25064, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_149.root", 
+                "nevents": 25064, 
+                "totEvents": 25064, 
+                "weights": 25064.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24874, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_2.root", 
+                "nevents": 24874, 
+                "totEvents": 24874, 
+                "weights": 24874.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25126, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_168.root", 
+                "nevents": 25126, 
+                "totEvents": 25126, 
+                "weights": 25126.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24849, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_24.root", 
+                "nevents": 24849, 
+                "totEvents": 24849, 
+                "weights": 24849.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25180, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_129.root", 
+                "nevents": 25180, 
+                "totEvents": 25180, 
+                "weights": 25180.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24995, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_36.root", 
+                "nevents": 24995, 
+                "totEvents": 24995, 
+                "weights": 24995.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24815, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_42.root", 
+                "nevents": 24815, 
+                "totEvents": 24815, 
+                "weights": 24815.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25111, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_218.root", 
+                "nevents": 25111, 
+                "totEvents": 25111, 
+                "weights": 25111.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24861, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_600.root", 
+                "nevents": 24861, 
+                "totEvents": 24861, 
+                "weights": 24861.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25190, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_419.root", 
+                "nevents": 25190, 
+                "totEvents": 25190, 
+                "weights": 25190.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25228, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_598.root", 
+                "nevents": 25228, 
+                "totEvents": 25228, 
+                "weights": 25228.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25072, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_264.root", 
+                "nevents": 25072, 
+                "totEvents": 25072, 
+                "weights": 25072.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25080, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_93.root", 
+                "nevents": 25080, 
+                "totEvents": 25080, 
+                "weights": 25080.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25136, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_121.root", 
+                "nevents": 25136, 
+                "totEvents": 25136, 
+                "weights": 25136.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25059, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_167.root", 
+                "nevents": 25059, 
+                "totEvents": 25059, 
+                "weights": 25059.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_289.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 25000.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25033, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_162.root", 
+                "nevents": 25033, 
+                "totEvents": 25033, 
+                "weights": 25033.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24927, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_367.root", 
+                "nevents": 24927, 
+                "totEvents": 24927, 
+                "weights": 24927.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25113, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_57.root", 
+                "nevents": 25113, 
+                "totEvents": 25113, 
+                "weights": 25113.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24986, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_386.root", 
+                "nevents": 24986, 
+                "totEvents": 24986, 
+                "weights": 24986.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24700, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_70.root", 
+                "nevents": 24700, 
+                "totEvents": 24700, 
+                "weights": 24700.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25059, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_114.root", 
+                "nevents": 25059, 
+                "totEvents": 25059, 
+                "weights": 25059.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24924, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_627.root", 
+                "nevents": 24924, 
+                "totEvents": 24924, 
+                "weights": 24924.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25122, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_135.root", 
+                "nevents": 25122, 
+                "totEvents": 25122, 
+                "weights": 25122.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25206, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_231.root", 
+                "nevents": 25206, 
+                "totEvents": 25206, 
+                "weights": 25206.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24847, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_284.root", 
+                "nevents": 24847, 
+                "totEvents": 24847, 
+                "weights": 24847.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25026, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_427.root", 
+                "nevents": 25026, 
+                "totEvents": 25026, 
+                "weights": 25026.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25224, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_393.root", 
+                "nevents": 25224, 
+                "totEvents": 25224, 
+                "weights": 25224.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24912, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_630.root", 
+                "nevents": 24912, 
+                "totEvents": 24912, 
+                "weights": 24912.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25038, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_260.root", 
+                "nevents": 25038, 
+                "totEvents": 25038, 
+                "weights": 25038.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25181, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_449.root", 
+                "nevents": 25181, 
+                "totEvents": 25181, 
+                "weights": 25181.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24883, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_72.root", 
+                "nevents": 24883, 
+                "totEvents": 24883, 
+                "weights": 24883.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25142, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_338.root", 
+                "nevents": 25142, 
+                "totEvents": 25142, 
+                "weights": 25142.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24748, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_14.root", 
+                "nevents": 24748, 
+                "totEvents": 24748, 
+                "weights": 24748.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24837, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_224.root", 
+                "nevents": 24837, 
+                "totEvents": 24837, 
+                "weights": 24837.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24969, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_412.root", 
+                "nevents": 24969, 
+                "totEvents": 24969, 
+                "weights": 24969.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_51.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 25000.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25155, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_634.root", 
+                "nevents": 25155, 
+                "totEvents": 25155, 
+                "weights": 25155.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25173, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_408.root", 
+                "nevents": 25173, 
+                "totEvents": 25173, 
+                "weights": 25173.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25144, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_596.root", 
+                "nevents": 25144, 
+                "totEvents": 25144, 
+                "weights": 25144.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24889, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_453.root", 
+                "nevents": 24889, 
+                "totEvents": 24889, 
+                "weights": 24889.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24873, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_359.root", 
+                "nevents": 24873, 
+                "totEvents": 24873, 
+                "weights": 24873.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25131, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_323.root", 
+                "nevents": 25131, 
+                "totEvents": 25131, 
+                "weights": 25131.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24960, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_40.root", 
+                "nevents": 24960, 
+                "totEvents": 24960, 
+                "weights": 24960.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25163, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_602.root", 
+                "nevents": 25163, 
+                "totEvents": 25163, 
+                "weights": 25163.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24988, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_639.root", 
+                "nevents": 24988, 
+                "totEvents": 24988, 
+                "weights": 24988.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25041, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_378.root", 
+                "nevents": 25041, 
+                "totEvents": 25041, 
+                "weights": 25041.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25008, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_126.root", 
+                "nevents": 25008, 
+                "totEvents": 25008, 
+                "weights": 25008.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24918, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_469.root", 
+                "nevents": 24918, 
+                "totEvents": 24918, 
+                "weights": 24918.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24790, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_613.root", 
+                "nevents": 24790, 
+                "totEvents": 24790, 
+                "weights": 24790.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25098, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_652.root", 
+                "nevents": 25098, 
+                "totEvents": 25098, 
+                "weights": 25098.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24951, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_18.root", 
+                "nevents": 24951, 
+                "totEvents": 24951, 
+                "weights": 24951.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24936, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_371.root", 
+                "nevents": 24936, 
+                "totEvents": 24936, 
+                "weights": 24936.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24836, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_143.root", 
+                "nevents": 24836, 
+                "totEvents": 24836, 
+                "weights": 24836.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25025, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_345.root", 
+                "nevents": 25025, 
+                "totEvents": 25025, 
+                "weights": 25025.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24888, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_601.root", 
+                "nevents": 24888, 
+                "totEvents": 24888, 
+                "weights": 24888.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25050, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_234.root", 
+                "nevents": 25050, 
+                "totEvents": 25050, 
+                "weights": 25050.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24968, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_396.root", 
+                "nevents": 24968, 
+                "totEvents": 24968, 
+                "weights": 24968.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25036, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_115.root", 
+                "nevents": 25036, 
+                "totEvents": 25036, 
+                "weights": 25036.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24917, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_374.root", 
+                "nevents": 24917, 
+                "totEvents": 24917, 
+                "weights": 24917.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25383, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_625.root", 
+                "nevents": 25383, 
+                "totEvents": 25383, 
+                "weights": 25383.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25078, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_384.root", 
+                "nevents": 25078, 
+                "totEvents": 25078, 
+                "weights": 25078.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24954, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_10.root", 
+                "nevents": 24954, 
+                "totEvents": 24954, 
+                "weights": 24954.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24966, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_391.root", 
+                "nevents": 24966, 
+                "totEvents": 24966, 
+                "weights": 24966.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24741, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_166.root", 
+                "nevents": 24741, 
+                "totEvents": 24741, 
+                "weights": 24741.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24916, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_99.root", 
+                "nevents": 24916, 
+                "totEvents": 24916, 
+                "weights": 24916.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24987, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_495.root", 
+                "nevents": 24987, 
+                "totEvents": 24987, 
+                "weights": 24987.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24844, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_640.root", 
+                "nevents": 24844, 
+                "totEvents": 24844, 
+                "weights": 24844.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25024, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_381.root", 
+                "nevents": 25024, 
+                "totEvents": 25024, 
+                "weights": 25024.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25020, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_316.root", 
+                "nevents": 25020, 
+                "totEvents": 25020, 
+                "weights": 25020.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24985, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_460.root", 
+                "nevents": 24985, 
+                "totEvents": 24985, 
+                "weights": 24985.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24972, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_164.root", 
+                "nevents": 24972, 
+                "totEvents": 24972, 
+                "weights": 24972.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25122, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_243.root", 
+                "nevents": 25122, 
+                "totEvents": 25122, 
+                "weights": 25122.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24819, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_59.root", 
+                "nevents": 24819, 
+                "totEvents": 24819, 
+                "weights": 24819.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24760, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_447.root", 
+                "nevents": 24760, 
+                "totEvents": 24760, 
+                "weights": 24760.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24976, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_470.root", 
+                "nevents": 24976, 
+                "totEvents": 24976, 
+                "weights": 24976.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24874, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_452.root", 
+                "nevents": 24874, 
+                "totEvents": 24874, 
+                "weights": 24874.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24802, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_373.root", 
+                "nevents": 24802, 
+                "totEvents": 24802, 
+                "weights": 24802.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24984, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_165.root", 
+                "nevents": 24984, 
+                "totEvents": 24984, 
+                "weights": 24984.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25096, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_268.root", 
+                "nevents": 25096, 
+                "totEvents": 25096, 
+                "weights": 25096.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25111, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_199.root", 
+                "nevents": 25111, 
+                "totEvents": 25111, 
+                "weights": 25111.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24985, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_273.root", 
+                "nevents": 24985, 
+                "totEvents": 24985, 
+                "weights": 24985.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24684, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_302.root", 
+                "nevents": 24684, 
+                "totEvents": 24684, 
+                "weights": 24684.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25075, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_102.root", 
+                "nevents": 25075, 
+                "totEvents": 25075, 
+                "weights": 25075.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24929, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_443.root", 
+                "nevents": 24929, 
+                "totEvents": 24929, 
+                "weights": 24929.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24874, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_108.root", 
+                "nevents": 24874, 
+                "totEvents": 24874, 
+                "weights": 24874.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24950, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_346.root", 
+                "nevents": 24950, 
+                "totEvents": 24950, 
+                "weights": 24950.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25069, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_300.root", 
+                "nevents": 25069, 
+                "totEvents": 25069, 
+                "weights": 25069.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25011, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_113.root", 
+                "nevents": 25011, 
+                "totEvents": 25011, 
+                "weights": 25011.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24729, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_604.root", 
+                "nevents": 24729, 
+                "totEvents": 24729, 
+                "weights": 24729.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24848, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_313.root", 
+                "nevents": 24848, 
+                "totEvents": 24848, 
+                "weights": 24848.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24771, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_661.root", 
+                "nevents": 24771, 
+                "totEvents": 24771, 
+                "weights": 24771.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24885, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_11.root", 
+                "nevents": 24885, 
+                "totEvents": 24885, 
+                "weights": 24885.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25078, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_314.root", 
+                "nevents": 25078, 
+                "totEvents": 25078, 
+                "weights": 25078.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24843, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_274.root", 
+                "nevents": 24843, 
+                "totEvents": 24843, 
+                "weights": 24843.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24927, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_198.root", 
+                "nevents": 24927, 
+                "totEvents": 24927, 
+                "weights": 24927.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24907, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_405.root", 
+                "nevents": 24907, 
+                "totEvents": 24907, 
+                "weights": 24907.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25020, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_629.root", 
+                "nevents": 25020, 
+                "totEvents": 25020, 
+                "weights": 25020.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25186, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_475.root", 
+                "nevents": 25186, 
+                "totEvents": 25186, 
+                "weights": 25186.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25359, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_242.root", 
+                "nevents": 25359, 
+                "totEvents": 25359, 
+                "weights": 25359.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24946, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_311.root", 
+                "nevents": 24946, 
+                "totEvents": 24946, 
+                "weights": 24946.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24987, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_184.root", 
+                "nevents": 24987, 
+                "totEvents": 24987, 
+                "weights": 24987.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25120, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_556.root", 
+                "nevents": 25120, 
+                "totEvents": 25120, 
+                "weights": 25120.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24978, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_626.root", 
+                "nevents": 24978, 
+                "totEvents": 24978, 
+                "weights": 24978.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25201, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_123.root", 
+                "nevents": 25201, 
+                "totEvents": 25201, 
+                "weights": 25201.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24986, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_157.root", 
+                "nevents": 24986, 
+                "totEvents": 24986, 
+                "weights": 24986.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25192, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_331.root", 
+                "nevents": 25192, 
+                "totEvents": 25192, 
+                "weights": 25192.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25117, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_112.root", 
+                "nevents": 25117, 
+                "totEvents": 25117, 
+                "weights": 25117.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25096, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_377.root", 
+                "nevents": 25096, 
+                "totEvents": 25096, 
+                "weights": 25096.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24947, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_297.root", 
+                "nevents": 24947, 
+                "totEvents": 24947, 
+                "weights": 24947.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25122, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_233.root", 
+                "nevents": 25122, 
+                "totEvents": 25122, 
+                "weights": 25122.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25076, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_344.root", 
+                "nevents": 25076, 
+                "totEvents": 25076, 
+                "weights": 25076.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24973, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_633.root", 
+                "nevents": 24973, 
+                "totEvents": 24973, 
+                "weights": 24973.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24959, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_382.root", 
+                "nevents": 24959, 
+                "totEvents": 24959, 
+                "weights": 24959.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25126, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_628.root", 
+                "nevents": 25126, 
+                "totEvents": 25126, 
+                "weights": 25126.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24888, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_380.root", 
+                "nevents": 24888, 
+                "totEvents": 24888, 
+                "weights": 24888.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25046, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_366.root", 
+                "nevents": 25046, 
+                "totEvents": 25046, 
+                "weights": 25046.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24940, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_325.root", 
+                "nevents": 24940, 
+                "totEvents": 24940, 
+                "weights": 24940.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24914, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_352.root", 
+                "nevents": 24914, 
+                "totEvents": 24914, 
+                "weights": 24914.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24804, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_620.root", 
+                "nevents": 24804, 
+                "totEvents": 24804, 
+                "weights": 24804.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25069, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_128.root", 
+                "nevents": 25069, 
+                "totEvents": 25069, 
+                "weights": 25069.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25219, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_186.root", 
+                "nevents": 25219, 
+                "totEvents": 25219, 
+                "weights": 25219.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24766, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_187.root", 
+                "nevents": 24766, 
+                "totEvents": 24766, 
+                "weights": 24766.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25265, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_347.root", 
+                "nevents": 25265, 
+                "totEvents": 25265, 
+                "weights": 25265.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24923, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_196.root", 
+                "nevents": 24923, 
+                "totEvents": 24923, 
+                "weights": 24923.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24956, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_482.root", 
+                "nevents": 24956, 
+                "totEvents": 24956, 
+                "weights": 24956.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24991, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_269.root", 
+                "nevents": 24991, 
+                "totEvents": 24991, 
+                "weights": 24991.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24808, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_327.root", 
+                "nevents": 24808, 
+                "totEvents": 24808, 
+                "weights": 24808.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24806, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_318.root", 
+                "nevents": 24806, 
+                "totEvents": 24806, 
+                "weights": 24806.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24966, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_329.root", 
+                "nevents": 24966, 
+                "totEvents": 24966, 
+                "weights": 24966.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24928, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_105.root", 
+                "nevents": 24928, 
+                "totEvents": 24928, 
+                "weights": 24928.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25103, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_651.root", 
+                "nevents": 25103, 
+                "totEvents": 25103, 
+                "weights": 25103.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25044, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_462.root", 
+                "nevents": 25044, 
+                "totEvents": 25044, 
+                "weights": 25044.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24917, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_559.root", 
+                "nevents": 24917, 
+                "totEvents": 24917, 
+                "weights": 24917.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24887, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_647.root", 
+                "nevents": 24887, 
+                "totEvents": 24887, 
+                "weights": 24887.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25024, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_637.root", 
+                "nevents": 25024, 
+                "totEvents": 25024, 
+                "weights": 25024.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25007, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_413.root", 
+                "nevents": 25007, 
+                "totEvents": 25007, 
+                "weights": 25007.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25038, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_552.root", 
+                "nevents": 25038, 
+                "totEvents": 25038, 
+                "weights": 25038.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24909, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_213.root", 
+                "nevents": 24909, 
+                "totEvents": 24909, 
+                "weights": 24909.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24967, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_642.root", 
+                "nevents": 24967, 
+                "totEvents": 24967, 
+                "weights": 24967.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24882, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_392.root", 
+                "nevents": 24882, 
+                "totEvents": 24882, 
+                "weights": 24882.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25026, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_654.root", 
+                "nevents": 25026, 
+                "totEvents": 25026, 
+                "weights": 25026.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24985, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_526.root", 
+                "nevents": 24985, 
+                "totEvents": 24985, 
+                "weights": 24985.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24903, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_510.root", 
+                "nevents": 24903, 
+                "totEvents": 24903, 
+                "weights": 24903.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24981, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_49.root", 
+                "nevents": 24981, 
+                "totEvents": 24981, 
+                "weights": 24981.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25111, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_203.root", 
+                "nevents": 25111, 
+                "totEvents": 25111, 
+                "weights": 25111.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24733, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_364.root", 
+                "nevents": 24733, 
+                "totEvents": 24733, 
+                "weights": 24733.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25109, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_201.root", 
+                "nevents": 25109, 
+                "totEvents": 25109, 
+                "weights": 25109.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24810, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_657.root", 
+                "nevents": 24810, 
+                "totEvents": 24810, 
+                "weights": 24810.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24854, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_244.root", 
+                "nevents": 24854, 
+                "totEvents": 24854, 
+                "weights": 24854.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24972, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_553.root", 
+                "nevents": 24972, 
+                "totEvents": 24972, 
+                "weights": 24972.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24949, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_246.root", 
+                "nevents": 24949, 
+                "totEvents": 24949, 
+                "weights": 24949.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24745, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_209.root", 
+                "nevents": 24745, 
+                "totEvents": 24745, 
+                "weights": 24745.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24875, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_561.root", 
+                "nevents": 24875, 
+                "totEvents": 24875, 
+                "weights": 24875.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25021, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_539.root", 
+                "nevents": 25021, 
+                "totEvents": 25021, 
+                "weights": 25021.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24957, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_175.root", 
+                "nevents": 24957, 
+                "totEvents": 24957, 
+                "weights": 24957.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24985, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_3.root", 
+                "nevents": 24985, 
+                "totEvents": 24985, 
+                "weights": 24985.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24990, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_618.root", 
+                "nevents": 24990, 
+                "totEvents": 24990, 
+                "weights": 24990.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25273, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_375.root", 
+                "nevents": 25273, 
+                "totEvents": 25273, 
+                "weights": 25273.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25102, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_296.root", 
+                "nevents": 25102, 
+                "totEvents": 25102, 
+                "weights": 25102.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24845, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_275.root", 
+                "nevents": 24845, 
+                "totEvents": 24845, 
+                "weights": 24845.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24758, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_649.root", 
+                "nevents": 24758, 
+                "totEvents": 24758, 
+                "weights": 24758.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25083, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_591.root", 
+                "nevents": 25083, 
+                "totEvents": 25083, 
+                "weights": 25083.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25132, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_385.root", 
+                "nevents": 25132, 
+                "totEvents": 25132, 
+                "weights": 25132.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25104, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_383.root", 
+                "nevents": 25104, 
+                "totEvents": 25104, 
+                "weights": 25104.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24802, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_609.root", 
+                "nevents": 24802, 
+                "totEvents": 24802, 
+                "weights": 24802.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24927, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_145.root", 
+                "nevents": 24927, 
+                "totEvents": 24927, 
+                "weights": 24927.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25076, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_407.root", 
+                "nevents": 25076, 
+                "totEvents": 25076, 
+                "weights": 25076.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25124, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_7.root", 
+                "nevents": 25124, 
+                "totEvents": 25124, 
+                "weights": 25124.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24848, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_474.root", 
+                "nevents": 24848, 
+                "totEvents": 24848, 
+                "weights": 24848.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24718, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_398.root", 
+                "nevents": 24718, 
+                "totEvents": 24718, 
+                "weights": 24718.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24809, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_624.root", 
+                "nevents": 24809, 
+                "totEvents": 24809, 
+                "weights": 24809.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25094, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_71.root", 
+                "nevents": 25094, 
+                "totEvents": 25094, 
+                "weights": 25094.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25195, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_148.root", 
+                "nevents": 25195, 
+                "totEvents": 25195, 
+                "weights": 25195.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24888, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_513.root", 
+                "nevents": 24888, 
+                "totEvents": 24888, 
+                "weights": 24888.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25048, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_418.root", 
+                "nevents": 25048, 
+                "totEvents": 25048, 
+                "weights": 25048.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25194, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_96.root", 
+                "nevents": 25194, 
+                "totEvents": 25194, 
+                "weights": 25194.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25063, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_226.root", 
+                "nevents": 25063, 
+                "totEvents": 25063, 
+                "weights": 25063.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24999, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_423.root", 
+                "nevents": 24999, 
+                "totEvents": 24999, 
+                "weights": 24999.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25103, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_29.root", 
+                "nevents": 25103, 
+                "totEvents": 25103, 
+                "weights": 25103.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24975, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_607.root", 
+                "nevents": 24975, 
+                "totEvents": 24975, 
+                "weights": 24975.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25220, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_227.root", 
+                "nevents": 25220, 
+                "totEvents": 25220, 
+                "weights": 25220.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24934, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_35.root", 
+                "nevents": 24934, 
+                "totEvents": 24934, 
+                "weights": 24934.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24840, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_451.root", 
+                "nevents": 24840, 
+                "totEvents": 24840, 
+                "weights": 24840.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24904, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_425.root", 
+                "nevents": 24904, 
+                "totEvents": 24904, 
+                "weights": 24904.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25034, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_426.root", 
+                "nevents": 25034, 
+                "totEvents": 25034, 
+                "weights": 25034.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25074, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_592.root", 
+                "nevents": 25074, 
+                "totEvents": 25074, 
+                "weights": 25074.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25152, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_257.root", 
+                "nevents": 25152, 
+                "totEvents": 25152, 
+                "weights": 25152.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25060, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_568.root", 
+                "nevents": 25060, 
+                "totEvents": 25060, 
+                "weights": 25060.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25408, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_439.root", 
+                "nevents": 25408, 
+                "totEvents": 25408, 
+                "weights": 25408.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24879, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_251.root", 
+                "nevents": 24879, 
+                "totEvents": 24879, 
+                "weights": 24879.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24742, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_254.root", 
+                "nevents": 24742, 
+                "totEvents": 24742, 
+                "weights": 24742.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25117, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_81.root", 
+                "nevents": 25117, 
+                "totEvents": 25117, 
+                "weights": 25117.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24918, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_25.root", 
+                "nevents": 24918, 
+                "totEvents": 24918, 
+                "weights": 24918.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24937, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_497.root", 
+                "nevents": 24937, 
+                "totEvents": 24937, 
+                "weights": 24937.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24742, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_597.root", 
+                "nevents": 24742, 
+                "totEvents": 24742, 
+                "weights": 24742.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25314, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_21.root", 
+                "nevents": 25314, 
+                "totEvents": 25314, 
+                "weights": 25314.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25088, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_33.root", 
+                "nevents": 25088, 
+                "totEvents": 25088, 
+                "weights": 25088.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25030, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_636.root", 
+                "nevents": 25030, 
+                "totEvents": 25030, 
+                "weights": 25030.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25017, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_169.root", 
+                "nevents": 25017, 
+                "totEvents": 25017, 
+                "weights": 25017.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24964, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_259.root", 
+                "nevents": 24964, 
+                "totEvents": 24964, 
+                "weights": 24964.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24838, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_217.root", 
+                "nevents": 24838, 
+                "totEvents": 24838, 
+                "weights": 24838.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24775, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_290.root", 
+                "nevents": 24775, 
+                "totEvents": 24775, 
+                "weights": 24775.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24892, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_17.root", 
+                "nevents": 24892, 
+                "totEvents": 24892, 
+                "weights": 24892.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25033, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_292.root", 
+                "nevents": 25033, 
+                "totEvents": 25033, 
+                "weights": 25033.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25096, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_31.root", 
+                "nevents": 25096, 
+                "totEvents": 25096, 
+                "weights": 25096.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24927, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_593.root", 
+                "nevents": 24927, 
+                "totEvents": 24927, 
+                "weights": 24927.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25083, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_63.root", 
+                "nevents": 25083, 
+                "totEvents": 25083, 
+                "weights": 25083.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25055, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_147.root", 
+                "nevents": 25055, 
+                "totEvents": 25055, 
+                "weights": 25055.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24809, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_56.root", 
+                "nevents": 24809, 
+                "totEvents": 24809, 
+                "weights": 24809.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25056, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_483.root", 
+                "nevents": 25056, 
+                "totEvents": 25056, 
+                "weights": 25056.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25026, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_91.root", 
+                "nevents": 25026, 
+                "totEvents": 25026, 
+                "weights": 25026.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24985, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_606.root", 
+                "nevents": 24985, 
+                "totEvents": 24985, 
+                "weights": 24985.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25030, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_222.root", 
+                "nevents": 25030, 
+                "totEvents": 25030, 
+                "weights": 25030.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24965, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_417.root", 
+                "nevents": 24965, 
+                "totEvents": 24965, 
+                "weights": 24965.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24799, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_414.root", 
+                "nevents": 24799, 
+                "totEvents": 24799, 
+                "weights": 24799.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_37.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 25000.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24525, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_271.root", 
+                "nevents": 24525, 
+                "totEvents": 24525, 
+                "weights": 24525.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24870, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_27.root", 
+                "nevents": 24870, 
+                "totEvents": 24870, 
+                "weights": 24870.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25112, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_348.root", 
+                "nevents": 25112, 
+                "totEvents": 25112, 
+                "weights": 25112.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25262, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_22.root", 
+                "nevents": 25262, 
+                "totEvents": 25262, 
+                "weights": 25262.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24971, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_420.root", 
+                "nevents": 24971, 
+                "totEvents": 24971, 
+                "weights": 24971.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24664, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_28.root", 
+                "nevents": 24664, 
+                "totEvents": 24664, 
+                "weights": 24664.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25176, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_358.root", 
+                "nevents": 25176, 
+                "totEvents": 25176, 
+                "weights": 25176.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25295, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_360.root", 
+                "nevents": 25295, 
+                "totEvents": 25295, 
+                "weights": 25295.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24931, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_421.root", 
+                "nevents": 24931, 
+                "totEvents": 24931, 
+                "weights": 24931.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25055, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_125.root", 
+                "nevents": 25055, 
+                "totEvents": 25055, 
+                "weights": 25055.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24997, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_12.root", 
+                "nevents": 24997, 
+                "totEvents": 24997, 
+                "weights": 24997.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25161, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_632.root", 
+                "nevents": 25161, 
+                "totEvents": 25161, 
+                "weights": 25161.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25024, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_104.root", 
+                "nevents": 25024, 
+                "totEvents": 25024, 
+                "weights": 25024.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25091, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_457.root", 
+                "nevents": 25091, 
+                "totEvents": 25091, 
+                "weights": 25091.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24938, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_256.root", 
+                "nevents": 24938, 
+                "totEvents": 24938, 
+                "weights": 24938.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24943, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_294.root", 
+                "nevents": 24943, 
+                "totEvents": 24943, 
+                "weights": 24943.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25255, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_616.root", 
+                "nevents": 25255, 
+                "totEvents": 25255, 
+                "weights": 25255.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24982, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_523.root", 
+                "nevents": 24982, 
+                "totEvents": 24982, 
+                "weights": 24982.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25109, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_472.root", 
+                "nevents": 25109, 
+                "totEvents": 25109, 
+                "weights": 25109.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24937, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_193.root", 
+                "nevents": 24937, 
+                "totEvents": 24937, 
+                "weights": 24937.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25004, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_179.root", 
+                "nevents": 25004, 
+                "totEvents": 25004, 
+                "weights": 25004.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24953, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_223.root", 
+                "nevents": 24953, 
+                "totEvents": 24953, 
+                "weights": 24953.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25101, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_517.root", 
+                "nevents": 25101, 
+                "totEvents": 25101, 
+                "weights": 25101.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24986, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_540.root", 
+                "nevents": 24986, 
+                "totEvents": 24986, 
+                "weights": 24986.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24844, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_54.root", 
+                "nevents": 24844, 
+                "totEvents": 24844, 
+                "weights": 24844.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24899, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_512.root", 
+                "nevents": 24899, 
+                "totEvents": 24899, 
+                "weights": 24899.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24831, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_305.root", 
+                "nevents": 24831, 
+                "totEvents": 24831, 
+                "weights": 24831.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24732, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_304.root", 
+                "nevents": 24732, 
+                "totEvents": 24732, 
+                "weights": 24732.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24840, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_401.root", 
+                "nevents": 24840, 
+                "totEvents": 24840, 
+                "weights": 24840.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25027, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_363.root", 
+                "nevents": 25027, 
+                "totEvents": 25027, 
+                "weights": 25027.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25037, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_337.root", 
+                "nevents": 25037, 
+                "totEvents": 25037, 
+                "weights": 25037.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25063, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_404.root", 
+                "nevents": 25063, 
+                "totEvents": 25063, 
+                "weights": 25063.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25189, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_119.root", 
+                "nevents": 25189, 
+                "totEvents": 25189, 
+                "weights": 25189.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25142, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_416.root", 
+                "nevents": 25142, 
+                "totEvents": 25142, 
+                "weights": 25142.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25051, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_560.root", 
+                "nevents": 25051, 
+                "totEvents": 25051, 
+                "weights": 25051.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25074, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_511.root", 
+                "nevents": 25074, 
+                "totEvents": 25074, 
+                "weights": 25074.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25074, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_76.root", 
+                "nevents": 25074, 
+                "totEvents": 25074, 
+                "weights": 25074.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24827, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_503.root", 
+                "nevents": 24827, 
+                "totEvents": 24827, 
+                "weights": 24827.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25163, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_525.root", 
+                "nevents": 25163, 
+                "totEvents": 25163, 
+                "weights": 25163.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24894, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_532.root", 
+                "nevents": 24894, 
+                "totEvents": 24894, 
+                "weights": 24894.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25110, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_50.root", 
+                "nevents": 25110, 
+                "totEvents": 25110, 
+                "weights": 25110.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24988, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_272.root", 
+                "nevents": 24988, 
+                "totEvents": 24988, 
+                "weights": 24988.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25099, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_39.root", 
+                "nevents": 25099, 
+                "totEvents": 25099, 
+                "weights": 25099.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24948, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_45.root", 
+                "nevents": 24948, 
+                "totEvents": 24948, 
+                "weights": 24948.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24788, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_20.root", 
+                "nevents": 24788, 
+                "totEvents": 24788, 
+                "weights": 24788.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24935, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_151.root", 
+                "nevents": 24935, 
+                "totEvents": 24935, 
+                "weights": 24935.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24949, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_43.root", 
+                "nevents": 24949, 
+                "totEvents": 24949, 
+                "weights": 24949.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25016, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_403.root", 
+                "nevents": 25016, 
+                "totEvents": 25016, 
+                "weights": 25016.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24915, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_321.root", 
+                "nevents": 24915, 
+                "totEvents": 24915, 
+                "weights": 24915.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24925, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_356.root", 
+                "nevents": 24925, 
+                "totEvents": 24925, 
+                "weights": 24925.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24941, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_444.root", 
+                "nevents": 24941, 
+                "totEvents": 24941, 
+                "weights": 24941.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24971, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_621.root", 
+                "nevents": 24971, 
+                "totEvents": 24971, 
+                "weights": 24971.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24802, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_594.root", 
+                "nevents": 24802, 
+                "totEvents": 24802, 
+                "weights": 24802.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24949, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_141.root", 
+                "nevents": 24949, 
+                "totEvents": 24949, 
+                "weights": 24949.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24969, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_518.root", 
+                "nevents": 24969, 
+                "totEvents": 24969, 
+                "weights": 24969.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25062, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_349.root", 
+                "nevents": 25062, 
+                "totEvents": 25062, 
+                "weights": 25062.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25276, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_195.root", 
+                "nevents": 25276, 
+                "totEvents": 25276, 
+                "weights": 25276.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25022, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_317.root", 
+                "nevents": 25022, 
+                "totEvents": 25022, 
+                "weights": 25022.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25010, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_270.root", 
+                "nevents": 25010, 
+                "totEvents": 25010, 
+                "weights": 25010.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25029, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_68.root", 
+                "nevents": 25029, 
+                "totEvents": 25029, 
+                "weights": 25029.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25199, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_571.root", 
+                "nevents": 25199, 
+                "totEvents": 25199, 
+                "weights": 25199.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25098, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_644.root", 
+                "nevents": 25098, 
+                "totEvents": 25098, 
+                "weights": 25098.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24981, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_650.root", 
+                "nevents": 24981, 
+                "totEvents": 24981, 
+                "weights": 24981.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24798, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_566.root", 
+                "nevents": 24798, 
+                "totEvents": 24798, 
+                "weights": 24798.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24954, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_441.root", 
+                "nevents": 24954, 
+                "totEvents": 24954, 
+                "weights": 24954.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25062, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_476.root", 
+                "nevents": 25062, 
+                "totEvents": 25062, 
+                "weights": 25062.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25078, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_527.root", 
+                "nevents": 25078, 
+                "totEvents": 25078, 
+                "weights": 25078.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24971, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_395.root", 
+                "nevents": 24971, 
+                "totEvents": 24971, 
+                "weights": 24971.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24825, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_542.root", 
+                "nevents": 24825, 
+                "totEvents": 24825, 
+                "weights": 24825.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24967, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_334.root", 
+                "nevents": 24967, 
+                "totEvents": 24967, 
+                "weights": 24967.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25130, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_455.root", 
+                "nevents": 25130, 
+                "totEvents": 25130, 
+                "weights": 25130.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25286, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_95.root", 
+                "nevents": 25286, 
+                "totEvents": 25286, 
+                "weights": 25286.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24808, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_435.root", 
+                "nevents": 24808, 
+                "totEvents": 24808, 
+                "weights": 24808.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24957, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_394.root", 
+                "nevents": 24957, 
+                "totEvents": 24957, 
+                "weights": 24957.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25091, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_648.root", 
+                "nevents": 25091, 
+                "totEvents": 25091, 
+                "weights": 25091.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25314, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_468.root", 
+                "nevents": 25314, 
+                "totEvents": 25314, 
+                "weights": 25314.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25068, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_110.root", 
+                "nevents": 25068, 
+                "totEvents": 25068, 
+                "weights": 25068.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25180, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_486.root", 
+                "nevents": 25180, 
+                "totEvents": 25180, 
+                "weights": 25180.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24841, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_501.root", 
+                "nevents": 24841, 
+                "totEvents": 24841, 
+                "weights": 24841.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25081, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_505.root", 
+                "nevents": 25081, 
+                "totEvents": 25081, 
+                "weights": 25081.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25178, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_658.root", 
+                "nevents": 25178, 
+                "totEvents": 25178, 
+                "weights": 25178.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24963, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_502.root", 
+                "nevents": 24963, 
+                "totEvents": 24963, 
+                "weights": 24963.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24782, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_376.root", 
+                "nevents": 24782, 
+                "totEvents": 24782, 
+                "weights": 24782.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24983, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_516.root", 
+                "nevents": 24983, 
+                "totEvents": 24983, 
+                "weights": 24983.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25069, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_450.root", 
+                "nevents": 25069, 
+                "totEvents": 25069, 
+                "weights": 25069.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25242, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_1.root", 
+                "nevents": 25242, 
+                "totEvents": 25242, 
+                "weights": 25242.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25056, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_466.root", 
+                "nevents": 25056, 
+                "totEvents": 25056, 
+                "weights": 25056.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25121, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_94.root", 
+                "nevents": 25121, 
+                "totEvents": 25121, 
+                "weights": 25121.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25113, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_5.root", 
+                "nevents": 25113, 
+                "totEvents": 25113, 
+                "weights": 25113.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24758, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_335.root", 
+                "nevents": 24758, 
+                "totEvents": 24758, 
+                "weights": 24758.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24946, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_471.root", 
+                "nevents": 24946, 
+                "totEvents": 24946, 
+                "weights": 24946.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25007, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_153.root", 
+                "nevents": 25007, 
+                "totEvents": 25007, 
+                "weights": 25007.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25052, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_500.root", 
+                "nevents": 25052, 
+                "totEvents": 25052, 
+                "weights": 25052.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24833, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_160.root", 
+                "nevents": 24833, 
+                "totEvents": 24833, 
+                "weights": 24833.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25025, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_117.root", 
+                "nevents": 25025, 
+                "totEvents": 25025, 
+                "weights": 25025.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24892, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_140.root", 
+                "nevents": 24892, 
+                "totEvents": 24892, 
+                "weights": 24892.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25074, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_477.root", 
+                "nevents": 25074, 
+                "totEvents": 25074, 
+                "weights": 25074.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25206, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_136.root", 
+                "nevents": 25206, 
+                "totEvents": 25206, 
+                "weights": 25206.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24845, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_124.root", 
+                "nevents": 24845, 
+                "totEvents": 24845, 
+                "weights": 24845.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25088, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_130.root", 
+                "nevents": 25088, 
+                "totEvents": 25088, 
+                "weights": 25088.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25160, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_159.root", 
+                "nevents": 25160, 
+                "totEvents": 25160, 
+                "weights": 25160.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25030, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_548.root", 
+                "nevents": 25030, 
+                "totEvents": 25030, 
+                "weights": 25030.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25134, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_216.root", 
+                "nevents": 25134, 
+                "totEvents": 25134, 
+                "weights": 25134.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24830, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_74.root", 
+                "nevents": 24830, 
+                "totEvents": 24830, 
+                "weights": 24830.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24957, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_142.root", 
+                "nevents": 24957, 
+                "totEvents": 24957, 
+                "weights": 24957.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25109, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_291.root", 
+                "nevents": 25109, 
+                "totEvents": 25109, 
+                "weights": 25109.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25278, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_62.root", 
+                "nevents": 25278, 
+                "totEvents": 25278, 
+                "weights": 25278.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25140, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_250.root", 
+                "nevents": 25140, 
+                "totEvents": 25140, 
+                "weights": 25140.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25148, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_66.root", 
+                "nevents": 25148, 
+                "totEvents": 25148, 
+                "weights": 25148.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25011, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_64.root", 
+                "nevents": 25011, 
+                "totEvents": 25011, 
+                "weights": 25011.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24960, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_15.root", 
+                "nevents": 24960, 
+                "totEvents": 24960, 
+                "weights": 24960.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25122, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_97.root", 
+                "nevents": 25122, 
+                "totEvents": 25122, 
+                "weights": 25122.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25168, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_428.root", 
+                "nevents": 25168, 
+                "totEvents": 25168, 
+                "weights": 25168.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24790, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_55.root", 
+                "nevents": 24790, 
+                "totEvents": 24790, 
+                "weights": 24790.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24960, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_219.root", 
+                "nevents": 24960, 
+                "totEvents": 24960, 
+                "weights": 24960.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24743, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_46.root", 
+                "nevents": 24743, 
+                "totEvents": 24743, 
+                "weights": 24743.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25170, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_58.root", 
+                "nevents": 25170, 
+                "totEvents": 25170, 
+                "weights": 25170.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24926, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_399.root", 
+                "nevents": 24926, 
+                "totEvents": 24926, 
+                "weights": 24926.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24972, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_38.root", 
+                "nevents": 24972, 
+                "totEvents": 24972, 
+                "weights": 24972.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25202, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_493.root", 
+                "nevents": 25202, 
+                "totEvents": 25202, 
+                "weights": 25202.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25016, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_252.root", 
+                "nevents": 25016, 
+                "totEvents": 25016, 
+                "weights": 25016.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25286, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_397.root", 
+                "nevents": 25286, 
+                "totEvents": 25286, 
+                "weights": 25286.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24943, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_519.root", 
+                "nevents": 24943, 
+                "totEvents": 24943, 
+                "weights": 24943.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24927, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_16.root", 
+                "nevents": 24927, 
+                "totEvents": 24927, 
+                "weights": 24927.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25084, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_293.root", 
+                "nevents": 25084, 
+                "totEvents": 25084, 
+                "weights": 25084.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24804, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_506.root", 
+                "nevents": 24804, 
+                "totEvents": 24804, 
+                "weights": 24804.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25134, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_19.root", 
+                "nevents": 25134, 
+                "totEvents": 25134, 
+                "weights": 25134.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25019, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_146.root", 
+                "nevents": 25019, 
+                "totEvents": 25019, 
+                "weights": 25019.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24967, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_660.root", 
+                "nevents": 24967, 
+                "totEvents": 24967, 
+                "weights": 24967.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24987, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_225.root", 
+                "nevents": 24987, 
+                "totEvents": 24987, 
+                "weights": 24987.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24657, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_34.root", 
+                "nevents": 24657, 
+                "totEvents": 24657, 
+                "weights": 24657.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24767, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_400.root", 
+                "nevents": 24767, 
+                "totEvents": 24767, 
+                "weights": 24767.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24959, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_612.root", 
+                "nevents": 24959, 
+                "totEvents": 24959, 
+                "weights": 24959.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24873, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_280.root", 
+                "nevents": 24873, 
+                "totEvents": 24873, 
+                "weights": 24873.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24942, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_249.root", 
+                "nevents": 24942, 
+                "totEvents": 24942, 
+                "weights": 24942.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24850, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_23.root", 
+                "nevents": 24850, 
+                "totEvents": 24850, 
+                "weights": 24850.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25027, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_65.root", 
+                "nevents": 25027, 
+                "totEvents": 25027, 
+                "weights": 25027.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24997, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_538.root", 
+                "nevents": 24997, 
+                "totEvents": 24997, 
+                "weights": 24997.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24803, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_422.root", 
+                "nevents": 24803, 
+                "totEvents": 24803, 
+                "weights": 24803.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24877, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_109.root", 
+                "nevents": 24877, 
+                "totEvents": 24877, 
+                "weights": 24877.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25081, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_73.root", 
+                "nevents": 25081, 
+                "totEvents": 25081, 
+                "weights": 25081.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24865, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_41.root", 
+                "nevents": 24865, 
+                "totEvents": 24865, 
+                "weights": 24865.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25095, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_67.root", 
+                "nevents": 25095, 
+                "totEvents": 25095, 
+                "weights": 25095.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24959, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_89.root", 
+                "nevents": 24959, 
+                "totEvents": 24959, 
+                "weights": 24959.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24812, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_406.root", 
+                "nevents": 24812, 
+                "totEvents": 24812, 
+                "weights": 24812.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24726, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_52.root", 
+                "nevents": 24726, 
+                "totEvents": 24726, 
+                "weights": 24726.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25129, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_595.root", 
+                "nevents": 25129, 
+                "totEvents": 25129, 
+                "weights": 25129.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25014, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_163.root", 
+                "nevents": 25014, 
+                "totEvents": 25014, 
+                "weights": 25014.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25288, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_221.root", 
+                "nevents": 25288, 
+                "totEvents": 25288, 
+                "weights": 25288.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24896, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_515.root", 
+                "nevents": 24896, 
+                "totEvents": 24896, 
+                "weights": 24896.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24890, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_521.root", 
+                "nevents": 24890, 
+                "totEvents": 24890, 
+                "weights": 24890.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24968, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_247.root", 
+                "nevents": 24968, 
+                "totEvents": 24968, 
+                "weights": 24968.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24981, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_424.root", 
+                "nevents": 24981, 
+                "totEvents": 24981, 
+                "weights": 24981.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24853, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_467.root", 
+                "nevents": 24853, 
+                "totEvents": 24853, 
+                "weights": 24853.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25268, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_514.root", 
+                "nevents": 25268, 
+                "totEvents": 25268, 
+                "weights": 25268.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25018, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_150.root", 
+                "nevents": 25018, 
+                "totEvents": 25018, 
+                "weights": 25018.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24865, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_61.root", 
+                "nevents": 24865, 
+                "totEvents": 24865, 
+                "weights": 24865.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24946, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_564.root", 
+                "nevents": 24946, 
+                "totEvents": 24946, 
+                "weights": 24946.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24975, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_220.root", 
+                "nevents": 24975, 
+                "totEvents": 24975, 
+                "weights": 24975.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25103, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_154.root", 
+                "nevents": 25103, 
+                "totEvents": 25103, 
+                "weights": 25103.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25075, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_137.root", 
+                "nevents": 25075, 
+                "totEvents": 25075, 
+                "weights": 25075.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24705, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_315.root", 
+                "nevents": 24705, 
+                "totEvents": 24705, 
+                "weights": 24705.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25040, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_229.root", 
+                "nevents": 25040, 
+                "totEvents": 25040, 
+                "weights": 25040.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24960, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_546.root", 
+                "nevents": 24960, 
+                "totEvents": 24960, 
+                "weights": 24960.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24909, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_599.root", 
+                "nevents": 24909, 
+                "totEvents": 24909, 
+                "weights": 24909.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24605, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_82.root", 
+                "nevents": 24605, 
+                "totEvents": 24605, 
+                "weights": 24605.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24713, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_659.root", 
+                "nevents": 24713, 
+                "totEvents": 24713, 
+                "weights": 24713.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24997, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_587.root", 
+                "nevents": 24997, 
+                "totEvents": 24997, 
+                "weights": 24997.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24900, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_283.root", 
+                "nevents": 24900, 
+                "totEvents": 24900, 
+                "weights": 24900.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25020, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_603.root", 
+                "nevents": 25020, 
+                "totEvents": 25020, 
+                "weights": 25020.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24966, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_611.root", 
+                "nevents": 24966, 
+                "totEvents": 24966, 
+                "weights": 24966.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24760, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_565.root", 
+                "nevents": 24760, 
+                "totEvents": 24760, 
+                "weights": 24760.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24749, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_87.root", 
+                "nevents": 24749, 
+                "totEvents": 24749, 
+                "weights": 24749.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25067, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_581.root", 
+                "nevents": 25067, 
+                "totEvents": 25067, 
+                "weights": 25067.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25066, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_583.root", 
+                "nevents": 25066, 
+                "totEvents": 25066, 
+                "weights": 25066.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25151, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_8.root", 
+                "nevents": 25151, 
+                "totEvents": 25151, 
+                "weights": 25151.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24915, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_653.root", 
+                "nevents": 24915, 
+                "totEvents": 24915, 
+                "weights": 24915.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25064, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_617.root", 
+                "nevents": 25064, 
+                "totEvents": 25064, 
+                "weights": 25064.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25151, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_285.root", 
+                "nevents": 25151, 
+                "totEvents": 25151, 
+                "weights": 25151.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25217, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_588.root", 
+                "nevents": 25217, 
+                "totEvents": 25217, 
+                "weights": 25217.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24599, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_437.root", 
+                "nevents": 24599, 
+                "totEvents": 24599, 
+                "weights": 24599.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25210, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_584.root", 
+                "nevents": 25210, 
+                "totEvents": 25210, 
+                "weights": 25210.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25017, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_75.root", 
+                "nevents": 25017, 
+                "totEvents": 25017, 
+                "weights": 25017.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25185, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_84.root", 
+                "nevents": 25185, 
+                "totEvents": 25185, 
+                "weights": 25185.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24893, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_79.root", 
+                "nevents": 24893, 
+                "totEvents": 24893, 
+                "weights": 24893.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25099, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_77.root", 
+                "nevents": 25099, 
+                "totEvents": 25099, 
+                "weights": 25099.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25008, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_44.root", 
+                "nevents": 25008, 
+                "totEvents": 25008, 
+                "weights": 25008.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24883, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_86.root", 
+                "nevents": 24883, 
+                "totEvents": 24883, 
+                "weights": 24883.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24808, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_85.root", 
+                "nevents": 24808, 
+                "totEvents": 24808, 
+                "weights": 24808.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25008, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_60.root", 
+                "nevents": 25008, 
+                "totEvents": 25008, 
+                "weights": 25008.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24858, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_80.root", 
+                "nevents": 24858, 
+                "totEvents": 24858, 
+                "weights": 24858.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24889, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_83.root", 
+                "nevents": 24889, 
+                "totEvents": 24889, 
+                "weights": 24889.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25080, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_69.root", 
+                "nevents": 25080, 
+                "totEvents": 25080, 
+                "weights": 25080.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24802, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_228.root", 
+                "nevents": 24802, 
+                "totEvents": 24802, 
+                "weights": 24802.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24898, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_478.root", 
+                "nevents": 24898, 
+                "totEvents": 24898, 
+                "weights": 24898.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24912, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_494.root", 
+                "nevents": 24912, 
+                "totEvents": 24912, 
+                "weights": 24912.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25171, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_255.root", 
+                "nevents": 25171, 
+                "totEvents": 25171, 
+                "weights": 25171.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24811, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_320.root", 
+                "nevents": 24811, 
+                "totEvents": 24811, 
+                "weights": 24811.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24943, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_440.root", 
+                "nevents": 24943, 
+                "totEvents": 24943, 
+                "weights": 24943.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24846, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_410.root", 
+                "nevents": 24846, 
+                "totEvents": 24846, 
+                "weights": 24846.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24911, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_438.root", 
+                "nevents": 24911, 
+                "totEvents": 24911, 
+                "weights": 24911.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24816, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_235.root", 
+                "nevents": 24816, 
+                "totEvents": 24816, 
+                "weights": 24816.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25026, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_340.root", 
+                "nevents": 25026, 
+                "totEvents": 25026, 
+                "weights": 25026.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25162, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_236.root", 
+                "nevents": 25162, 
+                "totEvents": 25162, 
+                "weights": 25162.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25044, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_463.root", 
+                "nevents": 25044, 
+                "totEvents": 25044, 
+                "weights": 25044.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25143, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_492.root", 
+                "nevents": 25143, 
+                "totEvents": 25143, 
+                "weights": 25143.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24984, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_354.root", 
+                "nevents": 24984, 
+                "totEvents": 24984, 
+                "weights": 24984.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25233, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_436.root", 
+                "nevents": 25233, 
+                "totEvents": 25233, 
+                "weights": 25233.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24961, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_262.root", 
+                "nevents": 24961, 
+                "totEvents": 24961, 
+                "weights": 24961.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25144, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_579.root", 
+                "nevents": 25144, 
+                "totEvents": 25144, 
+                "weights": 25144.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24956, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_194.root", 
+                "nevents": 24956, 
+                "totEvents": 24956, 
+                "weights": 24956.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24951, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_464.root", 
+                "nevents": 24951, 
+                "totEvents": 24951, 
+                "weights": 24951.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24786, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_638.root", 
+                "nevents": 24786, 
+                "totEvents": 24786, 
+                "weights": 24786.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24971, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_589.root", 
+                "nevents": 24971, 
+                "totEvents": 24971, 
+                "weights": 24971.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25105, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_241.root", 
+                "nevents": 25105, 
+                "totEvents": 25105, 
+                "weights": 25105.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25071, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_573.root", 
+                "nevents": 25071, 
+                "totEvents": 25071, 
+                "weights": 25071.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24818, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_575.root", 
+                "nevents": 24818, 
+                "totEvents": 24818, 
+                "weights": 24818.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25277, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_488.root", 
+                "nevents": 25277, 
+                "totEvents": 25277, 
+                "weights": 25277.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24925, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_487.root", 
+                "nevents": 24925, 
+                "totEvents": 24925, 
+                "weights": 24925.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24953, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_434.root", 
+                "nevents": 24953, 
+                "totEvents": 24953, 
+                "weights": 24953.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25089, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_232.root", 
+                "nevents": 25089, 
+                "totEvents": 25089, 
+                "weights": 25089.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25198, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_544.root", 
+                "nevents": 25198, 
+                "totEvents": 25198, 
+                "weights": 25198.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24858, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_563.root", 
+                "nevents": 24858, 
+                "totEvents": 24858, 
+                "weights": 24858.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24872, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_507.root", 
+                "nevents": 24872, 
+                "totEvents": 24872, 
+                "weights": 24872.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24806, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_491.root", 
+                "nevents": 24806, 
+                "totEvents": 24806, 
+                "weights": 24806.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25129, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_572.root", 
+                "nevents": 25129, 
+                "totEvents": 25129, 
+                "weights": 25129.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25033, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_557.root", 
+                "nevents": 25033, 
+                "totEvents": 25033, 
+                "weights": 25033.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25211, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_531.root", 
+                "nevents": 25211, 
+                "totEvents": 25211, 
+                "weights": 25211.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25012, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_461.root", 
+                "nevents": 25012, 
+                "totEvents": 25012, 
+                "weights": 25012.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24784, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_442.root", 
+                "nevents": 24784, 
+                "totEvents": 24784, 
+                "weights": 24784.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24904, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_541.root", 
+                "nevents": 24904, 
+                "totEvents": 24904, 
+                "weights": 24904.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25128, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_281.root", 
+                "nevents": 25128, 
+                "totEvents": 25128, 
+                "weights": 25128.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25089, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_558.root", 
+                "nevents": 25089, 
+                "totEvents": 25089, 
+                "weights": 25089.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25322, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_577.root", 
+                "nevents": 25322, 
+                "totEvents": 25322, 
+                "weights": 25322.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25011, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_530.root", 
+                "nevents": 25011, 
+                "totEvents": 25011, 
+                "weights": 25011.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25066, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_185.root", 
+                "nevents": 25066, 
+                "totEvents": 25066, 
+                "weights": 25066.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24814, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_547.root", 
+                "nevents": 24814, 
+                "totEvents": 24814, 
+                "weights": 24814.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24843, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_524.root", 
+                "nevents": 24843, 
+                "totEvents": 24843, 
+                "weights": 24843.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24833, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_536.root", 
+                "nevents": 24833, 
+                "totEvents": 24833, 
+                "weights": 24833.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25062, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_545.root", 
+                "nevents": 25062, 
+                "totEvents": 25062, 
+                "weights": 25062.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25203, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_529.root", 
+                "nevents": 25203, 
+                "totEvents": 25203, 
+                "weights": 25203.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25022, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_465.root", 
+                "nevents": 25022, 
+                "totEvents": 25022, 
+                "weights": 25022.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24745, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_576.root", 
+                "nevents": 24745, 
+                "totEvents": 24745, 
+                "weights": 24745.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24729, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_489.root", 
+                "nevents": 24729, 
+                "totEvents": 24729, 
+                "weights": 24729.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24945, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_567.root", 
+                "nevents": 24945, 
+                "totEvents": 24945, 
+                "weights": 24945.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24891, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_569.root", 
+                "nevents": 24891, 
+                "totEvents": 24891, 
+                "weights": 24891.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_432.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 25000.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24988, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_533.root", 
+                "nevents": 24988, 
+                "totEvents": 24988, 
+                "weights": 24988.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25056, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_528.root", 
+                "nevents": 25056, 
+                "totEvents": 25056, 
+                "weights": 25056.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25115, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_211.root", 
+                "nevents": 25115, 
+                "totEvents": 25115, 
+                "weights": 25115.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24919, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_509.root", 
+                "nevents": 24919, 
+                "totEvents": 24919, 
+                "weights": 24919.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24926, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_411.root", 
+                "nevents": 24926, 
+                "totEvents": 24926, 
+                "weights": 24926.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24950, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_554.root", 
+                "nevents": 24950, 
+                "totEvents": 24950, 
+                "weights": 24950.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24826, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_537.root", 
+                "nevents": 24826, 
+                "totEvents": 24826, 
+                "weights": 24826.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25081, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_550.root", 
+                "nevents": 25081, 
+                "totEvents": 25081, 
+                "weights": 25081.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24871, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_522.root", 
+                "nevents": 24871, 
+                "totEvents": 24871, 
+                "weights": 24871.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25096, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_534.root", 
+                "nevents": 25096, 
+                "totEvents": 25096, 
+                "weights": 25096.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25072, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_263.root", 
+                "nevents": 25072, 
+                "totEvents": 25072, 
+                "weights": 25072.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25093, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_429.root", 
+                "nevents": 25093, 
+                "totEvents": 25093, 
+                "weights": 25093.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24944, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_549.root", 
+                "nevents": 24944, 
+                "totEvents": 24944, 
+                "weights": 24944.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24957, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_543.root", 
+                "nevents": 24957, 
+                "totEvents": 24957, 
+                "weights": 24957.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25178, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_351.root", 
+                "nevents": 25178, 
+                "totEvents": 25178, 
+                "weights": 25178.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25135, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_535.root", 
+                "nevents": 25135, 
+                "totEvents": 25135, 
+                "weights": 25135.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25106, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_282.root", 
+                "nevents": 25106, 
+                "totEvents": 25106, 
+                "weights": 25106.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25050, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_551.root", 
+                "nevents": 25050, 
+                "totEvents": 25050, 
+                "weights": 25050.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25090, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_574.root", 
+                "nevents": 25090, 
+                "totEvents": 25090, 
+                "weights": 25090.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24887, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_286.root", 
+                "nevents": 24887, 
+                "totEvents": 24887, 
+                "weights": 24887.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25222, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_504.root", 
+                "nevents": 25222, 
+                "totEvents": 25222, 
+                "weights": 25222.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25023, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_430.root", 
+                "nevents": 25023, 
+                "totEvents": 25023, 
+                "weights": 25023.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25006, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_608.root", 
+                "nevents": 25006, 
+                "totEvents": 25006, 
+                "weights": 25006.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25224, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_484.root", 
+                "nevents": 25224, 
+                "totEvents": 25224, 
+                "weights": 25224.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24721, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_508.root", 
+                "nevents": 24721, 
+                "totEvents": 24721, 
+                "weights": 24721.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24927, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_498.root", 
+                "nevents": 24927, 
+                "totEvents": 24927, 
+                "weights": 24927.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24960, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_78.root", 
+                "nevents": 24960, 
+                "totEvents": 24960, 
+                "weights": 24960.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24895, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_570.root", 
+                "nevents": 24895, 
+                "totEvents": 24895, 
+                "weights": 24895.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25249, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_619.root", 
+                "nevents": 25249, 
+                "totEvents": 25249, 
+                "weights": 25249.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24971, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_445.root", 
+                "nevents": 24971, 
+                "totEvents": 24971, 
+                "weights": 24971.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25079, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_210.root", 
+                "nevents": 25079, 
+                "totEvents": 25079, 
+                "weights": 25079.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24948, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_156.root", 
+                "nevents": 24948, 
+                "totEvents": 24948, 
+                "weights": 24948.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24897, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_585.root", 
+                "nevents": 24897, 
+                "totEvents": 24897, 
+                "weights": 24897.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24933, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_582.root", 
+                "nevents": 24933, 
+                "totEvents": 24933, 
+                "weights": 24933.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25198, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_590.root", 
+                "nevents": 25198, 
+                "totEvents": 25198, 
+                "weights": 25198.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25109, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_212.root", 
+                "nevents": 25109, 
+                "totEvents": 25109, 
+                "weights": 25109.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24974, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_214.root", 
+                "nevents": 24974, 
+                "totEvents": 24974, 
+                "weights": 24974.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25089, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_409.root", 
+                "nevents": 25089, 
+                "totEvents": 25089, 
+                "weights": 25089.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25140, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_562.root", 
+                "nevents": 25140, 
+                "totEvents": 25140, 
+                "weights": 25140.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25123, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_646.root", 
+                "nevents": 25123, 
+                "totEvents": 25123, 
+                "weights": 25123.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24742, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_9.root", 
+                "nevents": 24742, 
+                "totEvents": 24742, 
+                "weights": 24742.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25221, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_139.root", 
+                "nevents": 25221, 
+                "totEvents": 25221, 
+                "weights": 25221.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24998, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_615.root", 
+                "nevents": 24998, 
+                "totEvents": 24998, 
+                "weights": 24998.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25192, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_580.root", 
+                "nevents": 25192, 
+                "totEvents": 25192, 
+                "weights": 25192.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24804, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_134.root", 
+                "nevents": 24804, 
+                "totEvents": 24804, 
+                "weights": 24804.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24885, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_132.root", 
+                "nevents": 24885, 
+                "totEvents": 24885, 
+                "weights": 24885.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24955, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_131.root", 
+                "nevents": 24955, 
+                "totEvents": 24955, 
+                "weights": 24955.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24866, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_655.root", 
+                "nevents": 24866, 
+                "totEvents": 24866, 
+                "weights": 24866.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25087, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_645.root", 
+                "nevents": 25087, 
+                "totEvents": 25087, 
+                "weights": 25087.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24816, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_605.root", 
+                "nevents": 24816, 
+                "totEvents": 24816, 
+                "weights": 24816.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25099, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_586.root", 
+                "nevents": 25099, 
+                "totEvents": 25099, 
+                "weights": 25099.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25040, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_158.root", 
+                "nevents": 25040, 
+                "totEvents": 25040, 
+                "weights": 25040.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25072, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_88.root", 
+                "nevents": 25072, 
+                "totEvents": 25072, 
+                "weights": 25072.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25007, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_90.root", 
+                "nevents": 25007, 
+                "totEvents": 25007, 
+                "weights": 25007.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24923, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_133.root", 
+                "nevents": 24923, 
+                "totEvents": 24923, 
+                "weights": 24923.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24926, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_132920/0000/myMicroAODOutputFile_578.root", 
+                "nevents": 24926, 
+                "totEvents": 24926, 
+                "weights": 24926.0
+            }
+        ], 
+        "parent_n_units": 16520994, 
+        "vetted": true
+    }, 
+    "/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/alesauva-UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1-8980ba169e8b72d53459e52844728ed8/USER": {
+        "dset_type": "mc", 
+        "files": [
+            {
+                "bad": false, 
+                "events": 24828, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_135736/0000/myMicroAODOutputFile_28.root", 
+                "nevents": 24828, 
+                "totEvents": 24828, 
+                "weights": 24828.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25239, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_135736/0000/myMicroAODOutputFile_78.root", 
+                "nevents": 25239, 
+                "totEvents": 25239, 
+                "weights": 25239.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24835, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_135736/0000/myMicroAODOutputFile_139.root", 
+                "nevents": 24835, 
+                "totEvents": 24835, 
+                "weights": 24835.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25335, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_135736/0000/myMicroAODOutputFile_53.root", 
+                "nevents": 25335, 
+                "totEvents": 25335, 
+                "weights": 25335.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25022, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_135736/0000/myMicroAODOutputFile_23.root", 
+                "nevents": 25022, 
+                "totEvents": 25022, 
+                "weights": 25022.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25158, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_135736/0000/myMicroAODOutputFile_6.root", 
+                "nevents": 25158, 
+                "totEvents": 25158, 
+                "weights": 25158.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25142, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_135736/0000/myMicroAODOutputFile_134.root", 
+                "nevents": 25142, 
+                "totEvents": 25142, 
+                "weights": 25142.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25232, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_135736/0000/myMicroAODOutputFile_20.root", 
+                "nevents": 25232, 
+                "totEvents": 25232, 
+                "weights": 25232.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25092, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_135736/0000/myMicroAODOutputFile_36.root", 
+                "nevents": 25092, 
+                "totEvents": 25092, 
+                "weights": 25092.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24913, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_135736/0000/myMicroAODOutputFile_156.root", 
+                "nevents": 24913, 
+                "totEvents": 24913, 
+                "weights": 24913.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24910, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_135736/0000/myMicroAODOutputFile_119.root", 
+                "nevents": 24910, 
+                "totEvents": 24910, 
+                "weights": 24910.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25011, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_135736/0000/myMicroAODOutputFile_101.root", 
+                "nevents": 25011, 
+                "totEvents": 25011, 
+                "weights": 25011.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24861, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_135736/0000/myMicroAODOutputFile_123.root", 
+                "nevents": 24861, 
+                "totEvents": 24861, 
+                "weights": 24861.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25071, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_135736/0000/myMicroAODOutputFile_7.root", 
+                "nevents": 25071, 
+                "totEvents": 25071, 
+                "weights": 25071.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24867, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_135736/0000/myMicroAODOutputFile_132.root", 
+                "nevents": 24867, 
+                "totEvents": 24867, 
+                "weights": 24867.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24825, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_135736/0000/myMicroAODOutputFile_38.root", 
+                "nevents": 24825, 
+                "totEvents": 24825, 
+                "weights": 24825.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24994, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_135736/0000/myMicroAODOutputFile_41.root", 
+                "nevents": 24994, 
+                "totEvents": 24994, 
+                "weights": 24994.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25089, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_135736/0000/myMicroAODOutputFile_33.root", 
+                "nevents": 25089, 
+                "totEvents": 25089, 
+                "weights": 25089.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25186, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_135736/0000/myMicroAODOutputFile_15.root", 
+                "nevents": 25186, 
+                "totEvents": 25186, 
+                "weights": 25186.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25170, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_135736/0000/myMicroAODOutputFile_13.root", 
+                "nevents": 25170, 
+                "totEvents": 25170, 
+                "weights": 25170.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24801, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_135736/0000/myMicroAODOutputFile_54.root", 
+                "nevents": 24801, 
+                "totEvents": 24801, 
+                "weights": 24801.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24963, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_135736/0000/myMicroAODOutputFile_61.root", 
+                "nevents": 24963, 
+                "totEvents": 24963, 
+                "weights": 24963.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24845, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_135736/0000/myMicroAODOutputFile_129.root", 
+                "nevents": 24845, 
+                "totEvents": 24845, 
+                "weights": 24845.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24860, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_135736/0000/myMicroAODOutputFile_115.root", 
+                "nevents": 24860, 
+                "totEvents": 24860, 
+                "weights": 24860.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24872, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_135736/0000/myMicroAODOutputFile_72.root", 
+                "nevents": 24872, 
+                "totEvents": 24872, 
+                "weights": 24872.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24966, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_135736/0000/myMicroAODOutputFile_91.root", 
+                "nevents": 24966, 
+                "totEvents": 24966, 
+                "weights": 24966.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25104, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_135736/0000/myMicroAODOutputFile_94.root", 
+                "nevents": 25104, 
+                "totEvents": 25104, 
+                "weights": 25104.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24810, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_135736/0000/myMicroAODOutputFile_39.root", 
+                "nevents": 24810, 
+                "totEvents": 24810, 
+                "weights": 24810.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25083, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_135736/0000/myMicroAODOutputFile_16.root", 
+                "nevents": 25083, 
+                "totEvents": 25083, 
+                "weights": 25083.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25053, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_135736/0000/myMicroAODOutputFile_98.root", 
+                "nevents": 25053, 
+                "totEvents": 25053, 
+                "weights": 25053.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25201, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_135736/0000/myMicroAODOutputFile_120.root", 
+                "nevents": 25201, 
+                "totEvents": 25201, 
+                "weights": 25201.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25131, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_135736/0000/myMicroAODOutputFile_3.root", 
+                "nevents": 25131, 
+                "totEvents": 25131, 
+                "weights": 25131.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25014, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_135736/0000/myMicroAODOutputFile_57.root", 
+                "nevents": 25014, 
+                "totEvents": 25014, 
+                "weights": 25014.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24895, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_135736/0000/myMicroAODOutputFile_74.root", 
+                "nevents": 24895, 
+                "totEvents": 24895, 
+                "weights": 24895.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24855, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_135736/0000/myMicroAODOutputFile_75.root", 
+                "nevents": 24855, 
+                "totEvents": 24855, 
+                "weights": 24855.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24675, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_135736/0000/myMicroAODOutputFile_30.root", 
+                "nevents": 24675, 
+                "totEvents": 24675, 
+                "weights": 24675.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24915, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_135736/0000/myMicroAODOutputFile_90.root", 
+                "nevents": 24915, 
+                "totEvents": 24915, 
+                "weights": 24915.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24939, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_135736/0000/myMicroAODOutputFile_151.root", 
+                "nevents": 24939, 
+                "totEvents": 24939, 
+                "weights": 24939.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24907, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_135736/0000/myMicroAODOutputFile_148.root", 
+                "nevents": 24907, 
+                "totEvents": 24907, 
+                "weights": 24907.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25047, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_135736/0000/myMicroAODOutputFile_32.root", 
+                "nevents": 25047, 
+                "totEvents": 25047, 
+                "weights": 25047.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25265, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_135736/0000/myMicroAODOutputFile_140.root", 
+                "nevents": 25265, 
+                "totEvents": 25265, 
+                "weights": 25265.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25093, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_135736/0000/myMicroAODOutputFile_103.root", 
+                "nevents": 25093, 
+                "totEvents": 25093, 
+                "weights": 25093.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24831, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_135736/0000/myMicroAODOutputFile_143.root", 
+                "nevents": 24831, 
+                "totEvents": 24831, 
+                "weights": 24831.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24988, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_135736/0000/myMicroAODOutputFile_146.root", 
+                "nevents": 24988, 
+                "totEvents": 24988, 
+                "weights": 24988.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25316, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_135736/0000/myMicroAODOutputFile_65.root", 
+                "nevents": 25316, 
+                "totEvents": 25316, 
+                "weights": 25316.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25125, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_135736/0000/myMicroAODOutputFile_150.root", 
+                "nevents": 25125, 
+                "totEvents": 25125, 
+                "weights": 25125.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24759, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_135736/0000/myMicroAODOutputFile_60.root", 
+                "nevents": 24759, 
+                "totEvents": 24759, 
+                "weights": 24759.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24928, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_135736/0000/myMicroAODOutputFile_159.root", 
+                "nevents": 24928, 
+                "totEvents": 24928, 
+                "weights": 24928.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25003, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_135736/0000/myMicroAODOutputFile_138.root", 
+                "nevents": 25003, 
+                "totEvents": 25003, 
+                "weights": 25003.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25012, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_135736/0000/myMicroAODOutputFile_4.root", 
+                "nevents": 25012, 
+                "totEvents": 25012, 
+                "weights": 25012.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25110, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_135736/0000/myMicroAODOutputFile_40.root", 
+                "nevents": 25110, 
+                "totEvents": 25110, 
+                "weights": 25110.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24938, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_135736/0000/myMicroAODOutputFile_142.root", 
+                "nevents": 24938, 
+                "totEvents": 24938, 
+                "weights": 24938.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25052, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_135736/0000/myMicroAODOutputFile_59.root", 
+                "nevents": 25052, 
+                "totEvents": 25052, 
+                "weights": 25052.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24749, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_135736/0000/myMicroAODOutputFile_14.root", 
+                "nevents": 24749, 
+                "totEvents": 24749, 
+                "weights": 24749.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25199, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_135736/0000/myMicroAODOutputFile_130.root", 
+                "nevents": 25199, 
+                "totEvents": 25199, 
+                "weights": 25199.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24886, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_135736/0000/myMicroAODOutputFile_157.root", 
+                "nevents": 24886, 
+                "totEvents": 24886, 
+                "weights": 24886.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24945, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_135736/0000/myMicroAODOutputFile_121.root", 
+                "nevents": 24945, 
+                "totEvents": 24945, 
+                "weights": 24945.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24930, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_135736/0000/myMicroAODOutputFile_118.root", 
+                "nevents": 24930, 
+                "totEvents": 24930, 
+                "weights": 24930.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25093, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_135736/0000/myMicroAODOutputFile_126.root", 
+                "nevents": 25093, 
+                "totEvents": 25093, 
+                "weights": 25093.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24915, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_135736/0000/myMicroAODOutputFile_136.root", 
+                "nevents": 24915, 
+                "totEvents": 24915, 
+                "weights": 24915.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24840, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_135736/0000/myMicroAODOutputFile_17.root", 
+                "nevents": 24840, 
+                "totEvents": 24840, 
+                "weights": 24840.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24984, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_135736/0000/myMicroAODOutputFile_73.root", 
+                "nevents": 24984, 
+                "totEvents": 24984, 
+                "weights": 24984.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24666, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_135736/0000/myMicroAODOutputFile_12.root", 
+                "nevents": 24666, 
+                "totEvents": 24666, 
+                "weights": 24666.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24855, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_135736/0000/myMicroAODOutputFile_128.root", 
+                "nevents": 24855, 
+                "totEvents": 24855, 
+                "weights": 24855.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25179, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_135736/0000/myMicroAODOutputFile_135.root", 
+                "nevents": 25179, 
+                "totEvents": 25179, 
+                "weights": 25179.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25116, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_135736/0000/myMicroAODOutputFile_44.root", 
+                "nevents": 25116, 
+                "totEvents": 25116, 
+                "weights": 25116.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25341, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_135736/0000/myMicroAODOutputFile_71.root", 
+                "nevents": 25341, 
+                "totEvents": 25341, 
+                "weights": 25341.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24846, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_135736/0000/myMicroAODOutputFile_26.root", 
+                "nevents": 24846, 
+                "totEvents": 24846, 
+                "weights": 24846.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24944, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_135736/0000/myMicroAODOutputFile_21.root", 
+                "nevents": 24944, 
+                "totEvents": 24944, 
+                "weights": 24944.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24909, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_135736/0000/myMicroAODOutputFile_31.root", 
+                "nevents": 24909, 
+                "totEvents": 24909, 
+                "weights": 24909.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25192, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_135736/0000/myMicroAODOutputFile_125.root", 
+                "nevents": 25192, 
+                "totEvents": 25192, 
+                "weights": 25192.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24967, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_135736/0000/myMicroAODOutputFile_108.root", 
+                "nevents": 24967, 
+                "totEvents": 24967, 
+                "weights": 24967.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24767, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_135736/0000/myMicroAODOutputFile_42.root", 
+                "nevents": 24767, 
+                "totEvents": 24767, 
+                "weights": 24767.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24893, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_135736/0000/myMicroAODOutputFile_25.root", 
+                "nevents": 24893, 
+                "totEvents": 24893, 
+                "weights": 24893.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25028, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_135736/0000/myMicroAODOutputFile_104.root", 
+                "nevents": 25028, 
+                "totEvents": 25028, 
+                "weights": 25028.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24668, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_135736/0000/myMicroAODOutputFile_5.root", 
+                "nevents": 24668, 
+                "totEvents": 24668, 
+                "weights": 24668.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25111, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_135736/0000/myMicroAODOutputFile_11.root", 
+                "nevents": 25111, 
+                "totEvents": 25111, 
+                "weights": 25111.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24951, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_135736/0000/myMicroAODOutputFile_24.root", 
+                "nevents": 24951, 
+                "totEvents": 24951, 
+                "weights": 24951.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24989, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_135736/0000/myMicroAODOutputFile_165.root", 
+                "nevents": 24989, 
+                "totEvents": 24989, 
+                "weights": 24989.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25186, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_135736/0000/myMicroAODOutputFile_149.root", 
+                "nevents": 25186, 
+                "totEvents": 25186, 
+                "weights": 25186.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25103, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_135736/0000/myMicroAODOutputFile_27.root", 
+                "nevents": 25103, 
+                "totEvents": 25103, 
+                "weights": 25103.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24873, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_135736/0000/myMicroAODOutputFile_56.root", 
+                "nevents": 24873, 
+                "totEvents": 24873, 
+                "weights": 24873.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25062, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_135736/0000/myMicroAODOutputFile_82.root", 
+                "nevents": 25062, 
+                "totEvents": 25062, 
+                "weights": 25062.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24871, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_135736/0000/myMicroAODOutputFile_51.root", 
+                "nevents": 24871, 
+                "totEvents": 24871, 
+                "weights": 24871.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24940, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_135736/0000/myMicroAODOutputFile_112.root", 
+                "nevents": 24940, 
+                "totEvents": 24940, 
+                "weights": 24940.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25030, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_135736/0000/myMicroAODOutputFile_122.root", 
+                "nevents": 25030, 
+                "totEvents": 25030, 
+                "weights": 25030.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24905, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_135736/0000/myMicroAODOutputFile_83.root", 
+                "nevents": 24905, 
+                "totEvents": 24905, 
+                "weights": 24905.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24895, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_135736/0000/myMicroAODOutputFile_158.root", 
+                "nevents": 24895, 
+                "totEvents": 24895, 
+                "weights": 24895.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24947, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_135736/0000/myMicroAODOutputFile_93.root", 
+                "nevents": 24947, 
+                "totEvents": 24947, 
+                "weights": 24947.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24856, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_135736/0000/myMicroAODOutputFile_169.root", 
+                "nevents": 24856, 
+                "totEvents": 24856, 
+                "weights": 24856.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24938, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_135736/0000/myMicroAODOutputFile_99.root", 
+                "nevents": 24938, 
+                "totEvents": 24938, 
+                "weights": 24938.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24762, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_135736/0000/myMicroAODOutputFile_10.root", 
+                "nevents": 24762, 
+                "totEvents": 24762, 
+                "weights": 24762.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25016, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_135736/0000/myMicroAODOutputFile_89.root", 
+                "nevents": 25016, 
+                "totEvents": 25016, 
+                "weights": 25016.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24978, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_135736/0000/myMicroAODOutputFile_105.root", 
+                "nevents": 24978, 
+                "totEvents": 24978, 
+                "weights": 24978.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25088, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_135736/0000/myMicroAODOutputFile_137.root", 
+                "nevents": 25088, 
+                "totEvents": 25088, 
+                "weights": 25088.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24981, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_135736/0000/myMicroAODOutputFile_84.root", 
+                "nevents": 24981, 
+                "totEvents": 24981, 
+                "weights": 24981.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24852, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_135736/0000/myMicroAODOutputFile_88.root", 
+                "nevents": 24852, 
+                "totEvents": 24852, 
+                "weights": 24852.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24950, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_135736/0000/myMicroAODOutputFile_106.root", 
+                "nevents": 24950, 
+                "totEvents": 24950, 
+                "weights": 24950.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24914, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_135736/0000/myMicroAODOutputFile_87.root", 
+                "nevents": 24914, 
+                "totEvents": 24914, 
+                "weights": 24914.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24935, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_135736/0000/myMicroAODOutputFile_152.root", 
+                "nevents": 24935, 
+                "totEvents": 24935, 
+                "weights": 24935.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24921, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_135736/0000/myMicroAODOutputFile_107.root", 
+                "nevents": 24921, 
+                "totEvents": 24921, 
+                "weights": 24921.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24827, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_135736/0000/myMicroAODOutputFile_114.root", 
+                "nevents": 24827, 
+                "totEvents": 24827, 
+                "weights": 24827.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25048, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_135736/0000/myMicroAODOutputFile_117.root", 
+                "nevents": 25048, 
+                "totEvents": 25048, 
+                "weights": 25048.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24906, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_135736/0000/myMicroAODOutputFile_92.root", 
+                "nevents": 24906, 
+                "totEvents": 24906, 
+                "weights": 24906.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24762, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_135736/0000/myMicroAODOutputFile_76.root", 
+                "nevents": 24762, 
+                "totEvents": 24762, 
+                "weights": 24762.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25009, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_135736/0000/myMicroAODOutputFile_100.root", 
+                "nevents": 25009, 
+                "totEvents": 25009, 
+                "weights": 25009.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25131, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_135736/0000/myMicroAODOutputFile_96.root", 
+                "nevents": 25131, 
+                "totEvents": 25131, 
+                "weights": 25131.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25106, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_135736/0000/myMicroAODOutputFile_77.root", 
+                "nevents": 25106, 
+                "totEvents": 25106, 
+                "weights": 25106.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25058, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_135736/0000/myMicroAODOutputFile_102.root", 
+                "nevents": 25058, 
+                "totEvents": 25058, 
+                "weights": 25058.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24992, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_135736/0000/myMicroAODOutputFile_97.root", 
+                "nevents": 24992, 
+                "totEvents": 24992, 
+                "weights": 24992.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25142, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_135736/0000/myMicroAODOutputFile_111.root", 
+                "nevents": 25142, 
+                "totEvents": 25142, 
+                "weights": 25142.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24991, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_135736/0000/myMicroAODOutputFile_18.root", 
+                "nevents": 24991, 
+                "totEvents": 24991, 
+                "weights": 24991.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25005, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_135736/0000/myMicroAODOutputFile_145.root", 
+                "nevents": 25005, 
+                "totEvents": 25005, 
+                "weights": 25005.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25207, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_135736/0000/myMicroAODOutputFile_8.root", 
+                "nevents": 25207, 
+                "totEvents": 25207, 
+                "weights": 25207.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24704, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_135736/0000/myMicroAODOutputFile_86.root", 
+                "nevents": 24704, 
+                "totEvents": 24704, 
+                "weights": 24704.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25024, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_135736/0000/myMicroAODOutputFile_110.root", 
+                "nevents": 25024, 
+                "totEvents": 25024, 
+                "weights": 25024.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25025, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_135736/0000/myMicroAODOutputFile_166.root", 
+                "nevents": 25025, 
+                "totEvents": 25025, 
+                "weights": 25025.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24710, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_135736/0000/myMicroAODOutputFile_95.root", 
+                "nevents": 24710, 
+                "totEvents": 24710, 
+                "weights": 24710.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25010, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_135736/0000/myMicroAODOutputFile_64.root", 
+                "nevents": 25010, 
+                "totEvents": 25010, 
+                "weights": 25010.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24960, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_135736/0000/myMicroAODOutputFile_81.root", 
+                "nevents": 24960, 
+                "totEvents": 24960, 
+                "weights": 24960.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24991, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_135736/0000/myMicroAODOutputFile_70.root", 
+                "nevents": 24991, 
+                "totEvents": 24991, 
+                "weights": 24991.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24991, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_135736/0000/myMicroAODOutputFile_131.root", 
+                "nevents": 24991, 
+                "totEvents": 24991, 
+                "weights": 24991.0
+            }, 
+            {
+                "bad": false, 
+                "events": 1076, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_135736/0000/myMicroAODOutputFile_109.root", 
+                "nevents": 1076, 
+                "totEvents": 1076, 
+                "weights": 1076.0
+            }, 
+            {
+                "bad": false, 
+                "events": 13677, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_135736/0000/myMicroAODOutputFile_171.root", 
+                "nevents": 13677, 
+                "totEvents": 13677, 
+                "weights": 13677.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25137, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_135736/0000/myMicroAODOutputFile_22.root", 
+                "nevents": 25137, 
+                "totEvents": 25137, 
+                "weights": 25137.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25183, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_135736/0000/myMicroAODOutputFile_153.root", 
+                "nevents": 25183, 
+                "totEvents": 25183, 
+                "weights": 25183.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25107, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_135736/0000/myMicroAODOutputFile_55.root", 
+                "nevents": 25107, 
+                "totEvents": 25107, 
+                "weights": 25107.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24696, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_135736/0000/myMicroAODOutputFile_155.root", 
+                "nevents": 24696, 
+                "totEvents": 24696, 
+                "weights": 24696.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24994, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_135736/0000/myMicroAODOutputFile_52.root", 
+                "nevents": 24994, 
+                "totEvents": 24994, 
+                "weights": 24994.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25145, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_135736/0000/myMicroAODOutputFile_1.root", 
+                "nevents": 25145, 
+                "totEvents": 25145, 
+                "weights": 25145.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25071, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_135736/0000/myMicroAODOutputFile_124.root", 
+                "nevents": 25071, 
+                "totEvents": 25071, 
+                "weights": 25071.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24913, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_135736/0000/myMicroAODOutputFile_161.root", 
+                "nevents": 24913, 
+                "totEvents": 24913, 
+                "weights": 24913.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24938, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_135736/0000/myMicroAODOutputFile_170.root", 
+                "nevents": 24938, 
+                "totEvents": 24938, 
+                "weights": 24938.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24974, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_135736/0000/myMicroAODOutputFile_35.root", 
+                "nevents": 24974, 
+                "totEvents": 24974, 
+                "weights": 24974.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24844, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_135736/0000/myMicroAODOutputFile_66.root", 
+                "nevents": 24844, 
+                "totEvents": 24844, 
+                "weights": 24844.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24916, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_135736/0000/myMicroAODOutputFile_80.root", 
+                "nevents": 24916, 
+                "totEvents": 24916, 
+                "weights": 24916.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24923, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_135736/0000/myMicroAODOutputFile_50.root", 
+                "nevents": 24923, 
+                "totEvents": 24923, 
+                "weights": 24923.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24845, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_135736/0000/myMicroAODOutputFile_58.root", 
+                "nevents": 24845, 
+                "totEvents": 24845, 
+                "weights": 24845.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25136, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_135736/0000/myMicroAODOutputFile_9.root", 
+                "nevents": 25136, 
+                "totEvents": 25136, 
+                "weights": 25136.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25077, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_135736/0000/myMicroAODOutputFile_62.root", 
+                "nevents": 25077, 
+                "totEvents": 25077, 
+                "weights": 25077.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24964, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_135736/0000/myMicroAODOutputFile_2.root", 
+                "nevents": 24964, 
+                "totEvents": 24964, 
+                "weights": 24964.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24870, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_135736/0000/myMicroAODOutputFile_67.root", 
+                "nevents": 24870, 
+                "totEvents": 24870, 
+                "weights": 24870.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25124, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_135736/0000/myMicroAODOutputFile_160.root", 
+                "nevents": 25124, 
+                "totEvents": 25124, 
+                "weights": 25124.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24863, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_135736/0000/myMicroAODOutputFile_85.root", 
+                "nevents": 24863, 
+                "totEvents": 24863, 
+                "weights": 24863.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24896, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_135736/0000/myMicroAODOutputFile_63.root", 
+                "nevents": 24896, 
+                "totEvents": 24896, 
+                "weights": 24896.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25101, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_135736/0000/myMicroAODOutputFile_113.root", 
+                "nevents": 25101, 
+                "totEvents": 25101, 
+                "weights": 25101.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24962, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_135736/0000/myMicroAODOutputFile_68.root", 
+                "nevents": 24962, 
+                "totEvents": 24962, 
+                "weights": 24962.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24989, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_135736/0000/myMicroAODOutputFile_19.root", 
+                "nevents": 24989, 
+                "totEvents": 24989, 
+                "weights": 24989.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24952, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_135736/0000/myMicroAODOutputFile_147.root", 
+                "nevents": 24952, 
+                "totEvents": 24952, 
+                "weights": 24952.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25153, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_135736/0000/myMicroAODOutputFile_168.root", 
+                "nevents": 25153, 
+                "totEvents": 25153, 
+                "weights": 25153.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24798, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_135736/0000/myMicroAODOutputFile_79.root", 
+                "nevents": 24798, 
+                "totEvents": 24798, 
+                "weights": 24798.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24832, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_135736/0000/myMicroAODOutputFile_69.root", 
+                "nevents": 24832, 
+                "totEvents": 24832, 
+                "weights": 24832.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25012, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_135736/0000/myMicroAODOutputFile_162.root", 
+                "nevents": 25012, 
+                "totEvents": 25012, 
+                "weights": 25012.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24839, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_135736/0000/myMicroAODOutputFile_167.root", 
+                "nevents": 24839, 
+                "totEvents": 24839, 
+                "weights": 24839.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25063, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_135736/0000/myMicroAODOutputFile_46.root", 
+                "nevents": 25063, 
+                "totEvents": 25063, 
+                "weights": 25063.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25183, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_135736/0000/myMicroAODOutputFile_141.root", 
+                "nevents": 25183, 
+                "totEvents": 25183, 
+                "weights": 25183.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24891, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_135736/0000/myMicroAODOutputFile_127.root", 
+                "nevents": 24891, 
+                "totEvents": 24891, 
+                "weights": 24891.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25005, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_135736/0000/myMicroAODOutputFile_163.root", 
+                "nevents": 25005, 
+                "totEvents": 25005, 
+                "weights": 25005.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25050, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_135736/0000/myMicroAODOutputFile_34.root", 
+                "nevents": 25050, 
+                "totEvents": 25050, 
+                "weights": 25050.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24913, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_135736/0000/myMicroAODOutputFile_116.root", 
+                "nevents": 24913, 
+                "totEvents": 24913, 
+                "weights": 24913.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25046, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_135736/0000/myMicroAODOutputFile_164.root", 
+                "nevents": 25046, 
+                "totEvents": 25046, 
+                "weights": 25046.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24843, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_135736/0000/myMicroAODOutputFile_29.root", 
+                "nevents": 24843, 
+                "totEvents": 24843, 
+                "weights": 24843.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24855, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_135736/0000/myMicroAODOutputFile_37.root", 
+                "nevents": 24855, 
+                "totEvents": 24855, 
+                "weights": 24855.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25349, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_135736/0000/myMicroAODOutputFile_49.root", 
+                "nevents": 25349, 
+                "totEvents": 25349, 
+                "weights": 25349.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24892, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_135736/0000/myMicroAODOutputFile_43.root", 
+                "nevents": 24892, 
+                "totEvents": 24892, 
+                "weights": 24892.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24975, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_135736/0000/myMicroAODOutputFile_47.root", 
+                "nevents": 24975, 
+                "totEvents": 24975, 
+                "weights": 24975.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24918, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_135736/0000/myMicroAODOutputFile_45.root", 
+                "nevents": 24918, 
+                "totEvents": 24918, 
+                "weights": 24918.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25102, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_135736/0000/myMicroAODOutputFile_133.root", 
+                "nevents": 25102, 
+                "totEvents": 25102, 
+                "weights": 25102.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24901, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_135736/0000/myMicroAODOutputFile_154.root", 
+                "nevents": 24901, 
+                "totEvents": 24901, 
+                "weights": 24901.0
+            }, 
+            {
+                "bad": false, 
+                "events": 24896, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_135736/0000/myMicroAODOutputFile_144.root", 
+                "nevents": 24896, 
+                "totEvents": 24896, 
+                "weights": 24896.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25001, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210202_135736/0000/myMicroAODOutputFile_48.root", 
+                "nevents": 25001, 
+                "totEvents": 25001, 
+                "weights": 25001.0
+            }
+        ], 
+        "parent_n_units": 4236591, 
+        "vetted": true
+    }, 
+    "/ttHJetToGG_M130_TuneCP5_13TeV-amcatnloFXFX-madspin-pythia8/alesauva-UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1-40c8f5e3297812fbf727853bb545f6df/USER": {
+        "dset_type": "mc", 
+        "files": [
+            {
+                "bad": false, 
+                "events": 847, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/ttHJetToGG_M130_TuneCP5_13TeV-amcatnloFXFX-madspin-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210225_130022/0000/myMicroAODOutputFile_14.root", 
+                "nevents": 847, 
+                "totEvents": 847, 
+                "weights": 647.7921142578125
+            }, 
+            {
+                "bad": false, 
+                "events": 24969, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/ttHJetToGG_M130_TuneCP5_13TeV-amcatnloFXFX-madspin-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210225_130022/0000/myMicroAODOutputFile_13.root", 
+                "nevents": 24969, 
+                "totEvents": 24969, 
+                "weights": 20994.005859375
+            }, 
+            {
+                "bad": false, 
+                "events": 25026, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/ttHJetToGG_M130_TuneCP5_13TeV-amcatnloFXFX-madspin-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210225_130022/0000/myMicroAODOutputFile_2.root", 
+                "nevents": 25026, 
+                "totEvents": 25026, 
+                "weights": 21132.63671875
+            }, 
+            {
+                "bad": false, 
+                "events": 24671, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/ttHJetToGG_M130_TuneCP5_13TeV-amcatnloFXFX-madspin-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210225_130022/0000/myMicroAODOutputFile_3.root", 
+                "nevents": 24671, 
+                "totEvents": 24671, 
+                "weights": 20706.666015625
+            }, 
+            {
+                "bad": false, 
+                "events": 24853, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/ttHJetToGG_M130_TuneCP5_13TeV-amcatnloFXFX-madspin-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210225_130022/0000/myMicroAODOutputFile_1.root", 
+                "nevents": 24853, 
+                "totEvents": 24853, 
+                "weights": 20792.35546875
+            }, 
+            {
+                "bad": false, 
+                "events": 24955, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/ttHJetToGG_M130_TuneCP5_13TeV-amcatnloFXFX-madspin-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210225_130022/0000/myMicroAODOutputFile_9.root", 
+                "nevents": 24955, 
+                "totEvents": 24955, 
+                "weights": 20994.015625
+            }, 
+            {
+                "bad": false, 
+                "events": 24874, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/ttHJetToGG_M130_TuneCP5_13TeV-amcatnloFXFX-madspin-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210225_130022/0000/myMicroAODOutputFile_12.root", 
+                "nevents": 24874, 
+                "totEvents": 24874, 
+                "weights": 20663.80859375
+            }, 
+            {
+                "bad": false, 
+                "events": 24840, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/ttHJetToGG_M130_TuneCP5_13TeV-amcatnloFXFX-madspin-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210225_130022/0000/myMicroAODOutputFile_6.root", 
+                "nevents": 24840, 
+                "totEvents": 24840, 
+                "weights": 21263.70703125
+            }, 
+            {
+                "bad": false, 
+                "events": 24846, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/ttHJetToGG_M130_TuneCP5_13TeV-amcatnloFXFX-madspin-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210225_130022/0000/myMicroAODOutputFile_4.root", 
+                "nevents": 24846, 
+                "totEvents": 24846, 
+                "weights": 20648.69140625
+            }, 
+            {
+                "bad": false, 
+                "events": 24999, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/ttHJetToGG_M130_TuneCP5_13TeV-amcatnloFXFX-madspin-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210225_130022/0000/myMicroAODOutputFile_10.root", 
+                "nevents": 24999, 
+                "totEvents": 24999, 
+                "weights": 21054.5078125
+            }, 
+            {
+                "bad": false, 
+                "events": 25114, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/ttHJetToGG_M130_TuneCP5_13TeV-amcatnloFXFX-madspin-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210225_130022/0000/myMicroAODOutputFile_7.root", 
+                "nevents": 25114, 
+                "totEvents": 25114, 
+                "weights": 21404.8671875
+            }, 
+            {
+                "bad": false, 
+                "events": 24965, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/ttHJetToGG_M130_TuneCP5_13TeV-amcatnloFXFX-madspin-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210225_130022/0000/myMicroAODOutputFile_8.root", 
+                "nevents": 24965, 
+                "totEvents": 24965, 
+                "weights": 21422.513671875
+            }, 
+            {
+                "bad": false, 
+                "events": 24947, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/ttHJetToGG_M130_TuneCP5_13TeV-amcatnloFXFX-madspin-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210225_130022/0000/myMicroAODOutputFile_11.root", 
+                "nevents": 24947, 
+                "totEvents": 24947, 
+                "weights": 21155.32421875
+            }, 
+            {
+                "bad": false, 
+                "events": 24924, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/ttHJetToGG_M130_TuneCP5_13TeV-amcatnloFXFX-madspin-pythia8/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210225_130022/0000/myMicroAODOutputFile_5.root", 
+                "nevents": 24924, 
+                "totEvents": 24924, 
+                "weights": 20915.865234375
+            }
+        ], 
+        "parent_n_units": 324830, 
+        "vetted": true
+    }
+}

--- a/MetaData/data/Era2017_legacy_v1/datasets_40.json
+++ b/MetaData/data/Era2017_legacy_v1/datasets_40.json
@@ -634,10 +634,10 @@
                 "totEvents": 25000, 
                 "weights": 96654.4375
             }, 
-            {
+                {
                 "bad": false, 
                 "events": 25000, 
-                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/VBFHToGG_M125_TuneCP5_13TeV-amcatnlo-pythia8_storeWeights/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210303_151213/0000/myMicroAODOutputFile_79.root", 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/VBFHToGG_M125_TuneCP5_13TeV-amcatnlo-pythia8_storeWeights/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210315_102436/0000/myMicroAODOutputFile_79.root", 
                 "nevents": 25000, 
                 "totEvents": 25000, 
                 "weights": 101122.2421875

--- a/MetaData/data/Era2017_legacy_v1/datasets_40.json
+++ b/MetaData/data/Era2017_legacy_v1/datasets_40.json
@@ -1,0 +1,792 @@
+{
+    "/VBFHToGG_M125_TuneCP5_13TeV-amcatnlo-pythia8_storeWeights/alesauva-UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1-8709e8b8d2daa2ed8fac18f6d4560942/USER": {
+        "dset_type": "mc", 
+        "files": [
+            {
+                "bad": false, 
+                "events": 5400, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/VBFHToGG_M125_TuneCP5_13TeV-amcatnlo-pythia8_storeWeights/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210303_151213/0000/myMicroAODOutputFile_80.root", 
+                "nevents": 5400, 
+                "totEvents": 5400, 
+                "weights": 22131.044921875
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/VBFHToGG_M125_TuneCP5_13TeV-amcatnlo-pythia8_storeWeights/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210303_151213/0000/myMicroAODOutputFile_43.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 103252.2578125
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/VBFHToGG_M125_TuneCP5_13TeV-amcatnlo-pythia8_storeWeights/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210303_151213/0000/myMicroAODOutputFile_38.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 104810.734375
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/VBFHToGG_M125_TuneCP5_13TeV-amcatnlo-pythia8_storeWeights/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210303_151213/0000/myMicroAODOutputFile_9.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 101589.8125
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/VBFHToGG_M125_TuneCP5_13TeV-amcatnlo-pythia8_storeWeights/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210303_151213/0000/myMicroAODOutputFile_31.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 103693.8125
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/VBFHToGG_M125_TuneCP5_13TeV-amcatnlo-pythia8_storeWeights/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210303_151213/0000/myMicroAODOutputFile_15.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 100109.21875
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/VBFHToGG_M125_TuneCP5_13TeV-amcatnlo-pythia8_storeWeights/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210303_151213/0000/myMicroAODOutputFile_68.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 103278.2265625
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/VBFHToGG_M125_TuneCP5_13TeV-amcatnlo-pythia8_storeWeights/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210303_151213/0000/myMicroAODOutputFile_25.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 104005.4921875
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/VBFHToGG_M125_TuneCP5_13TeV-amcatnlo-pythia8_storeWeights/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210303_151213/0000/myMicroAODOutputFile_52.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 101901.4921875
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/VBFHToGG_M125_TuneCP5_13TeV-amcatnlo-pythia8_storeWeights/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210303_151213/0000/myMicroAODOutputFile_77.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 101589.8203125
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/VBFHToGG_M125_TuneCP5_13TeV-amcatnlo-pythia8_storeWeights/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210303_151213/0000/myMicroAODOutputFile_47.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 101433.8828125
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/VBFHToGG_M125_TuneCP5_13TeV-amcatnlo-pythia8_storeWeights/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210303_151213/0000/myMicroAODOutputFile_78.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 105693.8984375
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/VBFHToGG_M125_TuneCP5_13TeV-amcatnlo-pythia8_storeWeights/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210303_151213/0000/myMicroAODOutputFile_70.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 100914.4296875
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/VBFHToGG_M125_TuneCP5_13TeV-amcatnlo-pythia8_storeWeights/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210303_151213/0000/myMicroAODOutputFile_35.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 100680.6640625
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/VBFHToGG_M125_TuneCP5_13TeV-amcatnlo-pythia8_storeWeights/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210303_151213/0000/myMicroAODOutputFile_40.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 101511.859375
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/VBFHToGG_M125_TuneCP5_13TeV-amcatnlo-pythia8_storeWeights/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210303_151213/0000/myMicroAODOutputFile_57.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 101849.5234375
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/VBFHToGG_M125_TuneCP5_13TeV-amcatnlo-pythia8_storeWeights/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210303_151213/0000/myMicroAODOutputFile_29.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 101408.0546875
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/VBFHToGG_M125_TuneCP5_13TeV-amcatnlo-pythia8_storeWeights/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210303_151213/0000/myMicroAODOutputFile_34.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 104654.875
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/VBFHToGG_M125_TuneCP5_13TeV-amcatnlo-pythia8_storeWeights/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210303_151213/0000/myMicroAODOutputFile_66.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 99407.828125
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/VBFHToGG_M125_TuneCP5_13TeV-amcatnlo-pythia8_storeWeights/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210303_151213/0000/myMicroAODOutputFile_54.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 100524.8203125
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/VBFHToGG_M125_TuneCP5_13TeV-amcatnlo-pythia8_storeWeights/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210303_151213/0000/myMicroAODOutputFile_14.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 101433.921875
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/VBFHToGG_M125_TuneCP5_13TeV-amcatnlo-pythia8_storeWeights/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210303_151213/0000/myMicroAODOutputFile_45.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 98446.78125
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/VBFHToGG_M125_TuneCP5_13TeV-amcatnlo-pythia8_storeWeights/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210303_151213/0000/myMicroAODOutputFile_60.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 100784.5703125
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/VBFHToGG_M125_TuneCP5_13TeV-amcatnlo-pythia8_storeWeights/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210303_151213/0000/myMicroAODOutputFile_24.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 101304.078125
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/VBFHToGG_M125_TuneCP5_13TeV-amcatnlo-pythia8_storeWeights/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210303_151213/0000/myMicroAODOutputFile_59.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 101485.8984375
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/VBFHToGG_M125_TuneCP5_13TeV-amcatnlo-pythia8_storeWeights/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210303_151213/0000/myMicroAODOutputFile_3.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 103408.078125
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/VBFHToGG_M125_TuneCP5_13TeV-amcatnlo-pythia8_storeWeights/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210303_151213/0000/myMicroAODOutputFile_2.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 102395.046875
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/VBFHToGG_M125_TuneCP5_13TeV-amcatnlo-pythia8_storeWeights/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210303_151213/0000/myMicroAODOutputFile_76.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 105408.1953125
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/VBFHToGG_M125_TuneCP5_13TeV-amcatnlo-pythia8_storeWeights/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210303_151213/0000/myMicroAODOutputFile_19.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 102161.28125
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/VBFHToGG_M125_TuneCP5_13TeV-amcatnlo-pythia8_storeWeights/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210303_151213/0000/myMicroAODOutputFile_7.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 100732.59375
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/VBFHToGG_M125_TuneCP5_13TeV-amcatnlo-pythia8_storeWeights/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210303_151213/0000/myMicroAODOutputFile_39.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 100914.46875
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/VBFHToGG_M125_TuneCP5_13TeV-amcatnlo-pythia8_storeWeights/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210303_151213/0000/myMicroAODOutputFile_56.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 101563.8359375
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/VBFHToGG_M125_TuneCP5_13TeV-amcatnlo-pythia8_storeWeights/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210303_151213/0000/myMicroAODOutputFile_58.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 103460.0703125
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/VBFHToGG_M125_TuneCP5_13TeV-amcatnlo-pythia8_storeWeights/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210303_151213/0000/myMicroAODOutputFile_48.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 102343.078125
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/VBFHToGG_M125_TuneCP5_13TeV-amcatnlo-pythia8_storeWeights/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210303_151213/0000/myMicroAODOutputFile_26.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 100680.671875
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/VBFHToGG_M125_TuneCP5_13TeV-amcatnlo-pythia8_storeWeights/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210303_151213/0000/myMicroAODOutputFile_32.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 106265.3671875
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/VBFHToGG_M125_TuneCP5_13TeV-amcatnlo-pythia8_storeWeights/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210303_151213/0000/myMicroAODOutputFile_65.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 101953.4609375
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/VBFHToGG_M125_TuneCP5_13TeV-amcatnlo-pythia8_storeWeights/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210303_151213/0000/myMicroAODOutputFile_37.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 97122.015625
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/VBFHToGG_M125_TuneCP5_13TeV-amcatnlo-pythia8_storeWeights/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210303_151213/0000/myMicroAODOutputFile_64.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 102187.2421875
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/VBFHToGG_M125_TuneCP5_13TeV-amcatnlo-pythia8_storeWeights/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210303_151213/0000/myMicroAODOutputFile_46.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 102057.359375
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/VBFHToGG_M125_TuneCP5_13TeV-amcatnlo-pythia8_storeWeights/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210303_151213/0000/myMicroAODOutputFile_22.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 100057.25
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/VBFHToGG_M125_TuneCP5_13TeV-amcatnlo-pythia8_storeWeights/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210303_151213/0000/myMicroAODOutputFile_73.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 99693.5703125
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/VBFHToGG_M125_TuneCP5_13TeV-amcatnlo-pythia8_storeWeights/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210303_151213/0000/myMicroAODOutputFile_36.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 99797.46875
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/VBFHToGG_M125_TuneCP5_13TeV-amcatnlo-pythia8_storeWeights/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210303_151213/0000/myMicroAODOutputFile_74.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 101563.8125
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/VBFHToGG_M125_TuneCP5_13TeV-amcatnlo-pythia8_storeWeights/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210303_151213/0000/myMicroAODOutputFile_42.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 103641.84375
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/VBFHToGG_M125_TuneCP5_13TeV-amcatnlo-pythia8_storeWeights/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210303_151213/0000/myMicroAODOutputFile_72.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 101330.0546875
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/VBFHToGG_M125_TuneCP5_13TeV-amcatnlo-pythia8_storeWeights/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210303_151213/0000/myMicroAODOutputFile_69.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 102784.671875
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/VBFHToGG_M125_TuneCP5_13TeV-amcatnlo-pythia8_storeWeights/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210303_151213/0000/myMicroAODOutputFile_23.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 100187.140625
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/VBFHToGG_M125_TuneCP5_13TeV-amcatnlo-pythia8_storeWeights/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210303_151213/0000/myMicroAODOutputFile_44.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 104369.171875
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/VBFHToGG_M125_TuneCP5_13TeV-amcatnlo-pythia8_storeWeights/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210303_151213/0000/myMicroAODOutputFile_41.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 100836.5
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/VBFHToGG_M125_TuneCP5_13TeV-amcatnlo-pythia8_storeWeights/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210303_151213/0000/myMicroAODOutputFile_51.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 102421.0
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/VBFHToGG_M125_TuneCP5_13TeV-amcatnlo-pythia8_storeWeights/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210303_151213/0000/myMicroAODOutputFile_61.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 100498.8125
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/VBFHToGG_M125_TuneCP5_13TeV-amcatnlo-pythia8_storeWeights/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210303_151213/0000/myMicroAODOutputFile_1.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 103615.890625
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/VBFHToGG_M125_TuneCP5_13TeV-amcatnlo-pythia8_storeWeights/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210303_151213/0000/myMicroAODOutputFile_62.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 103070.3671875
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/VBFHToGG_M125_TuneCP5_13TeV-amcatnlo-pythia8_storeWeights/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210303_151213/0000/myMicroAODOutputFile_28.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 101226.171875
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/VBFHToGG_M125_TuneCP5_13TeV-amcatnlo-pythia8_storeWeights/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210303_151213/0000/myMicroAODOutputFile_53.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 102654.7734375
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/VBFHToGG_M125_TuneCP5_13TeV-amcatnlo-pythia8_storeWeights/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210303_151213/0000/myMicroAODOutputFile_33.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 100836.5078125
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/VBFHToGG_M125_TuneCP5_13TeV-amcatnlo-pythia8_storeWeights/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210303_151213/0000/myMicroAODOutputFile_4.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 99745.546875
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/VBFHToGG_M125_TuneCP5_13TeV-amcatnlo-pythia8_storeWeights/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210303_151213/0000/myMicroAODOutputFile_75.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 102031.375
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/VBFHToGG_M125_TuneCP5_13TeV-amcatnlo-pythia8_storeWeights/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210303_151213/0000/myMicroAODOutputFile_10.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 98680.5625
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/VBFHToGG_M125_TuneCP5_13TeV-amcatnlo-pythia8_storeWeights/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210303_151213/0000/myMicroAODOutputFile_50.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 104706.8515625
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/VBFHToGG_M125_TuneCP5_13TeV-amcatnlo-pythia8_storeWeights/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210303_151213/0000/myMicroAODOutputFile_67.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 103719.75
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/VBFHToGG_M125_TuneCP5_13TeV-amcatnlo-pythia8_storeWeights/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210303_151213/0000/myMicroAODOutputFile_13.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 104784.7421875
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/VBFHToGG_M125_TuneCP5_13TeV-amcatnlo-pythia8_storeWeights/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210303_151213/0000/myMicroAODOutputFile_6.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 101148.2265625
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/VBFHToGG_M125_TuneCP5_13TeV-amcatnlo-pythia8_storeWeights/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210303_151213/0000/myMicroAODOutputFile_21.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 104317.203125
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/VBFHToGG_M125_TuneCP5_13TeV-amcatnlo-pythia8_storeWeights/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210303_151213/0000/myMicroAODOutputFile_12.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 99329.9296875
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/VBFHToGG_M125_TuneCP5_13TeV-amcatnlo-pythia8_storeWeights/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210303_151213/0000/myMicroAODOutputFile_20.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 101122.2421875
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/VBFHToGG_M125_TuneCP5_13TeV-amcatnlo-pythia8_storeWeights/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210303_151213/0000/myMicroAODOutputFile_16.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 100940.375
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/VBFHToGG_M125_TuneCP5_13TeV-amcatnlo-pythia8_storeWeights/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210303_151213/0000/myMicroAODOutputFile_17.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 100524.8125
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/VBFHToGG_M125_TuneCP5_13TeV-amcatnlo-pythia8_storeWeights/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210303_151213/0000/myMicroAODOutputFile_8.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 98394.8359375
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/VBFHToGG_M125_TuneCP5_13TeV-amcatnlo-pythia8_storeWeights/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210303_151213/0000/myMicroAODOutputFile_49.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 104395.1484375
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/VBFHToGG_M125_TuneCP5_13TeV-amcatnlo-pythia8_storeWeights/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210303_151213/0000/myMicroAODOutputFile_11.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 100732.59375
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/VBFHToGG_M125_TuneCP5_13TeV-amcatnlo-pythia8_storeWeights/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210303_151213/0000/myMicroAODOutputFile_5.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 99355.9140625
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/VBFHToGG_M125_TuneCP5_13TeV-amcatnlo-pythia8_storeWeights/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210303_151213/0000/myMicroAODOutputFile_55.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 103304.171875
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/VBFHToGG_M125_TuneCP5_13TeV-amcatnlo-pythia8_storeWeights/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210303_151213/0000/myMicroAODOutputFile_63.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 100810.5703125
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/VBFHToGG_M125_TuneCP5_13TeV-amcatnlo-pythia8_storeWeights/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210303_151213/0000/myMicroAODOutputFile_71.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 98602.625
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/VBFHToGG_M125_TuneCP5_13TeV-amcatnlo-pythia8_storeWeights/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210303_151213/0000/myMicroAODOutputFile_30.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 101330.015625
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/VBFHToGG_M125_TuneCP5_13TeV-amcatnlo-pythia8_storeWeights/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210303_151213/0000/myMicroAODOutputFile_27.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 101070.3125
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/VBFHToGG_M125_TuneCP5_13TeV-amcatnlo-pythia8_storeWeights/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210303_151213/0000/myMicroAODOutputFile_18.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 96654.4375
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/VBFHToGG_M125_TuneCP5_13TeV-amcatnlo-pythia8_storeWeights/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210303_151213/0000/myMicroAODOutputFile_79.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 101122.2421875
+            }
+        ], 
+        "parent_n_units": 1980400, 
+        "vetted": true
+    }, 
+    "/ttHJetToGG_M125_TuneCP5_13TeV-amcatnloFXFX-madspin-pythia8_storeWeights/alesauva-UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1-40c8f5e3297812fbf727853bb545f6df/USER": {
+        "dset_type": "mc", 
+        "files": [
+            {
+                "bad": false, 
+                "events": 24919, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/ttHJetToGG_M125_TuneCP5_13TeV-amcatnloFXFX-madspin-pythia8_storeWeights/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210303_153246/0000/myMicroAODOutputFile_7.root", 
+                "nevents": 24919, 
+                "totEvents": 24919, 
+                "weights": 23261.6171875
+            }, 
+            {
+                "bad": false, 
+                "events": 24881, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/ttHJetToGG_M125_TuneCP5_13TeV-amcatnloFXFX-madspin-pythia8_storeWeights/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210303_153246/0000/myMicroAODOutputFile_14.root", 
+                "nevents": 24881, 
+                "totEvents": 24881, 
+                "weights": 24246.92578125
+            }, 
+            {
+                "bad": false, 
+                "events": 25085, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/ttHJetToGG_M125_TuneCP5_13TeV-amcatnloFXFX-madspin-pythia8_storeWeights/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210303_153246/0000/myMicroAODOutputFile_4.root", 
+                "nevents": 25085, 
+                "totEvents": 25085, 
+                "weights": 23334.8125
+            }, 
+            {
+                "bad": false, 
+                "events": 18044, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/ttHJetToGG_M125_TuneCP5_13TeV-amcatnloFXFX-madspin-pythia8_storeWeights/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210303_153246/0000/myMicroAODOutputFile_17.root", 
+                "nevents": 18044, 
+                "totEvents": 18044, 
+                "weights": 17285.041015625
+            }, 
+            {
+                "bad": false, 
+                "events": 24884, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/ttHJetToGG_M125_TuneCP5_13TeV-amcatnloFXFX-madspin-pythia8_storeWeights/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210303_153246/0000/myMicroAODOutputFile_15.root", 
+                "nevents": 24884, 
+                "totEvents": 24884, 
+                "weights": 24052.66796875
+            }, 
+            {
+                "bad": false, 
+                "events": 24988, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/ttHJetToGG_M125_TuneCP5_13TeV-amcatnloFXFX-madspin-pythia8_storeWeights/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210303_153246/0000/myMicroAODOutputFile_8.root", 
+                "nevents": 24988, 
+                "totEvents": 24988, 
+                "weights": 23658.546875
+            }, 
+            {
+                "bad": false, 
+                "events": 24913, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/ttHJetToGG_M125_TuneCP5_13TeV-amcatnloFXFX-madspin-pythia8_storeWeights/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210303_153246/0000/myMicroAODOutputFile_12.root", 
+                "nevents": 24913, 
+                "totEvents": 24913, 
+                "weights": 23188.421875
+            }, 
+            {
+                "bad": false, 
+                "events": 24835, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/ttHJetToGG_M125_TuneCP5_13TeV-amcatnloFXFX-madspin-pythia8_storeWeights/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210303_153246/0000/myMicroAODOutputFile_3.root", 
+                "nevents": 24835, 
+                "totEvents": 24835, 
+                "weights": 22540.9296875
+            }, 
+            {
+                "bad": false, 
+                "events": 25009, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/ttHJetToGG_M125_TuneCP5_13TeV-amcatnloFXFX-madspin-pythia8_storeWeights/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210303_153246/0000/myMicroAODOutputFile_11.root", 
+                "nevents": 25009, 
+                "totEvents": 25009, 
+                "weights": 23453.03125
+            }, 
+            {
+                "bad": false, 
+                "events": 25013, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/ttHJetToGG_M125_TuneCP5_13TeV-amcatnloFXFX-madspin-pythia8_storeWeights/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210303_153246/0000/myMicroAODOutputFile_10.root", 
+                "nevents": 25013, 
+                "totEvents": 25013, 
+                "weights": 23689.5234375
+            }, 
+            {
+                "bad": false, 
+                "events": 24946, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/ttHJetToGG_M125_TuneCP5_13TeV-amcatnloFXFX-madspin-pythia8_storeWeights/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210303_153246/0000/myMicroAODOutputFile_13.root", 
+                "nevents": 24946, 
+                "totEvents": 24946, 
+                "weights": 23849.978515625
+            }, 
+            {
+                "bad": false, 
+                "events": 24857, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/ttHJetToGG_M125_TuneCP5_13TeV-amcatnloFXFX-madspin-pythia8_storeWeights/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210303_153246/0000/myMicroAODOutputFile_16.root", 
+                "nevents": 24857, 
+                "totEvents": 24857, 
+                "weights": 23391.109375
+            }, 
+            {
+                "bad": false, 
+                "events": 24899, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/ttHJetToGG_M125_TuneCP5_13TeV-amcatnloFXFX-madspin-pythia8_storeWeights/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210303_153246/0000/myMicroAODOutputFile_6.root", 
+                "nevents": 24899, 
+                "totEvents": 24899, 
+                "weights": 22676.052734375
+            }, 
+            {
+                "bad": false, 
+                "events": 24949, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/ttHJetToGG_M125_TuneCP5_13TeV-amcatnloFXFX-madspin-pythia8_storeWeights/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210303_153246/0000/myMicroAODOutputFile_1.root", 
+                "nevents": 24949, 
+                "totEvents": 24949, 
+                "weights": 24055.484375
+            }, 
+            {
+                "bad": false, 
+                "events": 24869, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/ttHJetToGG_M125_TuneCP5_13TeV-amcatnloFXFX-madspin-pythia8_storeWeights/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210303_153246/0000/myMicroAODOutputFile_9.root", 
+                "nevents": 24869, 
+                "totEvents": 24869, 
+                "weights": 24032.96484375
+            }, 
+            {
+                "bad": false, 
+                "events": 24940, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/ttHJetToGG_M125_TuneCP5_13TeV-amcatnloFXFX-madspin-pythia8_storeWeights/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210303_153246/0000/myMicroAODOutputFile_5.root", 
+                "nevents": 24940, 
+                "totEvents": 24940, 
+                "weights": 23816.193359375
+            }, 
+            {
+                "bad": false, 
+                "events": 25172, 
+                "name": "/store/user/alesauva/flashgg/UL2017_5/10_6_4/ttHJetToGG_M125_TuneCP5_13TeV-amcatnloFXFX-madspin-pythia8_storeWeights/UL2017_5-10_6_4-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/210303_153246/0000/myMicroAODOutputFile_2.root", 
+                "nevents": 25172, 
+                "totEvents": 25172, 
+                "weights": 23562.83203125
+            }
+        ], 
+        "parent_n_units": 417203, 
+        "vetted": true
+    }
+}


### PR DESCRIPTION
Add a few samples to the UL17 catalogue:

**signal:**
ttHJetToGG_M125_TuneCP5_13TeV-amcatnloFXFX-madspin-pythia8_storeWeight (contains needed weights for theory syst. computation)
VBFHToGG_M125_TuneCP5_13TeV-amcatnlo-pythia8_storeWeights (contains needed weights for theory syst. computation)
ttHJetToGG_M130_TuneCP5_13TeV-amcatnloFXFX-madspin

**background:**
GJets_HT-40To100_TuneCP5
GJets_HT-100To200_TuneCP5
GJets_HT-200To400_TuneCP5
GJets_HT-400To600_TuneCP5
GJets_HT-600ToInf_TuneCP5
QCD_Pt-30to50_EMEnriched_TuneCP5
QCD_Pt-20to30_EMEnriched_TuneCP5