### PR TITLE
Fix for dumping systematic variation of theory weights for ultra-legacy samples

### DIFF
--- a/MetaData/data/MetaConditions/Era2016_RR-17Jul2018_v1.json
+++ b/MetaData/data/MetaConditions/Era2016_RR-17Jul2018_v1.json
@@ -213,7 +213,7 @@
 	"eta" : 2.4
     },
 
-    "mc2hessianCSV" : "PhysicsTools/HepMCCandAlgos/data/NNPDF30_lo_as_0130_hessian_60.csv",
+    "mc2hessianCSV" : "PhysicsTools/HepMCCandAlgos/data/NNPDF30_nlo_as_0118_hessian_60.csv",
 
     "bRegression" :
     {

--- a/MetaData/data/MetaConditions/Era2017_legacy_v1.json
+++ b/MetaData/data/MetaConditions/Era2017_legacy_v1.json
@@ -237,7 +237,7 @@
 	"eta" : 2.5
     },
 
-    "mc2hessianCSV" : "PhysicsTools/HepMCCandAlgos/data/NNPDF30_lo_as_0130_hessian_60.csv",
+    "mc2hessianCSV" : "PhysicsTools/HepMCCandAlgos/data/NNPDF30_nlo_as_0118_hessian_60.csv",
 
     "bRegression" :
     {

--- a/MetaData/data/MetaConditions/Era2017_legacy_v1.json
+++ b/MetaData/data/MetaConditions/Era2017_legacy_v1.json
@@ -237,7 +237,7 @@
 	"eta" : 2.5
     },
 
-    "mc2hessianCSV" : "PhysicsTools/HepMCCandAlgos/data/NNPDF30_nlo_as_0118_hessian_60.csv",
+    "mc2hessianCSV" : "PhysicsTools/HepMCCandAlgos/data/NNPDF30_lo_as_0130_hessian_60.csv",
 
     "bRegression" :
     {

--- a/MetaData/data/MetaConditions/Era2017_legacy_v1.json
+++ b/MetaData/data/MetaConditions/Era2017_legacy_v1.json
@@ -237,7 +237,7 @@
 	"eta" : 2.5
     },
 
-    "mc2hessianCSV" : "PhysicsTools/HepMCCandAlgos/data/NNPDF30_lo_as_0130_hessian_60.csv",
+    "mc2hessianCSV" : "",
 
     "bRegression" :
     {

--- a/MetaData/data/MetaConditions/Era2018_RR-17Sep2018_v1.json
+++ b/MetaData/data/MetaConditions/Era2018_RR-17Sep2018_v1.json
@@ -213,7 +213,7 @@
 	"eta" : 2.5
     },
 
-    "mc2hessianCSV" : "PhysicsTools/HepMCCandAlgos/data/NNPDF30_lo_as_0130_hessian_60.csv",
+    "mc2hessianCSV" : "",
 
     "bRegression" :
     {

--- a/MicroAOD/interface/HadronicActivityProducer.h
+++ b/MicroAOD/interface/HadronicActivityProducer.h
@@ -98,6 +98,7 @@ namespace flashgg {
             auto & collection = *src;
             
             int count = ( max_ > 0 ? max_ : collection.size() );
+
             for( size_t iob = 0; iob<collection.size() && count > 0; ++iob ) {
                 auto & cand = collection.at(iob);
                 bool add = true;

--- a/MicroAOD/plugins/PDFWeightObjectProducer.cc
+++ b/MicroAOD/plugins/PDFWeightObjectProducer.cc
@@ -531,7 +531,7 @@ namespace flashgg {
         if(doAlphasWeights_)assert(PDFWeightProducer::alpha_indices.size() == 2);
 		
         // --- Get MCtoHessian PDF weights
-        if((isStandardSample_ && mc2hessianCSV_ != "") || (pdfvar.find("hessian") == std::string::npos && mc2hessianCSV_ != ""))
+        if(isStandardSample_  && mc2hessianCSV_ != "" && pdfvar.find("hessian") == std::string::npos)
         {
             edm::FileInPath mc2hessianCSVFile(mc2hessianCSV_);
             pdfweightshelper_.Init(PDFWeightProducer::pdf_indices.size(),nPdfEigWeights_,mc2hessianCSVFile);
@@ -542,7 +542,7 @@ namespace flashgg {
         //        double nomlheweight = LHEEventHandle->weights()[0].wgt;//ok, but not-safe to access the vector, see line below
         double nomlheweight = LHEEventHandle->originalXWGTUP();
         
-        if((isStandardSample_ && mc2hessianCSV_ != "") || (pdfvar.find("hessian") == std::string::npos && mc2hessianCSV_ != ""))
+        if(isStandardSample_  && mc2hessianCSV_ != "" && pdfvar.find("hessian") == std::string::npos)
             {
                 pdfweightshelper_.DoMC2Hessian(nomlheweight,inpdfweights.data(),outpdfweights.data());   
             }
@@ -551,7 +551,7 @@ namespace flashgg {
             
 
             double wgtval = inpdfweights[iwgt];
-            if ((isStandardSample_  && mc2hessianCSV_ != "") || (pdfvar.find("hessian") == std::string::npos && mc2hessianCSV_ != ""))wgtval = outpdfweights[iwgt];
+            if (isStandardSample_  && mc2hessianCSV_ != "" && pdfvar.find("hessian") == std::string::npos)wgtval = outpdfweights[iwgt];
             
             
             float real_weight = wgtval*gen_weight/nomlheweight;

--- a/MicroAOD/plugins/PDFWeightObjectProducer.cc
+++ b/MicroAOD/plugins/PDFWeightObjectProducer.cc
@@ -209,8 +209,8 @@ namespace flashgg {
         
         
         // --- Name of the weightgroup
-        string scalevar = "scale variation";
-        string pdfvar   = "hessian_pdfas";
+        string scalevar = "scale_variation";
+        string pdfvar   = "PDF_variation";
         //        string alphavar;  //only for thq samples
         //        string pdfnlovar; //only for thq samples (could be extended to the rest of samples)
 
@@ -248,7 +248,7 @@ namespace flashgg {
                         if(debug_) std::cout<<"customizing non-standard sample"<<std::endl;
                     
                     isStandardSample_=false;
-                    // doAlphasWeights_=false;
+                    doAlphasWeights_=false;
                     
                     for(auto it = PDFmapString_.begin(); it != PDFmapString_.end(); it++){
                         if(it->second == (unsigned int)pdfidx){
@@ -256,10 +256,16 @@ namespace flashgg {
                             if(debug_)std::cout<<"setting pdf var to "<<pdfvar<<std::endl;
                         }
                     }
+                    if (pdfidx == 325300 && pdfvar == "NNPDF31_nnlo_as_0118_mc_hessian_pdfas") {
+                        isStandardSample_=true;
+                        doAlphasWeights_=true;
+                    }
                     
 
                 }
                 }
+
+               
 
                 if (debug_) {
                     std::cout << "weightgroupname1 and weightgroupname2 are:" << std::endl;

--- a/MicroAOD/plugins/PDFWeightObjectProducer.cc
+++ b/MicroAOD/plugins/PDFWeightObjectProducer.cc
@@ -531,7 +531,7 @@ namespace flashgg {
         if(doAlphasWeights_)assert(PDFWeightProducer::alpha_indices.size() == 2);
 		
         // --- Get MCtoHessian PDF weights
-        if((isStandardSample_ && mc2hessianCSV_ != "") || (pdfvar.find("hessian") != std::string::npos && mc2hessianCSV_ != ""))
+        if((isStandardSample_ && mc2hessianCSV_ != "") || (pdfvar.find("hessian") == std::string::npos && mc2hessianCSV_ != ""))
         {
             edm::FileInPath mc2hessianCSVFile(mc2hessianCSV_);
             pdfweightshelper_.Init(PDFWeightProducer::pdf_indices.size(),nPdfEigWeights_,mc2hessianCSVFile);
@@ -542,7 +542,7 @@ namespace flashgg {
         //        double nomlheweight = LHEEventHandle->weights()[0].wgt;//ok, but not-safe to access the vector, see line below
         double nomlheweight = LHEEventHandle->originalXWGTUP();
         
-        if(isStandardSample_ || pdfvar.find("hessian") != std::string::npos)
+        if((isStandardSample_ && mc2hessianCSV_ != "") || (pdfvar.find("hessian") == std::string::npos && mc2hessianCSV_ != ""))
             {
                 pdfweightshelper_.DoMC2Hessian(nomlheweight,inpdfweights.data(),outpdfweights.data());   
             }
@@ -551,7 +551,7 @@ namespace flashgg {
             
 
             double wgtval = inpdfweights[iwgt];
-            if (isStandardSample_ || pdfvar.find("hessian") != std::string::npos)wgtval = outpdfweights[iwgt];
+            if ((isStandardSample_  && mc2hessianCSV_ != "") || (pdfvar.find("hessian") == std::string::npos && mc2hessianCSV_ != ""))wgtval = outpdfweights[iwgt];
             
             
             float real_weight = wgtval*gen_weight/nomlheweight;

--- a/MicroAOD/plugins/PDFWeightObjectProducer.cc
+++ b/MicroAOD/plugins/PDFWeightObjectProducer.cc
@@ -316,7 +316,6 @@ namespace flashgg {
                             
                             if (isStandardSample_){
                                 boost::split(strs, strw, boost::is_any_of("="));
-                                std::cout << "Standard sample strs " << strs.back() << std::endl;
                             }else{
                                 strs.push_back(std::to_string(pdfidx + variationindex));
                                 variationindex++;
@@ -346,7 +345,6 @@ namespace flashgg {
                 std::size_t wgN2ScaleV = 0;
                 bool wgN1ScaleVFound=false;
                 bool wgN2ScaleVFound=false;
-                std::cout << "scalevar: " << scalevar << std::endl;
                 if (weightgroupname1) {
                     wgN1ScaleV = weightgroupname1.get().find(scalevar);
                     if (wgN1ScaleV != std::string::npos) {
@@ -546,7 +544,6 @@ namespace flashgg {
         
         if(isStandardSample_ || pdfvar.find("hessian") != std::string::npos)
             {
-                std::cout << "Doing mc2hessian! File: " << mc2hessianCSV_ << std::endl;
                 pdfweightshelper_.DoMC2Hessian(nomlheweight,inpdfweights.data(),outpdfweights.data());   
             }
         

--- a/MicroAOD/plugins/PDFWeightObjectProducer.cc
+++ b/MicroAOD/plugins/PDFWeightObjectProducer.cc
@@ -315,6 +315,7 @@ namespace flashgg {
                             
                             if (isStandardSample_){
                                 boost::split(strs, strw, boost::is_any_of("="));
+                                std::cout << "Standard sample strs " << strs.back() << std::endl;
                             }else{
                                 strs.push_back(std::to_string(pdfidx + variationindex));
                                 variationindex++;

--- a/MicroAOD/plugins/PDFWeightObjectProducer.cc
+++ b/MicroAOD/plugins/PDFWeightObjectProducer.cc
@@ -60,7 +60,8 @@ namespace flashgg {
         bool doAlphasWeights_;
         bool doScaleWeights_;
         string generatorType ;
-
+        string pdfvar;
+        
         string runLabel_;
         bool debug_;
 
@@ -210,7 +211,7 @@ namespace flashgg {
         
         // --- Name of the weightgroup
         string scalevar = "scale_variation";
-        string pdfvar   = "PDF_variation";
+        pdfvar   = "PDF_variation";
         //        string alphavar;  //only for thq samples
         //        string pdfnlovar; //only for thq samples (could be extended to the rest of samples)
 
@@ -257,7 +258,7 @@ namespace flashgg {
                         }
                     }
                     if (pdfidx == 325300 && pdfvar == "NNPDF31_nnlo_as_0118_mc_hessian_pdfas") {
-                        isStandardSample_=true;
+                        // isStandardSample_=true;
                         doAlphasWeights_=true;
                     }
                     
@@ -532,7 +533,7 @@ namespace flashgg {
         if(doAlphasWeights_)assert(PDFWeightProducer::alpha_indices.size() == 2);
 		
         // --- Get MCtoHessian PDF weights
-        if(isStandardSample_ && mc2hessianCSV_ != "")
+        if((isStandardSample_ && mc2hessianCSV_ != "") || (pdfvar.find("hessian") != std::string::npos && mc2hessianCSV_ != ""))
         {
             edm::FileInPath mc2hessianCSVFile(mc2hessianCSV_);
             pdfweightshelper_.Init(PDFWeightProducer::pdf_indices.size(),nPdfEigWeights_,mc2hessianCSVFile);
@@ -543,14 +544,17 @@ namespace flashgg {
         //        double nomlheweight = LHEEventHandle->weights()[0].wgt;//ok, but not-safe to access the vector, see line below
         double nomlheweight = LHEEventHandle->originalXWGTUP();
         
-        if(isStandardSample_)
-            pdfweightshelper_.DoMC2Hessian(nomlheweight,inpdfweights.data(),outpdfweights.data());
+        if(isStandardSample_ || pdfvar.find("hessian") != std::string::npos)
+            {
+                std::cout << "Doing mc2hessian! File: " << mc2hessianCSV_ << std::endl;
+                pdfweightshelper_.DoMC2Hessian(nomlheweight,inpdfweights.data(),outpdfweights.data());   
+            }
         
         for (unsigned int iwgt=0; iwgt<nPdfEigWeights_; ++iwgt) {
             
 
             double wgtval = inpdfweights[iwgt];
-            if (isStandardSample_)wgtval = outpdfweights[iwgt];
+            if (isStandardSample_ || pdfvar.find("hessian") != std::string::npos)wgtval = outpdfweights[iwgt];
             
             
             float real_weight = wgtval*gen_weight/nomlheweight;

--- a/Systematics/python/SystematicsCustomize.py
+++ b/Systematics/python/SystematicsCustomize.py
@@ -369,10 +369,11 @@ def recalculatePDFWeights(process, options):
                                                     nPdfEigWeights = cms.uint32(60),
                                                     mc2hessianCSV = cms.untracked.string(options["mc2hessianCSV"].encode("ascii")),
                                                     LHERunLabel = cms.string("externalLHEProducer"),
-                                                    Debug = cms.bool(False),
+                                                    Debug = cms.bool(True),
                                                     PDFmap = cms.PSet(#see here https://lhapdf.hepforge.org/pdfsets.html to update the map if needed
-                                                        NNPDF30_lo_as_0130_nf_4 = cms.untracked.uint32(263400),
-                                                        NNPDF31_nnlo_as_0118_nf_4 = cms.untracked.uint32(320900)
+                                                        NNPDF31_nnlo_as_0118_mc_hessian_pdfas = cms.untracked.uint32(325300)
+                                                        # NNPDF30_lo_as_0130_nf_4 = cms.untracked.uint32(263400),
+                                                        # NNPDF31_nnlo_as_0118_nf_4 = cms.untracked.uint32(320900)
                                                     )
                                                 ) 
     process.p.insert(0, process.flashggPDFWeightObject)

--- a/Systematics/python/SystematicsCustomize.py
+++ b/Systematics/python/SystematicsCustomize.py
@@ -369,7 +369,7 @@ def recalculatePDFWeights(process, options):
                                                     nPdfEigWeights = cms.uint32(60),
                                                     mc2hessianCSV = cms.untracked.string(options["mc2hessianCSV"].encode("ascii")),
                                                     LHERunLabel = cms.string("externalLHEProducer"),
-                                                    Debug = cms.bool(True),
+                                                    Debug = cms.bool(False),
                                                     PDFmap = cms.PSet(#see here https://lhapdf.hepforge.org/pdfsets.html to update the map if needed
                                                         NNPDF31_nnlo_as_0118_mc_hessian_pdfas = cms.untracked.uint32(325300)
                                                         # NNPDF30_lo_as_0130_nf_4 = cms.untracked.uint32(263400),


### PR DESCRIPTION
Only tested with ultra legacy 2017 sample. Compatible with ReReco as well (tested on 2017, given the right settings) 
mc2hessian csv file should be confirmed to be correct here: https://github.com/cms-analysis/flashgg/blob/dd6661a55448c403b46d1155510c67a313cd44a8/MetaData/data/MetaConditions/Era2017_legacy_v1.json#L240

This is only a quick fix and it should be reviewed in the future how this information can be accessed in a more consistent way