### PR TITLE
Update the meta conditions for UL18 and the rest UL 17 

### DIFF
--- a/MetaData/data/MetaConditions/Era2016_RR-17Jul2018_v1.json
+++ b/MetaData/data/MetaConditions/Era2016_RR-17Jul2018_v1.json
@@ -200,8 +200,10 @@
 
 	"bTagEffBins" : "bTagEffBins2016",
         
-	"bTagger" : "pfDeepJet",  
-        
+	"bTagger" : "pfDeepJet",
+
+    "isNewCSVFormat" : false,
+
 	"bDiscriminatorValue_pfDeepCSV" : 0.6321,
 	"bTagCalibrationFile_Reshape_pfDeepCSV" : "flashgg/Systematics/data/DeepCSV_2016LegacySF_V1.csv",
 	"bTagCalibrationFile_WPCut_pfDeepCSV" : "flashgg/Systematics/data/DeepCSV_2016LegacySF_WP_V1.csv",

--- a/MetaData/data/MetaConditions/Era2016_legacyPostVFP_v1.json
+++ b/MetaData/data/MetaConditions/Era2016_legacyPostVFP_v1.json
@@ -90,7 +90,9 @@
 
 	"bTagEffBins" : "bTagEffBins2016",
     
-	"bTagger" : "pfDeepJet",  
+	"bTagger" : "pfDeepJet",
+
+    "isNewCSVFormat" : false,
     
 	"bDiscriminatorValue_pfDeepCSV" : 0.6321,
 	"bTagCalibrationFile_Reshape_pfDeepCSV" : "flashgg/Systematics/data/DeepCSV_2016LegacySF_V1.csv",

--- a/MetaData/data/MetaConditions/Era2016_legacyPreVFP_v1.json
+++ b/MetaData/data/MetaConditions/Era2016_legacyPreVFP_v1.json
@@ -90,8 +90,10 @@
 
 	"bTagEffBins" : "bTagEffBins2016",
     
-	"bTagger" : "pfDeepJet",  
-    
+	"bTagger" : "pfDeepJet",
+
+    "isNewCSVFormat" : false,
+
 	"bDiscriminatorValue_pfDeepCSV" : 0.6321,
 	"bTagCalibrationFile_Reshape_pfDeepCSV" : "flashgg/Systematics/data/DeepCSV_2016LegacySF_V1.csv",
 	"bTagCalibrationFile_WPCut_pfDeepCSV" : "flashgg/Systematics/data/DeepCSV_2016LegacySF_WP_V1.csv",

--- a/MetaData/data/MetaConditions/Era2017_RR-31Mar2018_v1.json
+++ b/MetaData/data/MetaConditions/Era2017_RR-31Mar2018_v1.json
@@ -214,6 +214,8 @@
 
 	"bTagger" : "pfDeepJet",
 
+    "isNewCSVFormat" : false,
+
 	"bDiscriminatorValue_pfDeepCSV" : 0.4941,
 	"bTagCalibrationFile_Reshape_pfDeepCSV" : "flashgg/Systematics/data/DeepCSV_94XSF_V4_B_F.csv",
 	"bTagCalibrationFile_WPCut_pfDeepCSV" : "flashgg/Systematics/data/DeepCSV_94XSF_WP_V4_B_F.csv",

--- a/MetaData/data/MetaConditions/Era2017_legacy_v1.json
+++ b/MetaData/data/MetaConditions/Era2017_legacy_v1.json
@@ -1,8 +1,8 @@
 {
     "globalTags" :
     {
-        "data" : "106X_dataRun2_v28",
-        "MC" : "106X_mc2017_realistic_v7"
+        "data" : "106X_dataRun2_v35",
+        "MC" : "106X_mc2017_realistic_v9"
     },
 
     "flashggMETsFunction" : "runMETs2017",

--- a/MetaData/data/MetaConditions/Era2017_legacy_v1.json
+++ b/MetaData/data/MetaConditions/Era2017_legacy_v1.json
@@ -226,13 +226,15 @@
 
 	"bTagger" : "pfDeepJet",
 
+    "isNewCSVFormat" : true,
+
 	"bDiscriminatorValue_pfDeepCSV" : 0.4506,
-	"bTagCalibrationFile_Reshape_pfDeepCSV" : "flashgg/Systematics/data/DeepCSV_106XUL17SF.csv",
-	"bTagCalibrationFile_WPCut_pfDeepCSV" : "flashgg/Systematics/data/DeepCSV_106XUL17SF_WPonly.csv",
+	"bTagCalibrationFile_Reshape_pfDeepCSV" : "flashgg/Systematics/data/reshaping_deepCSV_106XUL17_v3.csv",
+	"bTagCalibrationFile_WPCut_pfDeepCSV" : "flashgg/Systematics/data/wp_deepCSV_106XUL17_v3.csv",
 
 	"bDiscriminatorValue_pfDeepJet" : 0.3040,
-	"bTagCalibrationFile_Reshape_pfDeepJet" : "flashgg/Systematics/data/DeepJet_106XUL17SF.csv",
-	"bTagCalibrationFile_WPCut_pfDeepJet" : "flashgg/Systematics/data/DeepJet_106XUL17SF_WPonly.csv",
+	"bTagCalibrationFile_Reshape_pfDeepJet" : "flashgg/Systematics/data/reshaping_deepJet_106XUL17_v3.csv",
+	"bTagCalibrationFile_WPCut_pfDeepJet" : "flashgg/Systematics/data/wp_deepJet_106XUL17_v3.csv",
 
 	"eta" : 2.5
     },

--- a/MetaData/data/MetaConditions/Era2018_RR-17Sep2018_v1.json
+++ b/MetaData/data/MetaConditions/Era2018_RR-17Sep2018_v1.json
@@ -201,6 +201,8 @@
 
 	"bTagger" : "pfDeepJet",
 
+    "isNewCSVFormat" : false,
+
 	"bDiscriminatorValue_pfDeepCSV" : 0.4184,
 	"bTagCalibrationFile_Reshape_pfDeepCSV" : "flashgg/Systematics/data/DeepCSV_102XSF_V1.csv",
 	"bTagCalibrationFile_WPCut_pfDeepCSV" : "flashgg/Systematics/data/DeepCSV_102XSF_WP_V1.csv",

--- a/MetaData/data/MetaConditions/Era2018_legacy_v1.json
+++ b/MetaData/data/MetaConditions/Era2018_legacy_v1.json
@@ -202,13 +202,15 @@
 
 	"bTagger" : "pfDeepJet",
 
-	"bDiscriminatorValue_pfDeepCSV" : 0.4184,
-	"bTagCalibrationFile_Reshape_pfDeepCSV" : "flashgg/Systematics/data/DeepCSV_102XSF_V1.csv",
-	"bTagCalibrationFile_WPCut_pfDeepCSV" : "flashgg/Systematics/data/DeepCSV_102XSF_WP_V1.csv",
+    "isNewCSVFormat" : true,
 
-	"bDiscriminatorValue_pfDeepJet" : 0.2770,
-	"bTagCalibrationFile_Reshape_pfDeepJet" : "flashgg/Systematics/data/DeepJet_102XSF_V1.csv",
-	"bTagCalibrationFile_WPCut_pfDeepJet" : "flashgg/Systematics/data/DeepJet_102XSF_V1.csv",
+	"bDiscriminatorValue_pfDeepCSV" : 0.4168,
+	"bTagCalibrationFile_Reshape_pfDeepCSV" : "flashgg/Systematics/data/reshaping_deepCSV_106XUL18_v2.csv",
+	"bTagCalibrationFile_WPCut_pfDeepCSV" : "flashgg/Systematics/data/wp_deepCSV_106XUL18_v2.csv",
+
+	"bDiscriminatorValue_pfDeepJet" : 0.2783,
+	"bTagCalibrationFile_Reshape_pfDeepJet" : "flashgg/Systematics/data/reshaping_deepJet_106XUL18_v2.csv",
+	"bTagCalibrationFile_WPCut_pfDeepJet" : "flashgg/Systematics/data/wp_deepJet_106XUL18_v2.csv",
 
 	"eta" : 2.5
     },

--- a/MetaData/data/MetaConditions/Era2018_legacy_v1.json
+++ b/MetaData/data/MetaConditions/Era2018_legacy_v1.json
@@ -1,8 +1,8 @@
 {
     "globalTags" :
     {
-        "data" : "106X_dataRun2_v28",
-        "MC" : "106X_upgrade2018_realistic_v11_L1v1"
+        "data" : "106X_dataRun2_v35",
+        "MC" : "106X_upgrade2018_realistic_v16_L1v1"
     },
 
     "flashggMETsFunction" : "runMETs2016",
@@ -80,6 +80,25 @@
 
 
     "sigmaM_M_decorr" : "flashgg/Taggers/data/diphoMVA_sigmaMoMdecorr_split_2018_Mgg100to180.root",
+
+
+    "JetCorrectorParametersCollection_version" :
+    {
+        "data" : "JetCorrectorParametersCollection_Summer19UL18_V5_DATA_AK4PFchs",
+        "data_db" : "flashgg/Systematics/data/JEC/Summer19UL18_V5_DATA.db",
+        "MC" : "JetCorrectorParametersCollection_Summer19UL18_V5_MC_AK4PFchs",
+        "MC_db" : "flashgg/Systematics/data/JEC/Summer19UL18_V5_MC.db"
+    },
+
+    "JetResolutionParametersCollection_version" :
+    {
+        "data_res" : "JR_Summer19UL18_JRV2_DATA_PtResolution_AK4PFchs",
+        "data_sf" : "JR_Summer19UL18_JRV2_DATA_SF_AK4PFchs",
+        "data_db" : "flashgg/Systematics/data/JER/Summer19UL18_JRV2_DATA.db",
+        "MC_res" : "JR_Summer19UL18_JRV2_MC_PtResolution_AK4PFchs",
+        "MC_sf" : "JR_Summer19UL18_JRV2_MC_SF_AK4PFchs",
+        "MC_db" : "flashgg/Systematics/data/JER/Summer19UL18_JRV2_MC.db"
+    },
 
     "flashggDiPhotonMVA" :
     {

--- a/MetaData/python/JobConfig.py
+++ b/MetaData/python/JobConfig.py
@@ -190,12 +190,14 @@ class JobConfig(object):
         try:
             from flashgg.MetaData.mix_2017_25ns_UltraLegacy_PoissonOOTPU_cfi import mix as mix_UL17
             self.pu_distribs["Summer19UL17"] = mix_UL17.input.nbPileupEvents
+            self.pu_distribs["Summer20UL17"] = mix_UL17.input.nbPileupEvents
         except Exception:
             print "Failed to load UL17 mixing"
 
         try:
             from flashgg.MetaData.mix_2018_25ns_UltraLegacy_PoissonOOTPU_cfi import mix as mix_UL18
             self.pu_distribs["Summer19UL18"] = mix_UL18.input.nbPileupEvents
+            self.pu_distribs["Summer20UL18"] = mix_UL18.input.nbPileupEvents
         except Exception:
             print "Failed to load UL18 mixing"
 

--- a/Systematics/interface/BTagCalibrationStandalone.h
+++ b/Systematics/interface/BTagCalibrationStandalone.h
@@ -1,0 +1,188 @@
+#ifndef BTagEntry_H
+#define BTagEntry_H
+
+/**
+ *
+ * BTagEntry
+ *
+ * Represents one pt- or discriminator-dependent calibration function.
+ *
+ * measurement_type:    e.g. comb, ttbar, di-mu, boosted, ...
+ * sys_type:            e.g. central, plus, minus, plus_JEC, plus_JER, ...
+ *
+ * Everything is converted into a function, as it is easiest to store it in a
+ * txt or json file.
+ *
+ ************************************************************/
+
+#include <string>
+#include <TF1.h>
+#include <TH1.h>
+
+
+class BTagEntry
+{
+public:
+  enum OperatingPoint {
+    OP_LOOSE=0,
+    OP_MEDIUM=1,
+    OP_TIGHT=2,
+    OP_RESHAPING=3,
+  };
+  enum JetFlavor {
+    FLAV_B=0,
+    FLAV_C=1,
+    FLAV_UDSG=2,
+  };
+  struct Parameters {
+    OperatingPoint operatingPoint;
+    std::string measurementType;
+    std::string sysType;
+    JetFlavor jetFlavor;
+    float etaMin;
+    float etaMax;
+    float ptMin;
+    float ptMax;
+    float discrMin;
+    float discrMax;
+
+    // default constructor
+    Parameters(
+      OperatingPoint op=OP_TIGHT,
+      std::string measurement_type="comb",
+      std::string sys_type="central",
+      JetFlavor jf=FLAV_B,
+      float eta_min=-99999.,
+      float eta_max=99999.,
+      float pt_min=0.,
+      float pt_max=99999.,
+      float discr_min=0.,
+      float discr_max=99999.
+    );
+
+  };
+
+  BTagEntry() {}
+  BTagEntry(const std::string &csvLine, bool newFormat);
+  BTagEntry(const std::string &func, Parameters p);
+  BTagEntry(const TF1* func, Parameters p);
+  BTagEntry(const TH1* histo, Parameters p);
+  ~BTagEntry() {}
+  static std::string makeCSVHeader();
+  std::string makeCSVLine() const;
+  static std::string trimStr(std::string str);
+
+  // public, no getters needed
+  std::string formula;
+  Parameters params;
+
+};
+
+#endif  // BTagEntry_H
+
+
+#ifndef BTagCalibration_H
+#define BTagCalibration_H
+
+/**
+ * BTagCalibration
+ *
+ * The 'hierarchy' of stored information is this:
+ * - by tagger (BTagCalibration)
+ *   - by operating point or reshape bin
+ *     - by jet parton flavor
+ *       - by type of measurement
+ *         - by systematic
+ *           - by eta bin
+ *             - as 1D-function dependent of pt or discriminant
+ *
+ ************************************************************/
+
+#include <map>
+#include <vector>
+#include <string>
+#include <istream>
+#include <ostream>
+
+
+class BTagCalibration
+{
+public:
+  BTagCalibration() {}
+  BTagCalibration(const std::string &tagger);
+  BTagCalibration(const std::string &tagger, const std::string &filename, bool newFormat = true);
+  ~BTagCalibration() {}
+
+  std::string tagger() const {return tagger_;}
+
+  void addEntry(const BTagEntry &entry);
+  const std::vector<BTagEntry>& getEntries(const BTagEntry::Parameters &par) const;
+
+  void readCSV(std::istream &s, bool newFormat);
+  void readCSV(const std::string &s, bool newFormat);
+  void makeCSV(std::ostream &s) const;
+  std::string makeCSV() const;
+
+protected:
+  static std::string token(const BTagEntry::Parameters &par);
+
+  std::string tagger_;
+  std::map<std::string, std::vector<BTagEntry> > data_;
+
+};
+
+#endif  // BTagCalibration_H
+
+
+#ifndef BTagCalibrationReader_H
+#define BTagCalibrationReader_H
+
+/**
+ * BTagCalibrationReader
+ *
+ * Helper class to pull out a specific set of BTagEntry's out of a
+ * BTagCalibration. TF1 functions are set up at initialization time.
+ *
+ ************************************************************/
+
+#include <memory>
+#include <string>
+
+
+
+class BTagCalibrationReader
+{
+public:
+  class BTagCalibrationReaderImpl;
+
+  BTagCalibrationReader() {}
+  BTagCalibrationReader(BTagEntry::OperatingPoint op,
+                        const std::string & sysType="central",
+                        const std::vector<std::string> & otherSysTypes={});
+
+  void load(const BTagCalibration & c,
+            BTagEntry::JetFlavor jf,
+            const std::string & measurementType="comb");
+
+  double eval(BTagEntry::JetFlavor jf,
+              float eta,
+              float pt,
+              float discr=0.) const;
+
+  double eval_auto_bounds(const std::string & sys,
+                          BTagEntry::JetFlavor jf,
+                          float eta,
+                          float pt,
+                          float discr=0.) const;
+
+  std::pair<float, float> min_max_pt(BTagEntry::JetFlavor jf,
+                                     float eta,
+                                     float discr=0.) const;
+protected:
+  std::shared_ptr<BTagCalibrationReaderImpl> pimpl;
+};
+
+
+#endif  // BTagCalibrationReader_H
+
+

--- a/Systematics/plugins/JetBTagReshapeWeight.cc
+++ b/Systematics/plugins/JetBTagReshapeWeight.cc
@@ -4,8 +4,9 @@
 #include "DataFormats/Common/interface/PtrVector.h"
 #include "flashgg/DataFormats/interface/Jet.h"
 #include "CommonTools/Utils/interface/StringCutObjectSelector.h"
-#include "CondFormats/BTauObjects/interface/BTagCalibration.h"
-#include "CondTools/BTau/interface/BTagCalibrationReader.h"
+//#include "CondFormats/BTauObjects/interface/BTagCalibration.h"
+//#include "CondTools/BTau/interface/BTagCalibrationReader.h"
+#include "flashgg/Systematics/interface/BTagCalibrationStandalone.h"
 
 //For reshaping BTag shape
 
@@ -57,7 +58,7 @@ namespace flashgg {
         bTagReshapeSystOption_ = conf.getParameter<int>( "bTagReshapeSystOption"); 
         // std::string btag_algo = bTag_=="pfDeepJet" ? "DeepJet" : "pfDeepCSV" ? "DeepCSV" : "CSVv2";  //// DeepJet =  DeepFlavour
         std::string btag_algo = bTag_=="pfDeepJet" ? "DeepJet" : "DeepCSV" ;
-        calibReshape_ = BTagCalibration(btag_algo, conf.getParameter<edm::FileInPath>("bTagCalibrationFile").fullPath());
+        calibReshape_ = BTagCalibration(btag_algo, conf.getParameter<edm::FileInPath>("bTagCalibrationFile").fullPath(), conf.getParameter<bool>("isNewCSVFormat"));
     }
 
     std::string JetBTagReshapeWeight::shiftLabel( int syst_value ) const

--- a/Systematics/plugins/JetBTagWeight.cc
+++ b/Systematics/plugins/JetBTagWeight.cc
@@ -4,8 +4,9 @@
 #include "DataFormats/Common/interface/PtrVector.h"
 #include "flashgg/DataFormats/interface/Jet.h"
 #include "CommonTools/Utils/interface/StringCutObjectSelector.h"
-#include "CondFormats/BTauObjects/interface/BTagCalibration.h"
-#include "CondTools/BTau/interface/BTagCalibrationReader.h"
+//#include "CondFormats/BTauObjects/interface/BTagCalibration.h"
+//#include "CondTools/BTau/interface/BTagCalibrationReader.h"
+#include "flashgg/Systematics/interface/BTagCalibrationStandalone.h"
 
 //For medium working point
 
@@ -57,7 +58,7 @@ namespace flashgg {
     
         // std::string btag_algo = bTag_== "pfDeepJet" ? "DeepJet" : "pfDeepCSV" ? "DeepCSV" : "CSVv2";    //// DeepJet =  DeepFlavour
         std::string btag_algo = bTag_== "pfDeepJet" ? "DeepJet" : "DeepCSV" ;
-        calibReshape_ = BTagCalibration(btag_algo, conf.getParameter<edm::FileInPath>("bTagCalibrationFile").fullPath());
+        calibReshape_ = BTagCalibration(btag_algo, conf.getParameter<edm::FileInPath>("bTagCalibrationFile").fullPath(), conf.getParameter<bool>("isNewCSVFormat"));
     }
 
     std::string JetBTagWeight::shiftLabel( int syst_value ) const
@@ -130,7 +131,7 @@ namespace flashgg {
 
             //https://twiki.cern.ch/twiki/bin/view/CMS/BTagCalibration
             float JetPt = obj.pt();
-            float JetEta = obj.eta();
+            float JetEta = fabs(obj.eta());
             int JetFlav = obj.hadronFlavour();
             bool JetBTagStatus = false;
             float JetBDiscriminator;

--- a/Systematics/python/flashggJetSystematics_cfi.py
+++ b/Systematics/python/flashggJetSystematics_cfi.py
@@ -197,6 +197,7 @@ class jetSystematicsCustomize:
                                         #bTag = cms.string(flashggBTag),
                                         bTag = cms.string(str(bTagger)),
                                         bTagCalibrationFile = cms.FileInPath(str(self.metaConditions['bTagSystematics']['bTagCalibrationFile_WPCut_'+ str(bTagger)])),
+                                        isNewCSVFormat = cms.bool(self.metaConditions['bTagSystematics']['isNewCSVFormat']),
                                         bDiscriminator = cms.double(self.metaConditions['bTagSystematics']['bDiscriminatorValue_'+ str(bTagger)]),
                                         Debug = cms.untracked.bool(False),
                                         ApplyCentralValue = cms.bool(True)
@@ -209,6 +210,7 @@ class jetSystematicsCustomize:
                                         #                                                          bTag = cms.string(flashggBTag),
                                         bTag = cms.string(str(bTagger)), 
                                         bTagCalibrationFile = cms.FileInPath(str(self.metaConditions['bTagSystematics']['bTagCalibrationFile_Reshape_'+ str(bTagger)])),
+                                        isNewCSVFormat = cms.bool(self.metaConditions['bTagSystematics']['isNewCSVFormat']),
                                         bTagReshapeSystOption = cms.int32(1),#For changing the source of uncertainty
                                         Debug = cms.untracked.bool(False),
                                         ApplyCentralValue = cms.bool(True)

--- a/Systematics/src/BTagCalibrationStandalone.cc
+++ b/Systematics/src/BTagCalibrationStandalone.cc
@@ -1,0 +1,702 @@
+#include "flashgg/Systematics/interface/BTagCalibrationStandalone.h"
+#include <iostream>
+#include <exception>
+#include <algorithm>
+#include <sstream>
+
+
+BTagEntry::Parameters::Parameters(
+  OperatingPoint op,
+  std::string measurement_type,
+  std::string sys_type,
+  JetFlavor jf,
+  float eta_min,
+  float eta_max,
+  float pt_min,
+  float pt_max,
+  float discr_min,
+  float discr_max
+):
+  operatingPoint(op),
+  measurementType(measurement_type),
+  sysType(sys_type),
+  jetFlavor(jf),
+  etaMin(eta_min),
+  etaMax(eta_max),
+  ptMin(pt_min),
+  ptMax(pt_max),
+  discrMin(discr_min),
+  discrMax(discr_max)
+{
+  std::transform(measurementType.begin(), measurementType.end(),
+                 measurementType.begin(), ::tolower);
+  std::transform(sysType.begin(), sysType.end(),
+                 sysType.begin(), ::tolower);
+}
+
+BTagEntry::BTagEntry(const std::string &csvLine, bool newFormat)
+{
+  // make tokens
+  std::stringstream buff(csvLine);
+  std::vector<std::string> vec_tmp;
+  std::vector<std::string> vec;
+  std::string token;
+  while (std::getline(buff, token, "\""[0])) {
+    token = BTagEntry::trimStr(token);
+    if (token.empty()) continue;
+
+    vec_tmp.push_back(token);
+  }
+
+  std::stringstream buff2(vec_tmp[0]);
+  while (std::getline(buff2, token, ","[0])) {
+    token = BTagEntry::trimStr(token);
+    if (token.empty()) continue;
+
+    vec.push_back(token);
+  }
+  if (vec_tmp.size() > 1) vec.push_back(vec_tmp[1]);
+
+  if (vec.size() != 11) {
+std::cerr << "ERROR in BTagCalibration: "
+          << "Invalid csv line; num tokens != 11: "
+          << csvLine;
+throw std::exception();
+  }
+
+  // clean string values
+  char chars[] = " \"\n";
+  for (unsigned int i = 0; i < strlen(chars); ++i) {
+    vec[1].erase(remove(vec[1].begin(),vec[1].end(),chars[i]),vec[1].end());
+    vec[2].erase(remove(vec[2].begin(),vec[2].end(),chars[i]),vec[2].end());
+    vec[10].erase(remove(vec[10].begin(),vec[10].end(),chars[i]),vec[10].end());
+  }
+
+  // make formula
+  formula = vec[10];
+  TF1 f1("", formula.c_str());  // compile formula to check validity
+  if (f1.IsZombie()) {
+std::cerr << "ERROR in BTagCalibration: "
+          << "Invalid csv line; formula does not compile: "
+          << csvLine;
+throw std::exception();
+  }
+
+  // make parameters
+  unsigned op = newFormat ? 999 : stoi(vec[0]);
+
+  if (vec[0] == "L") op = 0;
+  else if (vec[0] == "M") op = 1;
+  else if (vec[0] == "T") op = 2;
+  else if (vec[0] == "shape") op = 3;
+
+  if (op > 3) {
+std::cerr << "ERROR in BTagCalibration: "
+          << "Invalid csv line; OperatingPoint > 3: "
+          << csvLine;
+throw std::exception();
+  }
+
+  unsigned jf = stoi(vec[3]);
+
+  if (newFormat) {
+    if (jf == 5) jf = 0;
+    else if (jf == 4) jf = 1;
+    else if (jf == 0) jf = 2;
+  }
+
+  if (jf > 2) {
+std::cerr << "ERROR in BTagCalibration: "
+          << "Invalid csv line; JetFlavor > 2: "
+          << csvLine;
+throw std::exception();
+  }
+  params = BTagEntry::Parameters(
+    BTagEntry::OperatingPoint(op),
+    vec[1],
+    vec[2],
+    BTagEntry::JetFlavor(jf),
+    stof(vec[4]),
+    stof(vec[5]),
+    stof(vec[6]),
+    stof(vec[7]),
+    stof(vec[8]),
+    stof(vec[9])
+  );
+}
+
+BTagEntry::BTagEntry(const std::string &func, BTagEntry::Parameters p):
+  formula(func),
+  params(p)
+{
+  TF1 f1("", formula.c_str());  // compile formula to check validity
+  if (f1.IsZombie()) {
+std::cerr << "ERROR in BTagCalibration: "
+          << "Invalid func string; formula does not compile: "
+          << func;
+throw std::exception();
+  }
+}
+
+BTagEntry::BTagEntry(const TF1* func, BTagEntry::Parameters p):
+  formula(std::string(func->GetExpFormula("p").Data())),
+  params(p)
+{
+  if (func->IsZombie()) {
+std::cerr << "ERROR in BTagCalibration: "
+          << "Invalid TF1 function; function is zombie: "
+          << func->GetName();
+throw std::exception();
+  }
+}
+
+// Creates chained step functions like this:
+// "<prevous_bin> : x<bin_high_bound ? bin_value : <next_bin>"
+// e.g. "x<0 ? 1 : x<1 ? 2 : x<2 ? 3 : 4"
+std::string th1ToFormulaLin(const TH1* hist) {
+  int nbins = hist->GetNbinsX();
+  TAxis const* axis = hist->GetXaxis();
+  std::stringstream buff;
+  buff << "x<" << axis->GetBinLowEdge(1) << " ? 0. : ";  // default value
+  for (int i=1; i<nbins+1; ++i) {
+    char tmp_buff[50];
+    sprintf(tmp_buff,
+            "x<%g ? %g : ",  // %g is the smaller one of %e or %f
+            axis->GetBinUpEdge(i),
+            hist->GetBinContent(i));
+    buff << tmp_buff;
+  }
+  buff << 0.;  // default value
+  return buff.str();
+}
+
+// Creates step functions making a binary search tree:
+// "x<mid_bin_bound ? (<left side tree>) : (<right side tree>)"
+// e.g. "x<2 ? (x<1 ? (x<0 ? 0:0.1) : (1)) : (x<4 ? (x<3 ? 2:3) : (0))"
+std::string th1ToFormulaBinTree(const TH1* hist, int start=0, int end=-1) {
+  if (end == -1) {                      // initialize
+    start = 0.;
+    end = hist->GetNbinsX()+1;
+    TH1* h2 = (TH1*) hist->Clone();
+    h2->SetBinContent(start, 0);  // kill underflow
+    h2->SetBinContent(end, 0);    // kill overflow
+    std::string res = th1ToFormulaBinTree(h2, start, end);
+    delete h2;
+    return res;
+  }
+  if (start == end) {                   // leave is reached
+    char tmp_buff[20];
+    sprintf(tmp_buff, "%g", hist->GetBinContent(start));
+    return std::string(tmp_buff);
+  }
+  if (start == end - 1) {               // no parenthesis for neighbors
+    char tmp_buff[70];
+    sprintf(tmp_buff,
+            "x<%g ? %g:%g",
+            hist->GetXaxis()->GetBinUpEdge(start),
+            hist->GetBinContent(start),
+            hist->GetBinContent(end));
+    return std::string(tmp_buff);
+  }
+
+  // top-down recursion
+  std::stringstream buff;
+  int mid = (end-start)/2 + start;
+  char tmp_buff[25];
+  sprintf(tmp_buff,
+          "x<%g ? (",
+          hist->GetXaxis()->GetBinUpEdge(mid));
+  buff << tmp_buff
+       << th1ToFormulaBinTree(hist, start, mid)
+       << ") : ("
+       << th1ToFormulaBinTree(hist, mid+1, end)
+       << ")";
+  return buff.str();
+}
+
+BTagEntry::BTagEntry(const TH1* hist, BTagEntry::Parameters p):
+  params(p)
+{
+  int nbins = hist->GetNbinsX();
+  TAxis const* axis = hist->GetXaxis();
+
+  // overwrite bounds with histo values
+  if (params.operatingPoint == BTagEntry::OP_RESHAPING) {
+    params.discrMin = axis->GetBinLowEdge(1);
+    params.discrMax = axis->GetBinUpEdge(nbins);
+  } else {
+    params.ptMin = axis->GetBinLowEdge(1);
+    params.ptMax = axis->GetBinUpEdge(nbins);
+  }
+
+  // balanced full binary tree height = ceil(log(2*n_leaves)/log(2))
+  // breakes even around 10, but lower values are more propable in pt-spectrum
+  if (nbins < 15) {
+    formula = th1ToFormulaLin(hist);
+  } else {
+    formula = th1ToFormulaBinTree(hist);
+  }
+
+  // compile formula to check validity
+  TF1 f1("", formula.c_str());
+  if (f1.IsZombie()) {
+std::cerr << "ERROR in BTagCalibration: "
+          << "Invalid histogram; formula does not compile (>150 bins?): "
+          << hist->GetName();
+throw std::exception();
+  }
+}
+
+std::string BTagEntry::makeCSVHeader()
+{
+  return "OperatingPoint, "
+         "measurementType, "
+         "sysType, "
+         "jetFlavor, "
+         "etaMin, "
+         "etaMax, "
+         "ptMin, "
+         "ptMax, "
+         "discrMin, "
+         "discrMax, "
+         "formula \n";
+}
+
+std::string BTagEntry::makeCSVLine() const
+{
+  std::stringstream buff;
+  buff << params.operatingPoint
+       << ", " << params.measurementType
+       << ", " << params.sysType
+       << ", " << params.jetFlavor
+       << ", " << params.etaMin
+       << ", " << params.etaMax
+       << ", " << params.ptMin
+       << ", " << params.ptMax
+       << ", " << params.discrMin
+       << ", " << params.discrMax
+       << ", \"" << formula
+       << "\" \n";
+  return buff.str();
+}
+
+std::string BTagEntry::trimStr(std::string str) {
+  size_t s = str.find_first_not_of(" \n\r\t");
+  size_t e = str.find_last_not_of (" \n\r\t");
+
+  if((std::string::npos == s) || (std::string::npos == e))
+    return "";
+  else
+    return str.substr(s, e-s+1);
+}
+
+
+#include <fstream>
+#include <sstream>
+
+
+
+BTagCalibration::BTagCalibration(const std::string &taggr):
+  tagger_(taggr)
+{}
+
+BTagCalibration::BTagCalibration(const std::string &taggr,
+                                 const std::string &filename,
+                                 bool newFormat):
+  tagger_(taggr)
+{
+  std::ifstream ifs(filename);
+  if (!ifs.good()) {
+std::cerr << "ERROR in BTagCalibration: "
+          << "input file not available: "
+          << filename;
+throw std::exception();
+  }
+  readCSV(ifs, newFormat);
+  ifs.close();
+}
+
+void BTagCalibration::addEntry(const BTagEntry &entry)
+{
+  data_[token(entry.params)].push_back(entry);
+}
+
+const std::vector<BTagEntry>& BTagCalibration::getEntries(
+  const BTagEntry::Parameters &par) const
+{
+  std::string tok = token(par);
+  if (!data_.count(tok)) {
+std::cerr << "ERROR in BTagCalibration: "
+          << "(OperatingPoint, measurementType, sysType) not available: "
+          << tok;
+throw std::exception();
+  }
+  return data_.at(tok);
+}
+
+void BTagCalibration::readCSV(const std::string &s, bool newFormat)
+{
+  std::stringstream buff(s);
+  readCSV(buff, newFormat);
+}
+
+void BTagCalibration::readCSV(std::istream &s, bool newFormat)
+{
+  std::string line;
+
+  // firstline might be the header
+  getline(s,line);
+  if (line.find("OperatingPoint") == std::string::npos) {
+    addEntry(BTagEntry(line, newFormat));
+  }
+
+  while (getline(s,line)) {
+    line = BTagEntry::trimStr(line);
+    if (line.empty()) {  // skip empty lines
+      continue;
+    }
+    addEntry(BTagEntry(line, newFormat));
+  }
+}
+
+void BTagCalibration::makeCSV(std::ostream &s) const
+{
+  s << tagger_ << ";" << BTagEntry::makeCSVHeader();
+  for (std::map<std::string, std::vector<BTagEntry> >::const_iterator i
+           = data_.cbegin(); i != data_.cend(); ++i) {
+    const std::vector<BTagEntry> &vec = i->second;
+    for (std::vector<BTagEntry>::const_iterator j
+             = vec.cbegin(); j != vec.cend(); ++j) {
+      s << j->makeCSVLine();
+    }
+  }
+}
+
+std::string BTagCalibration::makeCSV() const
+{
+  std::stringstream buff;
+  makeCSV(buff);
+  return buff.str();
+}
+
+std::string BTagCalibration::token(const BTagEntry::Parameters &par)
+{
+  std::stringstream buff;
+  buff << par.operatingPoint << ", "
+       << par.measurementType << ", "
+       << par.sysType;
+  return buff.str();
+}
+
+
+
+
+class BTagCalibrationReader::BTagCalibrationReaderImpl
+{
+  friend class BTagCalibrationReader;
+
+public:
+  struct TmpEntry {
+    float etaMin;
+    float etaMax;
+    float ptMin;
+    float ptMax;
+    float discrMin;
+    float discrMax;
+    TF1 func;
+  };
+
+private:
+  BTagCalibrationReaderImpl(BTagEntry::OperatingPoint op,
+                            const std::string & sysType,
+                            const std::vector<std::string> & otherSysTypes={});
+
+  void load(const BTagCalibration & c,
+            BTagEntry::JetFlavor jf,
+            std::string measurementType);
+
+  double eval(BTagEntry::JetFlavor jf,
+              float eta,
+              float pt,
+              float discr) const;
+
+  double eval_auto_bounds(const std::string & sys,
+                          BTagEntry::JetFlavor jf,
+                          float eta,
+                          float pt,
+                          float discr) const;
+
+  std::pair<float, float> min_max_pt(BTagEntry::JetFlavor jf,
+                                     float eta,
+                                     float discr) const;
+ 
+  std::pair<float, float> min_max_eta(BTagEntry::JetFlavor jf,
+                                     float discr) const;
+
+  BTagEntry::OperatingPoint op_;
+  std::string sysType_;
+  std::vector<std::vector<TmpEntry> > tmpData_;  // first index: jetFlavor
+  std::vector<bool> useAbsEta_;                  // first index: jetFlavor
+  std::map<std::string, std::shared_ptr<BTagCalibrationReaderImpl>> otherSysTypeReaders_;
+};
+
+
+BTagCalibrationReader::BTagCalibrationReaderImpl::BTagCalibrationReaderImpl(
+                                             BTagEntry::OperatingPoint op,
+                                             const std::string & sysType,
+                                             const std::vector<std::string> & otherSysTypes):
+  op_(op),
+  sysType_(sysType),
+  tmpData_(3),
+  useAbsEta_(3, true)
+{
+  for (const std::string & ost : otherSysTypes) {
+    if (otherSysTypeReaders_.count(ost)) {
+std::cerr << "ERROR in BTagCalibration: "
+            << "Every otherSysType should only be given once. Duplicate: "
+            << ost;
+throw std::exception();
+    }
+    otherSysTypeReaders_[ost] = std::unique_ptr<BTagCalibrationReaderImpl>(
+        new BTagCalibrationReaderImpl(op, ost)
+    );
+  }
+}
+
+void BTagCalibrationReader::BTagCalibrationReaderImpl::load(
+                                             const BTagCalibration & c,
+                                             BTagEntry::JetFlavor jf,
+                                             std::string measurementType)
+{
+  if (tmpData_[jf].size()) {
+std::cerr << "ERROR in BTagCalibration: "
+          << "Data for this jet-flavor is already loaded: "
+          << jf;
+throw std::exception();
+  }
+
+  BTagEntry::Parameters params(op_, measurementType, sysType_);
+  const std::vector<BTagEntry> &entries = c.getEntries(params);
+
+  for (const auto &be : entries) {
+    if (be.params.jetFlavor != jf) {
+      continue;
+    }
+
+    TmpEntry te;
+    te.etaMin = be.params.etaMin;
+    te.etaMax = be.params.etaMax;
+    te.ptMin = be.params.ptMin;
+    te.ptMax = be.params.ptMax;
+    te.discrMin = be.params.discrMin;
+    te.discrMax = be.params.discrMax;
+
+    if (op_ == BTagEntry::OP_RESHAPING) {
+      te.func = TF1("", be.formula.c_str(),
+                    be.params.discrMin, be.params.discrMax);
+    } else {
+      te.func = TF1("", be.formula.c_str(),
+                    be.params.ptMin, be.params.ptMax);
+    }
+
+    tmpData_[be.params.jetFlavor].push_back(te);
+    if (te.etaMin < 0) {
+      useAbsEta_[be.params.jetFlavor] = false;
+    }
+  }
+
+  for (auto & p : otherSysTypeReaders_) {
+    p.second->load(c, jf, measurementType);
+  }
+}
+
+double BTagCalibrationReader::BTagCalibrationReaderImpl::eval(
+                                             BTagEntry::JetFlavor jf,
+                                             float eta,
+                                             float pt,
+                                             float discr) const
+{
+  bool use_discr = (op_ == BTagEntry::OP_RESHAPING);
+  if (useAbsEta_[jf] && eta < 0) {
+    eta = -eta;
+  }
+
+  // search linearly through eta, pt and discr ranges and eval
+  // future: find some clever data structure based on intervals
+  const auto &entries = tmpData_.at(jf);
+  for (unsigned i=0; i<entries.size(); ++i) {
+    const auto &e = entries.at(i);
+    if (
+      e.etaMin <= eta && eta <= e.etaMax                   // find eta
+      && e.ptMin < pt && pt <= e.ptMax                    // check pt
+    ){
+      if (use_discr) {                                    // discr. reshaping?
+        if (e.discrMin <= discr && discr < e.discrMax) {  // check discr
+          return e.func.Eval(discr);
+        }
+      } else {
+        return e.func.Eval(pt);
+      }
+    }
+  }
+
+  return 0.;  // default value
+}
+
+double BTagCalibrationReader::BTagCalibrationReaderImpl::eval_auto_bounds(
+                                             const std::string & sys,
+                                             BTagEntry::JetFlavor jf,
+                                             float eta,
+                                             float pt,
+                                             float discr) const
+{
+  auto sf_bounds_eta = min_max_eta(jf, discr);
+  bool eta_is_out_of_bounds = false;
+
+  if (sf_bounds_eta.first < 0) sf_bounds_eta.first = -sf_bounds_eta.second;   
+  if (eta <= sf_bounds_eta.first || eta > sf_bounds_eta.second ) {
+    eta_is_out_of_bounds = true;
+  }
+   
+  if (eta_is_out_of_bounds) {
+    return 1.;
+  }
+
+
+   auto sf_bounds = min_max_pt(jf, eta, discr);
+   float pt_for_eval = pt;
+   bool is_out_of_bounds = false;
+
+   if (pt <= sf_bounds.first) {
+    pt_for_eval = sf_bounds.first + .0001;
+    is_out_of_bounds = true;
+  } else if (pt > sf_bounds.second) {
+    pt_for_eval = sf_bounds.second - .0001;
+    is_out_of_bounds = true;
+  }
+
+  // get central SF (and maybe return)
+  double sf = eval(jf, eta, pt_for_eval, discr);
+  if (sys == sysType_) {
+    return sf;
+  }
+
+  // get sys SF (and maybe return)
+  if (!otherSysTypeReaders_.count(sys)) {
+std::cerr << "ERROR in BTagCalibration: "
+        << "sysType not available (maybe not loaded?): "
+        << sys;
+throw std::exception();
+  }
+  double sf_err = otherSysTypeReaders_.at(sys)->eval(jf, eta, pt_for_eval, discr);
+  if (!is_out_of_bounds) {
+    return sf_err;
+  }
+
+  // double uncertainty on out-of-bounds and return
+  sf_err = sf + 2*(sf_err - sf);
+  return sf_err;
+}
+
+std::pair<float, float> BTagCalibrationReader::BTagCalibrationReaderImpl::min_max_pt(
+                                               BTagEntry::JetFlavor jf,
+                                               float eta,
+                                               float discr) const
+{
+  bool use_discr = (op_ == BTagEntry::OP_RESHAPING);
+  if (useAbsEta_[jf] && eta < 0) {
+    eta = -eta;
+  }
+
+  const auto &entries = tmpData_.at(jf);
+  float min_pt = -1., max_pt = -1.;
+  for (const auto & e: entries) {
+    if (
+      e.etaMin <= eta && eta <=e.etaMax                   // find eta
+    ){
+      if (min_pt < 0.) {                                  // init
+        min_pt = e.ptMin;
+        max_pt = e.ptMax;
+        continue;
+      }
+
+      if (use_discr) {                                    // discr. reshaping?
+        if (e.discrMin <= discr && discr < e.discrMax) {  // check discr
+          min_pt = min_pt < e.ptMin ? min_pt : e.ptMin;
+          max_pt = max_pt > e.ptMax ? max_pt : e.ptMax;
+        }
+      } else {
+        min_pt = min_pt < e.ptMin ? min_pt : e.ptMin;
+        max_pt = max_pt > e.ptMax ? max_pt : e.ptMax;
+      }
+    }
+  }
+
+  return std::make_pair(min_pt, max_pt);
+}
+
+std::pair<float, float> BTagCalibrationReader::BTagCalibrationReaderImpl::min_max_eta(
+                                               BTagEntry::JetFlavor jf,
+                                               float discr) const
+{
+  bool use_discr = (op_ == BTagEntry::OP_RESHAPING);
+
+  const auto &entries = tmpData_.at(jf);
+  float min_eta = 0., max_eta = 0.;
+  for (const auto & e: entries) {
+
+      if (use_discr) {                                    // discr. reshaping?
+        if (e.discrMin <= discr && discr < e.discrMax) {  // check discr
+          min_eta = min_eta < e.etaMin ? min_eta : e.etaMin;
+          max_eta = max_eta > e.etaMax ? max_eta : e.etaMax;
+        }
+      } else {
+        min_eta = min_eta < e.etaMin ? min_eta : e.etaMin;
+        max_eta = max_eta > e.etaMax ? max_eta : e.etaMax;
+      }
+    }
+
+
+  return std::make_pair(min_eta, max_eta);
+}
+
+
+BTagCalibrationReader::BTagCalibrationReader(BTagEntry::OperatingPoint op,
+                                             const std::string & sysType,
+                                             const std::vector<std::string> & otherSysTypes):
+  pimpl(new BTagCalibrationReaderImpl(op, sysType, otherSysTypes)) {}
+
+void BTagCalibrationReader::load(const BTagCalibration & c,
+                                 BTagEntry::JetFlavor jf,
+                                 const std::string & measurementType)
+{
+  pimpl->load(c, jf, measurementType);
+}
+
+double BTagCalibrationReader::eval(BTagEntry::JetFlavor jf,
+                                   float eta,
+                                   float pt,
+                                   float discr) const
+{
+  return pimpl->eval(jf, eta, pt, discr);
+}
+
+double BTagCalibrationReader::eval_auto_bounds(const std::string & sys,
+                                               BTagEntry::JetFlavor jf,
+                                               float eta,
+                                               float pt,
+                                               float discr) const
+{
+  return pimpl->eval_auto_bounds(sys, jf, eta, pt, discr);
+}
+
+std::pair<float, float> BTagCalibrationReader::min_max_pt(BTagEntry::JetFlavor jf,
+                                                          float eta,
+                                                          float discr) const
+{
+  return pimpl->min_max_pt(jf, eta, discr);
+}
+
+
+
+


### PR DESCRIPTION
* Follow up the new BTag SF for UL17 and UL18 in the following https://twiki.cern.ch/twiki/bin/view/CMS/BTagCalibration#General_Introduction_UltraLegacy
However, the SF source CSV files for the new UL17 and UL18 have a new format that cannot be supported by the old BTagCalibration codes. The modified standalone BTagCalibration is thus added into flashgg.

* Update the global tag for UL17 and UL18 and JEC/JER for UL18

The PR still needs to be further checked.