### PR TITLE
Add ParticleNet SV tagging for H+c analysis

### DIFF
--- a/DataFormats/interface/SecondaryVertex.h
+++ b/DataFormats/interface/SecondaryVertex.h
@@ -1,0 +1,39 @@
+#ifndef FLASHgg_SecondaryVertex_h
+#define FLASHgg_SecondaryVertex_h
+
+#include "DataFormats/Candidate/interface/VertexCompositePtrCandidate.h"
+#include "flashgg/DataFormats/interface/WeightedObject.h"
+
+namespace flashgg {
+
+    class SecondaryVertex : public reco::VertexCompositePtrCandidate, public WeightedObject
+    {
+
+    public:
+        SecondaryVertex();
+        SecondaryVertex( const reco::VertexCompositePtrCandidate & );
+        ~SecondaryVertex();
+
+        int svGenFlav() const {return svGenFlav_;}
+        void setSvGenFlav( int val ) { svGenFlav_ = val; }
+
+        std::vector<float> svTagProbs() const {return svTagProbs_;}
+        void setSvTagProbs( std::vector<float> val ) { svTagProbs_ = val; }
+
+        SecondaryVertex *clone() const { return ( new SecondaryVertex( *this ) ); }
+
+    private:
+        int svGenFlav_;
+        vector<float> svTagProbs_;
+    };
+}
+
+#endif
+// Local Variables:
+// mode:c++
+// indent-tabs-mode:nil
+// tab-width:4
+// c-basic-offset:4
+// End:
+// vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4
+

--- a/DataFormats/interface/SecondaryVertex.h
+++ b/DataFormats/interface/SecondaryVertex.h
@@ -17,6 +17,12 @@ namespace flashgg {
         int svGenFlav() const {return svGenFlav_;}
         void setSvGenFlav( int val ) { svGenFlav_ = val; }
 
+        int svNBHadrons() const {return svNBHadrons_;}
+        void setSvNBHadrons( int val ) { svNBHadrons_ = val; }
+
+        int svNCHadrons() const {return svNCHadrons_;}
+        void setSvNCHadrons( int val ) { svNCHadrons_ = val; }
+
         std::vector<float> svTagProbs() const {return svTagProbs_;}
         void setSvTagProbs( std::vector<float> val ) { svTagProbs_ = val; }
 
@@ -24,6 +30,8 @@ namespace flashgg {
 
     private:
         int svGenFlav_;
+        int svNBHadrons_;
+        int svNCHadrons_;
         vector<float> svTagProbs_;
     };
 }

--- a/DataFormats/src/SecondaryVertex.cc
+++ b/DataFormats/src/SecondaryVertex.cc
@@ -1,0 +1,21 @@
+#include "flashgg/DataFormats/interface/SecondaryVertex.h"
+
+using namespace flashgg;
+
+SecondaryVertex::SecondaryVertex() : reco::VertexCompositePtrCandidate()
+{}
+
+SecondaryVertex::~SecondaryVertex()
+{}
+
+SecondaryVertex::SecondaryVertex( const reco::VertexCompositePtrCandidate &asv ) : reco::VertexCompositePtrCandidate( asv )
+{}
+
+// Local Variables:
+// mode:c++
+// indent-tabs-mode:nil
+// tab-width:4
+// c-basic-offset:4
+// End:
+// vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4
+

--- a/DataFormats/src/classes.h
+++ b/DataFormats/src/classes.h
@@ -12,6 +12,7 @@
 #include "flashgg/DataFormats/interface/SigmaMpTTag.h"
 #include "flashgg/DataFormats/interface/Electron.h"
 #include "flashgg/DataFormats/interface/Muon.h"
+#include "flashgg/DataFormats/interface/SecondaryVertex.h"
 #include "flashgg/DataFormats/interface/GenPhotonExtra.h"
 #include "flashgg/DataFormats/interface/GenLeptonExtra.h"
 #include "flashgg/DataFormats/interface/GenJetExtra.h"
@@ -146,6 +147,11 @@ namespace  {
         edm::Wrapper<flashgg::Muon>				                        wrp_fgg_mu;
         std::vector<flashgg::Muon>				                        vec_fgg_mu;
         edm::Wrapper<std::vector<flashgg::Muon> >                   wrp_vec_fgg_mu;
+        flashgg::SecondaryVertex						                    fgg_sv;
+        edm::Ptr<flashgg::SecondaryVertex> 					            ptr_fgg_sv;
+        edm::Wrapper<flashgg::SecondaryVertex>				            wrp_fgg_sv;
+        std::vector<flashgg::SecondaryVertex>				            vec_fgg_sv;
+        edm::Wrapper<std::vector<flashgg::SecondaryVertex> >        wrp_vec_fgg_sv;
 
         std::map<edm::Ptr<reco::Vertex>, float>                    map_ptr_vtx_flo;
         std::pair<edm::Ptr<reco::Vertex>, float>                   pai_ptr_vtx_flo;

--- a/DataFormats/src/classes_def.xml
+++ b/DataFormats/src/classes_def.xml
@@ -357,6 +357,12 @@
 <class name="edm::Ptr<flashgg::Muon>"/>
 <class name="std::vector<flashgg::Muon>"/>
 <class name="edm::Wrapper<std::vector<flashgg::Muon> >"/>
+<class name="flashgg::SecondaryVertex" ClassVersion="10">
+ <version ClassVersion="10" checksum="794927205"/>
+</class>
+<class name="edm::Ptr<flashgg::SecondaryVertex>"/>
+<class name="std::vector<flashgg::SecondaryVertex>"/>
+<class name="edm::Wrapper<std::vector<flashgg::SecondaryVertex> >"/>
 <class name="flashgg::TagTruthBase" ClassVersion="15">
  <version ClassVersion="15" checksum="615975089"/>
  <version ClassVersion="14" checksum="2420283393"/>

--- a/DataFormats/src/classes_def.xml
+++ b/DataFormats/src/classes_def.xml
@@ -357,7 +357,8 @@
 <class name="edm::Ptr<flashgg::Muon>"/>
 <class name="std::vector<flashgg::Muon>"/>
 <class name="edm::Wrapper<std::vector<flashgg::Muon> >"/>
-<class name="flashgg::SecondaryVertex" ClassVersion="10">
+<class name="flashgg::SecondaryVertex" ClassVersion="11">
+ <version ClassVersion="11" checksum="809561912"/>
  <version ClassVersion="10" checksum="794927205"/>
 </class>
 <class name="edm::Ptr<flashgg::SecondaryVertex>"/>

--- a/MicroAOD/BuildFile.xml
+++ b/MicroAOD/BuildFile.xml
@@ -15,6 +15,7 @@
 <use name="root"/>
 <lib name="Geom" />
 <use name="XGBoostCMSSW/XGBoostInterface"/>
+<use name="DataFormats/BTauReco"/>
 <!-- Flags CXXFLAGS="-ggdb"/ -->
 <export>
   <lib   name="1"/>

--- a/MicroAOD/plugins/BuildFile.xml
+++ b/MicroAOD/plugins/BuildFile.xml
@@ -13,6 +13,9 @@
 <use   name="DataFormats/EgammaCandidates"/>
 <use   name="RecoEgamma/EgammaTools"/>
 <use   name="PhysicsTools/JetMCUtils"/>
+<use   name="DataFormats/BTauReco"/>
+<use   name="RecoBTag/FeatureTools"/>
+<use   name="PhysicsTools/ONNXRuntime"/>
 <use   name="roottmva"/>
 <!-- <use   name="HiggsAnalysis/GBRLikelihoodEGTools"/> -->
 <flags   EDM_PLUGIN="1"/>

--- a/MicroAOD/plugins/SVFlavourONNXTagsProducer.cc
+++ b/MicroAOD/plugins/SVFlavourONNXTagsProducer.cc
@@ -1,0 +1,320 @@
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+#include "FWCore/Framework/interface/makeRefToBaseProdFrom.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/StreamID.h"
+
+#include "DataFormats/BTauReco/interface/JetTag.h"
+
+#include "DataFormats/BTauReco/interface/DeepBoostedJetTagInfo.h"
+
+#include "PhysicsTools/ONNXRuntime/interface/ONNXRuntime.h"
+
+#include "RecoBTag/FeatureTools/interface/deep_helpers.h"
+
+#include "DataFormats/Candidate/interface/VertexCompositePtrCandidate.h"
+#include "flashgg/DataFormats/interface/SecondaryVertex.h"
+
+#include <iostream>
+#include <fstream>
+#include <algorithm>
+#include <numeric>
+#include <nlohmann/json.hpp>
+
+using namespace cms::Ort;
+using namespace btagbtvdeep;
+
+class SVFlavourONNXTagsProducer : public edm::stream::EDProducer<edm::GlobalCache<ONNXRuntime>> {
+public:
+  explicit SVFlavourONNXTagsProducer(const edm::ParameterSet &, const ONNXRuntime *);
+  ~SVFlavourONNXTagsProducer() override;
+
+  static void fillDescriptions(edm::ConfigurationDescriptions &);
+
+  static std::unique_ptr<ONNXRuntime> initializeGlobalCache(const edm::ParameterSet &);
+  static void globalEndJob(const ONNXRuntime *);
+
+private:
+  typedef std::vector<reco::DeepBoostedJetTagInfo> TagInfoCollection;
+  typedef reco::JetTagCollection JetTagCollection;
+  typedef std::vector<pat::Jet> JetCollection;
+  typedef std::vector<reco::VertexCompositePtrCandidate> SVCollection;
+
+  void produce(edm::Event &, const edm::EventSetup &) override;
+
+  std::vector<float> center_norm_pad(const std::vector<float> &input,
+                                     float center,
+                                     float scale,
+                                     unsigned min_length,
+                                     unsigned max_length,
+                                     float pad_value = 0,
+                                     float replace_inf_value = 0,
+                                     float min = 0,
+                                     float max = -1);
+  void make_inputs(const reco::DeepBoostedJetTagInfo &taginfo);
+
+  const edm::EDGetTokenT<TagInfoCollection> src_;
+  const edm::EDGetTokenT<JetCollection> jets_;
+  const edm::EDGetTokenT<SVCollection> svs_;
+  std::vector<std::string> flav_names_;             // names of the output scores
+  std::vector<std::string> input_names_;            // names of each input group - the ordering is important!
+  std::vector<std::vector<int64_t>> input_shapes_;  // shapes of each input group (-1 for dynamic axis)
+  std::vector<unsigned> input_sizes_;               // total length of each input vector
+  std::unordered_map<std::string, PreprocessParams> prep_info_map_;  // preprocessing info for each input group
+
+  FloatArrays data_;
+
+  bool debug_ = false;
+};
+
+SVFlavourONNXTagsProducer::SVFlavourONNXTagsProducer(const edm::ParameterSet &iConfig, const ONNXRuntime *cache)
+    : src_(consumes<TagInfoCollection>(iConfig.getParameter<edm::InputTag>("src"))),
+      jets_(consumes<JetCollection>(iConfig.getParameter<edm::InputTag>("phantom_jets"))),
+      svs_(consumes<SVCollection>(iConfig.getParameter<edm::InputTag>("secondary_vertices"))),
+      flav_names_(iConfig.getParameter<std::vector<std::string>>("flav_names")),
+      debug_(iConfig.getUntrackedParameter<bool>("debugMode", false)) {
+  // load preprocessing info
+  auto json_path = iConfig.getParameter<std::string>("preprocess_json");
+  if (!json_path.empty()) {
+    // use preprocessing json file if available
+    std::ifstream ifs(edm::FileInPath(json_path).fullPath());
+    nlohmann::json js = nlohmann::json::parse(ifs);
+    js.at("input_names").get_to(input_names_);
+    for (const auto &group_name : input_names_) {
+      const auto &group_pset = js.at(group_name);
+      auto &prep_params = prep_info_map_[group_name];
+      group_pset.at("var_names").get_to(prep_params.var_names);
+      if (group_pset.contains("var_length")) {
+        prep_params.min_length = group_pset.at("var_length");
+        prep_params.max_length = prep_params.min_length;
+      } else {
+        prep_params.min_length = group_pset.at("min_length");
+        prep_params.max_length = group_pset.at("max_length");
+        input_shapes_.push_back({1, (int64_t)prep_params.var_names.size(), -1});
+      }
+      const auto &var_info_pset = group_pset.at("var_infos");
+      for (const auto &var_name : prep_params.var_names) {
+        const auto &var_pset = var_info_pset.at(var_name);
+        double median = var_pset.at("median");
+        double norm_factor = var_pset.at("norm_factor");
+        double replace_inf_value = var_pset.at("replace_inf_value");
+        double lower_bound = var_pset.at("lower_bound");
+        double upper_bound = var_pset.at("upper_bound");
+        double pad = var_pset.contains("pad") ? double(var_pset.at("pad")) : 0;
+        prep_params.var_info_map[var_name] =
+            PreprocessParams::VarInfo(median, norm_factor, replace_inf_value, lower_bound, upper_bound, pad);
+      }
+
+      // create data storage with a fixed size vector initilized w/ 0
+      const auto &len = input_sizes_.emplace_back(prep_params.max_length * prep_params.var_names.size());
+      data_.emplace_back(len, 0);
+    }
+  } else {
+    // otherwise use the PSet in the python config file
+    const auto &prep_pset = iConfig.getParameterSet("preprocessParams");
+    input_names_ = prep_pset.getParameter<std::vector<std::string>>("input_names");
+    for (const auto &group_name : input_names_) {
+      const auto &group_pset = prep_pset.getParameterSet(group_name);
+      auto &prep_params = prep_info_map_[group_name];
+      prep_params.var_names = group_pset.getParameter<std::vector<std::string>>("var_names");
+      prep_params.min_length = group_pset.getParameter<unsigned>("var_length");
+      prep_params.max_length = prep_params.min_length;
+      const auto &var_info_pset = group_pset.getParameterSet("var_infos");
+      for (const auto &var_name : prep_params.var_names) {
+        const auto &var_pset = var_info_pset.getParameterSet(var_name);
+        double median = var_pset.getParameter<double>("median");
+        double norm_factor = var_pset.getParameter<double>("norm_factor");
+        double replace_inf_value = var_pset.getParameter<double>("replace_inf_value");
+        double lower_bound = var_pset.getParameter<double>("lower_bound");
+        double upper_bound = var_pset.getParameter<double>("upper_bound");
+        prep_params.var_info_map[var_name] =
+            PreprocessParams::VarInfo(median, norm_factor, replace_inf_value, lower_bound, upper_bound, 0);
+      }
+
+      // create data storage with a fixed size vector initiliazed w/ 0
+      const auto &len = input_sizes_.emplace_back(prep_params.max_length * prep_params.var_names.size());
+      data_.emplace_back(len, 0);
+    }
+  }
+
+  if (debug_) {
+    for (unsigned i = 0; i < input_names_.size(); ++i) {
+      const auto &group_name = input_names_.at(i);
+      if (!input_shapes_.empty()) {
+        std::cout << group_name << "\nshapes: ";
+        for (const auto &x : input_shapes_.at(i)) {
+          std::cout << x << ", ";
+        }
+      }
+      std::cout << "\nvariables: ";
+      for (const auto &x : prep_info_map_.at(group_name).var_names) {
+        std::cout << x << ", ";
+      }
+      std::cout << "\n";
+    }
+    std::cout << "flav_names: ";
+    for (const auto &flav_name : flav_names_) {
+      std::cout << flav_name << ", ";
+    }
+    std::cout << "\n";
+  }
+
+  produces<std::vector<flashgg::SecondaryVertex>>();
+}
+
+SVFlavourONNXTagsProducer::~SVFlavourONNXTagsProducer() {}
+
+void SVFlavourONNXTagsProducer::fillDescriptions(edm::ConfigurationDescriptions &descriptions) {
+  // pfDeepBoostedJetTags
+  edm::ParameterSetDescription desc;
+  desc.add<edm::InputTag>("src", edm::InputTag("pfDeepBoostedJetTagInfos"));
+  desc.add<edm::InputTag>("phantom_jets", edm::InputTag("pfDeepBoostedJetTagInfos", "jets"));
+  desc.add<edm::InputTag>("secondary_vertices", edm::InputTag("slimmedSecondaryVertices"));
+  desc.add<std::string>("preprocess_json", "");
+  // `preprocessParams` is deprecated -- use the preprocessing json file instead
+  edm::ParameterSetDescription preprocessParams;
+  preprocessParams.setAllowAnything();
+  preprocessParams.setComment("`preprocessParams` is deprecated, please use `preprocess_json` instead.");
+  desc.addOptional<edm::ParameterSetDescription>("preprocessParams", preprocessParams);
+  desc.add<edm::FileInPath>("model_path",
+                            edm::FileInPath("flashgg/MicroAOD/data/ParticleNetSV/V01/model.onnx"));
+  desc.add<std::vector<std::string>>("flav_names", std::vector<std::string>{});
+  desc.addOptionalUntracked<bool>("debugMode", false);
+
+  descriptions.addWithDefaultLabel(desc);
+  descriptions.add("pfSVFlavourONNXTagsProducer", desc);
+}
+
+std::unique_ptr<ONNXRuntime> SVFlavourONNXTagsProducer::initializeGlobalCache(const edm::ParameterSet &iConfig) {
+  return std::make_unique<ONNXRuntime>(iConfig.getParameter<edm::FileInPath>("model_path").fullPath());
+}
+
+void SVFlavourONNXTagsProducer::globalEndJob(const ONNXRuntime *cache) {}
+
+void SVFlavourONNXTagsProducer::produce(edm::Event &iEvent, const edm::EventSetup &iSetup) {
+  edm::Handle<TagInfoCollection> tag_infos;
+  edm::Handle<JetCollection> jets; // phantom jet collection to catch the gen-matching variable
+  edm::Handle<SVCollection> svs;
+  iEvent.getByToken(src_, tag_infos);
+  iEvent.getByToken(jets_, jets);
+  iEvent.getByToken(svs_, svs);
+
+  auto outSVs = std::make_unique<std::vector<flashgg::SecondaryVertex>>();
+  for (unsigned sv_n = 0; sv_n < tag_infos->size(); ++sv_n) {
+    const auto &taginfo = (*tag_infos)[sv_n];
+    outSVs->push_back(svs->at(sv_n)); // do a copy here
+    auto &sv = outSVs->back();
+
+    std::vector<float> outputs(flav_names_.size(), 0);  // init as all zeros
+
+    if (!taginfo.features().empty()) {
+      // convert inputs
+      make_inputs(taginfo);
+      // run prediction and get outputs
+      outputs = globalCache()->run(input_names_, data_, input_shapes_)[0];
+      assert(outputs.size() == flav_names_.size());
+    }
+
+    std::vector<float> probs;
+    for (std::size_t flav_n = 0; flav_n < flav_names_.size(); flav_n++) {
+      probs.push_back(outputs[flav_n]);
+    }
+    sv.setSvTagProbs(probs);
+    sv.setSvGenFlav(jets->at(sv_n).userFloat("gen_flavour"));
+  }
+
+  if (debug_) {
+    std::cout << "=== " << iEvent.id().run() << ":" << iEvent.id().luminosityBlock() << ":" << iEvent.id().event()
+              << " ===" << std::endl;
+    for (unsigned sv_n = 0; sv_n < tag_infos->size(); ++sv_n) {
+      std::cout << " - SV #" << sv_n << ", gen_flavour=" << outSVs->at(sv_n).svGenFlav() << std::endl;
+      for (std::size_t flav_n = 0; flav_n < flav_names_.size(); ++flav_n) {
+        std::cout << "    " << flav_names_.at(flav_n) << " = " << outSVs->at(sv_n).svTagProbs()[flav_n] << std::endl;
+      }
+    }
+  }
+
+  // put into the event
+  iEvent.put(std::move(outSVs));
+}
+
+std::vector<float> SVFlavourONNXTagsProducer::center_norm_pad(const std::vector<float> &input,
+                                                                  float center,
+                                                                  float norm_factor,
+                                                                  unsigned min_length,
+                                                                  unsigned max_length,
+                                                                  float pad_value,
+                                                                  float replace_inf_value,
+                                                                  float min,
+                                                                  float max) {
+  // do variable shifting/scaling/padding/clipping in one go
+
+  assert(min <= pad_value && pad_value <= max);
+  assert(min_length <= max_length);
+
+  unsigned target_length = std::clamp((unsigned)input.size(), min_length, max_length);
+  std::vector<float> out(target_length, pad_value);
+  for (unsigned i = 0; i < input.size() && i < target_length; ++i) {
+    out[i] = std::clamp((catch_infs(input[i], replace_inf_value) - center) * norm_factor, min, max);
+  }
+  return out;
+}
+
+void SVFlavourONNXTagsProducer::make_inputs(const reco::DeepBoostedJetTagInfo &taginfo) {
+  for (unsigned igroup = 0; igroup < input_names_.size(); ++igroup) {
+    const auto &group_name = input_names_[igroup];
+    const auto &prep_params = prep_info_map_.at(group_name);
+    auto &group_values = data_[igroup];
+    group_values.resize(input_sizes_[igroup]);
+    // first reset group_values to 0
+    std::fill(group_values.begin(), group_values.end(), 0);
+    unsigned curr_pos = 0;
+    // transform/pad
+    for (unsigned i = 0; i < prep_params.var_names.size(); ++i) {
+      const auto &varname = prep_params.var_names[i];
+      const auto &raw_value = taginfo.features().get(varname);
+      const auto &info = prep_params.info(varname);
+      auto val = center_norm_pad(raw_value,
+                                 info.center,
+                                 info.norm_factor,
+                                 prep_params.min_length,
+                                 prep_params.max_length,
+                                 info.pad,
+                                 info.replace_inf_value,
+                                 info.lower_bound,
+                                 info.upper_bound);
+      std::copy(val.begin(), val.end(), group_values.begin() + curr_pos);
+      curr_pos += val.size();
+      if (i == 0 && (!input_shapes_.empty())) {
+        input_shapes_[igroup][2] = val.size();
+      }
+
+      if (debug_) {
+        std::cout << " -- var=" << varname << ", center=" << info.center << ", scale=" << info.norm_factor
+                  << ", replace=" << info.replace_inf_value << ", pad=" << info.pad << std::endl;
+        for (const auto &v : val) {
+          std::cout << v << ",";
+        }
+        std::cout << std::endl;
+      }
+    }
+    group_values.resize(curr_pos);
+  }
+}
+
+//define this as a plug-in
+DEFINE_FWK_MODULE(SVFlavourONNXTagsProducer);
+
+// Local Variables:
+// mode:c++
+// indent-tabs-mode:nil
+// tab-width:4
+// c-basic-offset:4
+// End:
+// vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4
+

--- a/MicroAOD/plugins/SVFlavourONNXTagsProducer.cc
+++ b/MicroAOD/plugins/SVFlavourONNXTagsProducer.cc
@@ -226,13 +226,17 @@ void SVFlavourONNXTagsProducer::produce(edm::Event &iEvent, const edm::EventSetu
     }
     sv.setSvTagProbs(probs);
     sv.setSvGenFlav(jets->at(sv_n).hasUserFloat("gen_flavour") ? jets->at(sv_n).userFloat("gen_flavour") : -1);
+    sv.setSvNBHadrons(jets->at(sv_n).hasUserFloat("n_bhadrons") ? jets->at(sv_n).userFloat("n_bhadrons") : -1);
+    sv.setSvNCHadrons(jets->at(sv_n).hasUserFloat("n_chadrons") ? jets->at(sv_n).userFloat("n_chadrons") : -1);
   }
 
   if (debug_) {
     std::cout << "=== " << iEvent.id().run() << ":" << iEvent.id().luminosityBlock() << ":" << iEvent.id().event()
               << " ===" << std::endl;
     for (unsigned sv_n = 0; sv_n < tag_infos->size(); ++sv_n) {
-      std::cout << " - SV #" << sv_n << ", gen_flavour=" << outSVs->at(sv_n).svGenFlav() << std::endl;
+      std::cout << " - SV #" << sv_n << ", gen_flavour=" << outSVs->at(sv_n).svGenFlav() 
+                << ", n_b=" << outSVs->at(sv_n).svNBHadrons()
+                << ", n_c=" << outSVs->at(sv_n).svNCHadrons() << std::endl;
       for (std::size_t flav_n = 0; flav_n < flav_names_.size(); ++flav_n) {
         std::cout << "    " << flav_names_.at(flav_n) << " = " << outSVs->at(sv_n).svTagProbs()[flav_n] << std::endl;
       }

--- a/MicroAOD/plugins/SVFlavourONNXTagsProducer.cc
+++ b/MicroAOD/plugins/SVFlavourONNXTagsProducer.cc
@@ -225,7 +225,7 @@ void SVFlavourONNXTagsProducer::produce(edm::Event &iEvent, const edm::EventSetu
       probs.push_back(outputs[flav_n]);
     }
     sv.setSvTagProbs(probs);
-    sv.setSvGenFlav(jets->at(sv_n).userFloat("gen_flavour"));
+    sv.setSvGenFlav(jets->at(sv_n).hasUserFloat("gen_flavour") ? jets->at(sv_n).userFloat("gen_flavour") : -1);
   }
 
   if (debug_) {

--- a/MicroAOD/plugins/SVFlavourTagInfoProducer.cc
+++ b/MicroAOD/plugins/SVFlavourTagInfoProducer.cc
@@ -1,0 +1,504 @@
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/StreamID.h"
+
+#include "DataFormats/Candidate/interface/Candidate.h"
+
+#include "DataFormats/PatCandidates/interface/Jet.h"
+#include "DataFormats/PatCandidates/interface/PackedCandidate.h"
+
+#include "RecoBTag/FeatureTools/interface/TrackInfoBuilder.h"
+#include "RecoBTag/FeatureTools/interface/deep_helpers.h"
+#include "RecoBTag/FeatureTools/interface/sorting_modules.h"
+#include "TrackingTools/Records/interface/TransientTrackRecord.h"
+
+#include "DataFormats/Candidate/interface/VertexCompositePtrCandidate.h"
+#include "DataFormats/VertexReco/interface/VertexFwd.h"
+
+#include "DataFormats/BTauReco/interface/DeepBoostedJetTagInfo.h"
+
+using namespace btagbtvdeep;
+
+class SVFlavourTagInfoProducer : public edm::stream::EDProducer<> {
+public:
+  explicit SVFlavourTagInfoProducer(const edm::ParameterSet &);
+  ~SVFlavourTagInfoProducer() override;
+
+  static void fillDescriptions(edm::ConfigurationDescriptions &descriptions);
+
+private:
+  typedef std::vector<reco::DeepBoostedJetTagInfo> DeepBoostedJetTagInfoCollection;
+  typedef reco::VertexCompositePtrCandidateCollection SVCollection;
+  typedef reco::VertexCompositePtrCandidate SV;
+  typedef reco::VertexCollection VertexCollection;
+  typedef reco::GenParticleCollection GenParticleCollection;
+  typedef edm::View<reco::Candidate> CandidateView;
+  typedef std::vector<pat::Jet> JetCollection;
+
+  void beginStream(edm::StreamID) override {}
+  void produce(edm::Event &, const edm::EventSetup &) override;
+  void endStream() override {}
+
+  void fillParticleFeatures(DeepBoostedJetFeatures &fts, const SV &sv, std::vector<reco::CandidatePtr> &matched_cands);
+  void matchSVWithPFCands(std::unique_ptr<JetCollection> &svPhantomJets);
+
+  const double deltar_match_sv_pfcand_;
+  const bool is_mc_;
+
+  edm::EDGetTokenT<VertexCollection> vtx_token_;
+  edm::EDGetTokenT<SVCollection> sv_token_;
+  edm::EDGetTokenT<CandidateView> pfcand_token_;
+  edm::EDGetTokenT<GenParticleCollection> genpart_token_;
+
+  edm::Handle<VertexCollection> vtxs_;
+  edm::Handle<SVCollection> svs_;
+  edm::Handle<CandidateView> pfcands_;
+  edm::Handle<GenParticleCollection> genparts_;
+  edm::ESHandle<TransientTrackBuilder> track_builder_;
+
+  const static std::vector<std::string> particle_features_;
+  const static std::vector<std::string> sv_features_;
+  const reco::Vertex *pv_ = nullptr;
+
+  bool debug_ = false;
+};
+
+const std::vector<std::string> SVFlavourTagInfoProducer::particle_features_{
+    "pfcand_hcalFrac",      "pfcand_VTX_ass",        "pfcand_lostInnerHits",
+    "pfcand_quality",       "pfcand_charge",         "pfcand_isEl",         "pfcand_isMu",
+    "pfcand_isChargedHad",  "pfcand_isGamma",        "pfcand_isNeutralHad", "pfcand_phirel",
+    "pfcand_etarel",        "pfcand_deltaR",         "pfcand_abseta",       "pfcand_ptrel_log",
+    "pfcand_erel_log",      "pfcand_pt_log",         
+    "pfcand_normchi2",      "pfcand_dz",             "pfcand_dzsig",
+    "pfcand_dxy",           "pfcand_dxysig",         "pfcand_dptdpt",       "pfcand_detadeta",
+    "pfcand_dphidphi",      "pfcand_dxydxy",         "pfcand_dzdz",         "pfcand_dxydz",
+    "pfcand_dphidxy",       "pfcand_dlambdadz",      "pfcand_btagEtaRel",   "pfcand_btagPtRatio",
+    "pfcand_btagPParRatio", "pfcand_btagSip2dVal",   "pfcand_btagSip2dSig", "pfcand_btagSip3dVal",
+    "pfcand_btagSip3dSig",  "pfcand_btagJetDistVal", "pfcand_mask",         "pfcand_pt_log_nopuppi",
+    "pfcand_e_log_nopuppi", "pfcand_ptrel",          "pfcand_erel"};
+
+SVFlavourTagInfoProducer::SVFlavourTagInfoProducer(const edm::ParameterSet &iConfig)
+    : deltar_match_sv_pfcand_(iConfig.getParameter<double>("deltar_match_sv_pfcand")),
+      is_mc_(iConfig.getParameter<bool>("is_mc")),
+      vtx_token_(consumes<VertexCollection>(iConfig.getParameter<edm::InputTag>("vertices"))),
+      sv_token_(consumes<SVCollection>(iConfig.getParameter<edm::InputTag>("secondary_vertices"))),
+      pfcand_token_(consumes<CandidateView>(iConfig.getParameter<edm::InputTag>("pf_candidates"))),
+      genpart_token_(consumes<GenParticleCollection>(iConfig.getParameter<edm::InputTag>("genparticles"))),
+      debug_(iConfig.getUntrackedParameter<bool>("debugMode", false)) {
+
+  produces<DeepBoostedJetTagInfoCollection>();
+  produces<JetCollection>("svPhantomJets");
+}
+
+SVFlavourTagInfoProducer::~SVFlavourTagInfoProducer() {}
+
+void SVFlavourTagInfoProducer::fillDescriptions(edm::ConfigurationDescriptions &descriptions) {
+  // pfSVFlavourTagInfos
+  edm::ParameterSetDescription desc;
+  desc.add<double>("deltar_match_sv_pfcand", 0.4);
+  desc.add<bool>("is_mc", true);
+  desc.add<edm::InputTag>("vertices", edm::InputTag("offlinePrimaryVertices"));
+  desc.add<edm::InputTag>("secondary_vertices", edm::InputTag("inclusiveCandidateSecondaryVertices"));
+  desc.add<edm::InputTag>("pf_candidates", edm::InputTag("particleFlow"));
+  desc.add<edm::InputTag>("genparticles", edm::InputTag("prunedGenParticles"));
+  desc.addOptionalUntracked<bool>("debugMode", false);
+  descriptions.add("pfSVFlavourTagInfos", desc);
+}
+
+void SVFlavourTagInfoProducer::produce(edm::Event &iEvent, const edm::EventSetup &iSetup) {
+  auto output_tag_infos = std::make_unique<DeepBoostedJetTagInfoCollection>();
+
+  iEvent.getByToken(vtx_token_, vtxs_);
+  if (vtxs_->empty()) {
+    // produce empty TagInfos in case no primary vertex
+    iEvent.put(std::move(output_tag_infos));
+    return;  // exit event
+  }
+  // primary vertex
+  pv_ = &vtxs_->at(0);
+
+  iEvent.getByToken(sv_token_, svs_);
+  iEvent.getByToken(pfcand_token_, pfcands_);
+  iEvent.getByToken(genpart_token_, genparts_);
+
+  iSetup.get<TransientTrackRecord>().get("TransientTrackBuilder", track_builder_);
+
+  // create jet collection
+  auto svPhantomJets = std::make_unique<JetCollection>();
+  for (std::size_t sv_n = 0; sv_n < svs_->size(); sv_n++) {
+    pat::Jet ajet;
+    svPhantomJets->push_back(ajet);
+  }
+
+  // SV truth matching
+  if (is_mc_) {
+    matchSVWithPFCands(svPhantomJets);
+  }
+
+  for (std::size_t sv_n = 0; sv_n < svs_->size(); sv_n++) {
+    const auto &sv = svs_->at(sv_n);
+    auto jet_ref = edm::Ref<JetCollection>(svPhantomJets.get(), sv_n);
+    edm::RefToBase<reco::Jet> jet_refbase(jet_ref);
+
+    // create jet features
+    DeepBoostedJetFeatures features;
+    // declare all the feature variables (init as empty vector)
+    for (const auto &name : particle_features_) {
+      features.add(name);
+    }
+
+    // select daughters matched to the SV
+    std::vector<reco::CandidatePtr> matched_cands;
+    for (std::size_t cand_n = 0; cand_n < pfcands_->size(); cand_n++) {
+      const auto &cand = pfcands_->ptrAt(cand_n);
+      if (reco::deltaR(*cand, sv) < deltar_match_sv_pfcand_) {
+        matched_cands.push_back(cand);
+      }
+    }
+
+    // fill particle features
+    fillParticleFeatures(features, sv, matched_cands);
+    if (!matched_cands.empty()) {
+      features.check_consistency(particle_features_);
+    }
+    
+    if (debug_) {
+      std::cout << "SV # " << sv_n << "  candidates matched: " << matched_cands.size() << std::endl;
+      auto printFeatures = [&](const auto &vector) {
+        for (const auto &value : vector) std::cout << value << ", ";
+      };
+      for (const auto &name : particle_features_) {
+        std::cout << name << " : "; 
+        printFeatures(features.get(name));
+        std::cout << std::endl;
+      }
+    }
+
+    // this should always be done even if features are not filled
+    output_tag_infos->emplace_back(features, jet_refbase);
+  }
+
+  iEvent.put(std::move(output_tag_infos));
+  iEvent.put(std::move(svPhantomJets), "svPhantomJets");
+}
+
+void SVFlavourTagInfoProducer::fillParticleFeatures(DeepBoostedJetFeatures &fts, const SV &sv, std::vector<reco::CandidatePtr> &matched_cands) {
+
+  // some jet properties
+  math::XYZVector sv_dir = sv.momentum().Unit();
+  GlobalVector sv_ref_track_dir(sv.px(),sv.py(),sv.pz());
+  const float etasign = sv.eta() > 0 ? 1 : -1;
+
+  // reserve space
+  for (const auto &name : particle_features_) {
+    fts.reserve(name, matched_cands.size());
+  }
+
+  auto useTrackProperties = [&](const reco::PFCandidate *reco_cand) {
+    const auto *trk = reco_cand->bestTrack();
+    return trk != nullptr;
+  };
+
+  for (const auto &cand : matched_cands) {
+    const auto *packed_cand = dynamic_cast<const pat::PackedCandidate *>(&(*cand));
+    const auto *reco_cand = dynamic_cast<const reco::PFCandidate *>(&(*cand));
+
+    auto candP4 = cand->p4();
+    float hcal_fraction = 0.;
+    if (packed_cand->pdgId() == 1 || packed_cand->pdgId() == 130) {
+    hcal_fraction = packed_cand->hcalFraction();
+    } else if (packed_cand->isIsolatedChargedHadron()) {
+    hcal_fraction = packed_cand->rawHcalFraction();
+    }
+
+    fts.fill("pfcand_hcalFrac", hcal_fraction);
+    fts.fill("pfcand_VTX_ass", packed_cand->pvAssociationQuality());
+    fts.fill("pfcand_lostInnerHits", packed_cand->lostInnerHits());
+    fts.fill("pfcand_quality", packed_cand->bestTrack() ? packed_cand->bestTrack()->qualityMask() : 0);
+
+    fts.fill("pfcand_charge", packed_cand->charge());
+    fts.fill("pfcand_isEl", std::abs(packed_cand->pdgId()) == 11);
+    fts.fill("pfcand_isMu", std::abs(packed_cand->pdgId()) == 13);
+    fts.fill("pfcand_isChargedHad", std::abs(packed_cand->pdgId()) == 211);
+    fts.fill("pfcand_isGamma", std::abs(packed_cand->pdgId()) == 22);
+    fts.fill("pfcand_isNeutralHad", std::abs(packed_cand->pdgId()) == 130);
+
+    // impact parameters
+    fts.fill("pfcand_dz", packed_cand->dz());
+    fts.fill("pfcand_dxy", packed_cand->dxy());
+    fts.fill("pfcand_dzsig", packed_cand->bestTrack() ? packed_cand->dz() / packed_cand->dzError() : 0);
+    fts.fill("pfcand_dxysig", packed_cand->bestTrack() ? packed_cand->dxy() / packed_cand->dxyError() : 0);
+
+    // basic kinematics
+    fts.fill("pfcand_phirel", reco::deltaPhi(candP4, sv));
+    fts.fill("pfcand_etarel", etasign * (candP4.eta() - sv.eta()));
+    fts.fill("pfcand_deltaR", reco::deltaR(candP4, sv));
+    fts.fill("pfcand_abseta", std::abs(candP4.eta()));
+
+    fts.fill("pfcand_ptrel_log", std::log(candP4.pt() / sv.pt()));
+    fts.fill("pfcand_ptrel", candP4.pt() / sv.pt());
+    fts.fill("pfcand_erel_log", std::log(candP4.energy() / sv.energy()));
+    fts.fill("pfcand_erel", candP4.energy() / sv.energy());
+    fts.fill("pfcand_pt_log", std::log(candP4.pt()));
+
+    fts.fill("pfcand_mask", 1);
+    fts.fill("pfcand_pt_log_nopuppi", std::log(cand->pt()));
+    fts.fill("pfcand_e_log_nopuppi", std::log(cand->energy()));
+
+
+    const reco::Track *trk = nullptr;
+    if (packed_cand) {
+      trk = packed_cand->bestTrack();
+    } else if (reco_cand && useTrackProperties(reco_cand)) {
+      trk = reco_cand->bestTrack();
+    }
+    if (trk) {
+      fts.fill("pfcand_normchi2", std::floor(trk->normalizedChi2()));
+
+      // track covariance
+      auto cov = [&](unsigned i, unsigned j) { return trk->covariance(i, j); };
+      fts.fill("pfcand_dptdpt", cov(0, 0));
+      fts.fill("pfcand_detadeta", cov(1, 1));
+      fts.fill("pfcand_dphidphi", cov(2, 2));
+      fts.fill("pfcand_dxydxy", cov(3, 3));
+      fts.fill("pfcand_dzdz", cov(4, 4));
+      fts.fill("pfcand_dxydz", cov(3, 4));
+      fts.fill("pfcand_dphidxy", cov(2, 3));
+      fts.fill("pfcand_dlambdadz", cov(1, 4));
+
+      TrackInfoBuilder trkinfo(track_builder_);
+      trkinfo.buildTrackInfo(&(*cand), sv_dir, sv_ref_track_dir, *pv_);
+      fts.fill("pfcand_btagEtaRel", trkinfo.getTrackEtaRel());
+      fts.fill("pfcand_btagPtRatio", trkinfo.getTrackPtRatio());
+      fts.fill("pfcand_btagPParRatio", trkinfo.getTrackPParRatio());
+      fts.fill("pfcand_btagSip2dVal", trkinfo.getTrackSip2dVal());
+      fts.fill("pfcand_btagSip2dSig", trkinfo.getTrackSip2dSig());
+      fts.fill("pfcand_btagSip3dVal", trkinfo.getTrackSip3dVal());
+      fts.fill("pfcand_btagSip3dSig", trkinfo.getTrackSip3dSig());
+      fts.fill("pfcand_btagJetDistVal", trkinfo.getTrackJetDistVal());
+    } else {
+      fts.fill("pfcand_normchi2", 999);
+
+      fts.fill("pfcand_dptdpt", 0);
+      fts.fill("pfcand_detadeta", 0);
+      fts.fill("pfcand_dphidphi", 0);
+      fts.fill("pfcand_dxydxy", 0);
+      fts.fill("pfcand_dzdz", 0);
+      fts.fill("pfcand_dxydz", 0);
+      fts.fill("pfcand_dphidxy", 0);
+      fts.fill("pfcand_dlambdadz", 0);
+
+      fts.fill("pfcand_btagEtaRel", 0);
+      fts.fill("pfcand_btagPtRatio", 0);
+      fts.fill("pfcand_btagPParRatio", 0);
+      fts.fill("pfcand_btagSip2dVal", 0);
+      fts.fill("pfcand_btagSip2dSig", 0);
+      fts.fill("pfcand_btagSip3dVal", 0);
+      fts.fill("pfcand_btagSip3dSig", 0);
+      fts.fill("pfcand_btagJetDistVal", 0);
+    }
+  }
+}
+
+void SVFlavourTagInfoProducer::matchSVWithPFCands(std::unique_ptr<JetCollection> &svPhantomJets) {
+  auto &SVs = svs_;
+  auto &particles = genparts_;
+
+  int matchedIDs[SVs->size()] = {-1};
+  float lightdr;
+  auto hadronFlavorID = [](int id) {
+    if ((std::abs(id) > 400 && std::abs(id) < 500) || (std::abs(id) > 4000 && std::abs(id) < 5000)) {
+      return 4;
+    } else if ((std::abs(id) > 500 && std::abs(id) < 600) || (std::abs(id) > 5000 && std::abs(id) < 6000)) {
+      return 5;
+    } else {
+      return -1;
+    }
+  };
+  auto hadronFlavor = [&hadronFlavorID](const reco::GenParticle& gp) { // was GenParticle* gp
+    int id = hadronFlavorID(gp.pdgId());
+    if (id == 4) { // c -- may be b->c
+      reco::GenParticle const* gp_ = &gp;
+      //std::cout << "in hadrFlav, had id=4" << std::endl;
+      while (gp_->numberOfMothers() != 0) {
+        /*if (gp_->numberOfMothers() > 1) {
+          std::cout << "    IN HADRONFLAVOR:  Found >1 mothers: " << gp_->numberOfMothers() << std::endl;
+          for (unsigned i=0; i<gp_->numberOfMothers(); i++) {
+            std::cout << "       mother " << i << " pdgID: " << hadronFlavorID(gp_->mother(i)->pdgId()) << ", nmothers: " << gp_->mother(i)->numberOfMothers() << ", mother ID=" << hadronFlavorID(gp_->mother(i)->mother(0)->pdgId()) << std::endl;
+          }
+        }*/
+        if (hadronFlavorID(gp_->pdgId()) == 5) {
+          //std::cout << "  found mother, hadID 5" << std::endl;
+          return 10;
+        }
+        //std::cout << "  mother hadID incorrect, checking next mother" << std::endl;
+        gp_ = (reco::GenParticle*)(gp_->mother(0));
+      }
+    }
+    return id;
+  };
+
+
+  // ====================
+  // Adopt SV - PF candidates matching algorithm from code
+  // https://github.com/p-masterson/DNNTuples/blob/6dcc20fce79f78765ea690d8b130e0f5874d0d5e/Ntupler/src/SVFiller.cc#L109-L251
+
+  // matchedIDs = new int[SVs->size()];  // NOTE:  idxsv should give you the nth entry of matchedIDs
+
+  // //check num of good jets
+  // int n_good_jets = 0;
+  // for (unsigned j=0; j<jets->size(); j++) {
+  //   const auto& jet = jets->at(j);
+  //   if ((jet.pt() > 40) 
+  //      && (std::abs(jet.eta()) < 2.5) ) {
+  //      //&& (jet.hadronFlavour() & 4) ) {
+  //     n_good_jets++;
+  //   }
+  // }
+  //std::cout << "Found " << n_good_jets << " good jets" << std::endl;
+  //std::cout << "Init SVs: " << SVs->size() << std::endl;
+
+  // if sv close to a jet, assign ID of -999 and ignore it
+  /*
+  for (unsigned i=0; i<SVs->size(); i++) {
+    const auto& sv = SVs->at(i);
+    matchedIDs[i] = -1;  // initialize
+    for (unsigned j=0; j<jets->size(); j++) {
+      const auto& jet = jets->at(j);
+      if (  (reco::deltaR(jet, sv) < 0.4)
+         && (jet.pt() > 40)
+         && (std::abs(jet.eta()) < 2.5)) {
+         //&& (jet.hadronFlavour() & 4) ) {  // not 100% sure whether this is correct
+         //&& (jet.jetID() & 4) ) {  // don't know how to add this...
+        matchedIDs[i] = -999;  // -999 = ignore
+        //std::cout << "     SV " << i << " close to jet " << j << std::endl;
+      } else if (  (reco::deltaR(jet, sv) < 0.50)
+         && (jet.pt() > 35)
+         && (std::abs(jet.eta()) < 2.7)) {
+        //std::cout << "   close match" << std::endl;
+      }
+    }
+  }
+  */
+
+  // - create full list of (sv, hadr pairs); dr-sorted
+  //std::cout << "Jet-free SVs: " << jet_free_svs << std::endl;
+  std::vector<std::tuple<float, unsigned, unsigned>> pairList; // sv num, had num
+  for (unsigned i=0; i<SVs->size(); i++) {
+    const auto& sv = SVs->at(i);
+    if (matchedIDs[i] == -999) continue; // if sv is near a jet, skip it
+    //std::cout << "found sv " << i << std::endl;
+    for (unsigned j=0; j<particles->size(); j++) {
+      const auto& gp = particles->at(j);
+      //if (hadronFlavor(gp) > 0) std::cout << "   hadr flav: " << hadronFlavor(gp) << ", dr=" << reco::deltaR(gp, sv) << std::endl;
+      if (!gp.statusFlags().isLastCopy()) continue;
+      if ((hadronFlavor(gp) == 4 || hadronFlavor(gp) == 5 || hadronFlavor(gp) == 10)
+          && reco::deltaR(gp, sv) < 0.4) {
+        //std::cout << "   MATCHED SV " << i << " to particle " << j <<", flav=" << hadronFlavor(gp) << ", dR=" << reco::deltaR(gp, sv) << std::endl;
+        pairList.push_back(std::tuple<float, int, int>(deltaR(gp, sv), i, j));
+      }
+    }
+  }
+  std::sort(pairList.begin(), pairList.end(),
+    [](const std::tuple<float, unsigned, unsigned> & a, const std::tuple<float, unsigned, unsigned> & b) -> bool 
+    {return std::get<0>(a) < std::get<0>(b);}  // NOTE:  Flipped direction of <!  May have been wrong before...
+    );
+
+  // - take lowest-sep pair and match; remove sv AND hadr from consideration
+  //std::cout << "Assigning lowest-sep pairs" << std::endl;
+  while (pairList.size() > 0) {
+    // pair witih lowest dR:
+    std::tuple<float, unsigned, unsigned> sel_tuple = pairList[0];
+    const auto& gp = particles->at(std::get<2>(sel_tuple));
+    matchedIDs[std::get<1>(sel_tuple)] = hadronFlavor(gp); // matchedIDs[sv#] = gen hadron ID
+    //if (hadronFlavor(gp) > 10) {
+    //  std::cout << "  ASSIGNED SV " << std::get<1>(sel_tuple) << " to part " << std::get<2>(sel_tuple) << ", hadr type=" << hadronFlavor(gp) << std::endl;
+    //}
+    // remove all occurences of this sv, hadron
+    //for (unsigned i = 0; i < pairList.size(); i++) { // loop through each element of pairList, check for removal
+    unsigned ind = 0;
+    while (ind < pairList.size()) {
+      if (std::get<1>(pairList[ind]) == std::get<1>(sel_tuple) || std::get<2>(pairList[ind]) == std::get<2>(sel_tuple)) {
+        // if an element gets erased, do NOT increment ind; the next element will get slotted into ind
+        pairList.erase(pairList.begin()+ind);
+      } else {
+        ind++;
+      }
+    }
+  }
+  //std::cout << "Finished removing" << std::endl;
+
+  // - find lights in unmatched SVs (if dR>0.8 for all hadr)
+  // note: currently finding too many lights
+  int unmatched = 0;
+  for (unsigned i=0; i<SVs->size(); i++) {
+    if (matchedIDs[i] == -1) unmatched += 1;
+  }
+  //std::cout << "*Unmatched SVs: " << unmatched << std::endl;
+
+  lightdr = 10;  //unphysically high by default, I think
+  std::vector<std::tuple<float, unsigned, unsigned>> pairList_; // sv num, had num
+  for (unsigned i=0; i<SVs->size(); i++) {
+    const auto& sv = SVs->at(i);
+    bool isLight = true;
+    if (matchedIDs[i] == -999) continue; // if sv is near a jet, skip it
+    for (unsigned j=0; j<particles->size(); j++) {
+      const auto& gp = particles->at(j);
+      if ((hadronFlavor(gp) == 4 || hadronFlavor(gp) == 5 || hadronFlavor(gp) == 10)
+          && reco::deltaR(gp, sv) < 0.8) {
+        //pairList_.push_back(std::tuple<float, unsigned, unsigned>(deltaR(gp, sv), i, j));
+        isLight = false;
+        if (reco::deltaR(gp, sv) < lightdr) lightdr = reco::deltaR(gp, sv);
+      }
+    }
+    if (isLight) {
+      //if (matchedIDs[i] != -1) std::cout << "ERROR ERROR ERROR!" << std::endl;
+      matchedIDs[i] = 0;
+      //std::cout << "  SV " << i << " is light" << std::endl;
+    }
+    else if (matchedIDs[i] == -1) {
+      //std::cout << "  SV " << i << " is unassigned" << std::endl;
+    }
+  }
+  /*
+  //std::cout << "Finalizing matching" << std::endl;
+  std::cout << "pairList_ size is " << pairList_.size() << std::endl;
+  for (unsigned i=0; i<SVs->size(); i++) {
+    // if SV not found in pairList, call it a light
+    bool isLight = true;
+    for (unsigned j=0; j<pairList_.size(); j++) {
+      std::tuple<float, unsigned, unsigned> sel_tuple = pairList_[j];
+      if (std::get<1>(sel_tuple) == i) isLight = false;
+    }
+    if (isLight) matchedIDs[i] = 0;
+  }
+  */
+
+
+  //finally, move -999s to -1s (now okay to ignore these)
+  //for (unsigned i = 0; i<SVs->size(); i++) {
+  //  if (matchedIDs[i] == -999) matchedIDs[i] = -1;
+  //}
+
+  /*std::cout << "Matching results: [" << std::endl;
+  for (unsigned i=0; i<SVs->size(); i++) {
+    std::cout << matchedIDs[i] << ", ";
+  }
+  std::cout << "]\n\n";*/
+  //std::cout << "Leaving readevent" << std::endl;
+
+  // End of reference code
+  // ====================
+
+  for (std::size_t sv_n = 0; sv_n < svs_->size(); sv_n++) {
+    svPhantomJets->at(sv_n).addUserFloat("gen_flavour", matchedIDs[sv_n]);
+  }
+}
+
+// define this as a plug-in
+DEFINE_FWK_MODULE(SVFlavourTagInfoProducer);

--- a/MicroAOD/plugins/SVFlavourTagInfoProducer.cc
+++ b/MicroAOD/plugins/SVFlavourTagInfoProducer.cc
@@ -48,7 +48,6 @@ private:
   void matchSVWithPFCands(std::unique_ptr<JetCollection> &svPhantomJets);
 
   const double deltar_match_sv_pfcand_;
-  const bool is_mc_;
 
   edm::EDGetTokenT<VertexCollection> vtx_token_;
   edm::EDGetTokenT<SVCollection> sv_token_;
@@ -84,7 +83,6 @@ const std::vector<std::string> SVFlavourTagInfoProducer::particle_features_{
 
 SVFlavourTagInfoProducer::SVFlavourTagInfoProducer(const edm::ParameterSet &iConfig)
     : deltar_match_sv_pfcand_(iConfig.getParameter<double>("deltar_match_sv_pfcand")),
-      is_mc_(iConfig.getParameter<bool>("is_mc")),
       vtx_token_(consumes<VertexCollection>(iConfig.getParameter<edm::InputTag>("vertices"))),
       sv_token_(consumes<SVCollection>(iConfig.getParameter<edm::InputTag>("secondary_vertices"))),
       pfcand_token_(consumes<CandidateView>(iConfig.getParameter<edm::InputTag>("pf_candidates"))),
@@ -101,7 +99,6 @@ void SVFlavourTagInfoProducer::fillDescriptions(edm::ConfigurationDescriptions &
   // pfSVFlavourTagInfos
   edm::ParameterSetDescription desc;
   desc.add<double>("deltar_match_sv_pfcand", 0.4);
-  desc.add<bool>("is_mc", true);
   desc.add<edm::InputTag>("vertices", edm::InputTag("offlinePrimaryVertices"));
   desc.add<edm::InputTag>("secondary_vertices", edm::InputTag("inclusiveCandidateSecondaryVertices"));
   desc.add<edm::InputTag>("pf_candidates", edm::InputTag("particleFlow"));
@@ -124,7 +121,6 @@ void SVFlavourTagInfoProducer::produce(edm::Event &iEvent, const edm::EventSetup
 
   iEvent.getByToken(sv_token_, svs_);
   iEvent.getByToken(pfcand_token_, pfcands_);
-  iEvent.getByToken(genpart_token_, genparts_);
 
   iSetup.get<TransientTrackRecord>().get("TransientTrackBuilder", track_builder_);
 
@@ -136,7 +132,8 @@ void SVFlavourTagInfoProducer::produce(edm::Event &iEvent, const edm::EventSetup
   }
 
   // SV truth matching
-  if (is_mc_) {
+  if (!iEvent.isRealData()) {
+    iEvent.getByToken(genpart_token_, genparts_);
     matchSVWithPFCands(svPhantomJets);
   }
 
@@ -502,3 +499,10 @@ void SVFlavourTagInfoProducer::matchSVWithPFCands(std::unique_ptr<JetCollection>
 
 // define this as a plug-in
 DEFINE_FWK_MODULE(SVFlavourTagInfoProducer);
+// Local Variables:
+// mode:c++
+// indent-tabs-mode:nil
+// tab-width:4
+// c-basic-offset:4
+// End:
+// vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4

--- a/MicroAOD/python/MicroAODCustomize.py
+++ b/MicroAOD/python/MicroAODCustomize.py
@@ -292,6 +292,7 @@ class MicroAODCustomize(object):
         delattr(process,"flashggGenPhotons") # will be run due to unscheduled mode unless deleted
         delattr(process,"flashggGenPhotonsExtra") # will be run due to unscheduled mode unless deleted
         delattr(process,"flashggGenNeutrinos") # will be run due to unscheduled mode unless deleted
+        delattr(process,"flashggGenBCHadrons") # will be run due to unscheduled mode unless deleted
         from flashgg.MicroAOD.flashggJets_cfi import maxJetCollections
         for vtx in range(0,maxJetCollections):
 #            getattr(process,"flashggPFCHSJets%i"%vtx).Debug = True

--- a/MicroAOD/python/flashggGenBCHadrons_cfi.py
+++ b/MicroAOD/python/flashggGenBCHadrons_cfi.py
@@ -1,0 +1,8 @@
+import FWCore.ParameterSet.Config as cms
+
+flashggGenBCHadrons = cms.EDProducer('HadronAndPartonSelector',
+    src = cms.InputTag("generator"),
+    particles = cms.InputTag("prunedGenParticles"),
+    partonMode = cms.string("Auto"),
+    fullChainPhysPartons = cms.bool(True)
+)

--- a/MicroAOD/python/flashggMicroAODGenSequence_cff.py
+++ b/MicroAOD/python/flashggMicroAODGenSequence_cff.py
@@ -7,7 +7,7 @@ from flashgg.MicroAOD.flashggGenPhotonsExtra_cfi import flashggGenPhotonsExtra
 from flashgg.MicroAOD.flashggGenLeptons_cfi import flashggGenLeptons
 from flashgg.MicroAOD.flashggGenLeptonsExtra_cfi import flashggGenLeptonsExtra
 from flashgg.MicroAOD.flashggGenJetsExtra_cfi import flashggGenJetsExtra
+from flashgg.MicroAOD.flashggGenBCHadrons_cfi import flashggGenBCHadrons
 
-
-flashggMicroAODGenSequence = cms.Sequence(flashggPrunedGenParticles+flashggGenPhotons*flashggGenPhotonsExtra + flashggGenLeptons*flashggGenLeptonsExtra + flashggGenJetsExtra + flashggGenNeutrinos
+flashggMicroAODGenSequence = cms.Sequence(flashggPrunedGenParticles+flashggGenPhotons*flashggGenPhotonsExtra + flashggGenLeptons*flashggGenLeptonsExtra + flashggGenJetsExtra + flashggGenNeutrinos + flashggGenBCHadrons
 )

--- a/MicroAOD/python/flashggMicroAODOutputCommands_cff.py
+++ b/MicroAOD/python/flashggMicroAODOutputCommands_cff.py
@@ -43,7 +43,9 @@ microAODDefaultOutputCommand = cms.untracked.vstring("drop *",
                                                      "keep *_particleFlowEGammaGSFixed_dupECALClusters_*",
                                                      "keep *_ecalMultiAndGSGlobalRecHitEB_hitsNotReplaced_*",
 #                                                     "keep *_slimmedJets_*_*"
-                                                     "keep *_flashggGenJetsExtra_*_*"
+                                                     "keep *_flashggGenJetsExtra_*_*",
+                                                     "keep *_flashggSVs_*_*",
+                                                     "drop *_flashggSVFlavourTagInfos_*_*"
                                                      )
 
 # Should be included for now for ongoing studies, but to be removed some day

--- a/MicroAOD/python/flashggMicroAODSequence_cff.py
+++ b/MicroAOD/python/flashggMicroAODSequence_cff.py
@@ -8,6 +8,7 @@ from flashgg.MicroAOD.flashggDiPhotons_cfi import flashggDiPhotons
 from flashgg.MicroAOD.flashggJets_cfi import flashggFinalJets,flashggFinalPuppiJets
 from flashgg.MicroAOD.flashggElectrons_cfi import flashggElectrons
 from flashgg.MicroAOD.flashggMuons_cfi import flashggMuons
+from flashgg.MicroAOD.flashggSecondaryVertices_cfi import flashggSVFlavourTagInfos, flashggSVs
 
 from flashgg.MicroAOD.flashggLeptonSelectors_cff import flashggSelectedMuons,flashggSelectedElectrons
 from flashgg.MicroAOD.flashggMicroAODGenSequence_cff import *
@@ -49,4 +50,5 @@ flashggMicroAODSequence = cms.Sequence( eventCount+weightsCount
                                        +flashggMuonFilterSequence
                                        +flashggVertexMapForCHS*flashggFinalJets
                                        +flashggVertexMapForPUPPI*flashggFinalPuppiJets
+                                       +flashggSVFlavourTagInfos*flashggSVs
                                         )

--- a/MicroAOD/python/flashggSecondaryVertices_cfi.py
+++ b/MicroAOD/python/flashggSecondaryVertices_cfi.py
@@ -1,0 +1,23 @@
+import FWCore.ParameterSet.Config as cms
+
+from flashgg.MicroAOD.pfSVFlavourTagInfos_cfi import pfSVFlavourTagInfos
+# from RecoBTag.ONNXRuntime.boostedJetONNXJetTagsProducer_cfi import boostedJetONNXJetTagsProducer
+from flashgg.MicroAOD.pfSVFlavourONNXTagsProducer_cfi import pfSVFlavourONNXTagsProducer
+
+flashggSVFlavourTagInfos = pfSVFlavourTagInfos.clone(
+    deltar_match_sv_pfcand = 0.4,
+    pf_candidates = "packedPFCandidates",
+    secondary_vertices = "slimmedSecondaryVertices",
+    vertices = "offlineSlimmedPrimaryVertices",
+    debugMode = False,
+)
+
+flashggSVs =  pfSVFlavourONNXTagsProducer.clone(
+    src = 'flashggSVFlavourTagInfos',
+    phantom_jets = cms.InputTag('flashggSVFlavourTagInfos', 'svPhantomJets'), # a dummy jet selection for easy implementation
+    secondary_vertices = 'slimmedSecondaryVertices',
+    preprocess_json = 'flashgg/MicroAOD/data/ParticleNetSV/V01/preprocess_corr.json',
+    model_path = 'flashgg/MicroAOD/data/ParticleNetSV/V01/model.onnx',
+    flav_names = ['probb', 'probc', 'probcfromb', 'probl'],
+    debugMode = False,
+)

--- a/MicroAOD/python/flashggSecondaryVertices_cfi.py
+++ b/MicroAOD/python/flashggSecondaryVertices_cfi.py
@@ -6,18 +6,20 @@ from flashgg.MicroAOD.pfSVFlavourONNXTagsProducer_cfi import pfSVFlavourONNXTags
 
 flashggSVFlavourTagInfos = pfSVFlavourTagInfos.clone(
     deltar_match_sv_pfcand = 0.4,
-    pf_candidates = "packedPFCandidates",
-    secondary_vertices = "slimmedSecondaryVertices",
-    vertices = "offlineSlimmedPrimaryVertices",
+    pf_candidates = cms.InputTag("packedPFCandidates"),
+    secondary_vertices = cms.InputTag("slimmedSecondaryVertices"),
+    vertices = cms.InputTag("offlineSlimmedPrimaryVertices"),
+    bHadrons = cms.InputTag("flashggGenBCHadrons", "bHadrons"),
+    cHadrons = cms.InputTag("flashggGenBCHadrons", "cHadrons"),
     debugMode = False,
 )
 
 flashggSVs =  pfSVFlavourONNXTagsProducer.clone(
-    src = 'flashggSVFlavourTagInfos',
+    src = cms.InputTag('flashggSVFlavourTagInfos'),
     phantom_jets = cms.InputTag('flashggSVFlavourTagInfos', 'svPhantomJets'), # a dummy jet selection for easy implementation
-    secondary_vertices = 'slimmedSecondaryVertices',
-    preprocess_json = 'flashgg/MicroAOD/data/ParticleNetSV/V01/preprocess_corr.json',
-    model_path = 'flashgg/MicroAOD/data/ParticleNetSV/V01/model.onnx',
-    flav_names = ['probb', 'probc', 'probcfromb', 'probl'],
+    secondary_vertices = cms.InputTag('slimmedSecondaryVertices'),
+    preprocess_json = 'flashgg/MicroAOD/data/ParticleNetSV/V02/preprocess_corr.json',
+    model_path = 'flashgg/MicroAOD/data/ParticleNetSV/V02/model.onnx',
+    flav_names = ['probb', 'probbb', 'probc', 'probcc', 'probunmat'],
     debugMode = False,
 )

--- a/setup_flashgg.sh
+++ b/setup_flashgg.sh
@@ -76,6 +76,14 @@ cp XGBoostCMSSW/XGBoostInterface/toolbox/*xml $CMSSW_BASE/config/toolbox/$SCRAM_
 scram setup rabit
 scram setup xgboost
 
+echo "setting up ONNXRuntime"
+scram setup /cvmfs/cms.cern.ch/$SCRAM_ARCH/cms/cmssw/CMSSW_10_6_16/config/toolbox/$SCRAM_ARCH/tools/selected/onnxruntime.xml
+git cms-addpkg PhysicsTools/ONNXRuntime
+git cms-addpkg RecoBTag/FeatureTools
+# update files with the CMSSW_10_6_16 version
+rsync -a /cvmfs/cms.cern.ch/$SCRAM_ARCH/cms/cmssw/CMSSW_10_6_16/src/PhysicsTools/ONNXRuntime $CMSSW_BASE/src/PhysicsTools
+rsync -a /cvmfs/cms.cern.ch/$SCRAM_ARCH/cms/cmssw/CMSSW_10_6_16/src/RecoBTag/FeatureTools/interface/deep_helpers.h $CMSSW_BASE/src/RecoBTag/FeatureTools/interface/deep_helpers.h
+
 # Patch IOPool to avoid Run and Lumi trees being dropped when loading a parent dataset
 git cms-addpkg IOPool/Input
 git apply flashgg/LoadRunAndLumis.patch

--- a/setup_flashgg.sh
+++ b/setup_flashgg.sh
@@ -76,14 +76,6 @@ cp XGBoostCMSSW/XGBoostInterface/toolbox/*xml $CMSSW_BASE/config/toolbox/$SCRAM_
 scram setup rabit
 scram setup xgboost
 
-echo "setting up ONNXRuntime"
-scram setup /cvmfs/cms.cern.ch/$SCRAM_ARCH/cms/cmssw/CMSSW_10_6_16/config/toolbox/$SCRAM_ARCH/tools/selected/onnxruntime.xml
-git cms-addpkg PhysicsTools/ONNXRuntime
-git cms-addpkg RecoBTag/FeatureTools
-# update files with the CMSSW_10_6_16 version
-rsync -a /cvmfs/cms.cern.ch/$SCRAM_ARCH/cms/cmssw/CMSSW_10_6_16/src/PhysicsTools/ONNXRuntime $CMSSW_BASE/src/PhysicsTools
-rsync -a /cvmfs/cms.cern.ch/$SCRAM_ARCH/cms/cmssw/CMSSW_10_6_16/src/RecoBTag/FeatureTools/interface/deep_helpers.h $CMSSW_BASE/src/RecoBTag/FeatureTools/interface/deep_helpers.h
-
 # Patch IOPool to avoid Run and Lumi trees being dropped when loading a parent dataset
 git cms-addpkg IOPool/Input
 git apply flashgg/LoadRunAndLumis.patch


### PR DESCRIPTION
A pull request to add ParticleNet SV tagging for Higgs+charm analysis.

**Goal**: 

The analysis aims to use soft-charm tagging on secondary vertices (SV). We hope to include the SV collection with the flavour tagging score included.
We adopt the ParticleNet model to infer tagging scores for each SV in an event, using the information of all PF candidates associated with the SV. Please see details in the [[BTV talk](https://indico.cern.ch/event/1131377/contributions/4747608/attachments/2394986/4094864/hcc_particlenet_presentation.pdf)] by @p-masterson.

**This feature needs**:

(1) this PR which includes the following changes:
- add `flashgg::SecondaryVertex` output class;
- include ONNXRuntime package in flashgg setup;
- add two modules for inference of ParticleNet scores on SV basis, and include them to standard MicroAOD routine;
- write a new collection `flashggSVs` to the output file;

(2) inference model stored under `/eos/cms/store/group/phys_higgs/cmshgg/flashgg-data/MicroAOD/data/`, which is already there. (I gave it a try - it seems I have the permission to copy files into this dir, but I cannot remove them)

**Validation**:

The test command runs
`cmsRun MicroAOD/test/microAODstd.py processType=sig datasetName=hh conditionsJSON=MetaData/data/MetaConditions/Era2017_legacy_v1.json`

More validations to come.

----
ping people who are relevant: @p-masterson, @chenzhou36, @XuanhaoZhang, @chernyavskaya, @gouskos, @hqucms, @leaca, @mhl0116, @missirol, @TizianoBevilacqua, @selvaggi