### PR TITLE
Update UL18 lepton SFs & fix issue for ReReco16 Muon lowPt ID SFs

### DIFF
--- a/MetaData/data/MetaConditions/Era2016_RR-17Jul2018_v1.json
+++ b/MetaData/data/MetaConditions/Era2016_RR-17Jul2018_v1.json
@@ -83,7 +83,7 @@
     "MUON_ID" : "Medium",
     "MUON_ISO" : "LooseRel",
     "MUON_ID_JSON_FileName" : "flashgg/Systematics/data/Muon2016_RunBCDEFGH_SF_ID.json",
-    "MUON_ID_JSON_FileName_LowPt" : "",
+    "MUON_ID_JSON_FileName_LowPt" : "flashgg/Systematics/data/Muon2016_RunBCDEFGH_SF_ID_lowPt_finerEtaBin.json",
     "MUON_ISO_JSON_FileName" : "flashgg/Systematics/data/Muon2016_RunBCDEFGH_SF_ISO.json",
     "MUON_ID_RefTracks" : "genTracks",
     "MUON_ID_RefTracks_LowPt" : "genTracks",

--- a/MetaData/data/MetaConditions/Era2018_legacy_v1.json
+++ b/MetaData/data/MetaConditions/Era2018_legacy_v1.json
@@ -182,16 +182,16 @@
     "MUON_ID" : "Medium",
     "MUON_ISO" : "LooseRel",
 
-    "MUON_ID_JSON_FileName" : "flashgg/Systematics/data/Muon2018_RunABCD_SF_ID.json",
-    "MUON_ID_JSON_FileName_LowPt" : "flashgg/Systematics/data/Muon2018_RunABCD_SF_ID_lowPt.json",
-    "MUON_ISO_JSON_FileName" : "flashgg/Systematics/data/Muon2018_RunABCD_SF_ISO.json",
+    "MUON_ID_JSON_FileName" : "flashgg/Systematics/data/Muon_UL2018_RunABCD_SF_ID.json",
+    "MUON_ID_JSON_FileName_LowPt" : "flashgg/Systematics/data/Muon_UL2018_RunABCD_SF_ID_lowPt.json",
+    "MUON_ISO_JSON_FileName" : "flashgg/Systematics/data/Muon_UL2018_RunABCD_SF_ISO.json",
 
     "MUON_ID_RefTracks" : "TrackerMuons",
-    "MUON_ID_RefTracks_LowPt" : "genTracks",
+    "MUON_ID_RefTracks_LowPt" : "TrackerMuons",
 
 
-    "Ele_ID_SF_FileName" : "flashgg/Systematics/data/combined_eleIDSFs_2018.json",
-    "Ele_ID_version" : "mvaEleID-Fall17-iso-V2-wp90",
+    "Ele_ID_SF_FileName" : "flashgg/Systematics/data/combined_eleIDSFs_UL_2018.json",
+    "Ele_ID_version" : "mvaBasedElectronID-UL18-wp90iso",
 
     "Ele_reco_SF_FileName" : "flashgg/Systematics/data/2018_reco-eff.json",
 


### PR DESCRIPTION
Update for the lepton SFs in flashgg package

## New json files proposed to incorporate in flashgg
Muon_UL2018_RunABCD_SF_ID.json 
Muon_UL2018_RunABCD_SF_ID_lowPt.json
Muon_UL2018_RunABCD_SF_ISO.json
combined_eleIDSFs_UL_2018.json
combined_eleIDSFs_UL_2017.json
Muon2016_RunBCDEFGH_SF_ID_lowPt_finerEtaBin.json

These files can be found in the path: /eos/home-y/ykao/public/updated_scale_factors

## Comments on the UL17 and UL18 SFs
Following the official twiki pages [1], the json files for 2018 UL muon SFs are taken from [2][3][4]. The json files for 2017 UL electron ID SFs [5] and 2018 UL electron ID SFs [6] are also created (for individual year, both cut-based and mva-based ID SFs are incorporated in a json file).

[1] https://twiki.cern.ch/twiki/bin/view/CMS/PdmVRun2LegacyAnalysis
[2] UL18 muon ID low pT SFs: https://twiki.cern.ch/twiki/bin/viewauth/CMS/MuonUL2018#ID_efficiencies
[3] UL18 muon ID SFs: https://twiki.cern.ch/twiki/bin/viewauth/CMS/MuonUL2018#ID_efficiencies_AN1
[4] UL18 muon ISO SFs: https://twiki.cern.ch/twiki/bin/viewauth/CMS/MuonUL2018#ISO_efficiencies
[5] UL17 electron ID SFs: https://twiki.cern.ch/twiki/bin/view/CMS/EgammaUL2016To2018#SFs_for_Electrons_UL_2017
[6] UL18 electron ID SFs: https://twiki.cern.ch/twiki/bin/view/CMS/EgammaUL2016To2018#SFs_for_Electrons_UL_2018


## Comments on the ReReco 2016 low-pT muon ID SFs
The json file for 2016 ReReco low-pT muon ID SFs is also updated. It is noticed that there are 'key error' messages because the following two json files has different keys for eta bins:

Muon2016_RunBCDEFGH_SF_ID.json
Muon2016_RunBCDEFGH_SF_ID_lowPt.json

To address the issue, a mapping between eta bins and finer eta bins is considered [7] and another json files is created, which is named as Muon2016_RunBCDEFGH_SF_ID_lowPt_finerEtaBin.json

A few slight imperfect mapping are listed as follows ("adapted eta bin" : "original eta bin"),
"eta:[0.5,0.8]"   :  "eta:[0,0.9]"
"eta:[0.8,1.2]"   :  "eta:[0.9,1.2]"

where the eta range of [0.8, 0.9] should follow the scale factors in "eta:[0,0.9]" instead of "eta:[0.9,1.2]".

Depending on pT, the differences of SFs due to this mismatch are:

pT in range of [10, 20] GeV: <1%
pT in range of [3.75, 4.00] GeV: ~8%
pT in range of [2.00, 10.0] GeV (excluding [3.75, 4.00]): <4%

[7] Mapping ("adapted eta bin" : "original eta bin") for converting Muon2016_RunBCDEFGH_SF_ID_lowPt.json to Muon2016_RunBCDEFGH_SF_ID_lowPt_finerEtaBin.json

For example, in this updated json file, "eta:[-2.4,-2.3]" take the SFs from "eta:[-2.4,-2.1]" in Muon2016_RunBCDEFGH_SF_ID_lowPt.json.

```
map_eta_fine = {
    "eta:[-2.4,-2.3]" :  "eta:[-2.4,-2.1]",
    "eta:[-2.3,-2.2]" :  "eta:[-2.4,-2.1]",
    "eta:[-2.2,-2.1]" :  "eta:[-2.4,-2.1]",

    "eta:[-2.1,-2]"   :  "eta:[-2.1,-1.2]",
    "eta:[-2,-1.7]"   :  "eta:[-2.1,-1.2]",
    "eta:[-1.7,-1.6]" :  "eta:[-2.1,-1.2]",
    "eta:[-1.6,-1.5]" :  "eta:[-2.1,-1.2]",
    "eta:[-1.5,-1.4]" :  "eta:[-2.1,-1.2]",
    "eta:[-1.4,-1.2]" :  "eta:[-2.1,-1.2]",

    "eta:[-1.2,-0.8]" :  "eta:[-1.2,-0.9]",

    "eta:[-0.8,-0.5]" :  "eta:[-0.9,-0]",
    "eta:[-0.5,-0.3]" :  "eta:[-0.9,-0]",
    "eta:[-0.3,-0.2]" :  "eta:[-0.9,-0]",
    "eta:[-0.2,0]"    :  "eta:[-0.9,-0]",

    "eta:[0,0.2]"     :  "eta:[0,0.9]",
    "eta:[0.2,0.3]"   :  "eta:[0,0.9]",
    "eta:[0.3,0.5]"   :  "eta:[0,0.9]",
    "eta:[0.5,0.8]"   :  "eta:[0,0.9]",

    "eta:[0.8,1.2]"   :  "eta:[0.9,1.2]",

    "eta:[1.2,1.4]"   :  "eta:[1.2,2.1]",
    "eta:[1.4,1.5]"   :  "eta:[1.2,2.1]",
    "eta:[1.5,1.6]"   :  "eta:[1.2,2.1]",
    "eta:[1.6,1.7]"   :  "eta:[1.2,2.1]",
    "eta:[1.7,2]"     :  "eta:[1.2,2.1]",
    "eta:[2,2.1]"     :  "eta:[1.2,2.1]",

    "eta:[2.1,2.2]"   :  "eta:[2.1,2.4]",
    "eta:[2.2,2.3]"   :  "eta:[2.1,2.4]",
    "eta:[2.3,2.4]"   :  "eta:[2.1,2.4]",
}
```