### PR TITLE
Updated e-veto SFs for UL2018

### DIFF
--- a/Systematics/python/flashggDiPhotonSystematics2018_Legacy_cfi.py
+++ b/Systematics/python/flashggDiPhotonSystematics2018_Legacy_cfi.py
@@ -22,14 +22,14 @@ preselBins = cms.PSet(
         )
     )
 
-#JTao: slide 34 of https://indico.cern.ch/event/850506/contributions/3606914/attachments/1927946/3192290/201910_Zmmg_RhoBugFixed.pdf with 2018 data and MC samples, with new shower-shape and isolation corrections applied and photon PT > 20 GeV
+#JTao: slide 11 of https://indico.cern.ch/event/996926/contributions/4264412/attachments/2203745/3728187/202103ZmmgUL2018_ForHggUpdate.pdf for UL18
 electronVetoBins = cms.PSet(
     variables = cms.vstring("abs(superCluster.eta)","full5x5_r9"),
     bins = cms.VPSet(
-        cms.PSet( lowBounds = cms.vdouble( 0.0, 0.00 ) , upBounds = cms.vdouble( 1.5, 0.85 ) , values = cms.vdouble( 0.9819 ) , uncertainties = cms.vdouble( 0.0020 )  ) ,
-        cms.PSet( lowBounds = cms.vdouble( 0.0, 0.85 ) , upBounds = cms.vdouble( 1.5, 999. ) , values = cms.vdouble( 0.9931 ) , uncertainties = cms.vdouble( 0.0005 )  ) ,
-        cms.PSet( lowBounds = cms.vdouble( 1.5, 0.00 ) , upBounds = cms.vdouble( 6.0, 0.90 ) , values = cms.vdouble( 0.9680 ) , uncertainties = cms.vdouble( 0.0069 )  ) ,
-        cms.PSet( lowBounds = cms.vdouble( 1.5, 0.90 ) , upBounds = cms.vdouble( 6.0, 999. ) , values = cms.vdouble( 0.9785 ) , uncertainties = cms.vdouble( 0.0018 )  )
+        cms.PSet( lowBounds = cms.vdouble( 0.0, 0.00 ) , upBounds = cms.vdouble( 1.5, 0.85 ) , values = cms.vdouble( 0.9830 ) , uncertainties = cms.vdouble( 0.0021 )  ) ,
+        cms.PSet( lowBounds = cms.vdouble( 0.0, 0.85 ) , upBounds = cms.vdouble( 1.5, 999. ) , values = cms.vdouble( 0.9939 ) , uncertainties = cms.vdouble( 0.0005 )  ) ,
+        cms.PSet( lowBounds = cms.vdouble( 1.5, 0.00 ) , upBounds = cms.vdouble( 6.0, 0.90 ) , values = cms.vdouble( 0.9603 ) , uncertainties = cms.vdouble( 0.0077 )  ) ,
+        cms.PSet( lowBounds = cms.vdouble( 1.5, 0.90 ) , upBounds = cms.vdouble( 6.0, 999. ) , values = cms.vdouble( 0.9754 ) , uncertainties = cms.vdouble( 0.0017 )  )
         )
     )
 


### PR DESCRIPTION
Current ones in the file are for EOY 2018. 

The updated ones for UL2018 can also be found on  slide 11 of https://indico.cern.ch/event/996926/contributions/4264412/attachments/2203745/3728187/202103ZmmgUL2018_ForHggUpdate.pdf for UL18.
