### PR TITLE
switching off Deepjet rerunning for Summer20UL17 processing

### DIFF
--- a/MetaData/data/MetaConditions/Era2017_legacy_v1.json
+++ b/MetaData/data/MetaConditions/Era2017_legacy_v1.json
@@ -30,7 +30,7 @@
         ]
     },
 
-    "DeepJet" : "rerun",
+    "DeepJet" : "read",
 
     "flashggPhotons" :
     {


### PR DESCRIPTION
- switching off DeepJet rerunning to sync UL2017 setting with UL2016 and UL2018.
- All UL samples have the latest DeepJet training stored within them, so rerunning is not required.