### PR TITLE
Catalogs update after disks hardware problems in Rome Tier2 in April 2024

### DIFF
--- a/MetaData/data/Era2016_legacyPreVFP_v1_Summer20UL/datasets.json
+++ b/MetaData/data/Era2016_legacyPreVFP_v1_Summer20UL/datasets.json
@@ -156,6 +156,6 @@
             }
         ], 
         "parent_n_units": null, 
-        "vetted": false
+        "vetted": true
     }
 }

--- a/MetaData/data/Era2016_legacyPreVFP_v1_Summer20UL/datasets_1.json
+++ b/MetaData/data/Era2016_legacyPreVFP_v1_Summer20UL/datasets_1.json
@@ -34743,6 +34743,6 @@
             }
         ], 
         "parent_n_units": null, 
-        "vetted": false
+        "vetted": true
     }
 }

--- a/MetaData/data/Era2016_legacyPreVFP_v1_Summer20UL/datasets_21.json
+++ b/MetaData/data/Era2016_legacyPreVFP_v1_Summer20UL/datasets_21.json
@@ -2569,9 +2569,12 @@
                 "weights": 2168.01416015625
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 1230, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2016_legacyPreVFP_v1_Summer20UL/legacyRunII/WplusH_HToGG_WToAll_M125_TuneCP5_13TeV-powheg-pythia8/Era2016_legacyPreVFP_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v1/220923_112710/0000/myMicroAODOutputFile_7.root", 
-                "nevents": 1230
+                "nevents": 1230, 
+                "totEvents": 1230, 
+                "weights": 1061.95947265625
             }, 
             {
                 "bad": false, 

--- a/MetaData/data/Era2016_legacyPreVFP_v1_Summer20UL/datasets_28.json
+++ b/MetaData/data/Era2016_legacyPreVFP_v1_Summer20UL/datasets_28.json
@@ -5611,9 +5611,12 @@
                 "weights": 6819.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 5066, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2016_legacyPreVFP_v1_Summer20UL/legacyRunII/GJet_Pt-40toInf_DoubleEMEnriched_MGG-80toInf_TuneCP5_13TeV_Pythia8/Era2016_legacyPreVFP_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL16MiniAODAPV-106X_mcRun2_asymptotic_preVFP_v8-v3/230405_224654/0000/myMicroAODOutputFile_793.root", 
-                "nevents": 5066
+                "nevents": 5066, 
+                "totEvents": 5066, 
+                "weights": 5066.0
             }, 
             {
                 "bad": false, 

--- a/MetaData/data/Era2016_legacyPreVFP_v1_Summer20UL/datasets_9.json
+++ b/MetaData/data/Era2016_legacyPreVFP_v1_Summer20UL/datasets_9.json
@@ -3,19 +3,28 @@
         "dset_type": "mc", 
         "files": [
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 16000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2016_legacyPreVFP_v1_Summer20UL/tag-stxsac-v2-68-g2c15d6e7/TprimeBToTH_Hgg_M-1000_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_legacyPreVFP_v1_Summer20UL-tag-stxsac-v2-68-g2c15d6e7-v0-RunIISummer20UL16MiniAODAPV-106X_mcRun2_asymptotic_preVFP_v8-v2/231121_001257/0000/myMicroAODOutputFile_9.root", 
-                "nevents": 16000
+                "nevents": 16000, 
+                "totEvents": 16000, 
+                "weights": 16000.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2016_legacyPreVFP_v1_Summer20UL/tag-stxsac-v2-68-g2c15d6e7/TprimeBToTH_Hgg_M-1000_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_legacyPreVFP_v1_Summer20UL-tag-stxsac-v2-68-g2c15d6e7-v0-RunIISummer20UL16MiniAODAPV-106X_mcRun2_asymptotic_preVFP_v8-v2/231121_001257/0000/myMicroAODOutputFile_5.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 25000.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2016_legacyPreVFP_v1_Summer20UL/tag-stxsac-v2-68-g2c15d6e7/TprimeBToTH_Hgg_M-1000_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_legacyPreVFP_v1_Summer20UL-tag-stxsac-v2-68-g2c15d6e7-v0-RunIISummer20UL16MiniAODAPV-106X_mcRun2_asymptotic_preVFP_v8-v2/231121_001257/0000/myMicroAODOutputFile_8.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 25000.0
             }, 
             {
                 "bad": false, 
@@ -50,9 +59,12 @@
                 "weights": 25000.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2016_legacyPreVFP_v1_Summer20UL/tag-stxsac-v2-68-g2c15d6e7/TprimeBToTH_Hgg_M-1000_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_legacyPreVFP_v1_Summer20UL-tag-stxsac-v2-68-g2c15d6e7-v0-RunIISummer20UL16MiniAODAPV-106X_mcRun2_asymptotic_preVFP_v8-v2/231121_001257/0000/myMicroAODOutputFile_4.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 25000.0
             }, 
             {
                 "bad": false, 
@@ -86,9 +98,12 @@
                 "weights": 25000.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 16000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2016_legacyPreVFP_v1_Summer20UL/tag-stxsac-v2-68-g2c15d6e7/TprimeBToTH_Hgg_M-1100_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_legacyPreVFP_v1_Summer20UL-tag-stxsac-v2-68-g2c15d6e7-v0-RunIISummer20UL16MiniAODAPV-106X_mcRun2_asymptotic_preVFP_v8-v2/231121_001940/0000/myMicroAODOutputFile_9.root", 
-                "nevents": 16000
+                "nevents": 16000, 
+                "totEvents": 16000, 
+                "weights": 16000.0
             }, 
             {
                 "bad": false, 
@@ -162,14 +177,20 @@
                 "weights": 25000.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2016_legacyPreVFP_v1_Summer20UL/tag-stxsac-v2-68-g2c15d6e7/TprimeBToTH_Hgg_M-1200_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_legacyPreVFP_v1_Summer20UL-tag-stxsac-v2-68-g2c15d6e7-v0-RunIISummer20UL16MiniAODAPV-106X_mcRun2_asymptotic_preVFP_v8-v2/231121_002544/0000/myMicroAODOutputFile_3.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 25000.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 16000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2016_legacyPreVFP_v1_Summer20UL/tag-stxsac-v2-68-g2c15d6e7/TprimeBToTH_Hgg_M-1200_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_legacyPreVFP_v1_Summer20UL-tag-stxsac-v2-68-g2c15d6e7-v0-RunIISummer20UL16MiniAODAPV-106X_mcRun2_asymptotic_preVFP_v8-v2/231121_002544/0000/myMicroAODOutputFile_9.root", 
-                "nevents": 16000
+                "nevents": 16000, 
+                "totEvents": 16000, 
+                "weights": 16000.0
             }, 
             {
                 "bad": false, 
@@ -188,9 +209,12 @@
                 "weights": 25000.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2016_legacyPreVFP_v1_Summer20UL/tag-stxsac-v2-68-g2c15d6e7/TprimeBToTH_Hgg_M-1200_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_legacyPreVFP_v1_Summer20UL-tag-stxsac-v2-68-g2c15d6e7-v0-RunIISummer20UL16MiniAODAPV-106X_mcRun2_asymptotic_preVFP_v8-v2/231121_002544/0000/myMicroAODOutputFile_5.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 25000.0
             }, 
             {
                 "bad": false, 
@@ -303,14 +327,20 @@
                 "weights": 16000.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2016_legacyPreVFP_v1_Summer20UL/tag-stxsac-v2-68-g2c15d6e7/TprimeBToTH_Hgg_M-1500_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_legacyPreVFP_v1_Summer20UL-tag-stxsac-v2-68-g2c15d6e7-v0-RunIISummer20UL16MiniAODAPV-106X_mcRun2_asymptotic_preVFP_v8-v2/231121_003759/0000/myMicroAODOutputFile_4.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 25000.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2016_legacyPreVFP_v1_Summer20UL/tag-stxsac-v2-68-g2c15d6e7/TprimeBToTH_Hgg_M-1500_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_legacyPreVFP_v1_Summer20UL-tag-stxsac-v2-68-g2c15d6e7-v0-RunIISummer20UL16MiniAODAPV-106X_mcRun2_asymptotic_preVFP_v8-v2/231121_003759/0000/myMicroAODOutputFile_5.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 25000.0
             }, 
             {
                 "bad": false, 
@@ -329,9 +359,12 @@
                 "weights": 25000.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2016_legacyPreVFP_v1_Summer20UL/tag-stxsac-v2-68-g2c15d6e7/TprimeBToTH_Hgg_M-1500_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_legacyPreVFP_v1_Summer20UL-tag-stxsac-v2-68-g2c15d6e7-v0-RunIISummer20UL16MiniAODAPV-106X_mcRun2_asymptotic_preVFP_v8-v2/231121_003759/0000/myMicroAODOutputFile_8.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 25000.0
             }, 
             {
                 "bad": false, 
@@ -350,9 +383,12 @@
                 "weights": 25000.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2016_legacyPreVFP_v1_Summer20UL/tag-stxsac-v2-68-g2c15d6e7/TprimeBToTH_Hgg_M-1500_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_legacyPreVFP_v1_Summer20UL-tag-stxsac-v2-68-g2c15d6e7-v0-RunIISummer20UL16MiniAODAPV-106X_mcRun2_asymptotic_preVFP_v8-v2/231121_003759/0000/myMicroAODOutputFile_2.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 25000.0
             }
         ], 
         "parent_n_units": null, 
@@ -386,19 +422,28 @@
                 "weights": 25000.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2016_legacyPreVFP_v1_Summer20UL/tag-stxsac-v2-68-g2c15d6e7/TprimeBToTH_Hgg_M-1700_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_legacyPreVFP_v1_Summer20UL-tag-stxsac-v2-68-g2c15d6e7-v0-RunIISummer20UL16MiniAODAPV-106X_mcRun2_asymptotic_preVFP_v8-v2/231121_004240/0000/myMicroAODOutputFile_5.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 25000.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2016_legacyPreVFP_v1_Summer20UL/tag-stxsac-v2-68-g2c15d6e7/TprimeBToTH_Hgg_M-1700_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_legacyPreVFP_v1_Summer20UL-tag-stxsac-v2-68-g2c15d6e7-v0-RunIISummer20UL16MiniAODAPV-106X_mcRun2_asymptotic_preVFP_v8-v2/231121_004240/0000/myMicroAODOutputFile_6.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 25000.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2016_legacyPreVFP_v1_Summer20UL/tag-stxsac-v2-68-g2c15d6e7/TprimeBToTH_Hgg_M-1700_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_legacyPreVFP_v1_Summer20UL-tag-stxsac-v2-68-g2c15d6e7-v0-RunIISummer20UL16MiniAODAPV-106X_mcRun2_asymptotic_preVFP_v8-v2/231121_004240/0000/myMicroAODOutputFile_2.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 25000.0
             }, 
             {
                 "bad": false, 
@@ -456,9 +501,12 @@
                 "weights": 25000.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2016_legacyPreVFP_v1_Summer20UL/tag-stxsac-v2-68-g2c15d6e7/TprimeBToTH_Hgg_M-1800_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_legacyPreVFP_v1_Summer20UL-tag-stxsac-v2-68-g2c15d6e7-v0-RunIISummer20UL16MiniAODAPV-106X_mcRun2_asymptotic_preVFP_v8-v2/231121_004736/0000/myMicroAODOutputFile_3.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 25000.0
             }, 
             {
                 "bad": false, 
@@ -540,9 +588,12 @@
                 "weights": 25000.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2016_legacyPreVFP_v1_Summer20UL/tag-stxsac-v2-68-g2c15d6e7/TprimeBToTH_Hgg_M-625_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_legacyPreVFP_v1_Summer20UL-tag-stxsac-v2-68-g2c15d6e7-v0-RunIISummer20UL16MiniAODAPV-106X_mcRun2_asymptotic_preVFP_v8-v2/231121_010213/0000/myMicroAODOutputFile_5.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 25000.0
             }, 
             {
                 "bad": false, 
@@ -600,9 +651,12 @@
                 "weights": 25000.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2016_legacyPreVFP_v1_Summer20UL/tag-stxsac-v2-68-g2c15d6e7/TprimeBToTH_Hgg_M-650_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_legacyPreVFP_v1_Summer20UL-tag-stxsac-v2-68-g2c15d6e7-v0-RunIISummer20UL16MiniAODAPV-106X_mcRun2_asymptotic_preVFP_v8-v2/231121_011049/0000/myMicroAODOutputFile_5.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 25000.0
             }, 
             {
                 "bad": false, 
@@ -613,9 +667,12 @@
                 "weights": 25000.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2016_legacyPreVFP_v1_Summer20UL/tag-stxsac-v2-68-g2c15d6e7/TprimeBToTH_Hgg_M-650_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_legacyPreVFP_v1_Summer20UL-tag-stxsac-v2-68-g2c15d6e7-v0-RunIISummer20UL16MiniAODAPV-106X_mcRun2_asymptotic_preVFP_v8-v2/231121_011049/0000/myMicroAODOutputFile_1.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 25000.0
             }, 
             {
                 "bad": false, 
@@ -705,9 +762,12 @@
                 "weights": 25000.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2016_legacyPreVFP_v1_Summer20UL/tag-stxsac-v2-68-g2c15d6e7/TprimeBToTH_Hgg_M-675_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_legacyPreVFP_v1_Summer20UL-tag-stxsac-v2-68-g2c15d6e7-v0-RunIISummer20UL16MiniAODAPV-106X_mcRun2_asymptotic_preVFP_v8-v2/231121_011759/0000/myMicroAODOutputFile_4.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 25000.0
             }, 
             {
                 "bad": false, 
@@ -789,9 +849,12 @@
                 "weights": 25000.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2016_legacyPreVFP_v1_Summer20UL/tag-stxsac-v2-68-g2c15d6e7/TprimeBToTH_Hgg_M-700_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2016_legacyPreVFP_v1_Summer20UL-tag-stxsac-v2-68-g2c15d6e7-v0-RunIISummer20UL16MiniAODAPV-106X_mcRun2_asymptotic_preVFP_v8-v2/231121_012323/0000/myMicroAODOutputFile_6.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 25000.0
             }, 
             {
                 "bad": false, 

--- a/MetaData/data/Era2017_legacy_v1_Summer20UL/datasets.json
+++ b/MetaData/data/Era2017_legacy_v1_Summer20UL/datasets.json
@@ -1740,7 +1740,7 @@
             }
         ], 
         "parent_n_units": null, 
-        "vetted": false
+        "vetted": true
     }, 
     "/TTWJetsToLNu_TuneCP5_13TeV-amcatnloFXFX-madspin-pythia8/phys_higgs-Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1-dba47b1192ec1eec8f63d5c720fe8f2a/USER": {
         "dset_type": "mc", 
@@ -6293,7 +6293,7 @@
             }
         ], 
         "parent_n_units": null, 
-        "vetted": false
+        "vetted": true
     }, 
     "/ZHiggs0PHToGG_M125_TuneCP5_13TeV-JHUGenV7011-pythia8/phys_higgs-Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2-2d0531b4db33fa17307b0f4af20516e9/USER": {
         "dset_type": "mc", 
@@ -6636,6 +6636,6 @@
             }
         ], 
         "parent_n_units": null, 
-        "vetted": false
+        "vetted": true
     }
 }

--- a/MetaData/data/Era2017_legacy_v1_Summer20UL/datasets_1.json
+++ b/MetaData/data/Era2017_legacy_v1_Summer20UL/datasets_1.json
@@ -1724,7 +1724,7 @@
             }
         ], 
         "parent_n_units": null, 
-        "vetted": false
+        "vetted": true
     }, 
     "/QCD_Pt-40ToInf_DoubleEMEnriched_MGG-80ToInf_TuneCP5_13TeV-pythia8/phys_higgs-Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2-73d94ea6a324ae993f2729a14057b675/USER": {
         "dset_type": "mc", 
@@ -5290,7 +5290,7 @@
             }
         ], 
         "parent_n_units": null, 
-        "vetted": false
+        "vetted": true
     }, 
     "/VBFHToGG_M65_TuneCP5_13TeV-amcatnlo-pythia8/phys_higgs-Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2-b57456a118a639e045227184101d9dcf/USER": {
         "dset_type": "mc", 
@@ -5545,7 +5545,7 @@
             }
         ], 
         "parent_n_units": null, 
-        "vetted": false
+        "vetted": true
     }, 
     "/VBFHiggs0PHToGG_M125_TuneCP5_13TeV-JHUGenV7011-pythia8/phys_higgs-Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2-ca64037e1aeaaf0d4d2b197cdb41e4bc/USER": {
         "dset_type": "mc", 
@@ -5904,7 +5904,7 @@
             }
         ], 
         "parent_n_units": null, 
-        "vetted": false
+        "vetted": true
     }, 
     "/VHToGG_M123_TuneCP5_13TeV-amcatnloFXFX-madspin-pythia8/phys_higgs-Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v1-87ea3b90faed5199cfde26b1d7e045df/USER": {
         "dset_type": "mc", 
@@ -6119,7 +6119,7 @@
             }
         ], 
         "parent_n_units": null, 
-        "vetted": false
+        "vetted": true
     }, 
     "/VHToGG_M126_TuneCP5_13TeV-amcatnloFXFX-madspin-pythia8/phys_higgs-Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2-87ea3b90faed5199cfde26b1d7e045df/USER": {
         "dset_type": "mc", 
@@ -6278,7 +6278,7 @@
             }
         ], 
         "parent_n_units": null, 
-        "vetted": false
+        "vetted": true
     }, 
     "/WminusH_HToGG_WToAll_M120_TuneCP5_13TeV-powheg-pythia8/phys_higgs-Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v1-87ea3b90faed5199cfde26b1d7e045df/USER": {
         "dset_type": "mc", 
@@ -6501,7 +6501,7 @@
             }
         ], 
         "parent_n_units": null, 
-        "vetted": false
+        "vetted": true
     }, 
     "/ZHiggs0L1f05ph0ToGG_M125_TuneCP5_13TeV-JHUGenV7011-pythia8/phys_higgs-Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2-2d0531b4db33fa17307b0f4af20516e9/USER": {
         "dset_type": "mc", 
@@ -6844,7 +6844,7 @@
             }
         ], 
         "parent_n_units": null, 
-        "vetted": false
+        "vetted": true
     }, 
     "/ZHiggs0MToGG_M125_TuneCP5_13TeV-JHUGenV7011-pythia8/phys_higgs-Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2-2d0531b4db33fa17307b0f4af20516e9/USER": {
         "dset_type": "mc", 
@@ -7131,7 +7131,7 @@
             }
         ], 
         "parent_n_units": null, 
-        "vetted": false
+        "vetted": true
     }, 
     "/ttHJetToGG_M120_TuneCP5_13TeV-amcatnloFXFX-madspin-pythia8/phys_higgs-Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2-0f24d711b1039fdec08a0c31c2d98539/USER": {
         "dset_type": "mc", 
@@ -7345,12 +7345,16 @@
                 "weights": 27053.30859375
             }, 
             {
+                "bad": false, 
+                "events": 24772, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/ttHJetToGG_M120_TuneCP5_13TeV-amcatnloFXFX-madspin-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/220923_153659/0000/myMicroAODOutputFile_9.root", 
-                "nevents": 24772
+                "nevents": 24772, 
+                "totEvents": 24772, 
+                "weights": 26177.77734375
             }
         ], 
         "parent_n_units": null, 
-        "vetted": false
+        "vetted": true
     }, 
     "/ttHJetToGG_M123_TuneCP5_13TeV-amcatnloFXFX-madspin-pythia8/phys_higgs-Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2-c9fef38cafbf42997474836a0940bf17/USER": {
         "dset_type": "mc", 
@@ -7581,7 +7585,7 @@
             }
         ], 
         "parent_n_units": null, 
-        "vetted": false
+        "vetted": true
     }, 
     "/ttHJetToGG_M124_TuneCP5_13TeV-amcatnloFXFX-madspin-pythia8/phys_higgs-Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2-c9fef38cafbf42997474836a0940bf17/USER": {
         "dset_type": "mc", 
@@ -7892,7 +7896,7 @@
             }
         ], 
         "parent_n_units": null, 
-        "vetted": false
+        "vetted": true
     }, 
     "/ttHJetToGG_M126_TuneCP5_13TeV-amcatnloFXFX-madspin-pythia8/phys_higgs-Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2-c9fef38cafbf42997474836a0940bf17/USER": {
         "dset_type": "mc", 
@@ -8067,6 +8071,6 @@
             }
         ], 
         "parent_n_units": null, 
-        "vetted": false
+        "vetted": true
     }
 }

--- a/MetaData/data/Era2017_legacy_v1_Summer20UL/datasets_10.json
+++ b/MetaData/data/Era2017_legacy_v1_Summer20UL/datasets_10.json
@@ -9428,6 +9428,6 @@
             }
         ], 
         "parent_n_units": null, 
-        "vetted": false
+        "vetted": true
     }
 }

--- a/MetaData/data/Era2017_legacy_v1_Summer20UL/datasets_11.json
+++ b/MetaData/data/Era2017_legacy_v1_Summer20UL/datasets_11.json
@@ -6164,7 +6164,7 @@
             }
         ], 
         "parent_n_units": null, 
-        "vetted": false
+        "vetted": true
     }, 
     "/DYJetsToLL_M-50_HT-400to600_TuneCP5_PSweights_13TeV-madgraphMLM-pythia8/phys_higgs-Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v1-365a9eeb963575ce9edbdfce0f0ba4bf/USER": {
         "dset_type": "mc", 
@@ -7979,6 +7979,6 @@
             }
         ], 
         "parent_n_units": null, 
-        "vetted": false
+        "vetted": true
     }
 }

--- a/MetaData/data/Era2017_legacy_v1_Summer20UL/datasets_12.json
+++ b/MetaData/data/Era2017_legacy_v1_Summer20UL/datasets_12.json
@@ -564,7 +564,7 @@
             }
         ], 
         "parent_n_units": null, 
-        "vetted": false
+        "vetted": true
     }, 
     "/DiPhotonJets_MGG-80toInf_TuneCP5_13TeV-amcatnloFXFX-pythia8/phys_higgs-Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v1-73d94ea6a324ae993f2729a14057b675/USER": {
         "dset_type": "mc", 
@@ -2259,7 +2259,7 @@
             }
         ], 
         "parent_n_units": null, 
-        "vetted": false
+        "vetted": true
     }, 
     "/GluGluHToGG_M-125_TuneCP5_13TeV-powheg-pythia8/phys_higgs-Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v3-87ea3b90faed5199cfde26b1d7e045df/USER": {
         "dset_type": "mc", 
@@ -2513,9 +2513,12 @@
                 "weights": 425081.8125
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 21173, 
                 "name": "/store/group/phys_higgs/cmshgg/rasharma/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/GluGluHToGG_M-125_TuneCP5_13TeV-powheg-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v3/220705_091948/0000/myMicroAODOutputFile_64.root", 
-                "nevents": 21173
+                "nevents": 21173, 
+                "totEvents": 21173, 
+                "weights": 454544.40625
             }, 
             {
                 "bad": false, 
@@ -2887,7 +2890,7 @@
             }
         ], 
         "parent_n_units": null, 
-        "vetted": false
+        "vetted": true
     }, 
     "/GluGluHToGG_M120_TuneCP5_13TeV-amcatnloFXFX-pythia8/phys_higgs-Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v1-1af72e5f53759f2591bcde7d40e0cd5d/USER": {
         "dset_type": "mc", 
@@ -3318,20 +3321,26 @@
             }
         ], 
         "parent_n_units": null, 
-        "vetted": false
+        "vetted": true
     }, 
     "/TprimeBToTH_Hgg_M-1000_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/phys_higgs-Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL17MiniAOD-106X_mc2017_realistic_v6-v2-dba47b1192ec1eec8f63d5c720fe8f2a/USER": {
         "dset_type": "mc", 
         "files": [
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/TprimeBToTH_Hgg_M-1000_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_030826/0000/myMicroAODOutputFile_12.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 25000.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/TprimeBToTH_Hgg_M-1000_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_030826/0000/myMicroAODOutputFile_5.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 25000.0
             }, 
             {
                 "bad": false, 
@@ -3406,9 +3415,12 @@
                 "weights": 25000.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/TprimeBToTH_Hgg_M-1000_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_030826/0000/myMicroAODOutputFile_4.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 25000.0
             }, 
             {
                 "bad": false, 
@@ -3907,7 +3919,7 @@
             }
         ], 
         "parent_n_units": null, 
-        "vetted": false
+        "vetted": true
     }, 
     "/VBFHToGG_M125_TuneCP5_13TeV-amcatnlo-pythia8/phys_higgs-Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2-74df377dff8e976d6419dc49fe671f9b/USER": {
         "dset_type": "mc", 
@@ -5641,7 +5653,7 @@
             }
         ], 
         "parent_n_units": null, 
-        "vetted": false
+        "vetted": true
     }, 
     "/VBFHiggs0L1ZgToGG_M125_TuneCP5_13TeV-JHUGenV7011-pythia8/phys_higgs-Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2-ca64037e1aeaaf0d4d2b197cdb41e4bc/USER": {
         "dset_type": "mc", 
@@ -5944,7 +5956,7 @@
             }
         ], 
         "parent_n_units": null, 
-        "vetted": false
+        "vetted": true
     }, 
     "/VBFHiggs0Mf05ph0ToGG_M125_TuneCP5_13TeV-JHUGenV7011-pythia8/phys_higgs-Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2-ca64037e1aeaaf0d4d2b197cdb41e4bc/USER": {
         "dset_type": "mc", 
@@ -6295,7 +6307,7 @@
             }
         ], 
         "parent_n_units": null, 
-        "vetted": false
+        "vetted": true
     }, 
     "/VHToGG_M125_TuneCP5_13TeV-amcatnloFXFX-madspin-pythia8/phys_higgs-Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2-87ea3b90faed5199cfde26b1d7e045df/USER": {
         "dset_type": "mc", 
@@ -6670,7 +6682,7 @@
             }
         ], 
         "parent_n_units": null, 
-        "vetted": false
+        "vetted": true
     }, 
     "/WHiggs0L1f05ph0ToGG_M125_TuneCP5_13TeV-JHUGenV7011-pythia8/phys_higgs-Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2-2d0531b4db33fa17307b0f4af20516e9/USER": {
         "dset_type": "mc", 
@@ -6941,7 +6953,7 @@
             }
         ], 
         "parent_n_units": null, 
-        "vetted": false
+        "vetted": true
     }, 
     "/WHiggs0PHToGG_M125_TuneCP5_13TeV-JHUGenV7011-pythia8/phys_higgs-Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2-2d0531b4db33fa17307b0f4af20516e9/USER": {
         "dset_type": "mc", 
@@ -7220,7 +7232,7 @@
             }
         ], 
         "parent_n_units": null, 
-        "vetted": false
+        "vetted": true
     }, 
     "/ggZH_HToGG_ZToNuNu_M130_TuneCP5_13TeV-powheg-pythia8/phys_higgs-Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2-40c484617c8150a845705b37f7fbbebe/USER": {
         "dset_type": "mc", 
@@ -7234,9 +7246,12 @@
                 "weights": 287.6355895996094
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/ggZH_HToGG_ZToNuNu_M130_TuneCP5_13TeV-powheg-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_015025/0000/myMicroAODOutputFile_3.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 287.6355895996094
             }, 
             {
                 "bad": false, 
@@ -7271,9 +7286,12 @@
                 "weights": 287.6355895996094
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/ggZH_HToGG_ZToNuNu_M130_TuneCP5_13TeV-powheg-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_015343/0000/myMicroAODOutputFile_9.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 287.6355895996094
             }, 
             {
                 "bad": false, 
@@ -7292,9 +7310,12 @@
                 "weights": 287.6355895996094
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/ggZH_HToGG_ZToNuNu_M130_TuneCP5_13TeV-powheg-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_015343/0000/myMicroAODOutputFile_7.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 287.6355895996094
             }, 
             {
                 "bad": false, 
@@ -7377,9 +7398,12 @@
                 "weights": 287.6355895996094
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/ggZH_HToGG_ZToNuNu_M130_TuneCP5_13TeV-powheg-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_015025/0000/myMicroAODOutputFile_6.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 287.6355895996094
             }, 
             {
                 "bad": false, 
@@ -7398,9 +7422,12 @@
                 "weights": 287.6355895996094
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/ggZH_HToGG_ZToNuNu_M130_TuneCP5_13TeV-powheg-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_015025/0000/myMicroAODOutputFile_5.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 287.6355895996094
             }
         ], 
         "parent_n_units": null, 
@@ -7418,9 +7445,12 @@
                 "weights": 1145.3076171875
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 19600, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/ggZH_HToGG_ZToQQ_M120_TuneCP5_13TeV-powheg-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_015656/0000/myMicroAODOutputFile_12.root", 
-                "nevents": 19600
+                "nevents": 19600, 
+                "totEvents": 19600, 
+                "weights": 897.92236328125
             }, 
             {
                 "bad": false, 
@@ -7439,9 +7469,12 @@
                 "weights": 1145.3076171875
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/ggZH_HToGG_ZToQQ_M120_TuneCP5_13TeV-powheg-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_015656/0000/myMicroAODOutputFile_10.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 1145.3076171875
             }, 
             {
                 "bad": false, 
@@ -7524,9 +7557,12 @@
                 "weights": 1145.3076171875
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/ggZH_HToGG_ZToQQ_M120_TuneCP5_13TeV-powheg-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_020007/0000/myMicroAODOutputFile_10.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 1145.3076171875
             }, 
             {
                 "bad": false, 
@@ -7537,14 +7573,20 @@
                 "weights": 1145.3076171875
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/ggZH_HToGG_ZToQQ_M120_TuneCP5_13TeV-powheg-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_020007/0000/myMicroAODOutputFile_1.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 1145.3076171875
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/ggZH_HToGG_ZToQQ_M120_TuneCP5_13TeV-powheg-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_020007/0000/myMicroAODOutputFile_3.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 1145.3076171875
             }, 
             {
                 "bad": false, 
@@ -7594,9 +7636,12 @@
         "dset_type": "mc", 
         "files": [
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/ggZH_HToGG_ZToQQ_M125_TuneCP5_13TeV-powheg-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_020323/0000/myMicroAODOutputFile_3.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 1079.983154296875
             }, 
             {
                 "bad": false, 
@@ -7663,9 +7708,12 @@
                 "weights": 1079.983154296875
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/ggZH_HToGG_ZToQQ_M125_TuneCP5_13TeV-powheg-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_020638/0000/myMicroAODOutputFile_9.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 1079.983154296875
             }, 
             {
                 "bad": false, 
@@ -7676,14 +7724,20 @@
                 "weights": 1079.983154296875
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/ggZH_HToGG_ZToQQ_M125_TuneCP5_13TeV-powheg-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_020638/0000/myMicroAODOutputFile_3.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 1079.983154296875
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/ggZH_HToGG_ZToQQ_M125_TuneCP5_13TeV-powheg-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_020638/0000/myMicroAODOutputFile_8.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 1079.983154296875
             }, 
             {
                 "bad": false, 
@@ -7726,9 +7780,12 @@
                 "weights": 1079.983154296875
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/ggZH_HToGG_ZToQQ_M125_TuneCP5_13TeV-powheg-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_020323/0000/myMicroAODOutputFile_6.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 1079.983154296875
             }, 
             {
                 "bad": false, 
@@ -7762,14 +7819,20 @@
                 "weights": 1016.8295288085938
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 20900, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/ggZH_HToGG_ZToQQ_M130_TuneCP5_13TeV-powheg-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_021315/0000/myMicroAODOutputFile_12.root", 
-                "nevents": 20900
+                "nevents": 20900, 
+                "totEvents": 20900, 
+                "weights": 850.0693359375
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/ggZH_HToGG_ZToQQ_M130_TuneCP5_13TeV-powheg-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_021315/0000/myMicroAODOutputFile_9.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 1016.8295288085938
             }, 
             {
                 "bad": false, 
@@ -7804,9 +7867,12 @@
                 "weights": 1016.8295288085938
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/ggZH_HToGG_ZToQQ_M130_TuneCP5_13TeV-powheg-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_021315/0000/myMicroAODOutputFile_10.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 1016.8295288085938
             }, 
             {
                 "bad": false, 
@@ -7841,9 +7907,12 @@
                 "weights": 1016.8295288085938
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 20900, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/ggZH_HToGG_ZToQQ_M130_TuneCP5_13TeV-powheg-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_021000/0000/myMicroAODOutputFile_12.root", 
-                "nevents": 20900
+                "nevents": 20900, 
+                "totEvents": 20900, 
+                "weights": 850.0693359375
             }, 
             {
                 "bad": false, 
@@ -7870,9 +7939,12 @@
                 "weights": 1016.8295288085938
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/ggZH_HToGG_ZToQQ_M130_TuneCP5_13TeV-powheg-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_021000/0000/myMicroAODOutputFile_4.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 1016.8295288085938
             }, 
             {
                 "bad": false, 
@@ -7923,9 +7995,12 @@
                 "weights": 1016.8295288085938
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/ggZH_HToGG_ZToQQ_M130_TuneCP5_13TeV-powheg-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_021315/0000/myMicroAODOutputFile_6.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 1016.8295288085938
             }
         ], 
         "parent_n_units": null, 

--- a/MetaData/data/Era2017_legacy_v1_Summer20UL/datasets_14.json
+++ b/MetaData/data/Era2017_legacy_v1_Summer20UL/datasets_14.json
@@ -4084,7 +4084,7 @@
             }
         ], 
         "parent_n_units": null, 
-        "vetted": false
+        "vetted": true
     }, 
     "/DYJetsToLL_M-50_HT-2500toInf_TuneCP5_PSweights_13TeV-madgraphMLM-pythia8/phys_higgs-Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v1-365a9eeb963575ce9edbdfce0f0ba4bf/USER": {
         "dset_type": "mc", 
@@ -4627,7 +4627,7 @@
             }
         ], 
         "parent_n_units": null, 
-        "vetted": false
+        "vetted": true
     }, 
     "/DiPhotonJetsBox1BJet_MGG-80toInf_13TeV-sherpa/phys_higgs-Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2-7f9164c951f41bda15871bc40d81f510/USER": {
         "dset_type": "mc", 
@@ -5362,7 +5362,7 @@
             }
         ], 
         "parent_n_units": null, 
-        "vetted": false
+        "vetted": true
     }, 
     "/GluGluHToGG_M-120_TuneCP5_13TeV-powheg-pythia8/phys_higgs-Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2-87ea3b90faed5199cfde26b1d7e045df/USER": {
         "dset_type": "mc", 
@@ -5473,7 +5473,7 @@
             }
         ], 
         "parent_n_units": null, 
-        "vetted": false
+        "vetted": true
     }, 
     "/GluGluHToGG_M130_TuneCP5_13TeV-amcatnloFXFX-pythia8/phys_higgs-Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2-1af72e5f53759f2591bcde7d40e0cd5d/USER": {
         "dset_type": "mc", 
@@ -5888,7 +5888,7 @@
             }
         ], 
         "parent_n_units": null, 
-        "vetted": false
+        "vetted": true
     }, 
     "/GluGluHToGG_M70_TuneCP5_13TeV-amcatnloFXFX-pythia8/phys_higgs-Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2-9da8fb7b8a1cdca7b80e707a2ce21a84/USER": {
         "dset_type": "mc", 
@@ -6023,7 +6023,7 @@
             }
         ], 
         "parent_n_units": null, 
-        "vetted": false
+        "vetted": true
     }, 
     "/GluGluHToGG_M90_TuneCP5_13TeV-amcatnloFXFX-pythia8/phys_higgs-Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v4-9da8fb7b8a1cdca7b80e707a2ce21a84/USER": {
         "dset_type": "mc", 
@@ -6174,7 +6174,7 @@
             }
         ], 
         "parent_n_units": null, 
-        "vetted": false
+        "vetted": true
     }, 
     "/TprimeBToTH_Hgg_M-1400_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/phys_higgs-Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL17MiniAOD-106X_mc2017_realistic_v6-v2-dba47b1192ec1eec8f63d5c720fe8f2a/USER": {
         "dset_type": "mc", 
@@ -6220,9 +6220,12 @@
                 "weights": 25000.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/TprimeBToTH_Hgg_M-1400_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_032110/0000/myMicroAODOutputFile_5.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 25000.0
             }, 
             {
                 "bad": false, 
@@ -6233,9 +6236,12 @@
                 "weights": 25000.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/TprimeBToTH_Hgg_M-1400_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_032110/0000/myMicroAODOutputFile_12.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 25000.0
             }, 
             {
                 "bad": false, 
@@ -6278,14 +6284,20 @@
                 "weights": 25000.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/TprimeBToTH_Hgg_M-1400_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_032110/0000/myMicroAODOutputFile_14.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 25000.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/TprimeBToTH_Hgg_M-1400_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_032110/0000/myMicroAODOutputFile_4.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 25000.0
             }, 
             {
                 "bad": false, 
@@ -6319,9 +6331,12 @@
                 "weights": 25000.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/TprimeBToTH_Hgg_M-1500_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_032437/0000/myMicroAODOutputFile_3.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 25000.0
             }, 
             {
                 "bad": false, 
@@ -6364,9 +6379,12 @@
                 "weights": 25000.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/TprimeBToTH_Hgg_M-1500_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_032437/0000/myMicroAODOutputFile_4.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 25000.0
             }, 
             {
                 "bad": false, 
@@ -6385,9 +6403,12 @@
                 "weights": 25000.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/TprimeBToTH_Hgg_M-1500_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_032437/0000/myMicroAODOutputFile_9.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 25000.0
             }, 
             {
                 "bad": false, 
@@ -6398,9 +6419,12 @@
                 "weights": 25000.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/TprimeBToTH_Hgg_M-1500_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_032437/0000/myMicroAODOutputFile_8.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 25000.0
             }, 
             {
                 "bad": false, 
@@ -6482,9 +6506,12 @@
                 "weights": 25000.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/TprimeBToTH_Hgg_M-1600_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_032755/0000/myMicroAODOutputFile_1.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 25000.0
             }, 
             {
                 "bad": false, 
@@ -6511,9 +6538,12 @@
                 "weights": 25000.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/TprimeBToTH_Hgg_M-1600_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_032755/0000/myMicroAODOutputFile_14.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 25000.0
             }, 
             {
                 "bad": false, 
@@ -7483,7 +7513,7 @@
             }
         ], 
         "parent_n_units": null, 
-        "vetted": false
+        "vetted": true
     }, 
     "/WplusH_HToGG_WToAll_M130_TuneCP5_13TeV-powheg-pythia8/phys_higgs-Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v1-87ea3b90faed5199cfde26b1d7e045df/USER": {
         "dset_type": "mc", 
@@ -7985,6 +8015,6 @@
             }
         ], 
         "parent_n_units": null, 
-        "vetted": false
+        "vetted": true
     }
 }

--- a/MetaData/data/Era2017_legacy_v1_Summer20UL/datasets_15.json
+++ b/MetaData/data/Era2017_legacy_v1_Summer20UL/datasets_15.json
@@ -58572,6 +58572,6 @@
             }
         ], 
         "parent_n_units": null, 
-        "vetted": false
+        "vetted": true
     }
 }

--- a/MetaData/data/Era2017_legacy_v1_Summer20UL/datasets_17.json
+++ b/MetaData/data/Era2017_legacy_v1_Summer20UL/datasets_17.json
@@ -340,7 +340,7 @@
             }
         ], 
         "parent_n_units": null, 
-        "vetted": false
+        "vetted": true
     }, 
     "/HHHTo4B2G_c3_0_d4_0_TuneCP5_13TeV-amcatnlo-pythia8/athachay-Era2017_legacy_v1_Summer20UL--v0-RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2-dba47b1192ec1eec8f63d5c720fe8f2a/USER": {
         "dset_type": "mc", 
@@ -5210,7 +5210,7 @@
             }
         ], 
         "parent_n_units": null, 
-        "vetted": false
+        "vetted": true
     }, 
     "/VHToGG_M100_TuneCP5_13TeV-amcatnloFXFX-madspin-pythia8/phys_higgs-Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2-87ea3b90faed5199cfde26b1d7e045df/USER": {
         "dset_type": "mc", 
@@ -5609,7 +5609,7 @@
             }
         ], 
         "parent_n_units": null, 
-        "vetted": false
+        "vetted": true
     }, 
     "/VHToGG_M125_TuneCP5Up_13TeV-amcatnloFXFX-madspin-pythia8/phys_higgs-Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v1-40c484617c8150a845705b37f7fbbebe/USER": {
         "dset_type": "mc", 
@@ -5960,7 +5960,7 @@
             }
         ], 
         "parent_n_units": null, 
-        "vetted": false
+        "vetted": true
     }, 
     "/VHToGG_M70_TuneCP5_13TeV-amcatnloFXFX-madspin-pythia8/phys_higgs-Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2-87ea3b90faed5199cfde26b1d7e045df/USER": {
         "dset_type": "mc", 
@@ -6351,7 +6351,7 @@
             }
         ], 
         "parent_n_units": null, 
-        "vetted": false
+        "vetted": true
     }, 
     "/VHToGG_M85_TuneCP5_13TeV-amcatnloFXFX-madspin-pythia8/phys_higgs-Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v1-87ea3b90faed5199cfde26b1d7e045df/USER": {
         "dset_type": "mc", 
@@ -6798,7 +6798,7 @@
             }
         ], 
         "parent_n_units": null, 
-        "vetted": false
+        "vetted": true
     }, 
     "/ttHJetToGG_M110_TuneCP5_13TeV-amcatnloFXFX-madspin-pythia8/phys_higgs-Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2-c9fef38cafbf42997474836a0940bf17/USER": {
         "dset_type": "mc", 
@@ -7109,7 +7109,7 @@
             }
         ], 
         "parent_n_units": null, 
-        "vetted": false
+        "vetted": true
     }, 
     "/ttHJetToGG_M115_TuneCP5_13TeV-amcatnloFXFX-madspin-pythia8/phys_higgs-Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v3-c9fef38cafbf42997474836a0940bf17/USER": {
         "dset_type": "mc", 
@@ -7404,7 +7404,7 @@
             }
         ], 
         "parent_n_units": null, 
-        "vetted": false
+        "vetted": true
     }, 
     "/ttHJetToGG_M65_TuneCP5_13TeV-amcatnloFXFX-madspin-pythia8/phys_higgs-Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v1-c9fef38cafbf42997474836a0940bf17/USER": {
         "dset_type": "mc", 
@@ -7739,6 +7739,6 @@
             }
         ], 
         "parent_n_units": null, 
-        "vetted": false
+        "vetted": true
     }
 }

--- a/MetaData/data/Era2017_legacy_v1_Summer20UL/datasets_18.json
+++ b/MetaData/data/Era2017_legacy_v1_Summer20UL/datasets_18.json
@@ -4227,7 +4227,7 @@
             }
         ], 
         "parent_n_units": null, 
-        "vetted": false
+        "vetted": true
     }, 
     "/GluGluHToGG_M125_TuneCP5Down_13TeV-amcatnloFXFX-pythia8/phys_higgs-Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v1-6e0116571fff0f3c29761c67e059de6f/USER": {
         "dset_type": "mc", 
@@ -4922,7 +4922,7 @@
             }
         ], 
         "parent_n_units": null, 
-        "vetted": false
+        "vetted": true
     }, 
     "/GluGluHToGG_M126_TuneCP5_13TeV-amcatnloFXFX-pythia8/phys_higgs-Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v1-6e0116571fff0f3c29761c67e059de6f/USER": {
         "dset_type": "mc", 
@@ -5409,7 +5409,7 @@
             }
         ], 
         "parent_n_units": null, 
-        "vetted": false
+        "vetted": true
     }, 
     "/GluGluHToGG_M65_TuneCP5_13TeV-amcatnloFXFX-pythia8/phys_higgs-Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v1-9da8fb7b8a1cdca7b80e707a2ce21a84/USER": {
         "dset_type": "mc", 
@@ -5560,7 +5560,7 @@
             }
         ], 
         "parent_n_units": null, 
-        "vetted": false
+        "vetted": true
     }, 
     "/ttHJetToGG_M100_TuneCP5_13TeV-amcatnloFXFX-madspin-pythia8/phys_higgs-Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2-c9fef38cafbf42997474836a0940bf17/USER": {
         "dset_type": "mc", 
@@ -5839,7 +5839,7 @@
             }
         ], 
         "parent_n_units": null, 
-        "vetted": false
+        "vetted": true
     }, 
     "/ttHJetToGG_M105_TuneCP5_13TeV-amcatnloFXFX-madspin-pythia8/phys_higgs-Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v1-c9fef38cafbf42997474836a0940bf17/USER": {
         "dset_type": "mc", 
@@ -6158,7 +6158,7 @@
             }
         ], 
         "parent_n_units": null, 
-        "vetted": false
+        "vetted": true
     }, 
     "/ttHJetToGG_M125_TuneCP5_13TeV-amcatnloFXFX-madspin-pythia8/phys_higgs-Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2-0f24d711b1039fdec08a0c31c2d98539/USER": {
         "dset_type": "mc", 
@@ -6429,7 +6429,7 @@
             }
         ], 
         "parent_n_units": null, 
-        "vetted": false
+        "vetted": true
     }, 
     "/ttHJetToGG_M130_TuneCP5_13TeV-amcatnloFXFX-madspin-pythia8/phys_higgs-Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2-0f24d711b1039fdec08a0c31c2d98539/USER": {
         "dset_type": "mc", 
@@ -6692,6 +6692,6 @@
             }
         ], 
         "parent_n_units": null, 
-        "vetted": false
+        "vetted": true
     }
 }

--- a/MetaData/data/Era2017_legacy_v1_Summer20UL/datasets_19.json
+++ b/MetaData/data/Era2017_legacy_v1_Summer20UL/datasets_19.json
@@ -5794,7 +5794,7 @@
             }
         ], 
         "parent_n_units": null, 
-        "vetted": false
+        "vetted": true
     }, 
     "/VBFHToGG_M125_TuneCP5Up_13TeV-amcatnlo-pythia8/phys_higgs-Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v1-6e0d1283440262df82d3ba70dce75a20/USER": {
         "dset_type": "mc", 
@@ -7121,6 +7121,6 @@
             }
         ], 
         "parent_n_units": null, 
-        "vetted": false
+        "vetted": true
     }
 }

--- a/MetaData/data/Era2017_legacy_v1_Summer20UL/datasets_20.json
+++ b/MetaData/data/Era2017_legacy_v1_Summer20UL/datasets_20.json
@@ -132,7 +132,7 @@
             }
         ], 
         "parent_n_units": null, 
-        "vetted": false
+        "vetted": true
     }, 
     "/GluGluHToGG_M110_TuneCP5_13TeV-amcatnloFXFX-pythia8/phys_higgs-Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2-9da8fb7b8a1cdca7b80e707a2ce21a84/USER": {
         "dset_type": "mc", 
@@ -251,7 +251,7 @@
             }
         ], 
         "parent_n_units": null, 
-        "vetted": false
+        "vetted": true
     }, 
     "/GluGluHToGG_M95_TuneCP5_13TeV-amcatnloFXFX-pythia8/phys_higgs-Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2-9da8fb7b8a1cdca7b80e707a2ce21a84/USER": {
         "dset_type": "mc", 
@@ -346,7 +346,7 @@
             }
         ], 
         "parent_n_units": null, 
-        "vetted": false
+        "vetted": true
     }, 
     "/QCD_Pt-30toInf_DoubleEMEnriched_MGG-40to80_TuneCP5_13TeV-pythia8/phys_higgs-Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2-dba47b1192ec1eec8f63d5c720fe8f2a/USER": {
         "dset_type": "mc", 
@@ -3391,9 +3391,12 @@
                 "weights": 425.1414489746094
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/TTGG_0Jets_TuneCP5_13TeV-amcatnlo-madspin-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_035040/0000/myMicroAODOutputFile_12.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 420.8658447265625
             }, 
             {
                 "bad": false, 
@@ -3412,9 +3415,12 @@
                 "weights": 422.7145080566406
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/TTGG_0Jets_TuneCP5_13TeV-amcatnlo-madspin-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_035040/0000/myMicroAODOutputFile_10.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 411.5633239746094
             }, 
             {
                 "bad": false, 
@@ -3425,9 +3431,12 @@
                 "weights": 419.59442138671875
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/TTGG_0Jets_TuneCP5_13TeV-amcatnlo-madspin-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_035040/0000/myMicroAODOutputFile_16.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 420.6922607421875
             }, 
             {
                 "bad": false, 
@@ -3446,9 +3455,12 @@
                 "weights": 421.0968933105469
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/TTGG_0Jets_TuneCP5_13TeV-amcatnlo-madspin-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_035040/0000/myMicroAODOutputFile_8.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 419.3057861328125
             }, 
             {
                 "bad": false, 
@@ -3539,14 +3551,20 @@
                 "weights": 421.0967712402344
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/TTGG_0Jets_TuneCP5_13TeV-amcatnlo-madspin-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_035040/0000/myMicroAODOutputFile_36.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 417.3990173339844
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/TTGG_0Jets_TuneCP5_13TeV-amcatnlo-madspin-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_035040/0000/myMicroAODOutputFile_42.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 414.33660888671875
             }, 
             {
                 "bad": false, 
@@ -3557,9 +3575,12 @@
                 "weights": 415.4346008300781
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/TTGG_0Jets_TuneCP5_13TeV-amcatnlo-madspin-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_035040/0000/myMicroAODOutputFile_39.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 426.6438293457031
             }, 
             {
                 "bad": false, 
@@ -3570,9 +3591,12 @@
                 "weights": 421.5013732910156
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/TTGG_0Jets_TuneCP5_13TeV-amcatnlo-madspin-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_035040/0000/myMicroAODOutputFile_55.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 417.5722351074219
             }, 
             {
                 "bad": false, 
@@ -3591,9 +3615,12 @@
                 "weights": 422.6569519042969
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/TTGG_0Jets_TuneCP5_13TeV-amcatnlo-madspin-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_035040/0000/myMicroAODOutputFile_2.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 424.5058288574219
             }, 
             {
                 "bad": false, 
@@ -3700,9 +3727,12 @@
                 "weights": 418.84375
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/TTGG_0Jets_TuneCP5_13TeV-amcatnlo-madspin-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_035040/0000/myMicroAODOutputFile_38.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 418.4967956542969
             }, 
             {
                 "bad": false, 
@@ -3840,9 +3870,12 @@
                 "weights": 25000.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/TprimeBToTH_Hgg_M-1700_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_033107/0000/myMicroAODOutputFile_15.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 25000.0
             }, 
             {
                 "bad": false, 
@@ -3893,9 +3926,12 @@
                 "weights": 25000.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/TprimeBToTH_Hgg_M-1700_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_033107/0000/myMicroAODOutputFile_14.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 25000.0
             }, 
             {
                 "bad": false, 
@@ -3914,9 +3950,12 @@
                 "weights": 25000.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/TprimeBToTH_Hgg_M-1700_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_033107/0000/myMicroAODOutputFile_8.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 25000.0
             }, 
             {
                 "bad": false, 
@@ -3927,9 +3966,12 @@
                 "weights": 25000.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/TprimeBToTH_Hgg_M-1700_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_033107/0000/myMicroAODOutputFile_10.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 25000.0
             }
         ], 
         "parent_n_units": null, 
@@ -3939,9 +3981,12 @@
         "dset_type": "mc", 
         "files": [
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/TprimeBToTH_Hgg_M-1800_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_033418/0000/myMicroAODOutputFile_6.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 25000.0
             }, 
             {
                 "bad": false, 
@@ -4103,9 +4148,12 @@
                 "weights": 25000.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/TprimeBToTH_Hgg_M-650_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_033742/0000/myMicroAODOutputFile_1.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 25000.0
             }, 
             {
                 "bad": false, 
@@ -4116,9 +4164,12 @@
                 "weights": 25000.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/TprimeBToTH_Hgg_M-650_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_033742/0000/myMicroAODOutputFile_6.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 25000.0
             }, 
             {
                 "bad": false, 
@@ -4145,9 +4196,12 @@
                 "weights": 25000.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/TprimeBToTH_Hgg_M-650_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_033742/0000/myMicroAODOutputFile_7.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 25000.0
             }, 
             {
                 "bad": false, 
@@ -4182,9 +4236,12 @@
                 "weights": 25000.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/TprimeBToTH_Hgg_M-650_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_033742/0000/myMicroAODOutputFile_3.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 25000.0
             }
         ], 
         "parent_n_units": null, 
@@ -4306,9 +4363,12 @@
                 "weights": 25000.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/TprimeBToTH_Hgg_M-700_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_034055/0000/myMicroAODOutputFile_1.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 25000.0
             }, 
             {
                 "bad": false, 
@@ -4334,14 +4394,20 @@
                 "weights": 25000.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/TprimeBToTH_Hgg_M-800_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_034407/0000/myMicroAODOutputFile_9.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 25000.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/TprimeBToTH_Hgg_M-800_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_034407/0000/myMicroAODOutputFile_5.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 25000.0
             }, 
             {
                 "bad": false, 
@@ -4416,9 +4482,12 @@
                 "weights": 25000.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/TprimeBToTH_Hgg_M-800_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_034407/0000/myMicroAODOutputFile_4.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 25000.0
             }, 
             {
                 "bad": false, 
@@ -4733,7 +4802,7 @@
             }
         ], 
         "parent_n_units": null, 
-        "vetted": false
+        "vetted": true
     }, 
     "/VBFHToGG_M80_TuneCP5_13TeV-amcatnlo-pythia8/phys_higgs-Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2-b57456a118a639e045227184101d9dcf/USER": {
         "dset_type": "mc", 
@@ -4852,7 +4921,7 @@
             }
         ], 
         "parent_n_units": null, 
-        "vetted": false
+        "vetted": true
     }, 
     "/VHToGG_M90_TuneCP5_13TeV-amcatnloFXFX-madspin-pythia8/phys_higgs-Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v1-87ea3b90faed5199cfde26b1d7e045df/USER": {
         "dset_type": "mc", 
@@ -5235,7 +5304,7 @@
             }
         ], 
         "parent_n_units": null, 
-        "vetted": false
+        "vetted": true
     }, 
     "/ZGTo2NuG_TuneCP5_13TeV-amcatnloFXFX-pythia8/phys_higgs-Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2-dba47b1192ec1eec8f63d5c720fe8f2a/USER": {
         "dset_type": "mc", 
@@ -7073,7 +7142,7 @@
             }
         ], 
         "parent_n_units": null, 
-        "vetted": false
+        "vetted": true
     }, 
     "/ttHJetToGG_M75_TuneCP5_13TeV-amcatnloFXFX-madspin-pythia8/phys_higgs-Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2-c9fef38cafbf42997474836a0940bf17/USER": {
         "dset_type": "mc", 
@@ -7336,7 +7405,7 @@
             }
         ], 
         "parent_n_units": null, 
-        "vetted": false
+        "vetted": true
     }, 
     "/ttHJetToGG_M90_TuneCP5_13TeV-amcatnloFXFX-madspin-pythia8/phys_higgs-Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2-c9fef38cafbf42997474836a0940bf17/USER": {
         "dset_type": "mc", 
@@ -7719,6 +7788,6 @@
             }
         ], 
         "parent_n_units": null, 
-        "vetted": false
+        "vetted": true
     }
 }

--- a/MetaData/data/Era2017_legacy_v1_Summer20UL/datasets_21.json
+++ b/MetaData/data/Era2017_legacy_v1_Summer20UL/datasets_21.json
@@ -5523,7 +5523,7 @@
             }
         ], 
         "parent_n_units": null, 
-        "vetted": false
+        "vetted": true
     }, 
     "/TGJets_TuneCP5_13TeV-amcatnlo-madspin-pythia8/phys_higgs-Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1-dba47b1192ec1eec8f63d5c720fe8f2a/USER": {
         "dset_type": "mc", 
@@ -5537,14 +5537,20 @@
                 "weights": 74100.2421875
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/TGJets_TuneCP5_13TeV-amcatnlo-madspin-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_023309/0000/myMicroAODOutputFile_70.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 77929.9453125
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/TGJets_TuneCP5_13TeV-amcatnlo-madspin-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_023309/0000/myMicroAODOutputFile_68.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 75109.6015625
             }, 
             {
                 "bad": false, 
@@ -5571,9 +5577,12 @@
                 "weights": 75198.6875
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/TGJets_TuneCP5_13TeV-amcatnlo-madspin-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_023309/0000/myMicroAODOutputFile_27.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 77573.6796875
             }, 
             {
                 "bad": false, 
@@ -5640,9 +5649,12 @@
                 "weights": 72853.3359375
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/TGJets_TuneCP5_13TeV-amcatnlo-madspin-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_023309/0000/myMicroAODOutputFile_36.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 80334.625
             }, 
             {
                 "bad": false, 
@@ -5669,9 +5681,12 @@
                 "weights": 72823.6640625
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/TGJets_TuneCP5_13TeV-amcatnlo-madspin-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_023309/0000/myMicroAODOutputFile_42.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 72200.2109375
             }, 
             {
                 "bad": false, 
@@ -5682,9 +5697,12 @@
                 "weights": 76683.0390625
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/TGJets_TuneCP5_13TeV-amcatnlo-madspin-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_023309/0000/myMicroAODOutputFile_32.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 75940.8359375
             }, 
             {
                 "bad": false, 
@@ -5719,19 +5737,28 @@
                 "weights": 76059.6171875
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/TGJets_TuneCP5_13TeV-amcatnlo-madspin-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_023309/0000/myMicroAODOutputFile_54.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 73476.796875
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/TGJets_TuneCP5_13TeV-amcatnlo-madspin-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_023309/0000/myMicroAODOutputFile_43.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 76029.9140625
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/TGJets_TuneCP5_13TeV-amcatnlo-madspin-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_023309/0000/myMicroAODOutputFile_72.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 75317.4140625
             }, 
             {
                 "bad": false, 
@@ -5774,14 +5801,20 @@
                 "weights": 75050.21875
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/TGJets_TuneCP5_13TeV-amcatnlo-madspin-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_023309/0000/myMicroAODOutputFile_37.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 75347.125
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/TGJets_TuneCP5_13TeV-amcatnlo-madspin-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_023309/0000/myMicroAODOutputFile_15.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 75762.71875
             }, 
             {
                 "bad": false, 
@@ -5848,9 +5881,12 @@
                 "weights": 71250.203125
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/TGJets_TuneCP5_13TeV-amcatnlo-madspin-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_023309/0000/myMicroAODOutputFile_64.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 75347.1015625
             }, 
             {
                 "bad": false, 
@@ -5925,9 +5961,12 @@
                 "weights": 76386.171875
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/TGJets_TuneCP5_13TeV-amcatnlo-madspin-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_023309/0000/myMicroAODOutputFile_44.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 71843.9609375
             }, 
             {
                 "bad": false, 
@@ -5946,9 +5985,12 @@
                 "weights": 75911.1796875
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/TGJets_TuneCP5_13TeV-amcatnlo-madspin-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_023309/0000/myMicroAODOutputFile_71.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 78612.75
             }, 
             {
                 "bad": false, 
@@ -5959,9 +6001,12 @@
                 "weights": 77484.609375
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/TGJets_TuneCP5_13TeV-amcatnlo-madspin-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_023309/0000/myMicroAODOutputFile_58.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 74901.7890625
             }, 
             {
                 "bad": false, 
@@ -5972,9 +6017,12 @@
                 "weights": 71873.65625
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/TGJets_TuneCP5_13TeV-amcatnlo-madspin-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_023309/0000/myMicroAODOutputFile_41.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 79295.5546875
             }, 
             {
                 "bad": false, 
@@ -5985,9 +6033,12 @@
                 "weights": 75317.4140625
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/TGJets_TuneCP5_13TeV-amcatnlo-madspin-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_023309/0000/myMicroAODOutputFile_20.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 75109.609375
             }, 
             {
                 "bad": false, 
@@ -6006,9 +6057,12 @@
                 "weights": 75851.7890625
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/TGJets_TuneCP5_13TeV-amcatnlo-madspin-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_023309/0000/myMicroAODOutputFile_9.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 79325.21875
             }, 
             {
                 "bad": false, 
@@ -6035,9 +6089,12 @@
                 "weights": 74634.6171875
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/TGJets_TuneCP5_13TeV-amcatnlo-madspin-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_023309/0000/myMicroAODOutputFile_14.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 73001.78125
             }
         ], 
         "parent_n_units": null, 
@@ -6103,9 +6160,12 @@
                 "weights": 25000.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/TprimeBToTH_Hgg_M-1300_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_031800/0000/myMicroAODOutputFile_13.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 25000.0
             }, 
             {
                 "bad": false, 
@@ -6164,9 +6224,12 @@
                 "weights": 25000.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/TprimeBToTH_Hgg_M-1300_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_031800/0000/myMicroAODOutputFile_9.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 25000.0
             }
         ], 
         "parent_n_units": null, 
@@ -6393,7 +6456,7 @@
             }
         ], 
         "parent_n_units": null, 
-        "vetted": false
+        "vetted": true
     }, 
     "/VHToGG_M110_TuneCP5_13TeV-amcatnloFXFX-madspin-pythia8/phys_higgs-Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2-87ea3b90faed5199cfde26b1d7e045df/USER": {
         "dset_type": "mc", 
@@ -6832,7 +6895,7 @@
             }
         ], 
         "parent_n_units": null, 
-        "vetted": false
+        "vetted": true
     }, 
     "/VHToGG_M65_TuneCP5_13TeV-amcatnloFXFX-madspin-pythia8/phys_higgs-Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2-87ea3b90faed5199cfde26b1d7e045df/USER": {
         "dset_type": "mc", 
@@ -7279,7 +7342,7 @@
             }
         ], 
         "parent_n_units": null, 
-        "vetted": false
+        "vetted": true
     }, 
     "/VHToGG_M75_TuneCP5_13TeV-amcatnloFXFX-madspin-pythia8/phys_higgs-Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2-87ea3b90faed5199cfde26b1d7e045df/USER": {
         "dset_type": "mc", 
@@ -7702,7 +7765,7 @@
             }
         ], 
         "parent_n_units": null, 
-        "vetted": false
+        "vetted": true
     }, 
     "/ttHJetToGG_M60_TuneCP5_13TeV-amcatnloFXFX-madspin-pythia8/phys_higgs-Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2-c9fef38cafbf42997474836a0940bf17/USER": {
         "dset_type": "mc", 
@@ -7973,6 +8036,6 @@
             }
         ], 
         "parent_n_units": null, 
-        "vetted": false
+        "vetted": true
     }
 }

--- a/MetaData/data/Era2017_legacy_v1_Summer20UL/datasets_22.json
+++ b/MetaData/data/Era2017_legacy_v1_Summer20UL/datasets_22.json
@@ -651,14 +651,20 @@
                 "weights": 991344.6875
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24480, 
                 "name": "/store/user/jhossain/Era2017_legacy_v1_Summer20UL/v2/GluGluHToGGPlusTwoJets_CPodd_M125_TuneCP5_13TeV-amcatnlopowheg-minlo-pythia8/Era2017_legacy_v1_Summer20UL-v2-v0-RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/230305_090714/0000/myMicroAODOutputFile_433.root", 
-                "nevents": 24480
+                "nevents": 24480, 
+                "totEvents": 24480, 
+                "weights": 996186.25
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24480, 
                 "name": "/store/user/jhossain/Era2017_legacy_v1_Summer20UL/v2/GluGluHToGGPlusTwoJets_CPodd_M125_TuneCP5_13TeV-amcatnlopowheg-minlo-pythia8/Era2017_legacy_v1_Summer20UL-v2-v0-RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/230305_090714/0000/myMicroAODOutputFile_333.root", 
-                "nevents": 24480
+                "nevents": 24480, 
+                "totEvents": 24480, 
+                "weights": 991243.6875
             }, 
             {
                 "bad": false, 
@@ -5325,7 +5331,7 @@
             }
         ], 
         "parent_n_units": null, 
-        "vetted": false
+        "vetted": true
     }, 
     "/GluGluHToGG_M125_TuneCP5_13TeV-amcatnloFXFX-pythia8_storeWeights/phys_higgs-Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1-6e0116571fff0f3c29761c67e059de6f/USER": {
         "dset_type": "mc", 
@@ -5571,9 +5577,12 @@
                 "weights": 2759924.25
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25036, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/GluGluHToGG_M125_TuneCP5_13TeV-amcatnloFXFX-pythia8_storeWeights/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_022300/0000/myMicroAODOutputFile_19.root", 
-                "nevents": 25036
+                "nevents": 25036, 
+                "totEvents": 25036, 
+                "weights": 2783826.75
             }, 
             {
                 "bad": false, 
@@ -5680,9 +5689,12 @@
                 "weights": 2699399.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25007, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/GluGluHToGG_M125_TuneCP5_13TeV-amcatnloFXFX-pythia8_storeWeights/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_022300/0000/myMicroAODOutputFile_5.root", 
-                "nevents": 25007
+                "nevents": 25007, 
+                "totEvents": 25007, 
+                "weights": 2722337.0
             }, 
             {
                 "bad": false, 
@@ -5733,9 +5745,12 @@
                 "weights": 2744504.75
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25096, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/GluGluHToGG_M125_TuneCP5_13TeV-amcatnloFXFX-pythia8_storeWeights/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_022300/0000/myMicroAODOutputFile_76.root", 
-                "nevents": 25096
+                "nevents": 25096, 
+                "totEvents": 25096, 
+                "weights": 2757997.5
             }, 
             {
                 "bad": false, 
@@ -5746,14 +5761,20 @@
                 "weights": 2789030.75
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25003, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/GluGluHToGG_M125_TuneCP5_13TeV-amcatnloFXFX-pythia8_storeWeights/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_022300/0000/myMicroAODOutputFile_63.root", 
-                "nevents": 25003
+                "nevents": 25003, 
+                "totEvents": 25003, 
+                "weights": 2726577.5
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24800, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/GluGluHToGG_M125_TuneCP5_13TeV-amcatnloFXFX-pythia8_storeWeights/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_022300/0000/myMicroAODOutputFile_21.root", 
-                "nevents": 24800
+                "nevents": 24800, 
+                "totEvents": 24800, 
+                "weights": 2752214.5
             }, 
             {
                 "bad": false, 
@@ -5812,9 +5833,12 @@
                 "weights": 2730240.25
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25254, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/GluGluHToGG_M125_TuneCP5_13TeV-amcatnloFXFX-pythia8_storeWeights/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_022300/0000/myMicroAODOutputFile_74.root", 
-                "nevents": 25254
+                "nevents": 25254, 
+                "totEvents": 25254, 
+                "weights": 2795006.5
             }, 
             {
                 "bad": false, 
@@ -5921,9 +5945,12 @@
                 "weights": 2700555.5
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24868, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/GluGluHToGG_M125_TuneCP5_13TeV-amcatnloFXFX-pythia8_storeWeights/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_022300/0000/myMicroAODOutputFile_46.root", 
-                "nevents": 24868
+                "nevents": 24868, 
+                "totEvents": 24868, 
+                "weights": 2761082.5
             }, 
             {
                 "bad": false, 
@@ -6086,7 +6113,7 @@
             }
         ], 
         "parent_n_units": null, 
-        "vetted": false
+        "vetted": true
     }, 
     "/VBFHToGG_M75_TuneCP5_13TeV-amcatnlo-pythia8/phys_higgs-Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2-b57456a118a639e045227184101d9dcf/USER": {
         "dset_type": "mc", 
@@ -6333,7 +6360,7 @@
             }
         ], 
         "parent_n_units": null, 
-        "vetted": false
+        "vetted": true
     }, 
     "/VHToGG_M105_TuneCP5_13TeV-amcatnloFXFX-madspin-pythia8/phys_higgs-Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2-87ea3b90faed5199cfde26b1d7e045df/USER": {
         "dset_type": "mc", 
@@ -6756,7 +6783,7 @@
             }
         ], 
         "parent_n_units": null, 
-        "vetted": false
+        "vetted": true
     }, 
     "/VHToGG_M125_TuneCP5Down_13TeV-amcatnloFXFX-madspin-pythia8/phys_higgs-Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v3-40c484617c8150a845705b37f7fbbebe/USER": {
         "dset_type": "mc", 
@@ -7211,7 +7238,7 @@
             }
         ], 
         "parent_n_units": null, 
-        "vetted": false
+        "vetted": true
     }, 
     "/VHToGG_M60_TuneCP5_13TeV-amcatnloFXFX-madspin-pythia8/phys_higgs-Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2-87ea3b90faed5199cfde26b1d7e045df/USER": {
         "dset_type": "mc", 
@@ -7722,7 +7749,7 @@
             }
         ], 
         "parent_n_units": null, 
-        "vetted": false
+        "vetted": true
     }, 
     "/ttHJetToGG_M85_TuneCP5_13TeV-amcatnloFXFX-madspin-pythia8/phys_higgs-Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2-c9fef38cafbf42997474836a0940bf17/USER": {
         "dset_type": "mc", 
@@ -8017,6 +8044,6 @@
             }
         ], 
         "parent_n_units": null, 
-        "vetted": false
+        "vetted": true
     }
 }

--- a/MetaData/data/Era2017_legacy_v1_Summer20UL/datasets_23.json
+++ b/MetaData/data/Era2017_legacy_v1_Summer20UL/datasets_23.json
@@ -5563,7 +5563,7 @@
             }
         ], 
         "parent_n_units": null, 
-        "vetted": false
+        "vetted": true
     }, 
     "/GluGluHToGG_M75_TuneCP5_13TeV-amcatnloFXFX-pythia8/phys_higgs-Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v3-9da8fb7b8a1cdca7b80e707a2ce21a84/USER": {
         "dset_type": "mc", 
@@ -5714,7 +5714,7 @@
             }
         ], 
         "parent_n_units": null, 
-        "vetted": false
+        "vetted": true
     }, 
     "/VBFHToGG_M105_TuneCP5_13TeV-amcatnlo-pythia8/phys_higgs-Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2-b57456a118a639e045227184101d9dcf/USER": {
         "dset_type": "mc", 
@@ -5969,7 +5969,7 @@
             }
         ], 
         "parent_n_units": null, 
-        "vetted": false
+        "vetted": true
     }, 
     "/VBFHToGG_M115_TuneCP5_13TeV-amcatnlo-pythia8/phys_higgs-Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2-b57456a118a639e045227184101d9dcf/USER": {
         "dset_type": "mc", 
@@ -6184,7 +6184,7 @@
             }
         ], 
         "parent_n_units": null, 
-        "vetted": false
+        "vetted": true
     }, 
     "/VBFHToGG_M85_TuneCP5_13TeV-amcatnlo-pythia8/phys_higgs-Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2-b57456a118a639e045227184101d9dcf/USER": {
         "dset_type": "mc", 
@@ -6407,7 +6407,7 @@
             }
         ], 
         "parent_n_units": null, 
-        "vetted": false
+        "vetted": true
     }, 
     "/VBFHToGG_M95_TuneCP5_13TeV-amcatnlo-pythia8/phys_higgs-Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2-b57456a118a639e045227184101d9dcf/USER": {
         "dset_type": "mc", 
@@ -6654,7 +6654,7 @@
             }
         ], 
         "parent_n_units": null, 
-        "vetted": false
+        "vetted": true
     }, 
     "/VHToGG_M115_TuneCP5_13TeV-amcatnloFXFX-madspin-pythia8/phys_higgs-Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2-87ea3b90faed5199cfde26b1d7e045df/USER": {
         "dset_type": "mc", 
@@ -6997,7 +6997,7 @@
             }
         ], 
         "parent_n_units": null, 
-        "vetted": false
+        "vetted": true
     }, 
     "/VHToGG_M80_TuneCP5_13TeV-amcatnloFXFX-madspin-pythia8/phys_higgs-Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2-87ea3b90faed5199cfde26b1d7e045df/USER": {
         "dset_type": "mc", 
@@ -7436,7 +7436,7 @@
             }
         ], 
         "parent_n_units": null, 
-        "vetted": false
+        "vetted": true
     }, 
     "/ttHJetToGG_M125_TuneCP5Down_13TeV-amcatnloFXFX-madspin-pythia8/phys_higgs-Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v1-26f37e744f4de8c25bc5b8188812522c/USER": {
         "dset_type": "mc", 
@@ -7715,7 +7715,7 @@
             }
         ], 
         "parent_n_units": null, 
-        "vetted": false
+        "vetted": true
     }, 
     "/ttHJetToGG_M95_TuneCP5_13TeV-amcatnloFXFX-madspin-pythia8/phys_higgs-Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2-c9fef38cafbf42997474836a0940bf17/USER": {
         "dset_type": "mc", 
@@ -8002,6 +8002,6 @@
             }
         ], 
         "parent_n_units": null, 
-        "vetted": false
+        "vetted": true
     }
 }

--- a/MetaData/data/Era2017_legacy_v1_Summer20UL/datasets_25.json
+++ b/MetaData/data/Era2017_legacy_v1_Summer20UL/datasets_25.json
@@ -7207,9 +7207,12 @@
                 "weights": 2767444.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24940, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/GluGluHToEE_M125_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_021945/0000/myMicroAODOutputFile_18.root", 
-                "nevents": 24940
+                "nevents": 24940, 
+                "totEvents": 24940, 
+                "weights": 2760696.75
             }, 
             {
                 "bad": false, 
@@ -7276,9 +7279,12 @@
                 "weights": 2784019.25
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25039, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/GluGluHToEE_M125_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_021945/0000/myMicroAODOutputFile_59.root", 
-                "nevents": 25039
+                "nevents": 25039, 
+                "totEvents": 25039, 
+                "weights": 2773225.25
             }, 
             {
                 "bad": false, 
@@ -7313,9 +7319,12 @@
                 "weights": 2797513.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24936, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/GluGluHToEE_M125_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_021945/0000/myMicroAODOutputFile_24.root", 
-                "nevents": 24936
+                "nevents": 24936, 
+                "totEvents": 24936, 
+                "weights": 2735251.5
             }, 
             {
                 "bad": false, 
@@ -7326,9 +7335,12 @@
                 "weights": 2743540.75
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24960, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/GluGluHToEE_M125_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_021945/0000/myMicroAODOutputFile_27.root", 
-                "nevents": 24960
+                "nevents": 24960, 
+                "totEvents": 24960, 
+                "weights": 2765706.75
             }, 
             {
                 "bad": false, 
@@ -7387,9 +7399,12 @@
                 "weights": 2665472.5
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25085, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/GluGluHToEE_M125_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_021945/0000/myMicroAODOutputFile_36.root", 
-                "nevents": 25085
+                "nevents": 25085, 
+                "totEvents": 25085, 
+                "weights": 2816017.5
             }, 
             {
                 "bad": false, 
@@ -7400,14 +7415,20 @@
                 "weights": 2748360.5
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25256, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/GluGluHToEE_M125_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_021945/0000/myMicroAODOutputFile_13.root", 
-                "nevents": 25256
+                "nevents": 25256, 
+                "totEvents": 25256, 
+                "weights": 2747588.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24954, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/GluGluHToEE_M125_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_021945/0000/myMicroAODOutputFile_41.root", 
-                "nevents": 24954
+                "nevents": 24954, 
+                "totEvents": 24954, 
+                "weights": 2735637.25
             }, 
             {
                 "bad": false, 
@@ -7418,14 +7439,20 @@
                 "weights": 2690724.75
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24715, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/GluGluHToEE_M125_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_021945/0000/myMicroAODOutputFile_43.root", 
-                "nevents": 24715
+                "nevents": 24715, 
+                "totEvents": 24715, 
+                "weights": 2689568.75
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24825, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/GluGluHToEE_M125_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_021945/0000/myMicroAODOutputFile_12.root", 
-                "nevents": 24825
+                "nevents": 24825, 
+                "totEvents": 24825, 
+                "weights": 2725422.0
             }, 
             {
                 "bad": false, 
@@ -7468,9 +7495,12 @@
                 "weights": 2786139.5
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24928, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/GluGluHToEE_M125_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_021945/0000/myMicroAODOutputFile_62.root", 
-                "nevents": 24928
+                "nevents": 24928, 
+                "totEvents": 24928, 
+                "weights": 2777273.75
             }, 
             {
                 "bad": false, 
@@ -7489,9 +7519,12 @@
                 "weights": 2795971.25
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25189, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/GluGluHToEE_M125_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_021945/0000/myMicroAODOutputFile_60.root", 
-                "nevents": 25189
+                "nevents": 25189, 
+                "totEvents": 25189, 
+                "weights": 2776309.75
             }, 
             {
                 "bad": false, 
@@ -7502,9 +7535,12 @@
                 "weights": 2696699.75
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24842, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/GluGluHToEE_M125_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_021945/0000/myMicroAODOutputFile_57.root", 
-                "nevents": 24842
+                "nevents": 24842, 
+                "totEvents": 24842, 
+                "weights": 2736794.25
             }, 
             {
                 "bad": false, 
@@ -7523,9 +7559,12 @@
                 "weights": 2773803.25
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24882, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/GluGluHToEE_M125_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_021945/0000/myMicroAODOutputFile_61.root", 
-                "nevents": 24882
+                "nevents": 24882, 
+                "totEvents": 24882, 
+                "weights": 2765322.5
             }, 
             {
                 "bad": false, 
@@ -7536,9 +7575,12 @@
                 "weights": 2743926.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24996, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/GluGluHToEE_M125_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_021945/0000/myMicroAODOutputFile_53.root", 
-                "nevents": 24996
+                "nevents": 24996, 
+                "totEvents": 24996, 
+                "weights": 2776116.25
             }, 
             {
                 "bad": false, 
@@ -7629,9 +7671,12 @@
                 "weights": 2722529.5
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24878, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/GluGluHToEE_M125_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_021945/0000/myMicroAODOutputFile_72.root", 
-                "nevents": 24878
+                "nevents": 24878, 
+                "totEvents": 24878, 
+                "weights": 2772260.75
             }, 
             {
                 "bad": false, 
@@ -7769,9 +7814,12 @@
                 "weights": 25000.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/TprimeBToTH_Hgg_M-1200_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_031450/0000/myMicroAODOutputFile_9.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 25000.0
             }, 
             {
                 "bad": false, 
@@ -7790,9 +7838,12 @@
                 "weights": 25000.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/TprimeBToTH_Hgg_M-1200_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_031450/0000/myMicroAODOutputFile_2.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 25000.0
             }, 
             {
                 "bad": false, 

--- a/MetaData/data/Era2017_legacy_v1_Summer20UL/datasets_3.json
+++ b/MetaData/data/Era2017_legacy_v1_Summer20UL/datasets_3.json
@@ -30708,6 +30708,6 @@
             }
         ], 
         "parent_n_units": null, 
-        "vetted": false
+        "vetted": true
     }
 }

--- a/MetaData/data/Era2017_legacy_v1_Summer20UL/datasets_35.json
+++ b/MetaData/data/Era2017_legacy_v1_Summer20UL/datasets_35.json
@@ -4570,9 +4570,12 @@
                 "weights": 96513.1015625
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/VBFHToGG_M-125_TuneCP5_13TeV-powheg-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_043950/0000/myMicroAODOutputFile_1.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 96482.1796875
             }, 
             {
                 "bad": false, 
@@ -4591,19 +4594,28 @@
                 "weights": 96474.453125
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/VBFHToGG_M-125_TuneCP5_13TeV-powheg-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_043633/0000/myMicroAODOutputFile_7.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 96474.4453125
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/VBFHToGG_M-125_TuneCP5_13TeV-powheg-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_043633/0000/myMicroAODOutputFile_3.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 96544.015625
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/VBFHToGG_M-125_TuneCP5_13TeV-powheg-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_043633/0000/myMicroAODOutputFile_17.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 96520.828125
             }, 
             {
                 "bad": false, 
@@ -4622,9 +4634,12 @@
                 "weights": 96482.1875
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/VBFHToGG_M-125_TuneCP5_13TeV-powheg-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_043633/0000/myMicroAODOutputFile_8.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 96520.84375
             }, 
             {
                 "bad": false, 
@@ -4739,9 +4754,12 @@
                 "weights": 96474.453125
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/VBFHToGG_M-125_TuneCP5_13TeV-powheg-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_043950/0000/myMicroAODOutputFile_2.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 96428.078125
             }, 
             {
                 "bad": false, 
@@ -4776,9 +4794,12 @@
                 "weights": 96474.46875
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/VBFHToGG_M-125_TuneCP5_13TeV-powheg-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_043633/0000/myMicroAODOutputFile_25.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 96544.015625
             }, 
             {
                 "bad": false, 
@@ -4797,14 +4818,20 @@
                 "weights": 96528.5546875
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/VBFHToGG_M-125_TuneCP5_13TeV-powheg-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_043633/0000/myMicroAODOutputFile_19.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 96513.109375
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/VBFHToGG_M-125_TuneCP5_13TeV-powheg-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_043633/0000/myMicroAODOutputFile_6.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 96520.828125
             }, 
             {
                 "bad": false, 
@@ -4839,9 +4866,12 @@
                 "weights": 96559.4765625
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/VBFHToGG_M-125_TuneCP5_13TeV-powheg-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_043633/0000/myMicroAODOutputFile_37.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 96520.8359375
             }, 
             {
                 "bad": false, 
@@ -4892,9 +4922,12 @@
                 "weights": 96474.453125
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/VBFHToGG_M-125_TuneCP5_13TeV-powheg-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_043633/0000/myMicroAODOutputFile_24.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 96520.828125
             }, 
             {
                 "bad": false, 
@@ -4945,9 +4978,12 @@
                 "weights": 96482.1796875
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/VBFHToGG_M-125_TuneCP5_13TeV-powheg-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_043633/0000/myMicroAODOutputFile_23.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 96528.5625
             }, 
             {
                 "bad": false, 
@@ -4958,19 +4994,28 @@
                 "weights": 96489.90625
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/VBFHToGG_M-125_TuneCP5_13TeV-powheg-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_043633/0000/myMicroAODOutputFile_30.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 96443.5546875
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/VBFHToGG_M-125_TuneCP5_13TeV-powheg-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_043950/0000/myMicroAODOutputFile_25.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 96544.015625
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/VBFHToGG_M-125_TuneCP5_13TeV-powheg-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_043950/0000/myMicroAODOutputFile_24.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 96520.828125
             }, 
             {
                 "bad": false, 
@@ -5069,9 +5114,12 @@
                 "weights": 96528.5625
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/VBFHToGG_M-125_TuneCP5_13TeV-powheg-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_043950/0000/myMicroAODOutputFile_4.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 96497.640625
             }, 
             {
                 "bad": false, 
@@ -5121,9 +5169,12 @@
                 "weights": 92729.015625
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/VBFHToGG_M-130_TuneCP5_13TeV-powheg-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_044610/0000/myMicroAODOutputFile_3.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 92677.0234375
             }, 
             {
                 "bad": false, 
@@ -5262,9 +5313,12 @@
                 "weights": 92773.5546875
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/VBFHToGG_M-130_TuneCP5_13TeV-powheg-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_044259/0000/myMicroAODOutputFile_38.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 92729.0078125
             }, 
             {
                 "bad": false, 
@@ -5339,9 +5393,12 @@
                 "weights": 92699.296875
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/VBFHToGG_M-130_TuneCP5_13TeV-powheg-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_044610/0000/myMicroAODOutputFile_5.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 92714.15625
             }, 
             {
                 "bad": false, 
@@ -5368,9 +5425,12 @@
                 "weights": 92780.9921875
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/VBFHToGG_M-130_TuneCP5_13TeV-powheg-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_044610/0000/myMicroAODOutputFile_8.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 92714.15625
             }, 
             {
                 "bad": false, 
@@ -5389,9 +5449,12 @@
                 "weights": 92736.4296875
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/VBFHToGG_M-130_TuneCP5_13TeV-powheg-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_044610/0000/myMicroAODOutputFile_34.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 92736.4375
             }, 
             {
                 "bad": false, 
@@ -5410,9 +5473,12 @@
                 "weights": 92699.296875
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/VBFHToGG_M-130_TuneCP5_13TeV-powheg-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_044610/0000/myMicroAODOutputFile_24.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 92728.984375
             }, 
             {
                 "bad": false, 
@@ -5423,9 +5489,12 @@
                 "weights": 92729.0078125
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/VBFHToGG_M-130_TuneCP5_13TeV-powheg-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_044610/0000/myMicroAODOutputFile_36.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 92758.6953125
             }, 
             {
                 "bad": false, 
@@ -5436,9 +5505,12 @@
                 "weights": 92691.8515625
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/VBFHToGG_M-130_TuneCP5_13TeV-powheg-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_044610/0000/myMicroAODOutputFile_13.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 92729.0
             }, 
             {
                 "bad": false, 
@@ -5457,19 +5529,28 @@
                 "weights": 92736.4140625
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/VBFHToGG_M-130_TuneCP5_13TeV-powheg-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_044610/0000/myMicroAODOutputFile_15.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 92743.84375
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/VBFHToGG_M-130_TuneCP5_13TeV-powheg-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_044610/0000/myMicroAODOutputFile_18.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 92714.1484375
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/VBFHToGG_M-130_TuneCP5_13TeV-powheg-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_044610/0000/myMicroAODOutputFile_14.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 92751.2734375
             }, 
             {
                 "bad": false, 
@@ -5727,9 +5808,12 @@
                 "weights": 100524.8125
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/VBFHToGG_M125_TuneCP5_13TeV-amcatnlo-pythia8_storeWeights/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_043256/0000/myMicroAODOutputFile_54.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 103693.8359375
             }, 
             {
                 "bad": false, 
@@ -5772,9 +5856,12 @@
                 "weights": 96992.1875
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/VBFHToGG_M125_TuneCP5_13TeV-amcatnlo-pythia8_storeWeights/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_043256/0000/myMicroAODOutputFile_76.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 103486.0078125
             }, 
             {
                 "bad": false, 
@@ -6097,9 +6184,12 @@
                 "weights": 100239.0703125
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/VBFHToGG_M125_TuneCP5_13TeV-amcatnlo-pythia8_storeWeights/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_043256/0000/myMicroAODOutputFile_9.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 100317.03125
             }, 
             {
                 "bad": false, 
@@ -6134,14 +6224,20 @@
                 "weights": 100213.1171875
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/VBFHToGG_M125_TuneCP5_13TeV-amcatnlo-pythia8_storeWeights/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_043256/0000/myMicroAODOutputFile_53.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 101018.3359375
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/VBFHToGG_M125_TuneCP5_13TeV-amcatnlo-pythia8_storeWeights/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_043256/0000/myMicroAODOutputFile_43.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 102265.1796875
             }, 
             {
                 "bad": false, 
@@ -6152,9 +6248,12 @@
                 "weights": 105512.0859375
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/VBFHToGG_M125_TuneCP5_13TeV-amcatnlo-pythia8_storeWeights/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_043256/0000/myMicroAODOutputFile_55.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 98394.84375
             }, 
             {
                 "bad": false, 
@@ -6245,9 +6344,12 @@
                 "weights": 101875.5390625
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/VBFHToGG_M125_TuneCP5_13TeV-amcatnlo-pythia8_storeWeights/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_043256/0000/myMicroAODOutputFile_2.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 103252.2109375
             }
         ], 
         "parent_n_units": null, 

--- a/MetaData/data/Era2017_legacy_v1_Summer20UL/datasets_36.json
+++ b/MetaData/data/Era2017_legacy_v1_Summer20UL/datasets_36.json
@@ -35,9 +35,12 @@
                 "weights": 24961.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24975, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/WGToLNuG_TuneCP5_13TeV-madgraphMLM-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_045240/0000/myMicroAODOutputFile_17.root", 
-                "nevents": 24975
+                "nevents": 24975, 
+                "totEvents": 24975, 
+                "weights": 24975.0
             }, 
             {
                 "bad": false, 
@@ -56,14 +59,20 @@
                 "weights": 24974.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24958, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/WGToLNuG_TuneCP5_13TeV-madgraphMLM-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_045240/0000/myMicroAODOutputFile_14.root", 
-                "nevents": 24958
+                "nevents": 24958, 
+                "totEvents": 24958, 
+                "weights": 24958.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24914, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/WGToLNuG_TuneCP5_13TeV-madgraphMLM-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_045240/0000/myMicroAODOutputFile_15.root", 
-                "nevents": 24914
+                "nevents": 24914, 
+                "totEvents": 24914, 
+                "weights": 24914.0
             }, 
             {
                 "bad": false, 
@@ -90,14 +99,20 @@
                 "weights": 24909.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25006, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/WGToLNuG_TuneCP5_13TeV-madgraphMLM-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_045240/0000/myMicroAODOutputFile_152.root", 
-                "nevents": 25006
+                "nevents": 25006, 
+                "totEvents": 25006, 
+                "weights": 25006.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24971, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/WGToLNuG_TuneCP5_13TeV-madgraphMLM-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_045240/0000/myMicroAODOutputFile_7.root", 
-                "nevents": 24971
+                "nevents": 24971, 
+                "totEvents": 24971, 
+                "weights": 24971.0
             }, 
             {
                 "bad": false, 
@@ -196,9 +211,12 @@
                 "weights": 24762.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24926, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/WGToLNuG_TuneCP5_13TeV-madgraphMLM-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_045240/0000/myMicroAODOutputFile_97.root", 
-                "nevents": 24926
+                "nevents": 24926, 
+                "totEvents": 24926, 
+                "weights": 24926.0
             }, 
             {
                 "bad": false, 
@@ -217,9 +235,12 @@
                 "weights": 24859.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25058, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/WGToLNuG_TuneCP5_13TeV-madgraphMLM-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_045240/0000/myMicroAODOutputFile_91.root", 
-                "nevents": 25058
+                "nevents": 25058, 
+                "totEvents": 25058, 
+                "weights": 25058.0
             }, 
             {
                 "bad": false, 
@@ -262,9 +283,12 @@
                 "weights": 24923.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24961, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/WGToLNuG_TuneCP5_13TeV-madgraphMLM-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_045240/0000/myMicroAODOutputFile_94.root", 
-                "nevents": 24961
+                "nevents": 24961, 
+                "totEvents": 24961, 
+                "weights": 24961.0
             }, 
             {
                 "bad": false, 
@@ -275,9 +299,12 @@
                 "weights": 24840.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25068, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/WGToLNuG_TuneCP5_13TeV-madgraphMLM-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_045240/0000/myMicroAODOutputFile_143.root", 
-                "nevents": 25068
+                "nevents": 25068, 
+                "totEvents": 25068, 
+                "weights": 25068.0
             }, 
             {
                 "bad": false, 
@@ -304,9 +331,12 @@
                 "weights": 24879.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25094, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/WGToLNuG_TuneCP5_13TeV-madgraphMLM-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_045240/0000/myMicroAODOutputFile_87.root", 
-                "nevents": 25094
+                "nevents": 25094, 
+                "totEvents": 25094, 
+                "weights": 25094.0
             }, 
             {
                 "bad": false, 
@@ -317,9 +347,12 @@
                 "weights": 25002.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25093, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/WGToLNuG_TuneCP5_13TeV-madgraphMLM-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_045240/0000/myMicroAODOutputFile_134.root", 
-                "nevents": 25093
+                "nevents": 25093, 
+                "totEvents": 25093, 
+                "weights": 25093.0
             }, 
             {
                 "bad": false, 
@@ -402,9 +435,12 @@
                 "weights": 24891.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24991, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/WGToLNuG_TuneCP5_13TeV-madgraphMLM-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_045240/0000/myMicroAODOutputFile_18.root", 
-                "nevents": 24991
+                "nevents": 24991, 
+                "totEvents": 24991, 
+                "weights": 24991.0
             }, 
             {
                 "bad": false, 
@@ -455,9 +491,12 @@
                 "weights": 24897.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24765, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/WGToLNuG_TuneCP5_13TeV-madgraphMLM-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_045240/0000/myMicroAODOutputFile_38.root", 
-                "nevents": 24765
+                "nevents": 24765, 
+                "totEvents": 24765, 
+                "weights": 24765.0
             }, 
             {
                 "bad": false, 
@@ -484,9 +523,12 @@
                 "weights": 24893.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24966, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/WGToLNuG_TuneCP5_13TeV-madgraphMLM-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_045240/0000/myMicroAODOutputFile_24.root", 
-                "nevents": 24966
+                "nevents": 24966, 
+                "totEvents": 24966, 
+                "weights": 24966.0
             }, 
             {
                 "bad": false, 
@@ -497,9 +539,12 @@
                 "weights": 24739.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25073, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/WGToLNuG_TuneCP5_13TeV-madgraphMLM-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_045240/0000/myMicroAODOutputFile_47.root", 
-                "nevents": 25073
+                "nevents": 25073, 
+                "totEvents": 25073, 
+                "weights": 25073.0
             }, 
             {
                 "bad": false, 
@@ -638,9 +683,12 @@
                 "weights": 24774.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24929, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/WGToLNuG_TuneCP5_13TeV-madgraphMLM-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_045240/0000/myMicroAODOutputFile_37.root", 
-                "nevents": 24929
+                "nevents": 24929, 
+                "totEvents": 24929, 
+                "weights": 24929.0
             }, 
             {
                 "bad": false, 
@@ -675,9 +723,12 @@
                 "weights": 25098.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24967, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/WGToLNuG_TuneCP5_13TeV-madgraphMLM-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_045240/0000/myMicroAODOutputFile_99.root", 
-                "nevents": 24967
+                "nevents": 24967, 
+                "totEvents": 24967, 
+                "weights": 24967.0
             }, 
             {
                 "bad": false, 
@@ -728,9 +779,12 @@
                 "weights": 24813.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24790, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/WGToLNuG_TuneCP5_13TeV-madgraphMLM-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_045240/0000/myMicroAODOutputFile_111.root", 
-                "nevents": 24790
+                "nevents": 24790, 
+                "totEvents": 24790, 
+                "weights": 24790.0
             }, 
             {
                 "bad": false, 
@@ -845,9 +899,12 @@
                 "weights": 25162.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24907, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/WGToLNuG_TuneCP5_13TeV-madgraphMLM-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_045240/0000/myMicroAODOutputFile_125.root", 
-                "nevents": 24907
+                "nevents": 24907, 
+                "totEvents": 24907, 
+                "weights": 24907.0
             }, 
             {
                 "bad": false, 
@@ -866,9 +923,12 @@
                 "weights": 25066.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24856, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/WGToLNuG_TuneCP5_13TeV-madgraphMLM-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_045240/0000/myMicroAODOutputFile_59.root", 
-                "nevents": 24856
+                "nevents": 24856, 
+                "totEvents": 24856, 
+                "weights": 24856.0
             }, 
             {
                 "bad": false, 
@@ -943,9 +1003,12 @@
                 "weights": 25001.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24964, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/WGToLNuG_TuneCP5_13TeV-madgraphMLM-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_045240/0000/myMicroAODOutputFile_64.root", 
-                "nevents": 24964
+                "nevents": 24964, 
+                "totEvents": 24964, 
+                "weights": 24964.0
             }, 
             {
                 "bad": false, 
@@ -972,9 +1035,12 @@
                 "weights": 24977.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25013, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/WGToLNuG_TuneCP5_13TeV-madgraphMLM-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_045240/0000/myMicroAODOutputFile_65.root", 
-                "nevents": 25013
+                "nevents": 25013, 
+                "totEvents": 25013, 
+                "weights": 25013.0
             }, 
             {
                 "bad": false, 
@@ -993,14 +1059,20 @@
                 "weights": 24776.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24754, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/WGToLNuG_TuneCP5_13TeV-madgraphMLM-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_045240/0000/myMicroAODOutputFile_62.root", 
-                "nevents": 24754
+                "nevents": 24754, 
+                "totEvents": 24754, 
+                "weights": 24754.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25028, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/WGToLNuG_TuneCP5_13TeV-madgraphMLM-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_045240/0000/myMicroAODOutputFile_69.root", 
-                "nevents": 25028
+                "nevents": 25028, 
+                "totEvents": 25028, 
+                "weights": 25028.0
             }, 
             {
                 "bad": false, 
@@ -1091,9 +1163,12 @@
                 "weights": 25000.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24822, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/WGToLNuG_TuneCP5_13TeV-madgraphMLM-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_045240/0000/myMicroAODOutputFile_211.root", 
-                "nevents": 24822
+                "nevents": 24822, 
+                "totEvents": 24822, 
+                "weights": 24822.0
             }, 
             {
                 "bad": false, 
@@ -1200,9 +1275,12 @@
                 "weights": 24830.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24985, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/WGToLNuG_TuneCP5_13TeV-madgraphMLM-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_045240/0000/myMicroAODOutputFile_206.root", 
-                "nevents": 24985
+                "nevents": 24985, 
+                "totEvents": 24985, 
+                "weights": 24985.0
             }, 
             {
                 "bad": false, 
@@ -1293,9 +1371,12 @@
                 "weights": 24806.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24906, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/WGToLNuG_TuneCP5_13TeV-madgraphMLM-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_045240/0000/myMicroAODOutputFile_243.root", 
-                "nevents": 24906
+                "nevents": 24906, 
+                "totEvents": 24906, 
+                "weights": 24906.0
             }, 
             {
                 "bad": false, 
@@ -1330,9 +1411,12 @@
                 "weights": 25017.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24832, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/WGToLNuG_TuneCP5_13TeV-madgraphMLM-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_045240/0000/myMicroAODOutputFile_217.root", 
-                "nevents": 24832
+                "nevents": 24832, 
+                "totEvents": 24832, 
+                "weights": 24832.0
             }, 
             {
                 "bad": false, 
@@ -1351,9 +1435,12 @@
                 "weights": 24802.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24987, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/WGToLNuG_TuneCP5_13TeV-madgraphMLM-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_045240/0000/myMicroAODOutputFile_241.root", 
-                "nevents": 24987
+                "nevents": 24987, 
+                "totEvents": 24987, 
+                "weights": 24987.0
             }, 
             {
                 "bad": false, 
@@ -1364,14 +1451,20 @@
                 "weights": 24867.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25127, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/WGToLNuG_TuneCP5_13TeV-madgraphMLM-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_045240/0000/myMicroAODOutputFile_172.root", 
-                "nevents": 25127
+                "nevents": 25127, 
+                "totEvents": 25127, 
+                "weights": 25127.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25013, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/WGToLNuG_TuneCP5_13TeV-madgraphMLM-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_045240/0000/myMicroAODOutputFile_184.root", 
-                "nevents": 25013
+                "nevents": 25013, 
+                "totEvents": 25013, 
+                "weights": 25013.0
             }, 
             {
                 "bad": false, 
@@ -1398,14 +1491,20 @@
                 "weights": 24828.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25041, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/WGToLNuG_TuneCP5_13TeV-madgraphMLM-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_045240/0000/myMicroAODOutputFile_185.root", 
-                "nevents": 25041
+                "nevents": 25041, 
+                "totEvents": 25041, 
+                "weights": 25041.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24783, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/WGToLNuG_TuneCP5_13TeV-madgraphMLM-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_045240/0000/myMicroAODOutputFile_170.root", 
-                "nevents": 24783
+                "nevents": 24783, 
+                "totEvents": 24783, 
+                "weights": 24783.0
             }, 
             {
                 "bad": false, 
@@ -1472,9 +1571,12 @@
                 "weights": 24979.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25294, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/WGToLNuG_TuneCP5_13TeV-madgraphMLM-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_045240/0000/myMicroAODOutputFile_176.root", 
-                "nevents": 25294
+                "nevents": 25294, 
+                "totEvents": 25294, 
+                "weights": 25294.0
             }, 
             {
                 "bad": false, 
@@ -1501,14 +1603,20 @@
                 "weights": 24971.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25026, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/WGToLNuG_TuneCP5_13TeV-madgraphMLM-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_045240/0000/myMicroAODOutputFile_188.root", 
-                "nevents": 25026
+                "nevents": 25026, 
+                "totEvents": 25026, 
+                "weights": 25026.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24847, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/WGToLNuG_TuneCP5_13TeV-madgraphMLM-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_045240/0000/myMicroAODOutputFile_180.root", 
-                "nevents": 24847
+                "nevents": 24847, 
+                "totEvents": 24847, 
+                "weights": 24847.0
             }, 
             {
                 "bad": false, 
@@ -1535,9 +1643,12 @@
                 "weights": 24796.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24806, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/WGToLNuG_TuneCP5_13TeV-madgraphMLM-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_045240/0000/myMicroAODOutputFile_174.root", 
-                "nevents": 24806
+                "nevents": 24806, 
+                "totEvents": 24806, 
+                "weights": 24806.0
             }, 
             {
                 "bad": false, 
@@ -1612,9 +1723,12 @@
                 "weights": 24893.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24916, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/WGToLNuG_TuneCP5_13TeV-madgraphMLM-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_045240/0000/myMicroAODOutputFile_245.root", 
-                "nevents": 24916
+                "nevents": 24916, 
+                "totEvents": 24916, 
+                "weights": 24916.0
             }, 
             {
                 "bad": false, 
@@ -1697,9 +1811,12 @@
                 "weights": 25060.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24866, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/WGToLNuG_TuneCP5_13TeV-madgraphMLM-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_045240/0000/myMicroAODOutputFile_230.root", 
-                "nevents": 24866
+                "nevents": 24866, 
+                "totEvents": 24866, 
+                "weights": 24866.0
             }, 
             {
                 "bad": false, 
@@ -1845,9 +1962,12 @@
         "dset_type": "mc", 
         "files": [
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/tZq_ll_4f_ckm_NLO_TuneCP5_13TeV-amcatnlo-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_041626/0000/myMicroAODOutputFile_451.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 1973.07080078125
             }, 
             {
                 "bad": false, 
@@ -1946,9 +2066,12 @@
                 "weights": 2012.555419921875
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/tZq_ll_4f_ckm_NLO_TuneCP5_13TeV-amcatnlo-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_041626/0000/myMicroAODOutputFile_353.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 1926.7197265625
             }, 
             {
                 "bad": false, 
@@ -1959,14 +2082,20 @@
                 "weights": 2036.5894775390625
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/tZq_ll_4f_ckm_NLO_TuneCP5_13TeV-amcatnlo-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_041626/0000/myMicroAODOutputFile_53.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 1929.581298828125
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/tZq_ll_4f_ckm_NLO_TuneCP5_13TeV-amcatnlo-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_041626/0000/myMicroAODOutputFile_60.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 1937.02099609375
             }, 
             {
                 "bad": false, 
@@ -1993,9 +2122,12 @@
                 "weights": 1908.4073486328125
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/tZq_ll_4f_ckm_NLO_TuneCP5_13TeV-amcatnlo-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_041626/0000/myMicroAODOutputFile_355.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 1914.7027587890625
             }, 
             {
                 "bad": false, 
@@ -2006,9 +2138,12 @@
                 "weights": 1867.20703125
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/tZq_ll_4f_ckm_NLO_TuneCP5_13TeV-amcatnlo-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_041626/0000/myMicroAODOutputFile_343.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 1890.668701171875
             }, 
             {
                 "bad": false, 
@@ -2027,9 +2162,12 @@
                 "weights": 1974.78759765625
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/tZq_ll_4f_ckm_NLO_TuneCP5_13TeV-amcatnlo-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_041626/0000/myMicroAODOutputFile_519.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 1944.458984375
             }, 
             {
                 "bad": false, 
@@ -2072,9 +2210,12 @@
                 "weights": 1930.7255859375
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/tZq_ll_4f_ckm_NLO_TuneCP5_13TeV-amcatnlo-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_041626/0000/myMicroAODOutputFile_183.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 2007.4058837890625
             }, 
             {
                 "bad": false, 
@@ -2181,9 +2322,12 @@
                 "weights": 1923.285888671875
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/tZq_ll_4f_ckm_NLO_TuneCP5_13TeV-amcatnlo-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_041626/0000/myMicroAODOutputFile_28.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 1929.0089111328125
             }, 
             {
                 "bad": false, 
@@ -2290,14 +2434,20 @@
                 "weights": 1849.468017578125
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/tZq_ll_4f_ckm_NLO_TuneCP5_13TeV-amcatnlo-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_041626/0000/myMicroAODOutputFile_394.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 1946.1761474609375
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/tZq_ll_4f_ckm_NLO_TuneCP5_13TeV-amcatnlo-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_041626/0000/myMicroAODOutputFile_225.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 1848.895263671875
             }, 
             {
                 "bad": false, 
@@ -2348,9 +2498,12 @@
                 "weights": 2040.5943603515625
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/tZq_ll_4f_ckm_NLO_TuneCP5_13TeV-amcatnlo-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_041626/0000/myMicroAODOutputFile_56.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 1937.5924072265625
             }, 
             {
                 "bad": false, 
@@ -2377,14 +2530,20 @@
                 "weights": 1960.4818115234375
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/tZq_ll_4f_ckm_NLO_TuneCP5_13TeV-amcatnlo-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_041626/0000/myMicroAODOutputFile_305.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 1952.4698486328125
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/tZq_ll_4f_ckm_NLO_TuneCP5_13TeV-amcatnlo-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_041626/0000/myMicroAODOutputFile_314.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 1911.2694091796875
             }, 
             {
                 "bad": false, 
@@ -2451,9 +2610,12 @@
                 "weights": 1986.8045654296875
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/tZq_ll_4f_ckm_NLO_TuneCP5_13TeV-amcatnlo-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_041626/0000/myMicroAODOutputFile_432.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 1941.0257568359375
             }, 
             {
                 "bad": false, 
@@ -2464,9 +2626,12 @@
                 "weights": 1975.9324951171875
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/tZq_ll_4f_ckm_NLO_TuneCP5_13TeV-amcatnlo-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_041626/0000/myMicroAODOutputFile_370.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 1973.07080078125
             }, 
             {
                 "bad": false, 
@@ -2509,9 +2674,12 @@
                 "weights": 1937.020263671875
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/tZq_ll_4f_ckm_NLO_TuneCP5_13TeV-amcatnlo-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_041626/0000/myMicroAODOutputFile_141.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 1971.3538818359375
             }, 
             {
                 "bad": false, 
@@ -2522,14 +2690,20 @@
                 "weights": 1942.742431640625
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/tZq_ll_4f_ckm_NLO_TuneCP5_13TeV-amcatnlo-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_041626/0000/myMicroAODOutputFile_29.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 1966.7774658203125
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/tZq_ll_4f_ckm_NLO_TuneCP5_13TeV-amcatnlo-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_041626/0000/myMicroAODOutputFile_107.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 1977.64892578125
             }, 
             {
                 "bad": false, 
@@ -2540,9 +2714,12 @@
                 "weights": 1955.3319091796875
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/tZq_ll_4f_ckm_NLO_TuneCP5_13TeV-amcatnlo-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_041626/0000/myMicroAODOutputFile_25.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 1955.331787109375
             }, 
             {
                 "bad": false, 
@@ -2585,14 +2762,20 @@
                 "weights": 2011.41064453125
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/tZq_ll_4f_ckm_NLO_TuneCP5_13TeV-amcatnlo-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_041626/0000/myMicroAODOutputFile_419.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 1927.29248046875
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/tZq_ll_4f_ckm_NLO_TuneCP5_13TeV-amcatnlo-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_041626/0000/myMicroAODOutputFile_363.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 1935.3035888671875
             }, 
             {
                 "bad": false, 
@@ -2683,9 +2866,12 @@
                 "weights": 1945.6041259765625
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/tZq_ll_4f_ckm_NLO_TuneCP5_13TeV-amcatnlo-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_041626/0000/myMicroAODOutputFile_416.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 1950.75390625
             }, 
             {
                 "bad": false, 
@@ -2728,9 +2914,12 @@
                 "weights": 1977.6495361328125
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/tZq_ll_4f_ckm_NLO_TuneCP5_13TeV-amcatnlo-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_041626/0000/myMicroAODOutputFile_214.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 1920.9979248046875
             }, 
             {
                 "bad": false, 
@@ -2765,9 +2954,12 @@
                 "weights": 1975.9322509765625
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/tZq_ll_4f_ckm_NLO_TuneCP5_13TeV-amcatnlo-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_041626/0000/myMicroAODOutputFile_37.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 1903.2581787109375
             }, 
             {
                 "bad": false, 
@@ -2834,9 +3026,12 @@
                 "weights": 2026.28955078125
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/tZq_ll_4f_ckm_NLO_TuneCP5_13TeV-amcatnlo-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_041626/0000/myMicroAODOutputFile_381.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 1939.3094482421875
             }, 
             {
                 "bad": false, 
@@ -3031,9 +3226,12 @@
                 "weights": 2004.5438232421875
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/tZq_ll_4f_ckm_NLO_TuneCP5_13TeV-amcatnlo-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_041626/0000/myMicroAODOutputFile_162.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 1967.920166015625
             }, 
             {
                 "bad": false, 
@@ -3156,9 +3354,12 @@
                 "weights": 1932.442626953125
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/tZq_ll_4f_ckm_NLO_TuneCP5_13TeV-amcatnlo-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_041626/0000/myMicroAODOutputFile_270.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 1874.6463623046875
             }, 
             {
                 "bad": false, 
@@ -3329,14 +3530,20 @@
                 "weights": 1923.286865234375
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/tZq_ll_4f_ckm_NLO_TuneCP5_13TeV-amcatnlo-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_041626/0000/myMicroAODOutputFile_299.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 2015.4171142578125
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/tZq_ll_4f_ckm_NLO_TuneCP5_13TeV-amcatnlo-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_041626/0000/myMicroAODOutputFile_150.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 1975.93212890625
             }, 
             {
                 "bad": false, 
@@ -3347,9 +3554,12 @@
                 "weights": 1846.6072998046875
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/tZq_ll_4f_ckm_NLO_TuneCP5_13TeV-amcatnlo-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_041626/0000/myMicroAODOutputFile_240.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 1923.8582763671875
             }, 
             {
                 "bad": false, 
@@ -3376,14 +3586,20 @@
                 "weights": 1913.55908203125
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/tZq_ll_4f_ckm_NLO_TuneCP5_13TeV-amcatnlo-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_041626/0000/myMicroAODOutputFile_35.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 1971.926025390625
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/tZq_ll_4f_ckm_NLO_TuneCP5_13TeV-amcatnlo-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_041626/0000/myMicroAODOutputFile_287.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 1941.598388671875
             }, 
             {
                 "bad": false, 
@@ -3402,9 +3618,12 @@
                 "weights": 1868.351318359375
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/tZq_ll_4f_ckm_NLO_TuneCP5_13TeV-amcatnlo-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_041626/0000/myMicroAODOutputFile_129.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 1928.4366455078125
             }, 
             {
                 "bad": false, 
@@ -3455,9 +3674,12 @@
                 "weights": 1936.4478759765625
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/tZq_ll_4f_ckm_NLO_TuneCP5_13TeV-amcatnlo-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_041626/0000/myMicroAODOutputFile_306.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 1912.413818359375
             }, 
             {
                 "bad": false, 
@@ -3492,9 +3714,12 @@
                 "weights": 1990.238525390625
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/tZq_ll_4f_ckm_NLO_TuneCP5_13TeV-amcatnlo-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_041626/0000/myMicroAODOutputFile_283.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 1945.6041259765625
             }, 
             {
                 "bad": false, 
@@ -3505,9 +3730,12 @@
                 "weights": 1910.69775390625
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/tZq_ll_4f_ckm_NLO_TuneCP5_13TeV-amcatnlo-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_041626/0000/myMicroAODOutputFile_76.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 1960.48193359375
             }, 
             {
                 "bad": false, 
@@ -3638,9 +3866,12 @@
                 "weights": 1945.0318603515625
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/tZq_ll_4f_ckm_NLO_TuneCP5_13TeV-amcatnlo-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_041626/0000/myMicroAODOutputFile_294.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 2014.84423828125
             }, 
             {
                 "bad": false, 
@@ -3651,9 +3882,12 @@
                 "weights": 1915.275390625
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/tZq_ll_4f_ckm_NLO_TuneCP5_13TeV-amcatnlo-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_041626/0000/myMicroAODOutputFile_82.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 1932.4422607421875
             }, 
             {
                 "bad": false, 
@@ -3664,9 +3898,12 @@
                 "weights": 1956.4761962890625
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/tZq_ll_4f_ckm_NLO_TuneCP5_13TeV-amcatnlo-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_041626/0000/myMicroAODOutputFile_406.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 1915.8468017578125
             }, 
             {
                 "bad": false, 
@@ -3861,9 +4098,12 @@
                 "weights": 1916.9918212890625
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/tZq_ll_4f_ckm_NLO_TuneCP5_13TeV-amcatnlo-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_041626/0000/myMicroAODOutputFile_200.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 1913.5582275390625
             }, 
             {
                 "bad": false, 
@@ -3906,9 +4146,12 @@
                 "weights": 1959.9097900390625
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/tZq_ll_4f_ckm_NLO_TuneCP5_13TeV-amcatnlo-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_041626/0000/myMicroAODOutputFile_264.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 1847.75146484375
             }, 
             {
                 "bad": false, 
@@ -3919,9 +4162,12 @@
                 "weights": 1934.1591796875
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/tZq_ll_4f_ckm_NLO_TuneCP5_13TeV-amcatnlo-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_041626/0000/myMicroAODOutputFile_71.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 1998.2501220703125
             }, 
             {
                 "bad": false, 
@@ -3972,9 +4218,12 @@
                 "weights": 1908.40869140625
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/tZq_ll_4f_ckm_NLO_TuneCP5_13TeV-amcatnlo-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_041626/0000/myMicroAODOutputFile_13.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 1914.13037109375
             }, 
             {
                 "bad": false, 
@@ -4009,9 +4258,12 @@
                 "weights": 1923.286865234375
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/tZq_ll_4f_ckm_NLO_TuneCP5_13TeV-amcatnlo-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_041626/0000/myMicroAODOutputFile_362.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 1952.4703369140625
             }, 
             {
                 "bad": false, 
@@ -4030,9 +4282,12 @@
                 "weights": 1952.4705810546875
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/tZq_ll_4f_ckm_NLO_TuneCP5_13TeV-amcatnlo-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_041626/0000/myMicroAODOutputFile_277.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 1863.2021484375
             }, 
             {
                 "bad": false, 
@@ -4051,9 +4306,12 @@
                 "weights": 1939.3089599609375
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/tZq_ll_4f_ckm_NLO_TuneCP5_13TeV-amcatnlo-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_041626/0000/myMicroAODOutputFile_364.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 1860.340087890625
             }, 
             {
                 "bad": false, 
@@ -4096,9 +4354,12 @@
                 "weights": 1918.1357421875
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/tZq_ll_4f_ckm_NLO_TuneCP5_13TeV-amcatnlo-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_041626/0000/myMicroAODOutputFile_540.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 1894.674072265625
             }, 
             {
                 "bad": false, 
@@ -4173,9 +4434,12 @@
                 "weights": 1946.176513671875
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/tZq_ll_4f_ckm_NLO_TuneCP5_13TeV-amcatnlo-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_041626/0000/myMicroAODOutputFile_348.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 1995.961181640625
             }, 
             {
                 "bad": false, 
@@ -4194,9 +4458,12 @@
                 "weights": 1986.232421875
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/tZq_ll_4f_ckm_NLO_TuneCP5_13TeV-amcatnlo-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_041626/0000/myMicroAODOutputFile_296.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 1931.2987060546875
             }, 
             {
                 "bad": false, 
@@ -4207,9 +4474,12 @@
                 "weights": 1951.898193359375
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/tZq_ll_4f_ckm_NLO_TuneCP5_13TeV-amcatnlo-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_041626/0000/myMicroAODOutputFile_435.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 2008.5498046875
             }, 
             {
                 "bad": false, 
@@ -4364,9 +4634,12 @@
                 "weights": 2003.9722900390625
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/tZq_ll_4f_ckm_NLO_TuneCP5_13TeV-amcatnlo-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_041626/0000/myMicroAODOutputFile_161.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 2040.5953369140625
             }, 
             {
                 "bad": false, 
@@ -4425,9 +4698,12 @@
                 "weights": 1894.675048828125
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/tZq_ll_4f_ckm_NLO_TuneCP5_13TeV-amcatnlo-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_041626/0000/myMicroAODOutputFile_484.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 1929.008544921875
             }, 
             {
                 "bad": false, 
@@ -4582,9 +4858,12 @@
                 "weights": 1949.036865234375
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/tZq_ll_4f_ckm_NLO_TuneCP5_13TeV-amcatnlo-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_041626/0000/myMicroAODOutputFile_402.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 1950.181640625
             }, 
             {
                 "bad": false, 
@@ -4715,19 +4994,28 @@
                 "weights": 2006.2607421875
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/tZq_ll_4f_ckm_NLO_TuneCP5_13TeV-amcatnlo-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_041626/0000/myMicroAODOutputFile_517.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 1992.52685546875
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/tZq_ll_4f_ckm_NLO_TuneCP5_13TeV-amcatnlo-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_041626/0000/myMicroAODOutputFile_503.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 1888.95263671875
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/tZq_ll_4f_ckm_NLO_TuneCP5_13TeV-amcatnlo-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_041626/0000/myMicroAODOutputFile_470.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 1928.4356689453125
             }, 
             {
                 "bad": false, 
@@ -4762,9 +5050,12 @@
                 "weights": 1918.1358642578125
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/tZq_ll_4f_ckm_NLO_TuneCP5_13TeV-amcatnlo-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_041626/0000/myMicroAODOutputFile_482.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 1993.098876953125
             }, 
             {
                 "bad": false, 
@@ -4791,9 +5082,12 @@
                 "weights": 1880.94091796875
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/tZq_ll_4f_ckm_NLO_TuneCP5_13TeV-amcatnlo-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_041626/0000/myMicroAODOutputFile_7.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 1970.210693359375
             }, 
             {
                 "bad": false, 
@@ -4828,9 +5122,12 @@
                 "weights": 1925.5755615234375
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/tZq_ll_4f_ckm_NLO_TuneCP5_13TeV-amcatnlo-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_041626/0000/myMicroAODOutputFile_173.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 1942.1702880859375
             }, 
             {
                 "bad": false, 
@@ -4897,9 +5194,12 @@
                 "weights": 1970.2099609375
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/tZq_ll_4f_ckm_NLO_TuneCP5_13TeV-amcatnlo-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_041626/0000/myMicroAODOutputFile_271.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 1934.15869140625
             }, 
             {
                 "bad": false, 
@@ -4958,9 +5258,12 @@
                 "weights": 1998.8214111328125
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/tZq_ll_4f_ckm_NLO_TuneCP5_13TeV-amcatnlo-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_041626/0000/myMicroAODOutputFile_478.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 1968.492919921875
             }, 
             {
                 "bad": false, 
@@ -5011,9 +5314,12 @@
                 "weights": 1919.281005859375
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/tZq_ll_4f_ckm_NLO_TuneCP5_13TeV-amcatnlo-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_041626/0000/myMicroAODOutputFile_102.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 1965.06005859375
             }, 
             {
                 "bad": false, 
@@ -5032,9 +5338,12 @@
                 "weights": 2022.2833251953125
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/tZq_ll_4f_ckm_NLO_TuneCP5_13TeV-amcatnlo-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_041626/0000/myMicroAODOutputFile_232.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 1886.0906982421875
             }, 
             {
                 "bad": false, 
@@ -5045,14 +5354,20 @@
                 "weights": 1936.44873046875
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/tZq_ll_4f_ckm_NLO_TuneCP5_13TeV-amcatnlo-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_041626/0000/myMicroAODOutputFile_245.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 1943.31494140625
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/tZq_ll_4f_ckm_NLO_TuneCP5_13TeV-amcatnlo-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_041626/0000/myMicroAODOutputFile_372.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 1935.87548828125
             }, 
             {
                 "bad": false, 
@@ -5135,9 +5450,12 @@
                 "weights": 1931.870361328125
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/tZq_ll_4f_ckm_NLO_TuneCP5_13TeV-amcatnlo-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_041626/0000/myMicroAODOutputFile_143.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 1849.4683837890625
             }, 
             {
                 "bad": false, 
@@ -5284,9 +5602,12 @@
                 "weights": 2007.9775390625
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/tZq_ll_4f_ckm_NLO_TuneCP5_13TeV-amcatnlo-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_041626/0000/myMicroAODOutputFile_502.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 1945.6036376953125
             }, 
             {
                 "bad": false, 
@@ -5321,9 +5642,12 @@
                 "weights": 2029.7230224609375
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/tZq_ll_4f_ckm_NLO_TuneCP5_13TeV-amcatnlo-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_041626/0000/myMicroAODOutputFile_67.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 1990.23779296875
             }, 
             {
                 "bad": false, 
@@ -5454,9 +5778,12 @@
                 "weights": 1955.904052734375
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/tZq_ll_4f_ckm_NLO_TuneCP5_13TeV-amcatnlo-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_041626/0000/myMicroAODOutputFile_259.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 1941.0250244140625
             }, 
             {
                 "bad": false, 
@@ -5467,9 +5794,12 @@
                 "weights": 1919.2802734375
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/tZq_ll_4f_ckm_NLO_TuneCP5_13TeV-amcatnlo-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_041626/0000/myMicroAODOutputFile_345.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 1931.8702392578125
             }, 
             {
                 "bad": false, 
@@ -5496,9 +5826,12 @@
                 "weights": 1902.6859130859375
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/tZq_ll_4f_ckm_NLO_TuneCP5_13TeV-amcatnlo-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_041626/0000/myMicroAODOutputFile_379.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 1942.169677734375
             }, 
             {
                 "bad": false, 
@@ -5533,9 +5866,12 @@
                 "weights": 1879.2247314453125
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/tZq_ll_4f_ckm_NLO_TuneCP5_13TeV-amcatnlo-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_041626/0000/myMicroAODOutputFile_533.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 1965.0595703125
             }, 
             {
                 "bad": false, 
@@ -5610,9 +5946,12 @@
                 "weights": 1896.9639892578125
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/tZq_ll_4f_ckm_NLO_TuneCP5_13TeV-amcatnlo-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_041626/0000/myMicroAODOutputFile_340.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 1846.033935546875
             }, 
             {
                 "bad": false, 
@@ -5655,9 +5994,12 @@
                 "weights": 1904.974853515625
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/tZq_ll_4f_ckm_NLO_TuneCP5_13TeV-amcatnlo-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_041626/0000/myMicroAODOutputFile_216.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 1954.186767578125
             }, 
             {
                 "bad": false, 
@@ -5740,9 +6082,12 @@
                 "weights": 2006.260986328125
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/tZq_ll_4f_ckm_NLO_TuneCP5_13TeV-amcatnlo-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_041626/0000/myMicroAODOutputFile_184.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 1957.0482177734375
             }, 
             {
                 "bad": false, 
@@ -5849,9 +6194,12 @@
                 "weights": 1998.2493896484375
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/tZq_ll_4f_ckm_NLO_TuneCP5_13TeV-amcatnlo-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_041626/0000/myMicroAODOutputFile_72.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 1912.985595703125
             }, 
             {
                 "bad": false, 
@@ -5878,9 +6226,12 @@
                 "weights": 1890.669677734375
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/tZq_ll_4f_ckm_NLO_TuneCP5_13TeV-amcatnlo-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_041626/0000/myMicroAODOutputFile_174.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 1956.476318359375
             }, 
             {
                 "bad": false, 
@@ -5907,9 +6258,12 @@
                 "weights": 1892.3857421875
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/tZq_ll_4f_ckm_NLO_TuneCP5_13TeV-amcatnlo-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_041626/0000/myMicroAODOutputFile_549.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 1890.6690673828125
             }, 
             {
                 "bad": false, 
@@ -5920,14 +6274,20 @@
                 "weights": 1938.7379150390625
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/tZq_ll_4f_ckm_NLO_TuneCP5_13TeV-amcatnlo-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_041626/0000/myMicroAODOutputFile_89.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 2028.005859375
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/tZq_ll_4f_ckm_NLO_TuneCP5_13TeV-amcatnlo-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_041626/0000/myMicroAODOutputFile_469.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 1921.5694580078125
             }
         ], 
         "parent_n_units": null, 

--- a/MetaData/data/Era2017_legacy_v1_Summer20UL/datasets_37.json
+++ b/MetaData/data/Era2017_legacy_v1_Summer20UL/datasets_37.json
@@ -19,9 +19,12 @@
                 "weights": 8917554.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24951, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/WGToLNuG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_044922/0000/myMicroAODOutputFile_978.root", 
-                "nevents": 24951
+                "nevents": 24951, 
+                "totEvents": 24951, 
+                "weights": 8899736.0
             }, 
             {
                 "bad": false, 
@@ -120,9 +123,12 @@
                 "weights": 8964484.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24912, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/WGToLNuG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_044922/0000/myMicroAODOutputFile_210.root", 
-                "nevents": 24912
+                "nevents": 24912, 
+                "totEvents": 24912, 
+                "weights": 8876565.0
             }, 
             {
                 "bad": false, 
@@ -141,14 +147,20 @@
                 "weights": 8832010.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24922, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/WGToLNuG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_044922/0000/myMicroAODOutputFile_104.root", 
-                "nevents": 24922
+                "nevents": 24922, 
+                "totEvents": 24922, 
+                "weights": 8889633.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24962, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/WGToLNuG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_044922/0000/myMicroAODOutputFile_604.root", 
-                "nevents": 24962
+                "nevents": 24962, 
+                "totEvents": 24962, 
+                "weights": 8959732.0
             }, 
             {
                 "bad": false, 
@@ -167,9 +179,12 @@
                 "weights": 9046466.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24827, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/WGToLNuG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_044922/0000/myMicroAODOutputFile_150.root", 
-                "nevents": 24827
+                "nevents": 24827, 
+                "totEvents": 24827, 
+                "weights": 8912796.0
             }, 
             {
                 "bad": false, 
@@ -220,19 +235,28 @@
                 "weights": 8951419.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25053, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/WGToLNuG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_044922/0000/myMicroAODOutputFile_369.root", 
-                "nevents": 25053
+                "nevents": 25053, 
+                "totEvents": 25053, 
+                "weights": 8854583.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24934, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/WGToLNuG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_044922/0001/myMicroAODOutputFile_1076.root", 
-                "nevents": 24934
+                "nevents": 24934, 
+                "totEvents": 24934, 
+                "weights": 8874188.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24960, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/WGToLNuG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_044922/0000/myMicroAODOutputFile_956.root", 
-                "nevents": 24960
+                "nevents": 24960, 
+                "totEvents": 24960, 
+                "weights": 8875376.0
             }, 
             {
                 "bad": false, 
@@ -331,9 +355,12 @@
                 "weights": 8738740.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24975, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/WGToLNuG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_044922/0000/myMicroAODOutputFile_844.root", 
-                "nevents": 24975
+                "nevents": 24975, 
+                "totEvents": 24975, 
+                "weights": 8925871.0
             }, 
             {
                 "bad": false, 
@@ -344,9 +371,12 @@
                 "weights": 9022704.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24898, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/WGToLNuG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_044922/0000/myMicroAODOutputFile_824.root", 
-                "nevents": 24898
+                "nevents": 24898, 
+                "totEvents": 24898, 
+                "weights": 8861116.0
             }, 
             {
                 "bad": false, 
@@ -429,9 +459,12 @@
                 "weights": 8986468.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24834, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/WGToLNuG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_044922/0000/myMicroAODOutputFile_625.root", 
-                "nevents": 24834
+                "nevents": 24834, 
+                "totEvents": 24834, 
+                "weights": 8945472.0
             }, 
             {
                 "bad": false, 
@@ -490,9 +523,12 @@
                 "weights": 9004885.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24937, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/WGToLNuG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_044922/0001/myMicroAODOutputFile_1036.root", 
-                "nevents": 24937
+                "nevents": 24937, 
+                "totEvents": 24937, 
+                "weights": 8853392.0
             }, 
             {
                 "bad": false, 
@@ -687,9 +723,12 @@
                 "weights": 8761316.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25051, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/WGToLNuG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_044922/0000/myMicroAODOutputFile_946.root", 
-                "nevents": 25051
+                "nevents": 25051, 
+                "totEvents": 25051, 
+                "weights": 8858146.0
             }, 
             {
                 "bad": false, 
@@ -764,9 +803,12 @@
                 "weights": 8932997.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24987, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/WGToLNuG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_044922/0000/myMicroAODOutputFile_817.root", 
-                "nevents": 24987
+                "nevents": 24987, 
+                "totEvents": 24987, 
+                "weights": 8866465.0
             }, 
             {
                 "bad": false, 
@@ -777,9 +819,12 @@
                 "weights": 9104090.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24928, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/WGToLNuG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_044922/0000/myMicroAODOutputFile_921.root", 
-                "nevents": 24928
+                "nevents": 24928, 
+                "totEvents": 24928, 
+                "weights": 9063104.0
             }, 
             {
                 "bad": false, 
@@ -830,14 +875,20 @@
                 "weights": 8865275.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24937, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/WGToLNuG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_044922/0001/myMicroAODOutputFile_1124.root", 
-                "nevents": 24937
+                "nevents": 24937, 
+                "totEvents": 24937, 
+                "weights": 8917553.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24950, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/WGToLNuG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_044922/0001/myMicroAODOutputFile_1099.root", 
-                "nevents": 24950
+                "nevents": 24950, 
+                "totEvents": 24950, 
+                "weights": 9010824.0
             }, 
             {
                 "bad": false, 
@@ -848,9 +899,12 @@
                 "weights": 8818942.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24935, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/WGToLNuG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_044922/0000/myMicroAODOutputFile_556.root", 
-                "nevents": 24935
+                "nevents": 24935, 
+                "totEvents": 24935, 
+                "weights": 8998347.0
             }, 
             {
                 "bad": false, 
@@ -869,9 +923,12 @@
                 "weights": 8826661.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24726, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/WGToLNuG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_044922/0000/myMicroAODOutputFile_384.root", 
-                "nevents": 24726
+                "nevents": 24726, 
+                "totEvents": 24726, 
+                "weights": 8661517.0
             }, 
             {
                 "bad": false, 
@@ -882,9 +939,12 @@
                 "weights": 8948447.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25007, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/WGToLNuG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_044922/0000/myMicroAODOutputFile_708.root", 
-                "nevents": 25007
+                "nevents": 25007, 
+                "totEvents": 25007, 
+                "weights": 8998349.0
             }, 
             {
                 "bad": false, 
@@ -911,9 +971,12 @@
                 "weights": 8925278.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25128, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/WGToLNuG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_044922/0000/myMicroAODOutputFile_958.root", 
-                "nevents": 25128
+                "nevents": 25128, 
+                "totEvents": 25128, 
+                "weights": 8863491.0
             }, 
             {
                 "bad": false, 
@@ -940,9 +1003,12 @@
                 "weights": 8935970.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24910, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/WGToLNuG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_044922/0001/myMicroAODOutputFile_1055.root", 
-                "nevents": 24910
+                "nevents": 24910, 
+                "totEvents": 24910, 
+                "weights": 8772009.0
             }, 
             {
                 "bad": false, 
@@ -993,9 +1059,12 @@
                 "weights": 8867653.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24973, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/WGToLNuG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_044922/0000/myMicroAODOutputFile_277.root", 
-                "nevents": 24973
+                "nevents": 24973, 
+                "totEvents": 24973, 
+                "weights": 8871217.0
             }, 
             {
                 "bad": false, 
@@ -1030,14 +1099,20 @@
                 "weights": 8924683.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24745, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/WGToLNuG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_044922/0000/myMicroAODOutputFile_640.root", 
-                "nevents": 24745
+                "nevents": 24745, 
+                "totEvents": 24745, 
+                "weights": 8815375.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24878, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/WGToLNuG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_044922/0000/myMicroAODOutputFile_716.root", 
-                "nevents": 24878
+                "nevents": 24878, 
+                "totEvents": 24878, 
+                "weights": 8940725.0
             }, 
             {
                 "bad": false, 
@@ -1104,9 +1179,12 @@
                 "weights": 8957357.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24869, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/WGToLNuG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_044922/0000/myMicroAODOutputFile_970.root", 
-                "nevents": 24869
+                "nevents": 24869, 
+                "totEvents": 24869, 
+                "weights": 8792802.0
             }, 
             {
                 "bad": false, 
@@ -1117,9 +1195,12 @@
                 "weights": 8846862.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24971, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/WGToLNuG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_044922/0000/myMicroAODOutputFile_882.root", 
-                "nevents": 24971
+                "nevents": 24971, 
+                "totEvents": 24971, 
+                "weights": 8986466.0
             }, 
             {
                 "bad": false, 
@@ -1162,14 +1243,20 @@
                 "weights": 8794585.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24936, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/WGToLNuG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_044922/0000/myMicroAODOutputFile_762.root", 
-                "nevents": 24936
+                "nevents": 24936, 
+                "totEvents": 24936, 
+                "weights": 8777950.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24726, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/WGToLNuG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_044922/0000/myMicroAODOutputFile_794.root", 
-                "nevents": 24726
+                "nevents": 24726, 
+                "totEvents": 24726, 
+                "weights": 8874190.0
             }, 
             {
                 "bad": false, 
@@ -1188,9 +1275,12 @@
                 "weights": 8931218.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24880, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/WGToLNuG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_044922/0001/myMicroAODOutputFile_1128.root", 
-                "nevents": 24880
+                "nevents": 24880, 
+                "totEvents": 24880, 
+                "weights": 8673394.0
             }, 
             {
                 "bad": false, 
@@ -1209,9 +1299,12 @@
                 "weights": 8859338.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25051, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/WGToLNuG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_044922/0000/myMicroAODOutputFile_567.root", 
-                "nevents": 25051
+                "nevents": 25051, 
+                "totEvents": 25051, 
+                "weights": 8874782.0
             }, 
             {
                 "bad": false, 
@@ -1374,9 +1467,12 @@
                 "weights": 8877751.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24914, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/WGToLNuG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_044922/0000/myMicroAODOutputFile_727.root", 
-                "nevents": 24914
+                "nevents": 24914, 
+                "totEvents": 24914, 
+                "weights": 8900327.0
             }, 
             {
                 "bad": false, 
@@ -1419,9 +1515,12 @@
                 "weights": 8924683.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24854, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/WGToLNuG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_044922/0000/myMicroAODOutputFile_3.root", 
-                "nevents": 24854
+                "nevents": 24854, 
+                "totEvents": 24854, 
+                "weights": 8786265.0
             }, 
             {
                 "bad": false, 
@@ -1600,9 +1699,12 @@
                 "weights": 8774386.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24917, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/WGToLNuG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_044922/0000/myMicroAODOutputFile_17.root", 
-                "nevents": 24917
+                "nevents": 24917, 
+                "totEvents": 24917, 
+                "weights": 9047061.0
             }, 
             {
                 "bad": false, 
@@ -1741,9 +1843,12 @@
                 "weights": 8823096.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24775, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/WGToLNuG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_044922/0000/myMicroAODOutputFile_245.root", 
-                "nevents": 24775
+                "nevents": 24775, 
+                "totEvents": 24775, 
+                "weights": 8824881.0
             }, 
             {
                 "bad": false, 
@@ -1770,9 +1875,12 @@
                 "weights": 8772604.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24688, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/WGToLNuG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_044922/0000/myMicroAODOutputFile_84.root", 
-                "nevents": 24688
+                "nevents": 24688, 
+                "totEvents": 24688, 
+                "weights": 8817156.0
             }, 
             {
                 "bad": false, 
@@ -1783,14 +1891,20 @@
                 "weights": 8945479.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24854, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/WGToLNuG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_044922/0000/myMicroAODOutputFile_247.root", 
-                "nevents": 24854
+                "nevents": 24854, 
+                "totEvents": 24854, 
+                "weights": 8843298.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24916, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/WGToLNuG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_044922/0000/myMicroAODOutputFile_549.root", 
-                "nevents": 24916
+                "nevents": 24916, 
+                "totEvents": 24916, 
+                "weights": 8774383.0
             }, 
             {
                 "bad": false, 
@@ -1905,9 +2019,12 @@
                 "weights": 8873002.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24846, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/WGToLNuG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_044922/0000/myMicroAODOutputFile_99.root", 
-                "nevents": 24846
+                "nevents": 24846, 
+                "totEvents": 24846, 
+                "weights": 8815971.0
             }, 
             {
                 "bad": false, 
@@ -2006,9 +2123,12 @@
                 "weights": 8926463.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24923, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/WGToLNuG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_044922/0000/myMicroAODOutputFile_87.root", 
-                "nevents": 24923
+                "nevents": 24923, 
+                "totEvents": 24923, 
+                "weights": 8817752.0
             }, 
             {
                 "bad": false, 
@@ -2027,14 +2147,20 @@
                 "weights": 8907459.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24736, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/WGToLNuG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_044922/0000/myMicroAODOutputFile_454.root", 
-                "nevents": 24736
+                "nevents": 24736, 
+                "totEvents": 24736, 
+                "weights": 8887260.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24991, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/WGToLNuG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_044922/0000/myMicroAODOutputFile_930.root", 
-                "nevents": 24991
+                "nevents": 24991, 
+                "totEvents": 24991, 
+                "weights": 8764286.0
             }, 
             {
                 "bad": false, 
@@ -2141,9 +2267,12 @@
                 "weights": 8982901.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24864, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/WGToLNuG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_044922/0000/myMicroAODOutputFile_918.root", 
-                "nevents": 24864
+                "nevents": 24864, 
+                "totEvents": 24864, 
+                "weights": 8824289.0
             }, 
             {
                 "bad": false, 
@@ -2234,9 +2363,12 @@
                 "weights": 8862307.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24896, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/WGToLNuG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_044922/0000/myMicroAODOutputFile_792.root", 
-                "nevents": 24896
+                "nevents": 24896, 
+                "totEvents": 24896, 
+                "weights": 8935968.0
             }, 
             {
                 "bad": false, 
@@ -2367,9 +2499,12 @@
                 "weights": 8944885.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24944, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/WGToLNuG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_044922/0000/myMicroAODOutputFile_9.root", 
-                "nevents": 24944
+                "nevents": 24944, 
+                "totEvents": 24944, 
+                "weights": 8830227.0
             }, 
             {
                 "bad": false, 
@@ -2572,19 +2707,28 @@
                 "weights": 8914583.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24788, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/WGToLNuG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_044922/0000/myMicroAODOutputFile_123.root", 
-                "nevents": 24788
+                "nevents": 24788, 
+                "totEvents": 24788, 
+                "weights": 8852802.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24721, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/WGToLNuG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_044922/0000/myMicroAODOutputFile_20.root", 
-                "nevents": 24721
+                "nevents": 24721, 
+                "totEvents": 24721, 
+                "weights": 8845079.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/WGToLNuG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_044922/0000/myMicroAODOutputFile_224.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 8833792.0
             }, 
             {
                 "bad": false, 
@@ -2963,9 +3107,12 @@
                 "weights": 8883694.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25060, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/WGToLNuG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_044922/0000/myMicroAODOutputFile_353.root", 
-                "nevents": 25060
+                "nevents": 25060, 
+                "totEvents": 25060, 
+                "weights": 8878942.0
             }, 
             {
                 "bad": false, 
@@ -3000,9 +3147,12 @@
                 "weights": 8955577.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25064, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/WGToLNuG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_044922/0000/myMicroAODOutputFile_890.root", 
-                "nevents": 25064
+                "nevents": 25064, 
+                "totEvents": 25064, 
+                "weights": 9091616.0
             }, 
             {
                 "bad": false, 
@@ -3013,9 +3163,12 @@
                 "weights": 8879534.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25002, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/WGToLNuG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_044922/0000/myMicroAODOutputFile_428.root", 
-                "nevents": 25002
+                "nevents": 25002, 
+                "totEvents": 25002, 
+                "weights": 8863496.0
             }, 
             {
                 "bad": false, 
@@ -3074,9 +3227,12 @@
                 "weights": 9006668.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25025, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/WGToLNuG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_044922/0000/myMicroAODOutputFile_933.root", 
-                "nevents": 25025
+                "nevents": 25025, 
+                "totEvents": 25025, 
+                "weights": 8936567.0
             }, 
             {
                 "bad": false, 
@@ -3135,9 +3291,12 @@
                 "weights": 8878346.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24869, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/WGToLNuG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_044922/0000/myMicroAODOutputFile_443.root", 
-                "nevents": 24869
+                "nevents": 24869, 
+                "totEvents": 24869, 
+                "weights": 8904483.0
             }, 
             {
                 "bad": false, 
@@ -3172,9 +3331,12 @@
                 "weights": 8804090.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24724, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/WGToLNuG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_044922/0000/myMicroAODOutputFile_832.root", 
-                "nevents": 24724
+                "nevents": 24724, 
+                "totEvents": 24724, 
+                "weights": 8897947.0
             }, 
             {
                 "bad": false, 
@@ -3377,9 +3539,12 @@
                 "weights": 8943098.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25080, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/WGToLNuG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_044922/0000/myMicroAODOutputFile_838.root", 
-                "nevents": 25080
+                "nevents": 25080, 
+                "totEvents": 25080, 
+                "weights": 9025082.0
             }, 
             {
                 "bad": false, 
@@ -3654,9 +3819,12 @@
                 "weights": 8898545.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25025, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/WGToLNuG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_044922/0000/myMicroAODOutputFile_468.root", 
-                "nevents": 25025
+                "nevents": 25025, 
+                "totEvents": 25025, 
+                "weights": 8980527.0
             }, 
             {
                 "bad": false, 
@@ -3731,9 +3899,12 @@
                 "weights": 8759534.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24842, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/WGToLNuG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_044922/0000/myMicroAODOutputFile_37.root", 
-                "nevents": 24842
+                "nevents": 24842, 
+                "totEvents": 24842, 
+                "weights": 8890823.0
             }, 
             {
                 "bad": false, 
@@ -3744,9 +3915,12 @@
                 "weights": 8946072.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24956, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/WGToLNuG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_044922/0000/myMicroAODOutputFile_458.root", 
-                "nevents": 24956
+                "nevents": 24956, 
+                "totEvents": 24956, 
+                "weights": 8943097.0
             }, 
             {
                 "bad": false, 
@@ -3821,9 +3995,12 @@
                 "weights": 8735772.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24948, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/WGToLNuG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_044922/0000/myMicroAODOutputFile_945.root", 
-                "nevents": 24948
+                "nevents": 24948, 
+                "totEvents": 24948, 
+                "weights": 8940723.0
             }, 
             {
                 "bad": false, 
@@ -3970,9 +4147,12 @@
                 "weights": 8849237.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25159, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/WGToLNuG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_044922/0000/myMicroAODOutputFile_70.root", 
-                "nevents": 25159
+                "nevents": 25159, 
+                "totEvents": 25159, 
+                "weights": 8968644.0
             }, 
             {
                 "bad": false, 
@@ -3991,14 +4171,20 @@
                 "weights": 8913398.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24911, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/WGToLNuG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_044922/0000/myMicroAODOutputFile_342.root", 
-                "nevents": 24911
+                "nevents": 24911, 
+                "totEvents": 24911, 
+                "weights": 8878344.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24986, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/WGToLNuG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_044922/0000/myMicroAODOutputFile_427.root", 
-                "nevents": 24986
+                "nevents": 24986, 
+                "totEvents": 24986, 
+                "weights": 8989439.0
             }, 
             {
                 "bad": false, 
@@ -4065,9 +4251,12 @@
                 "weights": 8852210.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24840, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/WGToLNuG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_044922/0000/myMicroAODOutputFile_433.root", 
-                "nevents": 24840
+                "nevents": 24840, 
+                "totEvents": 24840, 
+                "weights": 8849237.0
             }, 
             {
                 "bad": false, 
@@ -4086,9 +4275,12 @@
                 "weights": 8778538.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24917, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/WGToLNuG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_044922/0000/myMicroAODOutputFile_338.root", 
-                "nevents": 24917
+                "nevents": 24917, 
+                "totEvents": 24917, 
+                "weights": 8877160.0
             }, 
             {
                 "bad": false, 
@@ -4227,9 +4419,12 @@
                 "weights": 8870029.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24797, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/WGToLNuG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_044922/0000/myMicroAODOutputFile_359.root", 
-                "nevents": 24797
+                "nevents": 24797, 
+                "totEvents": 24797, 
+                "weights": 8952013.0
             }, 
             {
                 "bad": false, 
@@ -4240,9 +4435,12 @@
                 "weights": 8788642.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24979, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/WGToLNuG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_044922/0000/myMicroAODOutputFile_354.root", 
-                "nevents": 24979
+                "nevents": 24979, 
+                "totEvents": 24979, 
+                "weights": 8969835.0
             }, 
             {
                 "bad": false, 
@@ -4301,9 +4499,12 @@
                 "weights": 8986467.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25146, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/WGToLNuG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_044922/0000/myMicroAODOutputFile_597.root", 
-                "nevents": 25146
+                "nevents": 25146, 
+                "totEvents": 25146, 
+                "weights": 9023894.0
             }, 
             {
                 "bad": false, 
@@ -4338,9 +4539,12 @@
                 "weights": 8962703.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24753, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/WGToLNuG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_044922/0000/myMicroAODOutputFile_644.root", 
-                "nevents": 24753
+                "nevents": 24753, 
+                "totEvents": 24753, 
+                "weights": 8798742.0
             }, 
             {
                 "bad": false, 
@@ -4359,14 +4563,20 @@
                 "weights": 8864685.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24832, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/WGToLNuG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_044922/0000/myMicroAODOutputFile_560.root", 
-                "nevents": 24832
+                "nevents": 24832, 
+                "totEvents": 24832, 
+                "weights": 8814780.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25147, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/WGToLNuG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_044922/0000/myMicroAODOutputFile_205.root", 
-                "nevents": 25147
+                "nevents": 25147, 
+                "totEvents": 25147, 
+                "weights": 9039932.0
             }, 
             {
                 "bad": false, 
@@ -4465,9 +4675,12 @@
                 "weights": 8919931.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24952, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/WGToLNuG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_044922/0001/myMicroAODOutputFile_1100.root", 
-                "nevents": 24952
+                "nevents": 24952, 
+                "totEvents": 24952, 
+                "weights": 8805274.0
             }, 
             {
                 "bad": false, 
@@ -4502,9 +4715,12 @@
                 "weights": 8855771.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24817, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/WGToLNuG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_044922/0000/myMicroAODOutputFile_460.root", 
-                "nevents": 24817
+                "nevents": 24817, 
+                "totEvents": 24817, 
+                "weights": 8886664.0
             }, 
             {
                 "bad": false, 
@@ -4523,9 +4739,12 @@
                 "weights": 8699531.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24994, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/WGToLNuG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_044922/0000/myMicroAODOutputFile_571.root", 
-                "nevents": 24994
+                "nevents": 24994, 
+                "totEvents": 24994, 
+                "weights": 8831412.0
             }, 
             {
                 "bad": false, 
@@ -4568,14 +4787,20 @@
                 "weights": 8887258.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24819, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/WGToLNuG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_044922/0000/myMicroAODOutputFile_593.root", 
-                "nevents": 24819
+                "nevents": 24819, 
+                "totEvents": 24819, 
+                "weights": 8813000.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24865, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/WGToLNuG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_044922/0000/myMicroAODOutputFile_380.root", 
-                "nevents": 24865
+                "nevents": 24865, 
+                "totEvents": 24865, 
+                "weights": 8935376.0
             }, 
             {
                 "bad": false, 
@@ -4714,9 +4939,12 @@
                 "weights": 8827255.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24845, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/WGToLNuG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_044922/0000/myMicroAODOutputFile_263.root", 
-                "nevents": 24845
+                "nevents": 24845, 
+                "totEvents": 24845, 
+                "weights": 8827257.0
             }, 
             {
                 "bad": false, 
@@ -4783,9 +5011,12 @@
                 "weights": 8852207.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24803, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/WGToLNuG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_044922/0000/myMicroAODOutputFile_398.root", 
-                "nevents": 24803
+                "nevents": 24803, 
+                "totEvents": 24803, 
+                "weights": 8840327.0
             }, 
             {
                 "bad": false, 
@@ -4796,9 +5027,12 @@
                 "weights": 8971614.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24771, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/WGToLNuG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_044922/0000/myMicroAODOutputFile_118.root", 
-                "nevents": 24771
+                "nevents": 24771, 
+                "totEvents": 24771, 
+                "weights": 8868842.0
             }, 
             {
                 "bad": false, 
@@ -4849,9 +5083,12 @@
                 "weights": 8879531.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24815, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/WGToLNuG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_044922/0000/myMicroAODOutputFile_612.root", 
-                "nevents": 24815
+                "nevents": 24815, 
+                "totEvents": 24815, 
+                "weights": 9014982.0
             }, 
             {
                 "bad": false, 
@@ -5054,9 +5291,12 @@
                 "weights": 8862305.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24927, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/WGToLNuG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_044922/0000/myMicroAODOutputFile_822.root", 
-                "nevents": 24927
+                "nevents": 24927, 
+                "totEvents": 24927, 
+                "weights": 8751217.0
             }, 
             {
                 "bad": false, 
@@ -5163,9 +5403,12 @@
                 "weights": 8872406.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24926, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/WGToLNuG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_044922/0000/myMicroAODOutputFile_783.root", 
-                "nevents": 24926
+                "nevents": 24926, 
+                "totEvents": 24926, 
+                "weights": 8804089.0
             }, 
             {
                 "bad": false, 
@@ -5184,9 +5427,12 @@
                 "weights": 8953792.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24892, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/WGToLNuG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_044922/0000/myMicroAODOutputFile_695.root", 
-                "nevents": 24892
+                "nevents": 24892, 
+                "totEvents": 24892, 
+                "weights": 8977560.0
             }, 
             {
                 "bad": false, 
@@ -5285,9 +5531,12 @@
                 "weights": 8957953.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24992, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/WGToLNuG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_044922/0000/myMicroAODOutputFile_516.root", 
-                "nevents": 24992
+                "nevents": 24992, 
+                "totEvents": 24992, 
+                "weights": 8962108.0
             }, 
             {
                 "bad": false, 
@@ -5354,9 +5603,12 @@
                 "weights": 8899728.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25008, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/WGToLNuG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_044922/0000/myMicroAODOutputFile_996.root", 
-                "nevents": 25008
+                "nevents": 25008, 
+                "totEvents": 25008, 
+                "weights": 8834980.0
             }, 
             {
                 "bad": false, 
@@ -5423,9 +5675,12 @@
                 "weights": 8927060.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25058, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/WGToLNuG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_044922/0000/myMicroAODOutputFile_804.root", 
-                "nevents": 25058
+                "nevents": 25058, 
+                "totEvents": 25058, 
+                "weights": 8905081.0
             }, 
             {
                 "bad": false, 
@@ -5444,9 +5699,12 @@
                 "weights": 8962704.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24979, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/WGToLNuG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_044922/0000/myMicroAODOutputFile_833.root", 
-                "nevents": 24979
+                "nevents": 24979, 
+                "totEvents": 24979, 
+                "weights": 8990032.0
             }, 
             {
                 "bad": false, 
@@ -5561,9 +5819,12 @@
                 "weights": 8791015.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24914, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/WGToLNuG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_044922/0000/myMicroAODOutputFile_973.root", 
-                "nevents": 24914
+                "nevents": 24914, 
+                "totEvents": 24914, 
+                "weights": 8962113.0
             }, 
             {
                 "bad": false, 
@@ -5638,9 +5899,12 @@
                 "weights": 8825478.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24839, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/WGToLNuG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_044922/0000/myMicroAODOutputFile_916.root", 
-                "nevents": 24839
+                "nevents": 24839, 
+                "totEvents": 24839, 
+                "weights": 8840327.0
             }, 
             {
                 "bad": false, 
@@ -5683,9 +5947,12 @@
                 "weights": 8905672.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24942, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/WGToLNuG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_044922/0000/myMicroAODOutputFile_191.root", 
-                "nevents": 24942
+                "nevents": 24942, 
+                "totEvents": 24942, 
+                "weights": 8874190.0
             }, 
             {
                 "bad": false, 
@@ -5728,9 +5995,12 @@
                 "weights": 8841514.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24902, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/WGToLNuG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_044922/0000/myMicroAODOutputFile_908.root", 
-                "nevents": 24902
+                "nevents": 24902, 
+                "totEvents": 24902, 
+                "weights": 8836165.0
             }, 
             {
                 "bad": false, 
@@ -5749,9 +6019,12 @@
                 "weights": 8760724.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25025, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/WGToLNuG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_044922/0001/myMicroAODOutputFile_1031.root", 
-                "nevents": 25025
+                "nevents": 25025, 
+                "totEvents": 25025, 
+                "weights": 8696559.0
             }, 
             {
                 "bad": false, 
@@ -5778,9 +6051,12 @@
                 "weights": 8696559.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25021, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/WGToLNuG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_044922/0001/myMicroAODOutputFile_1061.root", 
-                "nevents": 25021
+                "nevents": 25021, 
+                "totEvents": 25021, 
+                "weights": 9009039.0
             }, 
             {
                 "bad": false, 
@@ -5799,9 +6075,12 @@
                 "weights": 8922901.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24975, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/WGToLNuG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_044922/0000/myMicroAODOutputFile_677.root", 
-                "nevents": 24975
+                "nevents": 24975, 
+                "totEvents": 24975, 
+                "weights": 8858150.0
             }, 
             {
                 "bad": false, 
@@ -5812,9 +6091,12 @@
                 "weights": 8880126.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24961, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/WGToLNuG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_044922/0001/myMicroAODOutputFile_1091.root", 
-                "nevents": 24961
+                "nevents": 24961, 
+                "totEvents": 24961, 
+                "weights": 8815376.0
             }, 
             {
                 "bad": false, 
@@ -5865,9 +6147,12 @@
                 "weights": 8973992.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24970, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/WGToLNuG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_044922/0000/myMicroAODOutputFile_881.root", 
-                "nevents": 24970
+                "nevents": 24970, 
+                "totEvents": 24970, 
+                "weights": 8871812.0
             }, 
             {
                 "bad": false, 
@@ -6006,9 +6291,12 @@
                 "weights": 8881912.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25054, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/WGToLNuG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_044922/0000/myMicroAODOutputFile_291.root", 
-                "nevents": 25054
+                "nevents": 25054, 
+                "totEvents": 25054, 
+                "weights": 8859928.0
             }, 
             {
                 "bad": false, 
@@ -6083,9 +6371,12 @@
                 "weights": 8931809.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25085, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/WGToLNuG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_044922/0000/myMicroAODOutputFile_160.root", 
-                "nevents": 25085
+                "nevents": 25085, 
+                "totEvents": 25085, 
+                "weights": 8915179.0
             }, 
             {
                 "bad": false, 
@@ -6096,9 +6387,12 @@
                 "weights": 8839138.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25036, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/WGToLNuG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_044922/0000/myMicroAODOutputFile_969.root", 
-                "nevents": 25036
+                "nevents": 25036, 
+                "totEvents": 25036, 
+                "weights": 8981119.0
             }, 
             {
                 "bad": false, 
@@ -6205,9 +6499,12 @@
                 "weights": 8843299.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24876, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/WGToLNuG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_044922/0000/myMicroAODOutputFile_859.root", 
-                "nevents": 24876
+                "nevents": 24876, 
+                "totEvents": 24876, 
+                "weights": 8871810.0
             }, 
             {
                 "bad": false, 
@@ -6242,14 +6539,20 @@
                 "weights": 9001913.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24805, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/WGToLNuG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_044922/0000/myMicroAODOutputFile_491.root", 
-                "nevents": 24805
+                "nevents": 24805, 
+                "totEvents": 24805, 
+                "weights": 8812997.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25056, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/WGToLNuG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_044922/0000/myMicroAODOutputFile_273.root", 
-                "nevents": 25056
+                "nevents": 25056, 
+                "totEvents": 25056, 
+                "weights": 8945475.0
             }, 
             {
                 "bad": false, 
@@ -6292,9 +6595,12 @@
                 "weights": 9025676.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24960, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/WGToLNuG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_044922/0000/myMicroAODOutputFile_983.root", 
-                "nevents": 24960
+                "nevents": 24960, 
+                "totEvents": 24960, 
+                "weights": 9026272.0
             }, 
             {
                 "bad": false, 
@@ -6601,9 +6907,12 @@
                 "weights": 8815970.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24836, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/WGToLNuG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_044922/0000/myMicroAODOutputFile_511.root", 
-                "nevents": 24836
+                "nevents": 24836, 
+                "totEvents": 24836, 
+                "weights": 9064290.0
             }, 
             {
                 "bad": false, 
@@ -6646,9 +6955,12 @@
                 "weights": 8925280.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24731, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/WGToLNuG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_044922/0000/myMicroAODOutputFile_647.root", 
-                "nevents": 24731
+                "nevents": 24731, 
+                "totEvents": 24731, 
+                "weights": 8884286.0
             }, 
             {
                 "bad": false, 
@@ -6675,9 +6987,12 @@
                 "weights": 8817749.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24881, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/WGToLNuG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_044922/0000/myMicroAODOutputFile_712.root", 
-                "nevents": 24881
+                "nevents": 24881, 
+                "totEvents": 24881, 
+                "weights": 8867652.0
             }, 
             {
                 "bad": false, 
@@ -6728,9 +7043,12 @@
                 "weights": 8872412.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24880, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/WGToLNuG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_044922/0000/myMicroAODOutputFile_422.root", 
-                "nevents": 24880
+                "nevents": 24880, 
+                "totEvents": 24880, 
+                "weights": 8694779.0
             }, 
             {
                 "bad": false, 
@@ -6861,9 +7179,12 @@
                 "weights": 8828447.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24976, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/WGToLNuG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_044922/0000/myMicroAODOutputFile_49.root", 
-                "nevents": 24976
+                "nevents": 24976, 
+                "totEvents": 24976, 
+                "weights": 8930030.0
             }, 
             {
                 "bad": false, 
@@ -6938,9 +7259,12 @@
                 "weights": 8906862.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24934, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/WGToLNuG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_044922/0001/myMicroAODOutputFile_1009.root", 
-                "nevents": 24934
+                "nevents": 24934, 
+                "totEvents": 24934, 
+                "weights": 8834981.0
             }, 
             {
                 "bad": false, 
@@ -6959,9 +7283,12 @@
                 "weights": 9029833.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24939, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/WGToLNuG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_044922/0000/myMicroAODOutputFile_438.root", 
-                "nevents": 24939
+                "nevents": 24939, 
+                "totEvents": 24939, 
+                "weights": 8967455.0
             }, 
             {
                 "bad": false, 
@@ -7052,9 +7379,12 @@
                 "weights": 8912210.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24809, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/WGToLNuG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_044922/0000/myMicroAODOutputFile_949.root", 
-                "nevents": 24809
+                "nevents": 24809, 
+                "totEvents": 24809, 
+                "weights": 8941315.0
             }, 
             {
                 "bad": false, 
@@ -7121,9 +7451,12 @@
                 "weights": 8927655.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24838, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/WGToLNuG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_044922/0000/myMicroAODOutputFile_821.root", 
-                "nevents": 24838
+                "nevents": 24838, 
+                "totEvents": 24838, 
+                "weights": 8863492.0
             }, 
             {
                 "bad": false, 
@@ -7254,9 +7587,12 @@
                 "weights": 8875972.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24842, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/WGToLNuG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_044922/0000/myMicroAODOutputFile_826.root", 
-                "nevents": 24842
+                "nevents": 24842, 
+                "totEvents": 24842, 
+                "weights": 8780327.0
             }, 
             {
                 "bad": false, 
@@ -7331,9 +7667,12 @@
                 "weights": 8842107.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24995, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/WGToLNuG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_044922/0000/myMicroAODOutputFile_425.root", 
-                "nevents": 24995
+                "nevents": 24995, 
+                "totEvents": 24995, 
+                "weights": 8938944.0
             }, 
             {
                 "bad": false, 
@@ -7464,9 +7803,12 @@
                 "weights": 8807059.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24858, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/WGToLNuG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_044922/0000/myMicroAODOutputFile_363.root", 
-                "nevents": 24858
+                "nevents": 24858, 
+                "totEvents": 24858, 
+                "weights": 8744679.0
             }, 
             {
                 "bad": false, 
@@ -7525,9 +7867,12 @@
                 "weights": 9004881.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24959, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/WGToLNuG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_044922/0000/myMicroAODOutputFile_719.root", 
-                "nevents": 24959
+                "nevents": 24959, 
+                "totEvents": 24959, 
+                "weights": 8864090.0
             }, 
             {
                 "bad": false, 
@@ -7538,9 +7883,12 @@
                 "weights": 8856363.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24916, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/WGToLNuG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_044922/0000/myMicroAODOutputFile_424.root", 
-                "nevents": 24916
+                "nevents": 24916, 
+                "totEvents": 24916, 
+                "weights": 8855180.0
             }, 
             {
                 "bad": false, 
@@ -7575,9 +7923,12 @@
                 "weights": 8881912.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24872, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/WGToLNuG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_044922/0000/myMicroAODOutputFile_187.root", 
-                "nevents": 24872
+                "nevents": 24872, 
+                "totEvents": 24872, 
+                "weights": 8949041.0
             }, 
             {
                 "bad": false, 
@@ -7588,9 +7939,12 @@
                 "weights": 8836174.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25020, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/WGToLNuG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_044922/0000/myMicroAODOutputFile_529.root", 
-                "nevents": 25020
+                "nevents": 25020, 
+                "totEvents": 25020, 
+                "weights": 8977553.0
             }, 
             {
                 "bad": false, 
@@ -7633,9 +7987,12 @@
                 "weights": 8896758.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25299, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/WGToLNuG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_044922/0000/myMicroAODOutputFile_818.root", 
-                "nevents": 25299
+                "nevents": 25299, 
+                "totEvents": 25299, 
+                "weights": 9206270.0
             }, 
             {
                 "bad": false, 
@@ -7678,14 +8035,20 @@
                 "weights": 8862309.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24972, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/WGToLNuG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_044922/0000/myMicroAODOutputFile_533.root", 
-                "nevents": 24972
+                "nevents": 24972, 
+                "totEvents": 24972, 
+                "weights": 8884881.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24913, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/WGToLNuG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_044922/0000/myMicroAODOutputFile_31.root", 
-                "nevents": 24913
+                "nevents": 24913, 
+                "totEvents": 24913, 
+                "weights": 8938943.0
             }, 
             {
                 "bad": false, 
@@ -7968,9 +8331,12 @@
                 "weights": 8859927.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24719, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/WGToLNuG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_044922/0000/myMicroAODOutputFile_117.root", 
-                "nevents": 24719
+                "nevents": 24719, 
+                "totEvents": 24719, 
+                "weights": 8778544.0
             }, 
             {
                 "bad": false, 
@@ -7997,9 +8363,12 @@
                 "weights": 9066070.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24966, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/WGToLNuG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_044922/0000/myMicroAODOutputFile_266.root", 
-                "nevents": 24966
+                "nevents": 24966, 
+                "totEvents": 24966, 
+                "weights": 8890821.0
             }, 
             {
                 "bad": false, 
@@ -8090,9 +8459,12 @@
                 "weights": 8907453.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25041, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/WGToLNuG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_044922/0000/myMicroAODOutputFile_238.root", 
-                "nevents": 25041
+                "nevents": 25041, 
+                "totEvents": 25041, 
+                "weights": 8846268.0
             }, 
             {
                 "bad": false, 
@@ -8111,9 +8483,12 @@
                 "weights": 8863493.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24846, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/WGToLNuG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_044922/0000/myMicroAODOutputFile_851.root", 
-                "nevents": 24846
+                "nevents": 24846, 
+                "totEvents": 24846, 
+                "weights": 8928843.0
             }, 
             {
                 "bad": false, 
@@ -8180,9 +8555,12 @@
                 "weights": 8776167.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24835, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/WGToLNuG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_044922/0001/myMicroAODOutputFile_1021.root", 
-                "nevents": 24835
+                "nevents": 24835, 
+                "totEvents": 24835, 
+                "weights": 9039933.0
             }, 
             {
                 "bad": false, 
@@ -8281,9 +8659,12 @@
                 "weights": 8874785.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25040, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/WGToLNuG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_044922/0000/myMicroAODOutputFile_766.root", 
-                "nevents": 25040
+                "nevents": 25040, 
+                "totEvents": 25040, 
+                "weights": 8882506.0
             }, 
             {
                 "bad": false, 
@@ -8390,9 +8771,12 @@
                 "weights": 8885475.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24994, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/WGToLNuG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_044922/0000/myMicroAODOutputFile_856.root", 
-                "nevents": 24994
+                "nevents": 24994, 
+                "totEvents": 24994, 
+                "weights": 8939535.0
             }, 
             {
                 "bad": false, 
@@ -8411,9 +8795,12 @@
                 "weights": 8956167.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24697, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/WGToLNuG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v1/231121_044922/0000/myMicroAODOutputFile_538.root", 
-                "nevents": 24697
+                "nevents": 24697, 
+                "totEvents": 24697, 
+                "weights": 8830820.0
             }, 
             {
                 "bad": false, 

--- a/MetaData/data/Era2017_legacy_v1_Summer20UL/datasets_38.json
+++ b/MetaData/data/Era2017_legacy_v1_Summer20UL/datasets_38.json
@@ -139,9 +139,12 @@
                 "weights": 2725430.25
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24940, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/ZGToLLG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_045904/0000/myMicroAODOutputFile_39.root", 
-                "nevents": 24940
+                "nevents": 24940, 
+                "totEvents": 24940, 
+                "weights": 2748452.75
             }, 
             {
                 "bad": false, 
@@ -216,9 +219,12 @@
                 "weights": 2793987.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24789, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/ZGToLLG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_045904/0000/myMicroAODOutputFile_234.root", 
-                "nevents": 24789
+                "nevents": 24789, 
+                "totEvents": 24789, 
+                "weights": 2696735.0
             }, 
             {
                 "bad": false, 
@@ -277,9 +283,12 @@
                 "weights": 2713230.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24741, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/ZGToLLG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_045904/0000/myMicroAODOutputFile_239.root", 
-                "nevents": 24741
+                "nevents": 24741, 
+                "totEvents": 24741, 
+                "weights": 2712888.0
             }, 
             {
                 "bad": false, 
@@ -314,9 +323,12 @@
                 "weights": 2695533.75
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24897, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/ZGToLLG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_045904/0000/myMicroAODOutputFile_246.root", 
-                "nevents": 24897
+                "nevents": 24897, 
+                "totEvents": 24897, 
+                "weights": 2737973.75
             }, 
             {
                 "bad": false, 
@@ -327,9 +339,12 @@
                 "weights": 2677148.5
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24788, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/ZGToLLG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_045904/0000/myMicroAODOutputFile_232.root", 
-                "nevents": 24788
+                "nevents": 24788, 
+                "totEvents": 24788, 
+                "weights": 2708591.0
             }, 
             {
                 "bad": false, 
@@ -372,9 +387,12 @@
                 "weights": 2739003.75
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24935, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/ZGToLLG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_045904/0000/myMicroAODOutputFile_238.root", 
-                "nevents": 24935
+                "nevents": 24935, 
+                "totEvents": 24935, 
+                "weights": 2708419.5
             }, 
             {
                 "bad": false, 
@@ -385,9 +403,12 @@
                 "weights": 2738661.25
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24948, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/ZGToLLG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_045904/0000/myMicroAODOutputFile_227.root", 
-                "nevents": 24948
+                "nevents": 24948, 
+                "totEvents": 24948, 
+                "weights": 2711685.25
             }, 
             {
                 "bad": false, 
@@ -406,9 +427,12 @@
                 "weights": 2715464.75
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25004, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/ZGToLLG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_045904/0000/myMicroAODOutputFile_223.root", 
-                "nevents": 25004
+                "nevents": 25004, 
+                "totEvents": 25004, 
+                "weights": 2756014.5
             }, 
             {
                 "bad": false, 
@@ -475,9 +499,12 @@
                 "weights": 2697596.25
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24791, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/ZGToLLG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_045904/0000/myMicroAODOutputFile_27.root", 
-                "nevents": 24791
+                "nevents": 24791, 
+                "totEvents": 24791, 
+                "weights": 2692612.5
             }, 
             {
                 "bad": false, 
@@ -648,9 +675,12 @@
                 "weights": 2684192.5
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25041, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/ZGToLLG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_045904/0000/myMicroAODOutputFile_409.root", 
-                "nevents": 25041
+                "nevents": 25041, 
+                "totEvents": 25041, 
+                "weights": 2750344.75
             }, 
             {
                 "bad": false, 
@@ -757,9 +787,12 @@
                 "weights": 2706185.25
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24703, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/ZGToLLG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_045904/0000/myMicroAODOutputFile_399.root", 
-                "nevents": 24703
+                "nevents": 24703, 
+                "totEvents": 24703, 
+                "weights": 2690894.0
             }, 
             {
                 "bad": false, 
@@ -786,9 +819,12 @@
                 "weights": 2713575.5
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25184, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/ZGToLLG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_045904/0000/myMicroAODOutputFile_294.root", 
-                "nevents": 25184
+                "nevents": 25184, 
+                "totEvents": 25184, 
+                "weights": 2729897.75
             }, 
             {
                 "bad": false, 
@@ -807,9 +843,12 @@
                 "weights": 2701718.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25201, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/ZGToLLG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_045904/0000/myMicroAODOutputFile_343.root", 
-                "nevents": 25201
+                "nevents": 25201, 
+                "totEvents": 25201, 
+                "weights": 2750345.0
             }, 
             {
                 "bad": false, 
@@ -932,14 +971,20 @@
                 "weights": 2723712.25
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24934, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/ZGToLLG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_045904/0000/myMicroAODOutputFile_407.root", 
-                "nevents": 24934
+                "nevents": 24934, 
+                "totEvents": 24934, 
+                "weights": 2707903.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24908, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/ZGToLLG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_045904/0000/myMicroAODOutputFile_270.root", 
-                "nevents": 24908
+                "nevents": 24908, 
+                "totEvents": 24908, 
+                "weights": 2683849.5
             }, 
             {
                 "bad": false, 
@@ -950,9 +995,12 @@
                 "weights": 2663574.75
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24666, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/ZGToLLG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_045904/0000/myMicroAODOutputFile_393.root", 
-                "nevents": 24666
+                "nevents": 24666, 
+                "totEvents": 24666, 
+                "weights": 2643299.75
             }, 
             {
                 "bad": false, 
@@ -995,9 +1043,12 @@
                 "weights": 2722337.5
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24955, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/ZGToLLG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_045904/0000/myMicroAODOutputFile_357.root", 
-                "nevents": 24955
+                "nevents": 24955, 
+                "totEvents": 24955, 
+                "weights": 2711513.0
             }, 
             {
                 "bad": false, 
@@ -1128,9 +1179,12 @@
                 "weights": 2690207.75
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24855, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/ZGToLLG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_045904/0000/myMicroAODOutputFile_359.root", 
-                "nevents": 24855
+                "nevents": 24855, 
+                "totEvents": 24855, 
+                "weights": 2701203.75
             }, 
             {
                 "bad": false, 
@@ -1149,9 +1203,12 @@
                 "weights": 2737628.5
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24985, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/ZGToLLG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_045904/0000/myMicroAODOutputFile_269.root", 
-                "nevents": 24985
+                "nevents": 24985, 
+                "totEvents": 24985, 
+                "weights": 2678178.5
             }, 
             {
                 "bad": false, 
@@ -1210,9 +1267,12 @@
                 "weights": 2707216.25
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25044, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/ZGToLLG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_045904/0000/myMicroAODOutputFile_290.root", 
-                "nevents": 25044
+                "nevents": 25044, 
+                "totEvents": 25044, 
+                "weights": 2725087.0
             }, 
             {
                 "bad": false, 
@@ -1279,9 +1339,12 @@
                 "weights": 2673712.25
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25038, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/ZGToLLG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_045904/0000/myMicroAODOutputFile_313.root", 
-                "nevents": 25038
+                "nevents": 25038, 
+                "totEvents": 25038, 
+                "weights": 2729553.75
             }, 
             {
                 "bad": false, 
@@ -1340,9 +1403,12 @@
                 "weights": 2693126.5
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24859, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/ZGToLLG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_045904/0000/myMicroAODOutputFile_275.root", 
-                "nevents": 24859
+                "nevents": 24859, 
+                "totEvents": 24859, 
+                "weights": 2708764.0
             }, 
             {
                 "bad": false, 
@@ -1353,9 +1419,12 @@
                 "weights": 2697423.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24913, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/ZGToLLG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_045904/0000/myMicroAODOutputFile_266.root", 
-                "nevents": 24913
+                "nevents": 24913, 
+                "totEvents": 24913, 
+                "weights": 2708419.75
             }, 
             {
                 "bad": false, 
@@ -1390,9 +1459,12 @@
                 "weights": 2740722.75
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24691, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/ZGToLLG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_045904/0000/myMicroAODOutputFile_308.root", 
-                "nevents": 24691
+                "nevents": 24691, 
+                "totEvents": 24691, 
+                "weights": 2723196.0
             }, 
             {
                 "bad": false, 
@@ -1419,9 +1491,12 @@
                 "weights": 2702407.5
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24935, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/ZGToLLG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_045904/0000/myMicroAODOutputFile_361.root", 
-                "nevents": 24935
+                "nevents": 24935, 
+                "totEvents": 24935, 
+                "weights": 2739003.0
             }, 
             {
                 "bad": false, 
@@ -1440,9 +1515,12 @@
                 "weights": 2741064.75
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24958, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/ZGToLLG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_045904/0000/myMicroAODOutputFile_292.root", 
-                "nevents": 24958
+                "nevents": 24958, 
+                "totEvents": 24958, 
+                "weights": 2696220.75
             }, 
             {
                 "bad": false, 
@@ -1493,9 +1571,12 @@
                 "weights": 2716324.25
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24911, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/ZGToLLG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_045904/0000/myMicroAODOutputFile_350.root", 
-                "nevents": 24911
+                "nevents": 24911, 
+                "totEvents": 24911, 
+                "weights": 2730756.5
             }, 
             {
                 "bad": false, 
@@ -1658,9 +1739,12 @@
                 "weights": 2740722.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24774, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/ZGToLLG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_045904/0000/myMicroAODOutputFile_351.root", 
-                "nevents": 24774
+                "nevents": 24774, 
+                "totEvents": 24774, 
+                "weights": 2664261.25
             }, 
             {
                 "bad": false, 
@@ -1711,9 +1795,12 @@
                 "weights": 2731272.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24780, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/ZGToLLG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_045904/0000/myMicroAODOutputFile_367.root", 
-                "nevents": 24780
+                "nevents": 24780, 
+                "totEvents": 24780, 
+                "weights": 2650516.0
             }, 
             {
                 "bad": false, 
@@ -1804,9 +1891,12 @@
                 "weights": 2711683.5
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25079, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/ZGToLLG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_045904/0000/myMicroAODOutputFile_165.root", 
-                "nevents": 25079
+                "nevents": 25079, 
+                "totEvents": 25079, 
+                "weights": 2755842.25
             }, 
             {
                 "bad": false, 
@@ -1825,14 +1915,20 @@
                 "weights": 2678523.5
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24945, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/ZGToLLG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_045904/0000/myMicroAODOutputFile_152.root", 
-                "nevents": 24945
+                "nevents": 24945, 
+                "totEvents": 24945, 
+                "weights": 2725945.25
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24868, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/ZGToLLG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_045904/0000/myMicroAODOutputFile_73.root", 
-                "nevents": 24868
+                "nevents": 24868, 
+                "totEvents": 24868, 
+                "weights": 2671822.0
             }, 
             {
                 "bad": false, 
@@ -1859,9 +1955,12 @@
                 "weights": 2752406.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25022, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/ZGToLLG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_045904/0000/myMicroAODOutputFile_216.root", 
-                "nevents": 25022
+                "nevents": 25022, 
+                "totEvents": 25022, 
+                "weights": 2720275.25
             }, 
             {
                 "bad": false, 
@@ -1880,9 +1979,12 @@
                 "weights": 2694329.75
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24901, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/ZGToLLG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_045904/0000/myMicroAODOutputFile_136.root", 
-                "nevents": 24901
+                "nevents": 24901, 
+                "totEvents": 24901, 
+                "weights": 2714949.5
             }, 
             {
                 "bad": false, 
@@ -1917,9 +2019,12 @@
                 "weights": 2710482.75
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25015, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/ZGToLLG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_045904/0000/myMicroAODOutputFile_49.root", 
-                "nevents": 25015
+                "nevents": 25015, 
+                "totEvents": 25015, 
+                "weights": 2710825.75
             }, 
             {
                 "bad": false, 
@@ -1946,9 +2051,12 @@
                 "weights": 2716152.5
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24881, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/ZGToLLG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_045904/0000/myMicroAODOutputFile_138.root", 
-                "nevents": 24881
+                "nevents": 24881, 
+                "totEvents": 24881, 
+                "weights": 2714261.5
             }, 
             {
                 "bad": false, 
@@ -1959,9 +2067,12 @@
                 "weights": 2701032.25
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25157, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/ZGToLLG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_045904/0000/myMicroAODOutputFile_51.root", 
-                "nevents": 25157
+                "nevents": 25157, 
+                "totEvents": 25157, 
+                "weights": 2726290.25
             }, 
             {
                 "bad": false, 
@@ -1980,9 +2091,12 @@
                 "weights": 2699658.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24941, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/ZGToLLG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_045904/0000/myMicroAODOutputFile_181.root", 
-                "nevents": 24941
+                "nevents": 24941, 
+                "totEvents": 24941, 
+                "weights": 2712886.75
             }, 
             {
                 "bad": false, 
@@ -2009,9 +2123,12 @@
                 "weights": 2675430.5
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24874, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/ZGToLLG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_045904/0000/myMicroAODOutputFile_42.root", 
-                "nevents": 24874
+                "nevents": 24874, 
+                "totEvents": 24874, 
+                "weights": 2694846.5
             }, 
             {
                 "bad": false, 
@@ -2030,9 +2147,12 @@
                 "weights": 2724399.25
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24921, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/ZGToLLG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_045904/0000/myMicroAODOutputFile_77.root", 
-                "nevents": 24921
+                "nevents": 24921, 
+                "totEvents": 24921, 
+                "weights": 2727663.5
             }, 
             {
                 "bad": false, 
@@ -2075,9 +2195,12 @@
                 "weights": 2716838.75
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24872, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/ZGToLLG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_045904/0000/myMicroAODOutputFile_106.root", 
-                "nevents": 24872
+                "nevents": 24872, 
+                "totEvents": 24872, 
+                "weights": 2712028.5
             }, 
             {
                 "bad": false, 
@@ -2152,9 +2275,12 @@
                 "weights": 2748626.25
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24945, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/ZGToLLG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_045904/0000/myMicroAODOutputFile_59.root", 
-                "nevents": 24945
+                "nevents": 24945, 
+                "totEvents": 24945, 
+                "weights": 2701203.75
             }, 
             {
                 "bad": false, 
@@ -2181,9 +2307,12 @@
                 "weights": 2681271.5
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25055, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/ZGToLLG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_045904/0000/myMicroAODOutputFile_54.root", 
-                "nevents": 25055
+                "nevents": 25055, 
+                "totEvents": 25055, 
+                "weights": 2746908.25
             }, 
             {
                 "bad": false, 
@@ -2242,9 +2371,12 @@
                 "weights": 2701375.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24940, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/ZGToLLG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_045904/0000/myMicroAODOutputFile_184.root", 
-                "nevents": 24940
+                "nevents": 24940, 
+                "totEvents": 24940, 
+                "weights": 2652921.25
             }, 
             {
                 "bad": false, 
@@ -2303,9 +2435,12 @@
                 "weights": 2717526.75
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24989, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/ZGToLLG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_045904/0000/myMicroAODOutputFile_70.root", 
-                "nevents": 24989
+                "nevents": 24989, 
+                "totEvents": 24989, 
+                "weights": 2726976.75
             }, 
             {
                 "bad": false, 
@@ -2332,9 +2467,12 @@
                 "weights": 2701374.25
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24893, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/ZGToLLG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_045904/0000/myMicroAODOutputFile_85.root", 
-                "nevents": 24893
+                "nevents": 24893, 
+                "totEvents": 24893, 
+                "weights": 2730069.25
             }, 
             {
                 "bad": false, 
@@ -2409,14 +2547,20 @@
                 "weights": 2719760.25
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24884, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/ZGToLLG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_045904/0000/myMicroAODOutputFile_208.root", 
-                "nevents": 24884
+                "nevents": 24884, 
+                "totEvents": 24884, 
+                "weights": 2690379.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25041, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/ZGToLLG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_045904/0000/myMicroAODOutputFile_175.root", 
-                "nevents": 25041
+                "nevents": 25041, 
+                "totEvents": 25041, 
+                "weights": 2709451.0
             }, 
             {
                 "bad": false, 
@@ -2443,9 +2587,12 @@
                 "weights": 2716496.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24784, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/ZGToLLG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_045904/0000/myMicroAODOutputFile_127.root", 
-                "nevents": 24784
+                "nevents": 24784, 
+                "totEvents": 24784, 
+                "weights": 2704467.25
             }, 
             {
                 "bad": false, 
@@ -2504,9 +2651,12 @@
                 "weights": 2691067.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24814, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/ZGToLLG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_045904/0000/myMicroAODOutputFile_149.root", 
-                "nevents": 24814
+                "nevents": 24814, 
+                "totEvents": 24814, 
+                "weights": 2735053.0
             }, 
             {
                 "bad": false, 
@@ -2517,9 +2667,12 @@
                 "weights": 2680413.5
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24878, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/ZGToLLG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_045904/0000/myMicroAODOutputFile_119.root", 
-                "nevents": 24878
+                "nevents": 24878, 
+                "totEvents": 24878, 
+                "weights": 2729555.0
             }, 
             {
                 "bad": false, 
@@ -2578,9 +2731,12 @@
                 "weights": 2724227.5
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24878, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/ZGToLLG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_045904/0000/myMicroAODOutputFile_183.root", 
-                "nevents": 24878
+                "nevents": 24878, 
+                "totEvents": 24878, 
+                "weights": 2658763.25
             }, 
             {
                 "bad": false, 
@@ -2623,14 +2779,20 @@
                 "weights": 2643128.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24876, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/ZGToLLG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_045904/0000/myMicroAODOutputFile_185.root", 
-                "nevents": 24876
+                "nevents": 24876, 
+                "totEvents": 24876, 
+                "weights": 2681788.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24914, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/ZGToLLG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_045904/0000/myMicroAODOutputFile_155.root", 
-                "nevents": 24914
+                "nevents": 24914, 
+                "totEvents": 24914, 
+                "weights": 2714777.0
             }, 
             {
                 "bad": false, 
@@ -2737,9 +2899,12 @@
                 "weights": 2687629.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24998, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/ZGToLLG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_045904/0000/myMicroAODOutputFile_200.root", 
-                "nevents": 24998
+                "nevents": 24998, 
+                "totEvents": 24998, 
+                "weights": 2739175.25
             }, 
             {
                 "bad": false, 
@@ -2774,9 +2939,12 @@
                 "weights": 2714262.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24906, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/ZGToLLG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_045904/0000/myMicroAODOutputFile_164.root", 
-                "nevents": 24906
+                "nevents": 24906, 
+                "totEvents": 24906, 
+                "weights": 2737113.5
             }, 
             {
                 "bad": false, 
@@ -2811,9 +2979,12 @@
                 "weights": 2702234.25
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25112, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/ZGToLLG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_045904/0000/myMicroAODOutputFile_92.root", 
-                "nevents": 25112
+                "nevents": 25112, 
+                "totEvents": 25112, 
+                "weights": 2701031.75
             }, 
             {
                 "bad": false, 
@@ -2824,24 +2995,36 @@
                 "weights": 2689691.75
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24766, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/ZGToLLG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_045904/0000/myMicroAODOutputFile_187.root", 
-                "nevents": 24766
+                "nevents": 24766, 
+                "totEvents": 24766, 
+                "weights": 2692440.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24800, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/ZGToLLG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_045904/0000/myMicroAODOutputFile_206.root", 
-                "nevents": 24800
+                "nevents": 24800, 
+                "totEvents": 24800, 
+                "weights": 2706874.5
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25027, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/ZGToLLG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_045904/0000/myMicroAODOutputFile_176.root", 
-                "nevents": 25027
+                "nevents": 25027, 
+                "totEvents": 25027, 
+                "weights": 2709107.25
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25020, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/ZGToLLG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_045904/0000/myMicroAODOutputFile_156.root", 
-                "nevents": 25020
+                "nevents": 25020, 
+                "totEvents": 25020, 
+                "weights": 2688660.75
             }, 
             {
                 "bad": false, 
@@ -2860,9 +3043,12 @@
                 "weights": 2699656.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24948, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/ZGToLLG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_045904/0000/myMicroAODOutputFile_199.root", 
-                "nevents": 24948
+                "nevents": 24948, 
+                "totEvents": 24948, 
+                "weights": 2686942.5
             }, 
             {
                 "bad": false, 
@@ -2929,9 +3115,12 @@
                 "weights": 2699486.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24874, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/ZGToLLG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_045904/0000/myMicroAODOutputFile_143.root", 
-                "nevents": 24874
+                "nevents": 24874, 
+                "totEvents": 24874, 
+                "weights": 2682474.75
             }, 
             {
                 "bad": false, 
@@ -2974,9 +3163,12 @@
                 "weights": 2730412.75
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24886, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/ZGToLLG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_045904/0000/myMicroAODOutputFile_198.root", 
-                "nevents": 24886
+                "nevents": 24886, 
+                "totEvents": 24886, 
+                "weights": 2705154.75
             }, 
             {
                 "bad": false, 
@@ -3099,9 +3291,12 @@
                 "weights": 2696736.75
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25019, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/ZGToLLG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_045904/0000/myMicroAODOutputFile_424.root", 
-                "nevents": 25019
+                "nevents": 25019, 
+                "totEvents": 25019, 
+                "weights": 2678866.25
             }, 
             {
                 "bad": false, 
@@ -3120,9 +3315,12 @@
                 "weights": 2726804.5
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24989, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/ZGToLLG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_045904/0000/myMicroAODOutputFile_512.root", 
-                "nevents": 24989
+                "nevents": 24989, 
+                "totEvents": 24989, 
+                "weights": 2728351.25
             }, 
             {
                 "bad": false, 
@@ -3245,9 +3443,12 @@
                 "weights": 2731615.5
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24882, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/ZGToLLG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_045904/0000/myMicroAODOutputFile_479.root", 
-                "nevents": 24882
+                "nevents": 24882, 
+                "totEvents": 24882, 
+                "weights": 2689004.5
             }, 
             {
                 "bad": false, 
@@ -3274,9 +3475,12 @@
                 "weights": 2709621.25
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24780, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/ZGToLLG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_045904/0000/myMicroAODOutputFile_470.root", 
-                "nevents": 24780
+                "nevents": 24780, 
+                "totEvents": 24780, 
+                "weights": 2721306.0
             }, 
             {
                 "bad": false, 
@@ -3295,9 +3499,12 @@
                 "weights": 2719588.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24955, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/ZGToLLG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_045904/0000/myMicroAODOutputFile_471.root", 
-                "nevents": 24955
+                "nevents": 24955, 
+                "totEvents": 24955, 
+                "weights": 2716323.25
             }, 
             {
                 "bad": false, 
@@ -3348,9 +3555,12 @@
                 "weights": 2746394.25
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24797, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/ZGToLLG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_045904/0000/myMicroAODOutputFile_473.root", 
-                "nevents": 24797
+                "nevents": 24797, 
+                "totEvents": 24797, 
+                "weights": 2708764.5
             }, 
             {
                 "bad": false, 
@@ -3369,9 +3579,12 @@
                 "weights": 2715636.75
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24945, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/ZGToLLG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_045904/0000/myMicroAODOutputFile_418.root", 
-                "nevents": 24945
+                "nevents": 24945, 
+                "totEvents": 24945, 
+                "weights": 2670619.5
             }, 
             {
                 "bad": false, 
@@ -3414,9 +3627,12 @@
                 "weights": 2709622.5
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24978, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/ZGToLLG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_045904/0000/myMicroAODOutputFile_564.root", 
-                "nevents": 24978
+                "nevents": 24978, 
+                "totEvents": 24978, 
+                "weights": 2691754.5
             }, 
             {
                 "bad": false, 
@@ -3531,9 +3747,12 @@
                 "weights": 2696564.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24845, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/ZGToLLG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_045904/0000/myMicroAODOutputFile_539.root", 
-                "nevents": 24845
+                "nevents": 24845, 
+                "totEvents": 24845, 
+                "weights": 2700172.25
             }, 
             {
                 "bad": false, 
@@ -3624,14 +3843,20 @@
                 "weights": 2654640.25
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24883, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/ZGToLLG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_045904/0000/myMicroAODOutputFile_575.root", 
-                "nevents": 24883
+                "nevents": 24883, 
+                "totEvents": 24883, 
+                "weights": 2721478.25
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24917, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/ZGToLLG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_045904/0000/myMicroAODOutputFile_560.root", 
-                "nevents": 24917
+                "nevents": 24917, 
+                "totEvents": 24917, 
+                "weights": 2741754.75
             }, 
             {
                 "bad": false, 
@@ -3754,9 +3979,12 @@
                 "weights": 2695877.25
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24743, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/ZGToLLG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_045904/0000/myMicroAODOutputFile_426.root", 
-                "nevents": 24743
+                "nevents": 24743, 
+                "totEvents": 24743, 
+                "weights": 2720790.0
             }, 
             {
                 "bad": false, 
@@ -3791,14 +4019,20 @@
                 "weights": 2725774.5
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25027, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/ZGToLLG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_045904/0000/myMicroAODOutputFile_454.root", 
-                "nevents": 25027
+                "nevents": 25027, 
+                "totEvents": 25027, 
+                "weights": 2715292.5
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24843, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/ZGToLLG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_045904/0000/myMicroAODOutputFile_460.root", 
-                "nevents": 24843
+                "nevents": 24843, 
+                "totEvents": 24843, 
+                "weights": 2678179.5
             }, 
             {
                 "bad": false, 
@@ -3809,9 +4043,12 @@
                 "weights": 2719933.5
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24954, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/ZGToLLG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_045904/0000/myMicroAODOutputFile_467.root", 
-                "nevents": 24954
+                "nevents": 24954, 
+                "totEvents": 24954, 
+                "weights": 2734709.0
             }, 
             {
                 "bad": false, 
@@ -3862,9 +4099,12 @@
                 "weights": 2673025.25
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24911, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/ZGToLLG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_045904/0000/myMicroAODOutputFile_459.root", 
-                "nevents": 24911
+                "nevents": 24911, 
+                "totEvents": 24911, 
+                "weights": 2698453.5
             }, 
             {
                 "bad": false, 
@@ -3931,9 +4171,12 @@
                 "weights": 2689349.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24913, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/ZGToLLG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_045904/0000/myMicroAODOutputFile_529.root", 
-                "nevents": 24913
+                "nevents": 24913, 
+                "totEvents": 24913, 
+                "weights": 2682303.25
             }, 
             {
                 "bad": false, 
@@ -4056,9 +4299,12 @@
                 "weights": 2722337.75
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24876, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/ZGToLLG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_045904/0000/myMicroAODOutputFile_500.root", 
-                "nevents": 24876
+                "nevents": 24876, 
+                "totEvents": 24876, 
+                "weights": 2693471.75
             }, 
             {
                 "bad": false, 
@@ -4093,9 +4339,12 @@
                 "weights": 2674227.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24808, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/ZGToLLG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_045904/0000/myMicroAODOutputFile_515.root", 
-                "nevents": 24808
+                "nevents": 24808, 
+                "totEvents": 24808, 
+                "weights": 2696564.5
             }, 
             {
                 "bad": false, 
@@ -4138,9 +4387,12 @@
                 "weights": 2725602.5
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24871, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/ZGToLLG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_045904/0000/myMicroAODOutputFile_466.root", 
-                "nevents": 24871
+                "nevents": 24871, 
+                "totEvents": 24871, 
+                "weights": 2711512.25
             }, 
             {
                 "bad": false, 
@@ -4151,9 +4403,12 @@
                 "weights": 2678178.75
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25223, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/ZGToLLG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_045904/0000/myMicroAODOutputFile_432.root", 
-                "nevents": 25223
+                "nevents": 25223, 
+                "totEvents": 25223, 
+                "weights": 2724914.5
             }, 
             {
                 "bad": false, 
@@ -4252,9 +4507,12 @@
                 "weights": 2636083.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25011, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/ZGToLLG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_045904/0000/myMicroAODOutputFile_433.root", 
-                "nevents": 25011
+                "nevents": 25011, 
+                "totEvents": 25011, 
+                "weights": 2718729.25
             }, 
             {
                 "bad": false, 
@@ -4297,9 +4555,12 @@
                 "weights": 2708248.25
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24864, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/ZGToLLG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_045904/0000/myMicroAODOutputFile_581.root", 
-                "nevents": 24864
+                "nevents": 24864, 
+                "totEvents": 24864, 
+                "weights": 2715120.75
             }, 
             {
                 "bad": false, 
@@ -4310,9 +4571,12 @@
                 "weights": 2671307.25
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24992, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/ZGToLLG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_045904/0000/myMicroAODOutputFile_582.root", 
-                "nevents": 24992
+                "nevents": 24992, 
+                "totEvents": 24992, 
+                "weights": 2719587.75
             }, 
             {
                 "bad": false, 
@@ -4467,9 +4731,12 @@
                 "weights": 2728351.25
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24750, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/ZGToLLG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_045904/0000/myMicroAODOutputFile_610.root", 
-                "nevents": 24750
+                "nevents": 24750, 
+                "totEvents": 24750, 
+                "weights": 2663231.5
             }, 
             {
                 "bad": false, 
@@ -4504,9 +4771,12 @@
                 "weights": 2686082.5
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24705, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/ZGToLLG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_045904/0000/myMicroAODOutputFile_622.root", 
-                "nevents": 24705
+                "nevents": 24705, 
+                "totEvents": 24705, 
+                "weights": 2686427.25
             }, 
             {
                 "bad": false, 
@@ -4613,9 +4883,12 @@
                 "weights": 2728351.5
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24943, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/ZGToLLG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_045904/0000/myMicroAODOutputFile_583.root", 
-                "nevents": 24943
+                "nevents": 24943, 
+                "totEvents": 24943, 
+                "weights": 2708419.75
             }, 
             {
                 "bad": false, 
@@ -4706,9 +4979,12 @@
                 "weights": 2772854.25
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24726, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/ZGToLLG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_045904/0001/myMicroAODOutputFile_1122.root", 
-                "nevents": 24726
+                "nevents": 24726, 
+                "totEvents": 24726, 
+                "weights": 2701718.75
             }, 
             {
                 "bad": false, 
@@ -4727,9 +5003,12 @@
                 "weights": 2704639.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24819, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/ZGToLLG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_045904/0001/myMicroAODOutputFile_1127.root", 
-                "nevents": 24819
+                "nevents": 24819, 
+                "totEvents": 24819, 
+                "weights": 2684365.0
             }, 
             {
                 "bad": false, 
@@ -4772,9 +5051,12 @@
                 "weights": 2698282.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24979, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/ZGToLLG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_045904/0001/myMicroAODOutputFile_1167.root", 
-                "nevents": 24979
+                "nevents": 24979, 
+                "totEvents": 24979, 
+                "weights": 2720792.0
             }, 
             {
                 "bad": false, 
@@ -4849,9 +5131,12 @@
                 "weights": 2641066.5
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24888, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/ZGToLLG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_045904/0000/myMicroAODOutputFile_632.root", 
-                "nevents": 24888
+                "nevents": 24888, 
+                "totEvents": 24888, 
+                "weights": 2718900.5
             }, 
             {
                 "bad": false, 
@@ -4974,9 +5259,12 @@
                 "weights": 2706358.75
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24941, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/ZGToLLG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_045904/0001/myMicroAODOutputFile_1146.root", 
-                "nevents": 24941
+                "nevents": 24941, 
+                "totEvents": 24941, 
+                "weights": 2659623.25
             }, 
             {
                 "bad": false, 
@@ -5019,9 +5307,12 @@
                 "weights": 2713230.5
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24798, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/ZGToLLG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_045904/0001/myMicroAODOutputFile_1138.root", 
-                "nevents": 24798
+                "nevents": 24798, 
+                "totEvents": 24798, 
+                "weights": 2709622.25
             }, 
             {
                 "bad": false, 
@@ -5064,9 +5355,12 @@
                 "weights": 2740893.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25003, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/ZGToLLG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_045904/0001/myMicroAODOutputFile_1142.root", 
-                "nevents": 25003
+                "nevents": 25003, 
+                "totEvents": 25003, 
+                "weights": 2717699.25
             }, 
             {
                 "bad": false, 
@@ -5157,14 +5451,20 @@
                 "weights": 2699313.25
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25154, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/ZGToLLG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_045904/0001/myMicroAODOutputFile_1173.root", 
-                "nevents": 25154
+                "nevents": 25154, 
+                "totEvents": 25154, 
+                "weights": 2740207.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24827, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/ZGToLLG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_045904/0001/myMicroAODOutputFile_1177.root", 
-                "nevents": 24827
+                "nevents": 24827, 
+                "totEvents": 24827, 
+                "weights": 2692268.75
             }, 
             {
                 "bad": false, 
@@ -5183,9 +5483,12 @@
                 "weights": 2708935.5
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24916, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/ZGToLLG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_045904/0000/myMicroAODOutputFile_584.root", 
-                "nevents": 24916
+                "nevents": 24916, 
+                "totEvents": 24916, 
+                "weights": 2713058.25
             }, 
             {
                 "bad": false, 
@@ -5292,9 +5595,12 @@
                 "weights": 2733507.25
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24893, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/ZGToLLG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_045904/0001/myMicroAODOutputFile_1149.root", 
-                "nevents": 24893
+                "nevents": 24893, 
+                "totEvents": 24893, 
+                "weights": 2726632.5
             }, 
             {
                 "bad": false, 
@@ -5353,9 +5659,12 @@
                 "weights": 2697422.75
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24769, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/ZGToLLG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_045904/0001/myMicroAODOutputFile_1147.root", 
-                "nevents": 24769
+                "nevents": 24769, 
+                "totEvents": 24769, 
+                "weights": 2723195.0
             }, 
             {
                 "bad": false, 
@@ -5550,9 +5859,12 @@
                 "weights": 2282303.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25016, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/ZGToLLG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_045904/0001/myMicroAODOutputFile_1190.root", 
-                "nevents": 25016
+                "nevents": 25016, 
+                "totEvents": 25016, 
+                "weights": 2673197.0
             }, 
             {
                 "bad": false, 
@@ -5571,9 +5883,12 @@
                 "weights": 2702577.5
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24895, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/ZGToLLG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_045904/0001/myMicroAODOutputFile_1189.root", 
-                "nevents": 24895
+                "nevents": 24895, 
+                "totEvents": 24895, 
+                "weights": 2725602.0
             }, 
             {
                 "bad": false, 

--- a/MetaData/data/Era2017_legacy_v1_Summer20UL/datasets_4.json
+++ b/MetaData/data/Era2017_legacy_v1_Summer20UL/datasets_4.json
@@ -3540,7 +3540,7 @@
             }
         ], 
         "parent_n_units": null, 
-        "vetted": false
+        "vetted": true
     }, 
     "/DYJetsToLL_M-50_HT-800to1200_TuneCP5_PSweights_13TeV-madgraphMLM-pythia8/phys_higgs-Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v1-365a9eeb963575ce9edbdfce0f0ba4bf/USER": {
         "dset_type": "mc", 
@@ -4411,7 +4411,7 @@
             }
         ], 
         "parent_n_units": null, 
-        "vetted": false
+        "vetted": true
     }, 
     "/DiPhotonJetsBox2BJets_MGG-80toInf_13TeV-sherpa/phys_higgs-Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2-7f9164c951f41bda15871bc40d81f510/USER": {
         "dset_type": "mc", 
@@ -5146,7 +5146,7 @@
             }
         ], 
         "parent_n_units": null, 
-        "vetted": false
+        "vetted": true
     }, 
     "/GluGluHToGG_M60_TuneCP5_13TeV-amcatnloFXFX-pythia8/phys_higgs-Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v3-9da8fb7b8a1cdca7b80e707a2ce21a84/USER": {
         "dset_type": "mc", 
@@ -5273,7 +5273,7 @@
             }
         ], 
         "parent_n_units": null, 
-        "vetted": false
+        "vetted": true
     }, 
     "/VBFHToGG_M120_TuneCP5_13TeV-amcatnlo-pythia8/phys_higgs-Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2-74df377dff8e976d6419dc49fe671f9b/USER": {
         "dset_type": "mc", 
@@ -6255,7 +6255,7 @@
             }
         ], 
         "parent_n_units": null, 
-        "vetted": false
+        "vetted": true
     }, 
     "/VHToGG_M95_TuneCP5_13TeV-amcatnloFXFX-madspin-pythia8/phys_higgs-Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2-87ea3b90faed5199cfde26b1d7e045df/USER": {
         "dset_type": "mc", 
@@ -6630,7 +6630,7 @@
             }
         ], 
         "parent_n_units": null, 
-        "vetted": false
+        "vetted": true
     }, 
     "/WHiggs0L1ToGG_M125_TuneCP5_13TeV-JHUGenV7011-pythia8/phys_higgs-Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2-2d0531b4db33fa17307b0f4af20516e9/USER": {
         "dset_type": "mc", 
@@ -6901,7 +6901,7 @@
             }
         ], 
         "parent_n_units": null, 
-        "vetted": false
+        "vetted": true
     }, 
     "/WminusH_HToGG_WToAll_M125_TuneCP5_13TeV-powheg-pythia8/phys_higgs-Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v1-87ea3b90faed5199cfde26b1d7e045df/USER": {
         "dset_type": "mc", 
@@ -7060,7 +7060,7 @@
             }
         ], 
         "parent_n_units": null, 
-        "vetted": false
+        "vetted": true
     }, 
     "/WminusH_HToGG_WToAll_M130_TuneCP5_13TeV-powheg-pythia8/phys_higgs-Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v1-87ea3b90faed5199cfde26b1d7e045df/USER": {
         "dset_type": "mc", 
@@ -7307,7 +7307,7 @@
             }
         ], 
         "parent_n_units": null, 
-        "vetted": false
+        "vetted": true
     }, 
     "/WplusH_HToGG_WToAll_M125_TuneCP5_13TeV-powheg-pythia8/phys_higgs-Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v1-87ea3b90faed5199cfde26b1d7e045df/USER": {
         "dset_type": "mc", 
@@ -7705,7 +7705,7 @@
             }
         ], 
         "parent_n_units": null, 
-        "vetted": false
+        "vetted": true
     }, 
     "/ttHJetToGG_M80_TuneCP5_13TeV-amcatnloFXFX-madspin-pythia8/phys_higgs-Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2-c9fef38cafbf42997474836a0940bf17/USER": {
         "dset_type": "mc", 
@@ -8080,6 +8080,6 @@
             }
         ], 
         "parent_n_units": null, 
-        "vetted": false
+        "vetted": true
     }
 }

--- a/MetaData/data/Era2017_legacy_v1_Summer20UL/datasets_5.json
+++ b/MetaData/data/Era2017_legacy_v1_Summer20UL/datasets_5.json
@@ -7828,9 +7828,12 @@
                 "weights": 25000.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/TprimeBToTH_Hgg_M-1100_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_031138/0000/myMicroAODOutputFile_14.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 25000.0
             }, 
             {
                 "bad": false, 

--- a/MetaData/data/Era2017_legacy_v1_Summer20UL/datasets_7.json
+++ b/MetaData/data/Era2017_legacy_v1_Summer20UL/datasets_7.json
@@ -372,7 +372,7 @@
             }
         ], 
         "parent_n_units": null, 
-        "vetted": false
+        "vetted": true
     }, 
     "/GluGluHToGG_M125_TuneCP5_13TeV-amcatnloFXFX-pythia8/phys_higgs-Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v1-1af72e5f53759f2591bcde7d40e0cd5d/USER": {
         "dset_type": "mc", 
@@ -1883,7 +1883,7 @@
             }
         ], 
         "parent_n_units": null, 
-        "vetted": false
+        "vetted": true
     }, 
     "/GluGluHToGG_M85_TuneCP5_13TeV-amcatnloFXFX-pythia8/phys_higgs-Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v1-9da8fb7b8a1cdca7b80e707a2ce21a84/USER": {
         "dset_type": "mc", 
@@ -2026,7 +2026,7 @@
             }
         ], 
         "parent_n_units": null, 
-        "vetted": false
+        "vetted": true
     }, 
     "/VBFHToGG_M124_TuneCP5_13TeV-amcatnlo-pythia8/phys_higgs-Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2-b57456a118a639e045227184101d9dcf/USER": {
         "dset_type": "mc", 
@@ -2313,7 +2313,7 @@
             }
         ], 
         "parent_n_units": null, 
-        "vetted": false
+        "vetted": true
     }, 
     "/VBFHToGG_M60_TuneCP5_13TeV-amcatnlo-pythia8/phys_higgs-Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2-b57456a118a639e045227184101d9dcf/USER": {
         "dset_type": "mc", 
@@ -2456,7 +2456,7 @@
             }
         ], 
         "parent_n_units": null, 
-        "vetted": false
+        "vetted": true
     }, 
     "/VBFHToGG_M70_TuneCP5_13TeV-amcatnlo-pythia8/phys_higgs-Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2-b57456a118a639e045227184101d9dcf/USER": {
         "dset_type": "mc", 
@@ -2607,7 +2607,7 @@
             }
         ], 
         "parent_n_units": null, 
-        "vetted": false
+        "vetted": true
     }, 
     "/VBFHToGG_M90_TuneCP5_13TeV-amcatnlo-pythia8/phys_higgs-Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2-b57456a118a639e045227184101d9dcf/USER": {
         "dset_type": "mc", 
@@ -2742,7 +2742,7 @@
             }
         ], 
         "parent_n_units": null, 
-        "vetted": false
+        "vetted": true
     }, 
     "/VBFHiggs0L1f05ph0ToGG_M125_TuneCP5_13TeV-JHUGenV7011-pythia8/phys_higgs-Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2-ca64037e1aeaaf0d4d2b197cdb41e4bc/USER": {
         "dset_type": "mc", 
@@ -3133,7 +3133,7 @@
             }
         ], 
         "parent_n_units": null, 
-        "vetted": false
+        "vetted": true
     }, 
     "/VBFHiggs0MToGG_M125_TuneCP5_13TeV-JHUGenV7011-pythia8/phys_higgs-Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2-ca64037e1aeaaf0d4d2b197cdb41e4bc/USER": {
         "dset_type": "mc", 
@@ -3492,7 +3492,7 @@
             }
         ], 
         "parent_n_units": null, 
-        "vetted": false
+        "vetted": true
     }, 
     "/WHiggs0MToGG_M125_TuneCP5_13TeV-JHUGenV7011-pythia8/phys_higgs-Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2-2d0531b4db33fa17307b0f4af20516e9/USER": {
         "dset_type": "mc", 
@@ -3787,7 +3787,7 @@
             }
         ], 
         "parent_n_units": null, 
-        "vetted": false
+        "vetted": true
     }, 
     "/WHiggs0PMToGG_M125_TuneCP5_13TeV-JHUGenV7011-pythia8/phys_higgs-Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2-2d0531b4db33fa17307b0f4af20516e9/USER": {
         "dset_type": "mc", 
@@ -4034,7 +4034,7 @@
             }
         ], 
         "parent_n_units": null, 
-        "vetted": false
+        "vetted": true
     }, 
     "/WplusH_HToGG_WToAll_M120_TuneCP5_13TeV-powheg-pythia8/phys_higgs-Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v1-87ea3b90faed5199cfde26b1d7e045df/USER": {
         "dset_type": "mc", 
@@ -4281,7 +4281,7 @@
             }
         ], 
         "parent_n_units": null, 
-        "vetted": false
+        "vetted": true
     }, 
     "/ZH_HToGG_ZToAll_M125_TuneCP5_13TeV-powheg-pythia8/phys_higgs-Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v1-87ea3b90faed5199cfde26b1d7e045df/USER": {
         "dset_type": "mc", 
@@ -4752,7 +4752,7 @@
             }
         ], 
         "parent_n_units": null, 
-        "vetted": false
+        "vetted": true
     }, 
     "/ZH_HToGG_ZToAll_M130_TuneCP5_13TeV-powheg-pythia8/phys_higgs-Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v1-87ea3b90faed5199cfde26b1d7e045df/USER": {
         "dset_type": "mc", 
@@ -5127,7 +5127,7 @@
             }
         ], 
         "parent_n_units": null, 
-        "vetted": false
+        "vetted": true
     }, 
     "/ZHiggs0L1ToGG_M125_TuneCP5_13TeV-JHUGenV7011-pythia8/phys_higgs-Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2-2d0531b4db33fa17307b0f4af20516e9/USER": {
         "dset_type": "mc", 
@@ -5390,7 +5390,7 @@
             }
         ], 
         "parent_n_units": null, 
-        "vetted": false
+        "vetted": true
     }, 
     "/ZHiggs0L1ZgToGG_M125_TuneCP5_13TeV-JHUGenV7011-pythia8/phys_higgs-Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2-2d0531b4db33fa17307b0f4af20516e9/USER": {
         "dset_type": "mc", 
@@ -5469,7 +5469,7 @@
             }
         ], 
         "parent_n_units": null, 
-        "vetted": false
+        "vetted": true
     }, 
     "/ZHiggs0L1Zgf05ph0ToGG_M125_TuneCP5_13TeV-JHUGenV7011-pythia8/phys_higgs-Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2-2d0531b4db33fa17307b0f4af20516e9/USER": {
         "dset_type": "mc", 
@@ -5740,7 +5740,7 @@
             }
         ], 
         "parent_n_units": null, 
-        "vetted": false
+        "vetted": true
     }, 
     "/ZHiggs0PHf05ph0ToGG_M125_TuneCP5_13TeV-JHUGenV7011-pythia8/phys_higgs-Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2-2d0531b4db33fa17307b0f4af20516e9/USER": {
         "dset_type": "mc", 
@@ -6011,7 +6011,7 @@
             }
         ], 
         "parent_n_units": null, 
-        "vetted": false
+        "vetted": true
     }, 
     "/ggZH_HToGG_ZToLL_M125_TuneCP5_13TeV-powheg-pythia8/phys_higgs-Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2-40c484617c8150a845705b37f7fbbebe/USER": {
         "dset_type": "mc", 
@@ -6041,9 +6041,12 @@
                 "weights": 154.6328887939453
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/ggZH_HToGG_ZToLL_M125_TuneCP5_13TeV-powheg-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_005429/0000/myMicroAODOutputFile_11.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 154.6328887939453
             }, 
             {
                 "bad": false, 
@@ -6102,9 +6105,12 @@
                 "weights": 154.6328887939453
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/ggZH_HToGG_ZToLL_M125_TuneCP5_13TeV-powheg-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_005429/0000/myMicroAODOutputFile_8.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 154.6328887939453
             }, 
             {
                 "bad": false, 
@@ -6290,14 +6296,20 @@
                 "weights": 150.97967529296875
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/ggZH_HToGG_ZToLL_M127_TuneCP5_13TeV-powheg-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_010517/0000/myMicroAODOutputFile_5.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 150.97967529296875
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/ggZH_HToGG_ZToLL_M127_TuneCP5_13TeV-powheg-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_010517/0000/myMicroAODOutputFile_8.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 150.97967529296875
             }, 
             {
                 "bad": false, 
@@ -6308,9 +6320,12 @@
                 "weights": 150.97967529296875
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/ggZH_HToGG_ZToLL_M127_TuneCP5_13TeV-powheg-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_010517/0000/myMicroAODOutputFile_4.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 150.97967529296875
             }, 
             {
                 "bad": false, 
@@ -6488,24 +6503,36 @@
                 "weights": 100.7491683959961
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/ggZH_HToGG_ZToLL_M130_TuneCP5_13TeV-powheg-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_010847/0000/myMicroAODOutputFile_3.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 145.59141540527344
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/ggZH_HToGG_ZToLL_M130_TuneCP5_13TeV-powheg-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_010847/0000/myMicroAODOutputFile_10.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 145.59141540527344
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/ggZH_HToGG_ZToLL_M130_TuneCP5_13TeV-powheg-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_010847/0000/myMicroAODOutputFile_9.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 145.59141540527344
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/ggZH_HToGG_ZToLL_M130_TuneCP5_13TeV-powheg-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_010847/0000/myMicroAODOutputFile_8.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 145.59141540527344
             }, 
             {
                 "bad": false, 
@@ -6556,9 +6583,12 @@
                 "weights": 145.59141540527344
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/ggZH_HToGG_ZToLL_M130_TuneCP5_13TeV-powheg-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_010847/0000/myMicroAODOutputFile_6.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 145.59141540527344
             }, 
             {
                 "bad": false, 
@@ -6569,9 +6599,12 @@
                 "weights": 100.7491683959961
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/ggZH_HToGG_ZToLL_M130_TuneCP5_13TeV-powheg-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_011209/0000/myMicroAODOutputFile_8.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 145.59141540527344
             }
         ], 
         "parent_n_units": null, 
@@ -6653,9 +6686,12 @@
                 "weights": 323.9799499511719
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/ggZH_HToGG_ZToNuNu_M120_TuneCP5_13TeV-powheg-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_011858/0000/myMicroAODOutputFile_1.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 323.9799499511719
             }, 
             {
                 "bad": false, 
@@ -6698,9 +6734,12 @@
                 "weights": 323.9799499511719
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/ggZH_HToGG_ZToNuNu_M120_TuneCP5_13TeV-powheg-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_011858/0000/myMicroAODOutputFile_5.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 323.9799499511719
             }, 
             {
                 "bad": false, 
@@ -6910,9 +6949,12 @@
                 "weights": 309.1581115722656
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/ggZH_HToGG_ZToNuNu_M124_TuneCP5_13TeV-powheg-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_012540/0000/myMicroAODOutputFile_8.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 309.1581115722656
             }, 
             {
                 "bad": false, 
@@ -6962,9 +7004,12 @@
                 "weights": 305.4993896484375
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/ggZH_HToGG_ZToNuNu_M125_TuneCP5_13TeV-powheg-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_012900/0000/myMicroAODOutputFile_8.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 305.4993896484375
             }, 
             {
                 "bad": false, 
@@ -6983,14 +7028,20 @@
                 "weights": 305.4993896484375
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/ggZH_HToGG_ZToNuNu_M125_TuneCP5_13TeV-powheg-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_012900/0000/myMicroAODOutputFile_4.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 305.4993896484375
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/ggZH_HToGG_ZToNuNu_M125_TuneCP5_13TeV-powheg-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_012900/0000/myMicroAODOutputFile_1.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 305.4993896484375
             }, 
             {
                 "bad": false, 
@@ -7208,9 +7259,12 @@
                 "weights": 298.2820739746094
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/ggZH_HToGG_ZToNuNu_M127_TuneCP5_13TeV-powheg-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_014231/0000/myMicroAODOutputFile_6.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 298.2820739746094
             }, 
             {
                 "bad": false, 
@@ -7221,9 +7275,12 @@
                 "weights": 298.2820739746094
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/ggZH_HToGG_ZToNuNu_M127_TuneCP5_13TeV-powheg-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_014231/0000/myMicroAODOutputFile_7.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 298.2820739746094
             }, 
             {
                 "bad": false, 
@@ -7458,7 +7515,7 @@
             }
         ], 
         "parent_n_units": null, 
-        "vetted": false
+        "vetted": true
     }, 
     "/ttHiggs0MToGG_M125_TuneCP5_13TeV-JHUGenV7011-pythia8/phys_higgs-Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2-c1063618a596c295020f902ab9a75574/USER": {
         "dset_type": "mc", 
@@ -7793,7 +7850,7 @@
             }
         ], 
         "parent_n_units": null, 
-        "vetted": false
+        "vetted": true
     }, 
     "/ttHiggs0Mf05ph0ToGG_M125_TuneCP5_13TeV-JHUGenV7011-pythia8/phys_higgs-Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2-c1063618a596c295020f902ab9a75574/USER": {
         "dset_type": "mc", 
@@ -8072,6 +8129,6 @@
             }
         ], 
         "parent_n_units": null, 
-        "vetted": false
+        "vetted": true
     }
 }

--- a/MetaData/data/Era2017_legacy_v1_Summer20UL/datasets_9.json
+++ b/MetaData/data/Era2017_legacy_v1_Summer20UL/datasets_9.json
@@ -1596,7 +1596,7 @@
             }
         ], 
         "parent_n_units": null, 
-        "vetted": false
+        "vetted": true
     }, 
     "/DYJetsToLL_M-50_Zpt-100to200_BPSFilter_TuneCP5_13TeV-madgraphMLM-pythia8/phys_higgs-Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v1-365a9eeb963575ce9edbdfce0f0ba4bf/USER": {
         "dset_type": "mc", 
@@ -4955,7 +4955,7 @@
             }
         ], 
         "parent_n_units": null, 
-        "vetted": false
+        "vetted": true
     }, 
     "/GluGluHToGG_M-130_TuneCP5_13TeV-powheg-pythia8/phys_higgs-Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2-87ea3b90faed5199cfde26b1d7e045df/USER": {
         "dset_type": "mc", 
@@ -5130,7 +5130,7 @@
             }
         ], 
         "parent_n_units": null, 
-        "vetted": false
+        "vetted": true
     }, 
     "/VBFHiggs0L1Zgf05ph0ToGG_M125_TuneCP5_13TeV-JHUGenV7011-pythia8/phys_higgs-Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2-ca64037e1aeaaf0d4d2b197cdb41e4bc/USER": {
         "dset_type": "mc", 
@@ -5513,7 +5513,7 @@
             }
         ], 
         "parent_n_units": null, 
-        "vetted": false
+        "vetted": true
     }, 
     "/VBFHiggs0PHf05ph0ToGG_M125_TuneCP5_13TeV-JHUGenV7011-pythia8/phys_higgs-Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2-ca64037e1aeaaf0d4d2b197cdb41e4bc/USER": {
         "dset_type": "mc", 
@@ -5912,7 +5912,7 @@
             }
         ], 
         "parent_n_units": null, 
-        "vetted": false
+        "vetted": true
     }, 
     "/VHToGG_M120_TuneCP5_13TeV-amcatnloFXFX-madspin-pythia8/phys_higgs-Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2-87ea3b90faed5199cfde26b1d7e045df/USER": {
         "dset_type": "mc", 
@@ -6199,7 +6199,7 @@
             }
         ], 
         "parent_n_units": null, 
-        "vetted": false
+        "vetted": true
     }, 
     "/VHToGG_M124_TuneCP5_13TeV-amcatnloFXFX-madspin-pythia8/phys_higgs-Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2-87ea3b90faed5199cfde26b1d7e045df/USER": {
         "dset_type": "mc", 
@@ -6390,7 +6390,7 @@
             }
         ], 
         "parent_n_units": null, 
-        "vetted": false
+        "vetted": true
     }, 
     "/VHToGG_M127_TuneCP5_13TeV-amcatnloFXFX-madspin-pythia8/phys_higgs-Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2-87ea3b90faed5199cfde26b1d7e045df/USER": {
         "dset_type": "mc", 
@@ -6557,7 +6557,7 @@
             }
         ], 
         "parent_n_units": null, 
-        "vetted": false
+        "vetted": true
     }, 
     "/WHiggs0PHf05ph0ToGG_M125_TuneCP5_13TeV-JHUGenV7011-pythia8/phys_higgs-Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2-2d0531b4db33fa17307b0f4af20516e9/USER": {
         "dset_type": "mc", 
@@ -6916,7 +6916,7 @@
             }
         ], 
         "parent_n_units": null, 
-        "vetted": false
+        "vetted": true
     }, 
     "/ZHiggs0Mf05ph0ToGG_M125_TuneCP5_13TeV-JHUGenV7011-pythia8/phys_higgs-Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2-2d0531b4db33fa17307b0f4af20516e9/USER": {
         "dset_type": "mc", 
@@ -7267,7 +7267,7 @@
             }
         ], 
         "parent_n_units": null, 
-        "vetted": false
+        "vetted": true
     }, 
     "/ZHiggs0PMToGG_M125_TuneCP5_13TeV-JHUGenV7011-pythia8/phys_higgs-Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2-2d0531b4db33fa17307b0f4af20516e9/USER": {
         "dset_type": "mc", 
@@ -7346,7 +7346,7 @@
             }
         ], 
         "parent_n_units": null, 
-        "vetted": false
+        "vetted": true
     }, 
     "/ggZH_HToGG_ZToLL_M120_TuneCP5_13TeV-powheg-pythia8/phys_higgs-Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2-40c484617c8150a845705b37f7fbbebe/USER": {
         "dset_type": "mc", 
@@ -7360,9 +7360,12 @@
                 "weights": 163.98655700683594
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/ggZH_HToGG_ZToLL_M120_TuneCP5_13TeV-powheg-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_003416/0000/myMicroAODOutputFile_8.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 163.98655700683594
             }, 
             {
                 "bad": false, 
@@ -7389,9 +7392,12 @@
                 "weights": 163.98655700683594
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/ggZH_HToGG_ZToLL_M120_TuneCP5_13TeV-powheg-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_003031/0000/myMicroAODOutputFile_11.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 163.98655700683594
             }, 
             {
                 "bad": false, 
@@ -7410,9 +7416,12 @@
                 "weights": 156.11521911621094
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/ggZH_HToGG_ZToLL_M120_TuneCP5_13TeV-powheg-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_003031/0000/myMicroAODOutputFile_6.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 163.98655700683594
             }, 
             {
                 "bad": false, 
@@ -7582,9 +7591,12 @@
                 "weights": 158.34840393066406
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/ggZH_HToGG_ZToLL_M123_TuneCP5_13TeV-powheg-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_003830/0000/myMicroAODOutputFile_12.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 158.34840393066406
             }, 
             {
                 "bad": false, 
@@ -7651,9 +7663,12 @@
                 "weights": 158.34840393066406
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/ggZH_HToGG_ZToLL_M123_TuneCP5_13TeV-powheg-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_004320/0000/myMicroAODOutputFile_9.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 158.34840393066406
             }, 
             {
                 "bad": false, 
@@ -7751,14 +7766,20 @@
                 "weights": 156.48394775390625
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/ggZH_HToGG_ZToLL_M124_TuneCP5_13TeV-powheg-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_005059/0000/myMicroAODOutputFile_3.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 156.48394775390625
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/ggZH_HToGG_ZToLL_M124_TuneCP5_13TeV-powheg-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_005059/0000/myMicroAODOutputFile_6.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 156.48394775390625
             }, 
             {
                 "bad": false, 
@@ -7777,9 +7798,12 @@
                 "weights": 156.48394775390625
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/ggZH_HToGG_ZToLL_M124_TuneCP5_13TeV-powheg-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_005059/0000/myMicroAODOutputFile_11.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 156.48394775390625
             }, 
             {
                 "bad": false, 
@@ -7870,9 +7894,12 @@
                 "weights": 156.48394775390625
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2017_legacy_v1_Summer20UL/legacyRunII/ggZH_HToGG_ZToLL_M124_TuneCP5_13TeV-powheg-pythia8/Era2017_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v2/231121_004737/0000/myMicroAODOutputFile_1.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 156.48394775390625
             }, 
             {
                 "bad": false, 
@@ -8075,6 +8102,6 @@
             }
         ], 
         "parent_n_units": null, 
-        "vetted": false
+        "vetted": true
     }
 }

--- a/MetaData/data/Era2018_legacy_v1_Summer20UL/datasets.json
+++ b/MetaData/data/Era2018_legacy_v1_Summer20UL/datasets.json
@@ -2169,9 +2169,12 @@
                 "weights": 5811.12060546875
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/GluGluHToGG_M125_13TeV-sherpa/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/240308_153235/0000/myMicroAODOutputFile_42.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 5808.67236328125
             }, 
             {
                 "bad": false, 
@@ -2222,9 +2225,12 @@
                 "weights": 5811.005859375
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/GluGluHToGG_M125_13TeV-sherpa/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/240308_153235/0000/myMicroAODOutputFile_27.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 5816.3173828125
             }, 
             {
                 "bad": false, 
@@ -3066,9 +3072,12 @@
                 "weights": -760.2883911132812
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/GluGluHToGG_intqg_M125_13TeV-sherpa/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/240308_151430/0000/myMicroAODOutputFile_40.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": -1428.68701171875
             }, 
             {
                 "bad": false, 
@@ -3438,9 +3447,12 @@
                 "weights": 96219.1328125
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/VBFHToGG_M130_TuneCP5_13TeV-amcatnlo-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/220926_131241/0000/myMicroAODOutputFile_39.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 99782.8046875
             }, 
             {
                 "bad": false, 
@@ -3763,9 +3775,12 @@
                 "weights": 98511.84375
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 15000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/VBFHToGG_M130_TuneCP5_13TeV-amcatnlo-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/220926_131241/0000/myMicroAODOutputFile_88.root", 
-                "nevents": 15000
+                "nevents": 15000, 
+                "totEvents": 15000, 
+                "weights": 58364.4609375
             }, 
             {
                 "bad": false, 
@@ -3864,9 +3879,12 @@
                 "weights": 96842.1640625
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/VBFHToGG_M130_TuneCP5_13TeV-amcatnlo-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/220926_131241/0000/myMicroAODOutputFile_19.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 97614.6953125
             }, 
             {
                 "bad": false, 
@@ -3909,9 +3927,12 @@
                 "weights": 98262.6328125
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/VBFHToGG_M130_TuneCP5_13TeV-amcatnlo-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/220926_131241/0000/myMicroAODOutputFile_67.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 95446.578125
             }, 
             {
                 "bad": false, 
@@ -4161,14 +4182,20 @@
                 "weights": 7000.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 17000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/VBFHiggs0MToGG_M125_TuneCP5_13TeV-JHUGenV7011-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/220926_124831/0000/myMicroAODOutputFile_2.root", 
-                "nevents": 17000
+                "nevents": 17000, 
+                "totEvents": 17000, 
+                "weights": 17000.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 16000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/VBFHiggs0MToGG_M125_TuneCP5_13TeV-JHUGenV7011-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/220926_124831/0000/myMicroAODOutputFile_39.root", 
-                "nevents": 16000
+                "nevents": 16000, 
+                "totEvents": 16000, 
+                "weights": 16000.0
             }, 
             {
                 "bad": false, 
@@ -4283,9 +4310,12 @@
                 "weights": 25000.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/VBFHiggs0MToGG_M125_TuneCP5_13TeV-JHUGenV7011-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/220926_124831/0000/myMicroAODOutputFile_1.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 25000.0
             }, 
             {
                 "bad": false, 
@@ -4304,9 +4334,12 @@
                 "weights": 10000.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/VBFHiggs0MToGG_M125_TuneCP5_13TeV-JHUGenV7011-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/220926_124831/0000/myMicroAODOutputFile_18.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 25000.0
             }, 
             {
                 "bad": false, 
@@ -4349,9 +4382,12 @@
                 "weights": 25000.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/VBFHiggs0MToGG_M125_TuneCP5_13TeV-JHUGenV7011-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/220926_124620/0000/myMicroAODOutputFile_43.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 25000.0
             }, 
             {
                 "bad": false, 
@@ -4553,9 +4589,12 @@
                 "weights": 12000.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/VBFHiggs0Mf05ph0ToGG_M125_TuneCP5_13TeV-JHUGenV7011-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/220926_124408/0000/myMicroAODOutputFile_8.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 25000.0
             }, 
             {
                 "bad": false, 
@@ -4710,9 +4749,12 @@
                 "weights": 25000.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/VBFHiggs0Mf05ph0ToGG_M125_TuneCP5_13TeV-JHUGenV7011-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/220926_124158/0000/myMicroAODOutputFile_31.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 25000.0
             }, 
             {
                 "bad": false, 
@@ -4779,14 +4821,20 @@
                 "weights": 25000.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/VBFHiggs0Mf05ph0ToGG_M125_TuneCP5_13TeV-JHUGenV7011-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/220926_124408/0000/myMicroAODOutputFile_9.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 25000.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/VBFHiggs0Mf05ph0ToGG_M125_TuneCP5_13TeV-JHUGenV7011-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/220926_124408/0000/myMicroAODOutputFile_21.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 25000.0
             }, 
             {
                 "bad": false, 
@@ -5044,9 +5092,12 @@
                 "weights": 25000.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/WHiggs0L1f05ph0ToGG_M125_TuneCP5_13TeV-JHUGenV7011-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/220926_131710/0000/myMicroAODOutputFile_23.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 25000.0
             }, 
             {
                 "bad": false, 
@@ -5598,9 +5649,12 @@
         "dset_type": "mc", 
         "files": [
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 12987, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/ZH_HToGG_ZToAll_M130_TuneCP5_13TeV-powheg-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v1/220927_080056/0000/myMicroAODOutputFile_45.root", 
-                "nevents": 12987
+                "nevents": 12987, 
+                "totEvents": 12987, 
+                "weights": 9079.51171875
             }, 
             {
                 "bad": false, 
@@ -5779,9 +5833,12 @@
                 "weights": 817.11865234375
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 468, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/ZH_HToGG_ZToAll_M130_TuneCP5_13TeV-powheg-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v1/220927_080056/0000/myMicroAODOutputFile_49.root", 
-                "nevents": 468
+                "nevents": 468, 
+                "totEvents": 468, 
+                "weights": 324.77130126953125
             }, 
             {
                 "bad": false, 
@@ -5928,9 +5985,12 @@
                 "weights": 6438.33203125
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 6669, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/ZH_HToGG_ZToAll_M130_TuneCP5_13TeV-powheg-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v1/220927_080056/0000/myMicroAODOutputFile_4.root", 
-                "nevents": 6669
+                "nevents": 6669, 
+                "totEvents": 6669, 
+                "weights": 4683.97412109375
             }, 
             {
                 "bad": false, 
@@ -5973,9 +6033,12 @@
                 "weights": 80.82208251953125
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 936, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/ZH_HToGG_ZToAll_M130_TuneCP5_13TeV-powheg-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v1/220927_080056/0000/myMicroAODOutputFile_33.root", 
-                "nevents": 936
+                "nevents": 936, 
+                "totEvents": 936, 
+                "weights": 655.4744873046875
             }
         ], 
         "parent_n_units": null, 
@@ -6001,14 +6064,20 @@
                 "weights": 25000.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/ZHiggs0L1ZgToGG_M125_TuneCP5_13TeV-JHUGenV7011-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/220927_080924/0000/myMicroAODOutputFile_3.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 25000.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/ZHiggs0L1ZgToGG_M125_TuneCP5_13TeV-JHUGenV7011-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/220927_080924/0000/myMicroAODOutputFile_25.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 25000.0
             }, 
             {
                 "bad": false, 
@@ -6147,9 +6216,12 @@
                 "weights": 3000.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 12000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/ZHiggs0L1ZgToGG_M125_TuneCP5_13TeV-JHUGenV7011-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/220927_080924/0000/myMicroAODOutputFile_17.root", 
-                "nevents": 12000
+                "nevents": 12000, 
+                "totEvents": 12000, 
+                "weights": 12000.0
             }, 
             {
                 "bad": false, 
@@ -6176,9 +6248,12 @@
                 "weights": 25000.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/ZHiggs0L1ZgToGG_M125_TuneCP5_13TeV-JHUGenV7011-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/220927_080924/0000/myMicroAODOutputFile_2.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 25000.0
             }, 
             {
                 "bad": false, 
@@ -6197,9 +6272,12 @@
                 "weights": 25000.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/ZHiggs0L1ZgToGG_M125_TuneCP5_13TeV-JHUGenV7011-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/220927_080924/0000/myMicroAODOutputFile_31.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 25000.0
             }, 
             {
                 "bad": false, 

--- a/MetaData/data/Era2018_legacy_v1_Summer20UL/datasets_10.json
+++ b/MetaData/data/Era2018_legacy_v1_Summer20UL/datasets_10.json
@@ -361,9 +361,12 @@
                 "weights": 1641.377685546875
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/GluGluHToGG_int_M125_13TeV-sherpa/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/240308_150139/0000/myMicroAODOutputFile_25.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 437.421875
             }, 
             {
                 "bad": false, 
@@ -774,9 +777,12 @@
                 "weights": 1185.56689453125
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/GluGluHToGG_int_M125_13TeV-sherpa/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/240308_150139/0000/myMicroAODOutputFile_2.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 507.5538024902344
             }, 
             {
                 "bad": false, 
@@ -795,9 +801,12 @@
                 "weights": 1158.1888427734375
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 3000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/GluGluHToGG_int_M125_13TeV-sherpa/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/240308_150139/0000/myMicroAODOutputFile_81.root", 
-                "nevents": 3000
+                "nevents": 3000, 
+                "totEvents": 3000, 
+                "weights": 93.20747375488281
             }, 
             {
                 "bad": false, 
@@ -808,9 +817,12 @@
                 "weights": 453.8855285644531
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/GluGluHToGG_int_M125_13TeV-sherpa/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/240308_150139/0000/myMicroAODOutputFile_36.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 449.9859619140625
             }, 
             {
                 "bad": false, 
@@ -940,9 +952,12 @@
                 "weights": 24137.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24527, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/QCD_Pt-40ToInf_DoubleEMEnriched_MGG-80ToInf_TuneCP5_13TeV-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/240308_155547/0000/myMicroAODOutputFile_117.root", 
-                "nevents": 24527
+                "nevents": 24527, 
+                "totEvents": 24527, 
+                "weights": 24527.0
             }, 
             {
                 "bad": false, 
@@ -993,9 +1008,12 @@
                 "weights": 24659.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24689, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/QCD_Pt-40ToInf_DoubleEMEnriched_MGG-80ToInf_TuneCP5_13TeV-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/240308_155547/0000/myMicroAODOutputFile_59.root", 
-                "nevents": 24689
+                "nevents": 24689, 
+                "totEvents": 24689, 
+                "weights": 24689.0
             }, 
             {
                 "bad": false, 
@@ -1006,9 +1024,12 @@
                 "weights": 24767.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24769, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/QCD_Pt-40ToInf_DoubleEMEnriched_MGG-80ToInf_TuneCP5_13TeV-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/240308_155547/0000/myMicroAODOutputFile_60.root", 
-                "nevents": 24769
+                "nevents": 24769, 
+                "totEvents": 24769, 
+                "weights": 24769.0
             }, 
             {
                 "bad": false, 
@@ -1155,9 +1176,12 @@
                 "weights": 24577.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24102, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/QCD_Pt-40ToInf_DoubleEMEnriched_MGG-80ToInf_TuneCP5_13TeV-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/240308_155547/0000/myMicroAODOutputFile_89.root", 
-                "nevents": 24102
+                "nevents": 24102, 
+                "totEvents": 24102, 
+                "weights": 24102.0
             }, 
             {
                 "bad": false, 
@@ -1256,9 +1280,12 @@
                 "weights": 24948.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24609, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/QCD_Pt-40ToInf_DoubleEMEnriched_MGG-80ToInf_TuneCP5_13TeV-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/240308_155547/0000/myMicroAODOutputFile_359.root", 
-                "nevents": 24609
+                "nevents": 24609, 
+                "totEvents": 24609, 
+                "weights": 24609.0
             }, 
             {
                 "bad": false, 
@@ -1301,9 +1328,12 @@
                 "weights": 24673.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24936, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/QCD_Pt-40ToInf_DoubleEMEnriched_MGG-80ToInf_TuneCP5_13TeV-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/240308_155547/0000/myMicroAODOutputFile_348.root", 
-                "nevents": 24936
+                "nevents": 24936, 
+                "totEvents": 24936, 
+                "weights": 24936.0
             }, 
             {
                 "bad": false, 
@@ -1434,9 +1464,12 @@
                 "weights": 24981.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24628, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/QCD_Pt-40ToInf_DoubleEMEnriched_MGG-80ToInf_TuneCP5_13TeV-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/240308_155547/0000/myMicroAODOutputFile_315.root", 
-                "nevents": 24628
+                "nevents": 24628, 
+                "totEvents": 24628, 
+                "weights": 24628.0
             }, 
             {
                 "bad": false, 
@@ -1471,9 +1504,12 @@
                 "weights": 24835.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24859, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/QCD_Pt-40ToInf_DoubleEMEnriched_MGG-80ToInf_TuneCP5_13TeV-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/240308_155547/0000/myMicroAODOutputFile_243.root", 
-                "nevents": 24859
+                "nevents": 24859, 
+                "totEvents": 24859, 
+                "weights": 24859.0
             }, 
             {
                 "bad": false, 
@@ -1716,9 +1752,12 @@
                 "weights": 24856.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 23909, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/QCD_Pt-40ToInf_DoubleEMEnriched_MGG-80ToInf_TuneCP5_13TeV-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/240308_155547/0000/myMicroAODOutputFile_84.root", 
-                "nevents": 23909
+                "nevents": 23909, 
+                "totEvents": 23909, 
+                "weights": 23909.0
             }, 
             {
                 "bad": false, 
@@ -1737,9 +1776,12 @@
                 "weights": 24747.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24962, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/QCD_Pt-40ToInf_DoubleEMEnriched_MGG-80ToInf_TuneCP5_13TeV-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/240308_155547/0000/myMicroAODOutputFile_13.root", 
-                "nevents": 24962
+                "nevents": 24962, 
+                "totEvents": 24962, 
+                "weights": 24962.0
             }, 
             {
                 "bad": false, 
@@ -1814,9 +1856,12 @@
                 "weights": 24052.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24080, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/QCD_Pt-40ToInf_DoubleEMEnriched_MGG-80ToInf_TuneCP5_13TeV-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/240308_155547/0000/myMicroAODOutputFile_90.root", 
-                "nevents": 24080
+                "nevents": 24080, 
+                "totEvents": 24080, 
+                "weights": 24080.0
             }, 
             {
                 "bad": false, 
@@ -1939,9 +1984,12 @@
                 "weights": 24889.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24567, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/QCD_Pt-40ToInf_DoubleEMEnriched_MGG-80ToInf_TuneCP5_13TeV-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/240308_155547/0000/myMicroAODOutputFile_316.root", 
-                "nevents": 24567
+                "nevents": 24567, 
+                "totEvents": 24567, 
+                "weights": 24567.0
             }, 
             {
                 "bad": false, 
@@ -2008,9 +2056,12 @@
                 "weights": 25033.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24781, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/QCD_Pt-40ToInf_DoubleEMEnriched_MGG-80ToInf_TuneCP5_13TeV-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/240308_155547/0000/myMicroAODOutputFile_264.root", 
-                "nevents": 24781
+                "nevents": 24781, 
+                "totEvents": 24781, 
+                "weights": 24781.0
             }, 
             {
                 "bad": false, 
@@ -2021,9 +2072,12 @@
                 "weights": 24928.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24961, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/QCD_Pt-40ToInf_DoubleEMEnriched_MGG-80ToInf_TuneCP5_13TeV-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/240308_155547/0000/myMicroAODOutputFile_273.root", 
-                "nevents": 24961
+                "nevents": 24961, 
+                "totEvents": 24961, 
+                "weights": 24961.0
             }, 
             {
                 "bad": false, 
@@ -2170,9 +2224,12 @@
                 "weights": 24956.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24792, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/QCD_Pt-40ToInf_DoubleEMEnriched_MGG-80ToInf_TuneCP5_13TeV-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/240308_155547/0000/myMicroAODOutputFile_141.root", 
-                "nevents": 24792
+                "nevents": 24792, 
+                "totEvents": 24792, 
+                "weights": 24792.0
             }, 
             {
                 "bad": false, 
@@ -2279,9 +2336,12 @@
                 "weights": 24744.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24883, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/QCD_Pt-40ToInf_DoubleEMEnriched_MGG-80ToInf_TuneCP5_13TeV-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/240308_155547/0000/myMicroAODOutputFile_300.root", 
-                "nevents": 24883
+                "nevents": 24883, 
+                "totEvents": 24883, 
+                "weights": 24883.0
             }, 
             {
                 "bad": false, 
@@ -2420,9 +2480,12 @@
                 "weights": 24811.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24133, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/QCD_Pt-40ToInf_DoubleEMEnriched_MGG-80ToInf_TuneCP5_13TeV-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/240308_155547/0000/myMicroAODOutputFile_349.root", 
-                "nevents": 24133
+                "nevents": 24133, 
+                "totEvents": 24133, 
+                "weights": 24133.0
             }, 
             {
                 "bad": false, 
@@ -2457,9 +2520,12 @@
                 "weights": 24951.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24955, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/QCD_Pt-40ToInf_DoubleEMEnriched_MGG-80ToInf_TuneCP5_13TeV-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/240308_155547/0000/myMicroAODOutputFile_132.root", 
-                "nevents": 24955
+                "nevents": 24955, 
+                "totEvents": 24955, 
+                "weights": 24955.0
             }, 
             {
                 "bad": false, 
@@ -2726,9 +2792,12 @@
                 "weights": 24424.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24989, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/QCD_Pt-40ToInf_DoubleEMEnriched_MGG-80ToInf_TuneCP5_13TeV-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/240308_155547/0000/myMicroAODOutputFile_187.root", 
-                "nevents": 24989
+                "nevents": 24989, 
+                "totEvents": 24989, 
+                "weights": 24989.0
             }, 
             {
                 "bad": false, 
@@ -2923,9 +2992,12 @@
                 "weights": 24955.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24904, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/QCD_Pt-40ToInf_DoubleEMEnriched_MGG-80ToInf_TuneCP5_13TeV-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/240308_155547/0000/myMicroAODOutputFile_376.root", 
-                "nevents": 24904
+                "nevents": 24904, 
+                "totEvents": 24904, 
+                "weights": 24904.0
             }, 
             {
                 "bad": false, 
@@ -2960,9 +3032,12 @@
                 "weights": 24856.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25051, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/QCD_Pt-40ToInf_DoubleEMEnriched_MGG-80ToInf_TuneCP5_13TeV-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/240308_155547/0000/myMicroAODOutputFile_188.root", 
-                "nevents": 25051
+                "nevents": 25051, 
+                "totEvents": 25051, 
+                "weights": 25051.0
             }, 
             {
                 "bad": false, 
@@ -3101,9 +3176,12 @@
                 "weights": 24372.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24797, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/QCD_Pt-40ToInf_DoubleEMEnriched_MGG-80ToInf_TuneCP5_13TeV-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/240308_155547/0000/myMicroAODOutputFile_298.root", 
-                "nevents": 24797
+                "nevents": 24797, 
+                "totEvents": 24797, 
+                "weights": 24797.0
             }, 
             {
                 "bad": false, 
@@ -3410,9 +3488,12 @@
                 "weights": 24851.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24653, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/QCD_Pt-40ToInf_DoubleEMEnriched_MGG-80ToInf_TuneCP5_13TeV-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/240308_155547/0000/myMicroAODOutputFile_246.root", 
-                "nevents": 24653
+                "nevents": 24653, 
+                "totEvents": 24653, 
+                "weights": 24653.0
             }, 
             {
                 "bad": false, 
@@ -3495,9 +3576,12 @@
                 "weights": 24737.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24902, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/QCD_Pt-40ToInf_DoubleEMEnriched_MGG-80ToInf_TuneCP5_13TeV-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/240308_155547/0000/myMicroAODOutputFile_22.root", 
-                "nevents": 24902
+                "nevents": 24902, 
+                "totEvents": 24902, 
+                "weights": 24902.0
             }, 
             {
                 "bad": false, 
@@ -3556,9 +3640,12 @@
                 "weights": 24845.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24613, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/QCD_Pt-40ToInf_DoubleEMEnriched_MGG-80ToInf_TuneCP5_13TeV-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/240308_155547/0000/myMicroAODOutputFile_325.root", 
-                "nevents": 24613
+                "nevents": 24613, 
+                "totEvents": 24613, 
+                "weights": 24613.0
             }, 
             {
                 "bad": false, 
@@ -4892,9 +4979,12 @@
         "dset_type": "mc", 
         "files": [
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 3000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/VBFHiggs0L1ZgToGG_M125_TuneCP5_13TeV-JHUGenV7011-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/220926_123735/0000/myMicroAODOutputFile_1.root", 
-                "nevents": 3000
+                "nevents": 3000, 
+                "totEvents": 3000, 
+                "weights": 3000.0
             }, 
             {
                 "bad": false, 
@@ -5001,9 +5091,12 @@
                 "weights": 25000.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/VBFHiggs0L1ZgToGG_M125_TuneCP5_13TeV-JHUGenV7011-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/220926_123735/0000/myMicroAODOutputFile_12.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 25000.0
             }, 
             {
                 "bad": false, 
@@ -5070,9 +5163,12 @@
                 "weights": 25000.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/VBFHiggs0L1ZgToGG_M125_TuneCP5_13TeV-JHUGenV7011-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/220926_123947/0000/myMicroAODOutputFile_26.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 25000.0
             }, 
             {
                 "bad": false, 
@@ -5234,9 +5330,12 @@
                 "weights": 25000.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 22000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/VBFHiggs0PHf05ph0ToGG_M125_TuneCP5_13TeV-JHUGenV7011-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/220926_125255/0000/myMicroAODOutputFile_1.root", 
-                "nevents": 22000
+                "nevents": 22000, 
+                "totEvents": 22000, 
+                "weights": 22000.0
             }, 
             {
                 "bad": false, 
@@ -5287,9 +5386,12 @@
                 "weights": 25000.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/VBFHiggs0PHf05ph0ToGG_M125_TuneCP5_13TeV-JHUGenV7011-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/220926_125255/0000/myMicroAODOutputFile_24.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 25000.0
             }, 
             {
                 "bad": false, 
@@ -5332,9 +5434,12 @@
                 "weights": 25000.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/VBFHiggs0PHf05ph0ToGG_M125_TuneCP5_13TeV-JHUGenV7011-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/220926_125044/0000/myMicroAODOutputFile_12.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 25000.0
             }, 
             {
                 "bad": false, 
@@ -5456,9 +5561,12 @@
                 "weights": 6000.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/WHiggs0L1ToGG_M125_TuneCP5_13TeV-JHUGenV7011-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/220926_131921/0000/myMicroAODOutputFile_22.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 25000.0
             }, 
             {
                 "bad": false, 
@@ -5501,14 +5609,20 @@
                 "weights": 25000.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/WHiggs0L1ToGG_M125_TuneCP5_13TeV-JHUGenV7011-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/220926_131921/0000/myMicroAODOutputFile_29.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 25000.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 3000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/WHiggs0L1ToGG_M125_TuneCP5_13TeV-JHUGenV7011-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/220926_131921/0000/myMicroAODOutputFile_2.root", 
-                "nevents": 3000
+                "nevents": 3000, 
+                "totEvents": 3000, 
+                "weights": 3000.0
             }, 
             {
                 "bad": false, 
@@ -5663,9 +5777,12 @@
                 "weights": 25000.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/WHiggs0L1ToGG_M125_TuneCP5_13TeV-JHUGenV7011-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/220926_131921/0000/myMicroAODOutputFile_32.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 25000.0
             }
         ], 
         "parent_n_units": null, 
@@ -5827,9 +5944,12 @@
                 "weights": 25000.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/WHiggs0PHf05ph0ToGG_M125_TuneCP5_13TeV-JHUGenV7011-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/220926_132554/0000/myMicroAODOutputFile_16.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 25000.0
             }, 
             {
                 "bad": false, 
@@ -5840,9 +5960,12 @@
                 "weights": 25000.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/WHiggs0PHf05ph0ToGG_M125_TuneCP5_13TeV-JHUGenV7011-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/220926_132554/0000/myMicroAODOutputFile_28.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 25000.0
             }, 
             {
                 "bad": false, 
@@ -5853,14 +5976,20 @@
                 "weights": 25000.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/WHiggs0PHf05ph0ToGG_M125_TuneCP5_13TeV-JHUGenV7011-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/220926_132554/0000/myMicroAODOutputFile_15.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 25000.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/WHiggs0PHf05ph0ToGG_M125_TuneCP5_13TeV-JHUGenV7011-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/220926_132554/0000/myMicroAODOutputFile_21.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 25000.0
             }, 
             {
                 "bad": false, 
@@ -5895,9 +6024,12 @@
                 "weights": 25000.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/WHiggs0PHf05ph0ToGG_M125_TuneCP5_13TeV-JHUGenV7011-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/220926_132554/0000/myMicroAODOutputFile_20.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 25000.0
             }, 
             {
                 "bad": false, 
@@ -6027,9 +6159,12 @@
                 "weights": 22000.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/WHiggs0PMToGG_M125_TuneCP5_13TeV-JHUGenV7011-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/220926_133017/0000/myMicroAODOutputFile_31.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 25000.0
             }, 
             {
                 "bad": false, 
@@ -6040,14 +6175,20 @@
                 "weights": 25000.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/WHiggs0PMToGG_M125_TuneCP5_13TeV-JHUGenV7011-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/220926_133017/0000/myMicroAODOutputFile_25.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 25000.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/WHiggs0PMToGG_M125_TuneCP5_13TeV-JHUGenV7011-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/220926_133017/0000/myMicroAODOutputFile_8.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 25000.0
             }, 
             {
                 "bad": false, 
@@ -6082,9 +6223,12 @@
                 "weights": 25000.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/WHiggs0PMToGG_M125_TuneCP5_13TeV-JHUGenV7011-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/220926_133017/0000/myMicroAODOutputFile_11.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 25000.0
             }, 
             {
                 "bad": false, 
@@ -6103,9 +6247,12 @@
                 "weights": 25000.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/WHiggs0PMToGG_M125_TuneCP5_13TeV-JHUGenV7011-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/220926_133017/0000/myMicroAODOutputFile_10.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 25000.0
             }, 
             {
                 "bad": false, 
@@ -6140,9 +6287,12 @@
                 "weights": 25000.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/WHiggs0PMToGG_M125_TuneCP5_13TeV-JHUGenV7011-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/220926_133017/0000/myMicroAODOutputFile_24.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 25000.0
             }, 
             {
                 "bad": false, 
@@ -6233,9 +6383,12 @@
                 "weights": 25000.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/WHiggs0PMToGG_M125_TuneCP5_13TeV-JHUGenV7011-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/220926_133017/0000/myMicroAODOutputFile_20.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 25000.0
             }, 
             {
                 "bad": false, 
@@ -6269,9 +6422,12 @@
                 "weights": 10174.326171875
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24966, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/ZH_HToGG_ZToAll_M125_TuneCP5_13TeV-powheg-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v1/220927_075848/0000/myMicroAODOutputFile_45.root", 
-                "nevents": 24966
+                "nevents": 24966, 
+                "totEvents": 24966, 
+                "weights": 19709.779296875
             }, 
             {
                 "bad": false, 
@@ -6354,9 +6510,12 @@
                 "weights": 224.69869995117188
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 5621, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/ZH_HToGG_ZToAll_M125_TuneCP5_13TeV-powheg-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v1/220927_075848/0000/myMicroAODOutputFile_31.root", 
-                "nevents": 5621
+                "nevents": 5621, 
+                "totEvents": 5621, 
+                "weights": 4426.06103515625
             }, 
             {
                 "bad": false, 
@@ -6367,9 +6526,12 @@
                 "weights": 6135.61474609375
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 6059, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/ZH_HToGG_ZToAll_M125_TuneCP5_13TeV-powheg-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v1/220927_075848/0000/myMicroAODOutputFile_27.root", 
-                "nevents": 6059
+                "nevents": 6059, 
+                "totEvents": 6059, 
+                "weights": 4781.5537109375
             }, 
             {
                 "bad": false, 

--- a/MetaData/data/Era2018_legacy_v1_Summer20UL/datasets_11.json
+++ b/MetaData/data/Era2018_legacy_v1_Summer20UL/datasets_11.json
@@ -75,9 +75,12 @@
                 "weights": 5377.03515625
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/GluGluHToGG_M120_13TeV-sherpa/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/240308_152341/0000/myMicroAODOutputFile_6.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 5373.8369140625
             }, 
             {
                 "bad": false, 
@@ -175,19 +178,28 @@
                 "weights": 1032828.5
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 13415, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/GluGluHToGG_M120_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v3/220926_114554/0000/myMicroAODOutputFile_9.root", 
-                "nevents": 13415
+                "nevents": 13415, 
+                "totEvents": 13415, 
+                "weights": 1597533.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 6645, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/GluGluHToGG_M120_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v3/220926_114554/0000/myMicroAODOutputFile_41.root", 
-                "nevents": 6645
+                "nevents": 6645, 
+                "totEvents": 6645, 
+                "weights": 786173.5
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 4512, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/GluGluHToGG_M120_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v3/220926_114554/0000/myMicroAODOutputFile_4.root", 
-                "nevents": 4512
+                "nevents": 4512, 
+                "totEvents": 4512, 
+                "weights": 509545.375
             }, 
             {
                 "bad": false, 
@@ -390,9 +402,12 @@
                 "weights": 2853079.25
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24286, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/GluGluHToGG_M120_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v3/220926_114554/0000/myMicroAODOutputFile_39.root", 
-                "nevents": 24286
+                "nevents": 24286, 
+                "totEvents": 24286, 
+                "weights": 2882428.25
             }, 
             {
                 "bad": false, 
@@ -538,9 +553,12 @@
                 "weights": 1361457.75
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 11504, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/GluGluHToGG_M125_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v1/220926_115115/0000/myMicroAODOutputFile_174.root", 
-                "nevents": 11504
+                "nevents": 11504, 
+                "totEvents": 11504, 
+                "weights": 1266042.0
             }, 
             {
                 "bad": false, 
@@ -551,9 +569,12 @@
                 "weights": 1370132.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 11532, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/GluGluHToGG_M125_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v1/220926_115115/0000/myMicroAODOutputFile_113.root", 
-                "nevents": 11532
+                "nevents": 11532, 
+                "totEvents": 11532, 
+                "weights": 1256404.0
             }, 
             {
                 "bad": false, 
@@ -604,9 +625,12 @@
                 "weights": 2659112.5
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24149, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/GluGluHToGG_M125_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v1/220926_115115/0000/myMicroAODOutputFile_118.root", 
-                "nevents": 24149
+                "nevents": 24149, 
+                "totEvents": 24149, 
+                "weights": 2623644.75
             }, 
             {
                 "bad": false, 
@@ -649,9 +673,12 @@
                 "weights": 2678581.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24940, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/GluGluHToGG_M125_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v1/220926_115115/0000/myMicroAODOutputFile_6.root", 
-                "nevents": 24940
+                "nevents": 24940, 
+                "totEvents": 24940, 
+                "weights": 2737180.0
             }, 
             {
                 "bad": false, 
@@ -726,9 +753,12 @@
                 "weights": 2614006.5
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24793, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/GluGluHToGG_M125_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v1/220926_115115/0000/myMicroAODOutputFile_129.root", 
-                "nevents": 24793
+                "nevents": 24793, 
+                "totEvents": 24793, 
+                "weights": 2680701.75
             }, 
             {
                 "bad": false, 
@@ -787,9 +817,12 @@
                 "weights": 2662967.5
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24060, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/GluGluHToGG_M125_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v1/220926_115115/0000/myMicroAODOutputFile_120.root", 
-                "nevents": 24060
+                "nevents": 24060, 
+                "totEvents": 24060, 
+                "weights": 2634246.75
             }, 
             {
                 "bad": false, 
@@ -856,9 +889,12 @@
                 "weights": 2426066.5
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24968, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/GluGluHToGG_M125_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v1/220926_115115/0000/myMicroAODOutputFile_18.root", 
-                "nevents": 24968
+                "nevents": 24968, 
+                "totEvents": 24968, 
+                "weights": 2739493.25
             }, 
             {
                 "bad": false, 
@@ -997,9 +1033,12 @@
                 "weights": 2577768.25
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24029, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/GluGluHToGG_M125_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v1/220926_115115/0000/myMicroAODOutputFile_108.root", 
-                "nevents": 24029
+                "nevents": 24029, 
+                "totEvents": 24029, 
+                "weights": 2666051.75
             }, 
             {
                 "bad": false, 
@@ -1010,9 +1049,12 @@
                 "weights": 2745082.75
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24109, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/GluGluHToGG_M125_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v1/220926_115115/0000/myMicroAODOutputFile_45.root", 
-                "nevents": 24109
+                "nevents": 24109, 
+                "totEvents": 24109, 
+                "weights": 2668364.75
             }, 
             {
                 "bad": false, 
@@ -1079,9 +1121,12 @@
                 "weights": 2673762.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24966, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/GluGluHToGG_M125_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v1/220926_115115/0000/myMicroAODOutputFile_11.root", 
-                "nevents": 24966
+                "nevents": 24966, 
+                "totEvents": 24966, 
+                "weights": 2699013.75
             }, 
             {
                 "bad": false, 
@@ -1092,9 +1137,12 @@
                 "weights": 2476955.25
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 23073, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/GluGluHToGG_M125_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v1/220926_115115/0000/myMicroAODOutputFile_110.root", 
-                "nevents": 23073
+                "nevents": 23073, 
+                "totEvents": 23073, 
+                "weights": 2588177.25
             }, 
             {
                 "bad": false, 
@@ -1113,9 +1161,12 @@
                 "weights": 2609958.75
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 16775, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/GluGluHToGG_M125_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v1/220926_115115/0000/myMicroAODOutputFile_97.root", 
-                "nevents": 16775
+                "nevents": 16775, 
+                "totEvents": 16775, 
+                "weights": 1858005.375
             }, 
             {
                 "bad": false, 
@@ -1222,14 +1273,20 @@
                 "weights": 2743541.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24021, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/GluGluHToGG_M125_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v1/220926_115115/0000/myMicroAODOutputFile_127.root", 
-                "nevents": 24021
+                "nevents": 24021, 
+                "totEvents": 24021, 
+                "weights": 2621717.5
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24960, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/GluGluHToGG_M125_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v1/220926_115115/0000/myMicroAODOutputFile_36.root", 
-                "nevents": 24960
+                "nevents": 24960, 
+                "totEvents": 24960, 
+                "weights": 2756455.75
             }, 
             {
                 "bad": false, 
@@ -1248,9 +1305,12 @@
                 "weights": 2660847.25
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24952, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/GluGluHToGG_M125_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v1/220926_115115/0000/myMicroAODOutputFile_37.root", 
-                "nevents": 24952
+                "nevents": 24952, 
+                "totEvents": 24952, 
+                "weights": 2784984.5
             }, 
             {
                 "bad": false, 
@@ -1269,9 +1329,12 @@
                 "weights": 2188587.5
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24008, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/GluGluHToGG_M125_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v1/220926_115115/0000/myMicroAODOutputFile_55.root", 
-                "nevents": 24008
+                "nevents": 24008, 
+                "totEvents": 24008, 
+                "weights": 2624608.5
             }, 
             {
                 "bad": false, 
@@ -1410,9 +1473,12 @@
                 "weights": 2690146.5
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 23988, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/GluGluHToGG_M125_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v1/220926_115115/0000/myMicroAODOutputFile_44.root", 
-                "nevents": 23988
+                "nevents": 23988, 
+                "totEvents": 23988, 
+                "weights": 2614970.5
             }, 
             {
                 "bad": false, 
@@ -1527,14 +1593,20 @@
                 "weights": 2686484.25
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24190, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/GluGluHToGG_M125_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v1/220926_115115/0000/myMicroAODOutputFile_155.root", 
-                "nevents": 24190
+                "nevents": 24190, 
+                "totEvents": 24190, 
+                "weights": 2644655.75
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24144, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/GluGluHToGG_M125_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v1/220926_115115/0000/myMicroAODOutputFile_148.root", 
-                "nevents": 24144
+                "nevents": 24144, 
+                "totEvents": 24144, 
+                "weights": 2674340.75
             }, 
             {
                 "bad": false, 
@@ -1801,14 +1873,20 @@
                 "weights": 2621138.75
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24129, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/GluGluHToGG_M125_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v1/220926_115115/0000/myMicroAODOutputFile_143.root", 
-                "nevents": 24129
+                "nevents": 24129, 
+                "totEvents": 24129, 
+                "weights": 2634824.75
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 23854, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/GluGluHToGG_M125_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v1/220926_115115/0000/myMicroAODOutputFile_149.root", 
-                "nevents": 23854
+                "nevents": 23854, 
+                "totEvents": 23854, 
+                "weights": 2582587.0
             }, 
             {
                 "bad": false, 
@@ -1819,9 +1897,12 @@
                 "weights": 2634824.75
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24107, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/GluGluHToGG_M125_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v1/220926_115115/0000/myMicroAODOutputFile_136.root", 
-                "nevents": 24107
+                "nevents": 24107, 
+                "totEvents": 24107, 
+                "weights": 2661425.5
             }, 
             {
                 "bad": false, 
@@ -2207,9 +2288,12 @@
                 "weights": 2456411.5
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24338, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/GluGluHToGG_M130_TuneCP5_13TeV-amcatnloFXFX-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v1/220926_115541/0000/myMicroAODOutputFile_25.root", 
-                "nevents": 24338
+                "nevents": 24338, 
+                "totEvents": 24338, 
+                "weights": 2457486.5
             }, 
             {
                 "bad": false, 
@@ -2323,9 +2407,12 @@
                 "weights": 24950.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24843, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/QCD_Pt-30to40_DoubleEMEnriched_MGG-80toInf_TuneCP5_13TeV-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v1/240308_154520/0000/myMicroAODOutputFile_87.root", 
-                "nevents": 24843
+                "nevents": 24843, 
+                "totEvents": 24843, 
+                "weights": 24843.0
             }, 
             {
                 "bad": false, 
@@ -2432,9 +2519,12 @@
                 "weights": 25233.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24882, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/QCD_Pt-30to40_DoubleEMEnriched_MGG-80toInf_TuneCP5_13TeV-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v1/240308_154520/0000/myMicroAODOutputFile_6.root", 
-                "nevents": 24882
+                "nevents": 24882, 
+                "totEvents": 24882, 
+                "weights": 24882.0
             }, 
             {
                 "bad": false, 
@@ -2517,9 +2607,12 @@
                 "weights": 24994.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25012, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/QCD_Pt-30to40_DoubleEMEnriched_MGG-80toInf_TuneCP5_13TeV-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v1/240308_154520/0000/myMicroAODOutputFile_95.root", 
-                "nevents": 25012
+                "nevents": 25012, 
+                "totEvents": 25012, 
+                "weights": 25012.0
             }, 
             {
                 "bad": false, 
@@ -2554,9 +2647,12 @@
                 "weights": 24940.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25074, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/QCD_Pt-30to40_DoubleEMEnriched_MGG-80toInf_TuneCP5_13TeV-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v1/240308_154520/0000/myMicroAODOutputFile_60.root", 
-                "nevents": 25074
+                "nevents": 25074, 
+                "totEvents": 25074, 
+                "weights": 25074.0
             }, 
             {
                 "bad": false, 
@@ -2575,9 +2671,12 @@
                 "weights": 25274.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25153, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/QCD_Pt-30to40_DoubleEMEnriched_MGG-80toInf_TuneCP5_13TeV-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v1/240308_154520/0000/myMicroAODOutputFile_73.root", 
-                "nevents": 25153
+                "nevents": 25153, 
+                "totEvents": 25153, 
+                "weights": 25153.0
             }, 
             {
                 "bad": false, 
@@ -2620,9 +2719,12 @@
                 "weights": 24966.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24890, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/QCD_Pt-30to40_DoubleEMEnriched_MGG-80toInf_TuneCP5_13TeV-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v1/240308_154520/0000/myMicroAODOutputFile_68.root", 
-                "nevents": 24890
+                "nevents": 24890, 
+                "totEvents": 24890, 
+                "weights": 24890.0
             }, 
             {
                 "bad": false, 
@@ -2673,9 +2775,12 @@
                 "weights": 25017.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24948, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/QCD_Pt-30to40_DoubleEMEnriched_MGG-80toInf_TuneCP5_13TeV-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v1/240308_154520/0000/myMicroAODOutputFile_78.root", 
-                "nevents": 24948
+                "nevents": 24948, 
+                "totEvents": 24948, 
+                "weights": 24948.0
             }, 
             {
                 "bad": false, 
@@ -2830,9 +2935,12 @@
                 "weights": 24759.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24819, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/QCD_Pt-30to40_DoubleEMEnriched_MGG-80toInf_TuneCP5_13TeV-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v1/240308_154520/0000/myMicroAODOutputFile_21.root", 
-                "nevents": 24819
+                "nevents": 24819, 
+                "totEvents": 24819, 
+                "weights": 24819.0
             }, 
             {
                 "bad": false, 
@@ -2971,9 +3079,12 @@
                 "weights": 24960.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24973, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/QCD_Pt-30to40_DoubleEMEnriched_MGG-80toInf_TuneCP5_13TeV-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v1/240308_154520/0000/myMicroAODOutputFile_82.root", 
-                "nevents": 24973
+                "nevents": 24973, 
+                "totEvents": 24973, 
+                "weights": 24973.0
             }, 
             {
                 "bad": false, 
@@ -3040,9 +3151,12 @@
                 "weights": 24879.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25023, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/QCD_Pt-30to40_DoubleEMEnriched_MGG-80toInf_TuneCP5_13TeV-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v1/240308_154520/0000/myMicroAODOutputFile_122.root", 
-                "nevents": 25023
+                "nevents": 25023, 
+                "totEvents": 25023, 
+                "weights": 25023.0
             }, 
             {
                 "bad": false, 
@@ -3101,9 +3215,12 @@
                 "weights": 25078.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25231, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/QCD_Pt-30to40_DoubleEMEnriched_MGG-80toInf_TuneCP5_13TeV-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v1/240308_154520/0000/myMicroAODOutputFile_132.root", 
-                "nevents": 25231
+                "nevents": 25231, 
+                "totEvents": 25231, 
+                "weights": 25231.0
             }, 
             {
                 "bad": false, 
@@ -3258,9 +3375,12 @@
                 "weights": 25205.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24819, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/QCD_Pt-30to40_DoubleEMEnriched_MGG-80toInf_TuneCP5_13TeV-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v1/240308_154520/0000/myMicroAODOutputFile_33.root", 
-                "nevents": 24819
+                "nevents": 24819, 
+                "totEvents": 24819, 
+                "weights": 24819.0
             }, 
             {
                 "bad": false, 
@@ -3287,9 +3407,12 @@
                 "weights": 24950.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24919, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/QCD_Pt-30to40_DoubleEMEnriched_MGG-80toInf_TuneCP5_13TeV-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v1/240308_154520/0000/myMicroAODOutputFile_39.root", 
-                "nevents": 24919
+                "nevents": 24919, 
+                "totEvents": 24919, 
+                "weights": 24919.0
             }, 
             {
                 "bad": false, 
@@ -3308,9 +3431,12 @@
                 "weights": 25199.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24775, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/QCD_Pt-30to40_DoubleEMEnriched_MGG-80toInf_TuneCP5_13TeV-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v1/240308_154520/0000/myMicroAODOutputFile_168.root", 
-                "nevents": 24775
+                "nevents": 24775, 
+                "totEvents": 24775, 
+                "weights": 24775.0
             }, 
             {
                 "bad": false, 
@@ -3393,9 +3519,12 @@
                 "weights": 24738.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24703, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/QCD_Pt-30to40_DoubleEMEnriched_MGG-80toInf_TuneCP5_13TeV-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v1/240308_154520/0000/myMicroAODOutputFile_18.root", 
-                "nevents": 24703
+                "nevents": 24703, 
+                "totEvents": 24703, 
+                "weights": 24703.0
             }, 
             {
                 "bad": false, 
@@ -3493,9 +3622,12 @@
                 "weights": 16124.5302734375
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 12000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/VBFHToGG_M120_TuneCP5_13TeV-amcatnlo-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/220926_130353/0000/myMicroAODOutputFile_13.root", 
-                "nevents": 12000
+                "nevents": 12000, 
+                "totEvents": 12000, 
+                "weights": 50165.20703125
             }, 
             {
                 "bad": false, 
@@ -3546,9 +3678,12 @@
                 "weights": 8252.28515625
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 4000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/VBFHToGG_M120_TuneCP5_13TeV-amcatnlo-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/220926_130353/0000/myMicroAODOutputFile_14.root", 
-                "nevents": 4000
+                "nevents": 4000, 
+                "totEvents": 4000, 
+                "weights": 17291.79296875
             }, 
             {
                 "bad": false, 
@@ -3575,14 +3710,20 @@
                 "weights": 89933.6171875
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/VBFHToGG_M120_TuneCP5_13TeV-amcatnlo-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/220926_130353/0000/myMicroAODOutputFile_75.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 106899.6640625
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/VBFHToGG_M120_TuneCP5_13TeV-amcatnlo-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/220926_130353/0000/myMicroAODOutputFile_58.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 108446.96875
             }, 
             {
                 "bad": false, 
@@ -3681,9 +3822,12 @@
                 "weights": 106085.2890625
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/VBFHToGG_M120_TuneCP5_13TeV-amcatnlo-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/220926_130353/0000/myMicroAODOutputFile_34.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 104809.453125
             }, 
             {
                 "bad": false, 
@@ -3694,9 +3838,12 @@
                 "weights": 104646.5625
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/VBFHToGG_M120_TuneCP5_13TeV-amcatnlo-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/220926_130353/0000/myMicroAODOutputFile_54.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 106655.359375
             }, 
             {
                 "bad": false, 
@@ -3739,9 +3886,12 @@
                 "weights": 106655.3359375
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/VBFHToGG_M120_TuneCP5_13TeV-amcatnlo-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/220926_130353/0000/myMicroAODOutputFile_83.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 102936.3984375
             }, 
             {
                 "bad": false, 
@@ -3776,9 +3926,12 @@
                 "weights": 106519.609375
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/VBFHToGG_M120_TuneCP5_13TeV-amcatnlo-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/220926_130353/0000/myMicroAODOutputFile_48.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 108962.734375
             }, 
             {
                 "bad": false, 
@@ -3789,9 +3942,12 @@
                 "weights": 105705.25
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/VBFHToGG_M120_TuneCP5_13TeV-amcatnlo-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/220926_130353/0000/myMicroAODOutputFile_24.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 108609.8515625
             }, 
             {
                 "bad": false, 
@@ -3834,9 +3990,12 @@
                 "weights": 107089.6875
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/VBFHToGG_M120_TuneCP5_13TeV-amcatnlo-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/220926_130353/0000/myMicroAODOutputFile_85.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 108908.4375
             }, 
             {
                 "bad": false, 
@@ -3863,9 +4022,12 @@
                 "weights": 105732.3984375
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/VBFHToGG_M120_TuneCP5_13TeV-amcatnlo-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/220926_130353/0000/myMicroAODOutputFile_28.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 106139.5859375
             }, 
             {
                 "bad": false, 
@@ -3892,9 +4054,12 @@
                 "weights": 105650.96875
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/VBFHToGG_M120_TuneCP5_13TeV-amcatnlo-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/220926_130353/0000/myMicroAODOutputFile_78.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 104565.1328125
             }, 
             {
                 "bad": false, 
@@ -3913,9 +4078,12 @@
                 "weights": 104728.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/VBFHToGG_M120_TuneCP5_13TeV-amcatnlo-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/220926_130353/0000/myMicroAODOutputFile_43.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 109179.8984375
             }, 
             {
                 "bad": false, 
@@ -3926,9 +4094,12 @@
                 "weights": 100520.4296875
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/VBFHToGG_M120_TuneCP5_13TeV-amcatnlo-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/220926_130353/0000/myMicroAODOutputFile_7.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 104510.84375
             }, 
             {
                 "bad": false, 
@@ -3963,9 +4134,12 @@
                 "weights": 108636.984375
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/VBFHToGG_M120_TuneCP5_13TeV-amcatnlo-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/220926_130353/0000/myMicroAODOutputFile_61.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 105569.5234375
             }, 
             {
                 "bad": false, 
@@ -4167,9 +4341,12 @@
                 "weights": 464.4625244140625
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 2232, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/WminusH_HToGG_WToAll_M120_TuneCP5_13TeV-powheg-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v1/220926_133231/0000/myMicroAODOutputFile_14.root", 
-                "nevents": 2232
+                "nevents": 2232, 
+                "totEvents": 2232, 
+                "weights": 1356.8568115234375
             }, 
             {
                 "bad": false, 
@@ -4204,9 +4381,12 @@
                 "weights": 7809.75390625
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 5208, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/WminusH_HToGG_WToAll_M120_TuneCP5_13TeV-powheg-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v1/220926_133231/0000/myMicroAODOutputFile_13.root", 
-                "nevents": 5208
+                "nevents": 5208, 
+                "totEvents": 5208, 
+                "weights": 3206.87890625
             }, 
             {
                 "bad": false, 
@@ -4233,9 +4413,12 @@
                 "weights": 9589.3251953125
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 5952, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/WminusH_HToGG_WToAll_M120_TuneCP5_13TeV-powheg-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v1/220926_133231/0000/myMicroAODOutputFile_8.root", 
-                "nevents": 5952
+                "nevents": 5952, 
+                "totEvents": 5952, 
+                "weights": 3692.21630859375
             }, 
             {
                 "bad": false, 
@@ -4286,9 +4469,12 @@
                 "weights": 15117.2138671875
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 22320, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/WminusH_HToGG_WToAll_M120_TuneCP5_13TeV-powheg-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v1/220926_133231/0000/myMicroAODOutputFile_4.root", 
-                "nevents": 22320
+                "nevents": 22320, 
+                "totEvents": 22320, 
+                "weights": 13798.1923828125
             }, 
             {
                 "bad": false, 
@@ -4315,9 +4501,12 @@
                 "weights": 13803.41015625
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24552, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/WminusH_HToGG_WToAll_M120_TuneCP5_13TeV-powheg-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v1/220926_133231/0000/myMicroAODOutputFile_22.root", 
-                "nevents": 24552
+                "nevents": 24552, 
+                "totEvents": 24552, 
+                "weights": 15173.3154296875
             }, 
             {
                 "bad": false, 
@@ -4367,9 +4556,12 @@
                 "weights": 25000.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/ZHiggs0PHToGG_M125_TuneCP5_13TeV-JHUGenV7011-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/220927_081751/0000/myMicroAODOutputFile_26.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 25000.0
             }, 
             {
                 "bad": false, 
@@ -4476,9 +4668,12 @@
                 "weights": 24000.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/ZHiggs0PHToGG_M125_TuneCP5_13TeV-JHUGenV7011-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/220927_081751/0000/myMicroAODOutputFile_7.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 25000.0
             }, 
             {
                 "bad": false, 
@@ -4712,9 +4907,12 @@
                 "weights": 25000.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/ZHiggs0PMToGG_M125_TuneCP5_13TeV-JHUGenV7011-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/220927_081956/0000/myMicroAODOutputFile_18.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 25000.0
             }, 
             {
                 "bad": false, 
@@ -4757,9 +4955,12 @@
                 "weights": 9000.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 9000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/ZHiggs0PMToGG_M125_TuneCP5_13TeV-JHUGenV7011-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/220927_081956/0000/myMicroAODOutputFile_20.root", 
-                "nevents": 9000
+                "nevents": 9000, 
+                "totEvents": 9000, 
+                "weights": 9000.0
             }, 
             {
                 "bad": false, 
@@ -4794,9 +4995,12 @@
                 "weights": 25000.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/ZHiggs0PMToGG_M125_TuneCP5_13TeV-JHUGenV7011-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/220927_081956/0000/myMicroAODOutputFile_19.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 25000.0
             }, 
             {
                 "bad": false, 
@@ -4863,9 +5067,12 @@
                 "weights": 25000.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/ZHiggs0PMToGG_M125_TuneCP5_13TeV-JHUGenV7011-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/220927_081956/0000/myMicroAODOutputFile_4.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 25000.0
             }, 
             {
                 "bad": false, 
@@ -4876,9 +5083,12 @@
                 "weights": 25000.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/ZHiggs0PMToGG_M125_TuneCP5_13TeV-JHUGenV7011-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/220927_081956/0000/myMicroAODOutputFile_1.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 25000.0
             }, 
             {
                 "bad": false, 
@@ -4921,9 +5131,12 @@
                 "weights": 25000.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/ZHiggs0PMToGG_M125_TuneCP5_13TeV-JHUGenV7011-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/220927_081956/0000/myMicroAODOutputFile_10.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 25000.0
             }, 
             {
                 "bad": false, 

--- a/MetaData/data/Era2018_legacy_v1_Summer20UL/datasets_14.json
+++ b/MetaData/data/Era2018_legacy_v1_Summer20UL/datasets_14.json
@@ -56,9 +56,12 @@
         "dset_type": "mc", 
         "files": [
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 15000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/GluGluHToGG_M130_13TeV-sherpa/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/240308_153955/0000/myMicroAODOutputFile_11.root", 
-                "nevents": 15000
+                "nevents": 15000, 
+                "totEvents": 15000, 
+                "weights": 4137.4169921875
             }, 
             {
                 "bad": false, 
@@ -181,14 +184,20 @@
                 "weights": 3298.000732421875
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 15000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/GluGluHToGG_M130_13TeV-sherpa/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/240308_153955/0000/myMicroAODOutputFile_24.root", 
-                "nevents": 15000
+                "nevents": 15000, 
+                "totEvents": 15000, 
+                "weights": 4133.02978515625
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/GluGluHToGG_M130_13TeV-sherpa/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/240308_153955/0000/myMicroAODOutputFile_3.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 6889.44970703125
             }, 
             {
                 "bad": false, 
@@ -1908,9 +1917,12 @@
                 "weights": 15000.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 4000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/VBFHiggs0PMToGG_M125_TuneCP5_13TeV-JHUGenV7011-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/220926_130139/0000/myMicroAODOutputFile_21.root", 
-                "nevents": 4000
+                "nevents": 4000, 
+                "totEvents": 4000, 
+                "weights": 4000.0
             }, 
             {
                 "bad": false, 
@@ -5467,9 +5479,12 @@
                 "weights": 25220.361328125
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 19777, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/ttHJetToGG_M120_TuneCP5_13TeV-amcatnloFXFX-madspin-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/220926_121332/0000/myMicroAODOutputFile_6.root", 
-                "nevents": 19777
+                "nevents": 19777, 
+                "totEvents": 19777, 
+                "weights": 20726.169921875
             }, 
             {
                 "bad": false, 
@@ -5488,9 +5503,12 @@
                 "weights": 25758.91015625
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 7540, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/ttHJetToGG_M120_TuneCP5_13TeV-amcatnloFXFX-madspin-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/220926_121332/0000/myMicroAODOutputFile_3.root", 
-                "nevents": 7540
+                "nevents": 7540, 
+                "totEvents": 7540, 
+                "weights": 8219.921875
             }, 
             {
                 "bad": false, 
@@ -5701,9 +5719,12 @@
                 "weights": 25336.88671875
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 16395, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/ttHJetToGG_M120_TuneCP5_13TeV-amcatnloFXFX-madspin-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/220926_121332/0000/myMicroAODOutputFile_26.root", 
-                "nevents": 16395
+                "nevents": 16395, 
+                "totEvents": 16395, 
+                "weights": 17079.173828125
             }, 
             {
                 "bad": false, 

--- a/MetaData/data/Era2018_legacy_v1_Summer20UL/datasets_5.json
+++ b/MetaData/data/Era2018_legacy_v1_Summer20UL/datasets_5.json
@@ -1465,9 +1465,12 @@
         "dset_type": "mc", 
         "files": [
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/DiPhotonJetsBox_MGG-80toInf_13TeV-sherpa/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/230503_125855/0000/myMicroAODOutputFile_559.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 11746.298828125
             }, 
             {
                 "bad": false, 
@@ -1534,9 +1537,12 @@
                 "weights": 11758.80078125
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/DiPhotonJetsBox_MGG-80toInf_13TeV-sherpa/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/230503_125855/0000/myMicroAODOutputFile_84.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 11715.4990234375
             }, 
             {
                 "bad": false, 
@@ -1571,9 +1577,12 @@
                 "weights": 11729.2998046875
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/DiPhotonJetsBox_MGG-80toInf_13TeV-sherpa/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/230503_125855/0000/myMicroAODOutputFile_546.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 11671.6015625
             }, 
             {
                 "bad": false, 
@@ -1752,9 +1761,12 @@
                 "weights": 11740.201171875
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/DiPhotonJetsBox_MGG-80toInf_13TeV-sherpa/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/230503_125855/0000/myMicroAODOutputFile_185.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 11720.3994140625
             }, 
             {
                 "bad": false, 
@@ -2109,9 +2121,12 @@
                 "weights": 11732.8994140625
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/DiPhotonJetsBox_MGG-80toInf_13TeV-sherpa/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/230503_125855/0000/myMicroAODOutputFile_305.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 11615.099609375
             }, 
             {
                 "bad": false, 
@@ -2186,14 +2201,20 @@
                 "weights": 11736.0986328125
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/DiPhotonJetsBox_MGG-80toInf_13TeV-sherpa/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/230503_125855/0000/myMicroAODOutputFile_263.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 11758.298828125
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/DiPhotonJetsBox_MGG-80toInf_13TeV-sherpa/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/230503_125855/0000/myMicroAODOutputFile_227.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 11659.7998046875
             }, 
             {
                 "bad": false, 
@@ -2332,9 +2353,12 @@
                 "weights": 11838.201171875
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/DiPhotonJetsBox_MGG-80toInf_13TeV-sherpa/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/230503_125855/0000/myMicroAODOutputFile_519.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 11716.5009765625
             }, 
             {
                 "bad": false, 
@@ -2361,9 +2385,12 @@
                 "weights": 11639.7998046875
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/DiPhotonJetsBox_MGG-80toInf_13TeV-sherpa/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/230503_125855/0000/myMicroAODOutputFile_226.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 11659.3984375
             }, 
             {
                 "bad": false, 
@@ -2446,9 +2473,12 @@
                 "weights": 11656.0009765625
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24999, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/DiPhotonJetsBox_MGG-80toInf_13TeV-sherpa/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/230503_125855/0000/myMicroAODOutputFile_198.root", 
-                "nevents": 24999
+                "nevents": 24999, 
+                "totEvents": 24999, 
+                "weights": 11763.099609375
             }, 
             {
                 "bad": false, 
@@ -2475,9 +2505,12 @@
                 "weights": 11644.8017578125
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24999, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/DiPhotonJetsBox_MGG-80toInf_13TeV-sherpa/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/230503_125855/0000/myMicroAODOutputFile_490.root", 
-                "nevents": 24999
+                "nevents": 24999, 
+                "totEvents": 24999, 
+                "weights": 11685.6005859375
             }, 
             {
                 "bad": false, 
@@ -2520,9 +2553,12 @@
                 "weights": 11791.099609375
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/DiPhotonJetsBox_MGG-80toInf_13TeV-sherpa/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/230503_125855/0000/myMicroAODOutputFile_28.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 11688.2001953125
             }, 
             {
                 "bad": false, 
@@ -2581,9 +2617,12 @@
                 "weights": 11756.5
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/DiPhotonJetsBox_MGG-80toInf_13TeV-sherpa/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/230503_125855/0000/myMicroAODOutputFile_231.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 11663.4990234375
             }, 
             {
                 "bad": false, 
@@ -2682,14 +2721,20 @@
                 "weights": 11711.2001953125
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/DiPhotonJetsBox_MGG-80toInf_13TeV-sherpa/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/230503_125855/0000/myMicroAODOutputFile_405.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 11630.2001953125
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/DiPhotonJetsBox_MGG-80toInf_13TeV-sherpa/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/230503_125855/0000/myMicroAODOutputFile_359.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 11779.3017578125
             }, 
             {
                 "bad": false, 
@@ -2932,9 +2977,12 @@
                 "weights": 11668.900390625
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24999, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/DiPhotonJetsBox_MGG-80toInf_13TeV-sherpa/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/230503_125855/0000/myMicroAODOutputFile_352.root", 
-                "nevents": 24999
+                "nevents": 24999, 
+                "totEvents": 24999, 
+                "weights": 11659.3994140625
             }, 
             {
                 "bad": false, 
@@ -3201,9 +3249,12 @@
                 "weights": 11695.69921875
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/DiPhotonJetsBox_MGG-80toInf_13TeV-sherpa/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/230503_125855/0000/myMicroAODOutputFile_401.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 11699.8994140625
             }, 
             {
                 "bad": false, 
@@ -3254,9 +3305,12 @@
                 "weights": 11601.80078125
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/DiPhotonJetsBox_MGG-80toInf_13TeV-sherpa/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/230503_125855/0000/myMicroAODOutputFile_323.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 11584.7001953125
             }, 
             {
                 "bad": false, 
@@ -3283,9 +3337,12 @@
                 "weights": 11757.7001953125
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/DiPhotonJetsBox_MGG-80toInf_13TeV-sherpa/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/230503_125855/0000/myMicroAODOutputFile_520.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 11751.1005859375
             }, 
             {
                 "bad": false, 
@@ -3352,9 +3409,12 @@
                 "weights": 924.4000244140625
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/DiPhotonJetsBox_MGG-80toInf_13TeV-sherpa/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/230503_125855/0000/myMicroAODOutputFile_56.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 11763.6005859375
             }, 
             {
                 "bad": false, 
@@ -3365,9 +3425,12 @@
                 "weights": 11589.5009765625
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/DiPhotonJetsBox_MGG-80toInf_13TeV-sherpa/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/230503_125855/0000/myMicroAODOutputFile_514.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 11748.798828125
             }, 
             {
                 "bad": false, 
@@ -3682,9 +3745,12 @@
                 "weights": 11716.30078125
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24998, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/DiPhotonJetsBox_MGG-80toInf_13TeV-sherpa/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/230503_125855/0000/myMicroAODOutputFile_536.root", 
-                "nevents": 24998
+                "nevents": 24998, 
+                "totEvents": 24998, 
+                "weights": 11679.099609375
             }, 
             {
                 "bad": false, 
@@ -3783,9 +3849,12 @@
                 "weights": 11763.3984375
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/DiPhotonJetsBox_MGG-80toInf_13TeV-sherpa/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/230503_125855/0000/myMicroAODOutputFile_434.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 11706.5
             }, 
             {
                 "bad": false, 
@@ -3812,9 +3881,12 @@
                 "weights": 11756.599609375
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/DiPhotonJetsBox_MGG-80toInf_13TeV-sherpa/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/230503_125855/0000/myMicroAODOutputFile_418.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 11794.2001953125
             }, 
             {
                 "bad": false, 
@@ -3889,9 +3961,12 @@
                 "weights": 11696.5986328125
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/DiPhotonJetsBox_MGG-80toInf_13TeV-sherpa/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/230503_125855/0000/myMicroAODOutputFile_426.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 11566.9990234375
             }, 
             {
                 "bad": false, 
@@ -4094,9 +4169,12 @@
                 "weights": 11644.900390625
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/DiPhotonJetsBox_MGG-80toInf_13TeV-sherpa/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/230503_125855/0000/myMicroAODOutputFile_467.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 11779.5009765625
             }, 
             {
                 "bad": false, 
@@ -4163,9 +4241,12 @@
                 "weights": 11715.6005859375
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/DiPhotonJetsBox_MGG-80toInf_13TeV-sherpa/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/230503_125855/0000/myMicroAODOutputFile_349.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 11772.599609375
             }, 
             {
                 "bad": false, 
@@ -4312,14 +4393,20 @@
                 "weights": 11600.900390625
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/DiPhotonJetsBox_MGG-80toInf_13TeV-sherpa/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/230503_125855/0000/myMicroAODOutputFile_85.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 11684.7998046875
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/DiPhotonJetsBox_MGG-80toInf_13TeV-sherpa/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/230503_125855/0000/myMicroAODOutputFile_31.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 11650.298828125
             }, 
             {
                 "bad": false, 
@@ -4362,9 +4449,12 @@
                 "weights": 11636.19921875
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24999, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/DiPhotonJetsBox_MGG-80toInf_13TeV-sherpa/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/230503_125855/0000/myMicroAODOutputFile_58.root", 
-                "nevents": 24999
+                "nevents": 24999, 
+                "totEvents": 24999, 
+                "weights": 11800.2001953125
             }, 
             {
                 "bad": false, 
@@ -4527,9 +4617,12 @@
                 "weights": 11771.4990234375
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/DiPhotonJetsBox_MGG-80toInf_13TeV-sherpa/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/230503_125855/0000/myMicroAODOutputFile_119.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 11695.80078125
             }, 
             {
                 "bad": false, 
@@ -4668,9 +4761,12 @@
                 "weights": 11784.4013671875
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/DiPhotonJetsBox_MGG-80toInf_13TeV-sherpa/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/230503_125855/0000/myMicroAODOutputFile_453.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 11757.5
             }, 
             {
                 "bad": false, 
@@ -4681,9 +4777,12 @@
                 "weights": 11650.3994140625
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/DiPhotonJetsBox_MGG-80toInf_13TeV-sherpa/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/230503_125855/0000/myMicroAODOutputFile_480.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 11784.099609375
             }, 
             {
                 "bad": false, 
@@ -4694,9 +4793,12 @@
                 "weights": 11779.701171875
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/DiPhotonJetsBox_MGG-80toInf_13TeV-sherpa/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/230503_125855/0000/myMicroAODOutputFile_284.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 11671.7001953125
             }, 
             {
                 "bad": false, 
@@ -4715,9 +4817,12 @@
                 "weights": 11760.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/DiPhotonJetsBox_MGG-80toInf_13TeV-sherpa/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/230503_125855/0000/myMicroAODOutputFile_290.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 11679.599609375
             }, 
             {
                 "bad": false, 
@@ -5072,9 +5177,12 @@
                 "weights": 11809.6005859375
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/DiPhotonJetsBox_MGG-80toInf_13TeV-sherpa/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/230503_125855/0000/myMicroAODOutputFile_501.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 11789.099609375
             }, 
             {
                 "bad": false, 
@@ -5221,14 +5329,20 @@
                 "weights": 11706.1982421875
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24999, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/DiPhotonJetsBox_MGG-80toInf_13TeV-sherpa/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/230503_125855/0000/myMicroAODOutputFile_229.root", 
-                "nevents": 24999
+                "nevents": 24999, 
+                "totEvents": 24999, 
+                "weights": 11659.2001953125
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/DiPhotonJetsBox_MGG-80toInf_13TeV-sherpa/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/230503_125855/0000/myMicroAODOutputFile_116.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 11710.8994140625
             }, 
             {
                 "bad": false, 
@@ -5503,14 +5617,20 @@
                 "weights": 11619.099609375
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/DiPhotonJetsBox_MGG-80toInf_13TeV-sherpa/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/230503_125855/0000/myMicroAODOutputFile_303.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 11639.2001953125
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/DiPhotonJetsBox_MGG-80toInf_13TeV-sherpa/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/230503_125855/0000/myMicroAODOutputFile_174.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 11725.701171875
             }, 
             {
                 "bad": false, 
@@ -5585,9 +5705,12 @@
                 "weights": 11678.19921875
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/DiPhotonJetsBox_MGG-80toInf_13TeV-sherpa/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/230503_125855/0000/myMicroAODOutputFile_505.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 11708.3994140625
             }, 
             {
                 "bad": false, 
@@ -5598,9 +5721,12 @@
                 "weights": 11729.7998046875
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/DiPhotonJetsBox_MGG-80toInf_13TeV-sherpa/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/230503_125855/0000/myMicroAODOutputFile_60.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 11719.2978515625
             }, 
             {
                 "bad": false, 
@@ -5611,9 +5737,12 @@
                 "weights": 11701.2998046875
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/DiPhotonJetsBox_MGG-80toInf_13TeV-sherpa/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/230503_125855/0000/myMicroAODOutputFile_281.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 11633.099609375
             }, 
             {
                 "bad": false, 
@@ -5752,9 +5881,12 @@
                 "weights": 11717.099609375
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/DiPhotonJetsBox_MGG-80toInf_13TeV-sherpa/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/230503_125855/0000/myMicroAODOutputFile_178.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 11572.8994140625
             }, 
             {
                 "bad": false, 
@@ -5781,9 +5913,12 @@
                 "weights": 11768.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/DiPhotonJetsBox_MGG-80toInf_13TeV-sherpa/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/230503_125855/0000/myMicroAODOutputFile_459.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 11618.5
             }, 
             {
                 "bad": false, 
@@ -5818,9 +5953,12 @@
                 "weights": 11734.7021484375
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/DiPhotonJetsBox_MGG-80toInf_13TeV-sherpa/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/230503_125855/0000/myMicroAODOutputFile_420.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 11745.0
             }, 
             {
                 "bad": false, 
@@ -7597,9 +7735,12 @@
                 "weights": 13000.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/WHiggs0Mf05ph0ToGG_M125_TuneCP5_13TeV-JHUGenV7011-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/220926_132132/0000/myMicroAODOutputFile_16.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 25000.0
             }, 
             {
                 "bad": false, 
@@ -7618,9 +7759,12 @@
                 "weights": 5000.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 3000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/WHiggs0Mf05ph0ToGG_M125_TuneCP5_13TeV-JHUGenV7011-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/220926_132132/0000/myMicroAODOutputFile_26.root", 
-                "nevents": 3000
+                "nevents": 3000, 
+                "totEvents": 3000, 
+                "weights": 3000.0
             }, 
             {
                 "bad": false, 
@@ -7687,9 +7831,12 @@
                 "weights": 3000.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 3000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/WHiggs0Mf05ph0ToGG_M125_TuneCP5_13TeV-JHUGenV7011-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/220926_132132/0000/myMicroAODOutputFile_11.root", 
-                "nevents": 3000
+                "nevents": 3000, 
+                "totEvents": 3000, 
+                "weights": 3000.0
             }, 
             {
                 "bad": false, 
@@ -7756,9 +7903,12 @@
                 "weights": 25000.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/WHiggs0Mf05ph0ToGG_M125_TuneCP5_13TeV-JHUGenV7011-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/220926_132132/0000/myMicroAODOutputFile_3.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 25000.0
             }, 
             {
                 "bad": false, 
@@ -7841,9 +7991,12 @@
                 "weights": 25000.0
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 25000, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/WHiggs0Mf05ph0ToGG_M125_TuneCP5_13TeV-JHUGenV7011-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/220926_132132/0000/myMicroAODOutputFile_38.root", 
-                "nevents": 25000
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": 25000.0
             }, 
             {
                 "bad": false, 

--- a/MetaData/data/Era2018_legacy_v1_Summer20UL/datasets_9.json
+++ b/MetaData/data/Era2018_legacy_v1_Summer20UL/datasets_9.json
@@ -3242,6 +3242,197 @@
         "parent_n_units": null, 
         "vetted": true
     }, 
+    "/GluGluHToGG_intqg_M120_13TeV-sherpa/phys_higgs-Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2-d14905ea5c6057223ff666bc6aa8d93d/USER": {
+        "dset_type": "mc", 
+        "files": [
+            {
+                "bad": false, 
+                "events": 14000, 
+                "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/GluGluHToGG_intqg_M120_13TeV-sherpa/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/240308_151007/0000/myMicroAODOutputFile_5.root", 
+                "nevents": 14000, 
+                "totEvents": 14000, 
+                "weights": -162.7824249267578
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/GluGluHToGG_intqg_M120_13TeV-sherpa/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/240308_151007/0000/myMicroAODOutputFile_3.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": -2777.696533203125
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/GluGluHToGG_intqg_M120_13TeV-sherpa/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/240308_151007/0000/myMicroAODOutputFile_6.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": -1553.799560546875
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/GluGluHToGG_intqg_M120_13TeV-sherpa/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/240308_151007/0000/myMicroAODOutputFile_10.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": -3612.5576171875
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/GluGluHToGG_intqg_M120_13TeV-sherpa/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/240308_151007/0000/myMicroAODOutputFile_21.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": -2312.430419921875
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/GluGluHToGG_intqg_M120_13TeV-sherpa/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/240308_151007/0000/myMicroAODOutputFile_16.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": -1211.667724609375
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/GluGluHToGG_intqg_M120_13TeV-sherpa/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/240308_151007/0000/myMicroAODOutputFile_17.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": -1786.8262939453125
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/GluGluHToGG_intqg_M120_13TeV-sherpa/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/240308_151007/0000/myMicroAODOutputFile_11.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": -2774.67138671875
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/GluGluHToGG_intqg_M120_13TeV-sherpa/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/240308_151007/0000/myMicroAODOutputFile_2.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": -5099.744140625
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/GluGluHToGG_intqg_M120_13TeV-sherpa/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/240308_151007/0000/myMicroAODOutputFile_22.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": -2378.634765625
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/GluGluHToGG_intqg_M120_13TeV-sherpa/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/240308_151007/0000/myMicroAODOutputFile_19.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": -2028.312255859375
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/GluGluHToGG_intqg_M120_13TeV-sherpa/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/240308_151007/0000/myMicroAODOutputFile_7.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": -3962.62939453125
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/GluGluHToGG_intqg_M120_13TeV-sherpa/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/240308_151007/0000/myMicroAODOutputFile_13.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": -999.6600341796875
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/GluGluHToGG_intqg_M120_13TeV-sherpa/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/240308_151007/0000/myMicroAODOutputFile_18.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": -3416.46630859375
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/GluGluHToGG_intqg_M120_13TeV-sherpa/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/240308_151007/0000/myMicroAODOutputFile_8.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": -3010.08544921875
+            }, 
+            {
+                "bad": false, 
+                "events": 23000, 
+                "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/GluGluHToGG_intqg_M120_13TeV-sherpa/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/240308_151007/0000/myMicroAODOutputFile_14.root", 
+                "nevents": 23000, 
+                "totEvents": 23000, 
+                "weights": -1647.8912353515625
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/GluGluHToGG_intqg_M120_13TeV-sherpa/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/240308_151007/0000/myMicroAODOutputFile_15.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": -1328.904052734375
+            }, 
+            {
+                "bad": false, 
+                "events": 3000, 
+                "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/GluGluHToGG_intqg_M120_13TeV-sherpa/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/240308_151007/0000/myMicroAODOutputFile_9.root", 
+                "nevents": 3000, 
+                "totEvents": 3000, 
+                "weights": 79.470947265625
+            }, 
+            {
+                "bad": false, 
+                "events": 9000, 
+                "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/GluGluHToGG_intqg_M120_13TeV-sherpa/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/240308_151007/0000/myMicroAODOutputFile_4.root", 
+                "nevents": 9000, 
+                "totEvents": 9000, 
+                "weights": -1389.7490234375
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/GluGluHToGG_intqg_M120_13TeV-sherpa/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/240308_151007/0000/myMicroAODOutputFile_12.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": -2375.3994140625
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/GluGluHToGG_intqg_M120_13TeV-sherpa/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/240308_151007/0000/myMicroAODOutputFile_20.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": -3948.156982421875
+            }, 
+            {
+                "bad": false, 
+                "events": 1000, 
+                "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/GluGluHToGG_intqg_M120_13TeV-sherpa/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/240308_151007/0000/myMicroAODOutputFile_23.root", 
+                "nevents": 1000, 
+                "totEvents": 1000, 
+                "weights": -13.698694229125977
+            }, 
+            {
+                "bad": false, 
+                "events": 25000, 
+                "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/GluGluHToGG_intqg_M120_13TeV-sherpa/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/240308_151007/0000/myMicroAODOutputFile_1.root", 
+                "nevents": 25000, 
+                "totEvents": 25000, 
+                "weights": -3776.1474609375
+            }
+        ], 
+        "parent_n_units": null, 
+        "vetted": true
+    }, 
     "/TprimeBToTH_Hgg_M-1000_LH_TuneCP5_PSweights_13TeV-madgraph_pythia8/phys_higgs-Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAOD-106X_upgrade2018_realistic_v11_L1v1-v2-97c275f549c87d4f369e8ebaadaaa94e/USER": {
         "dset_type": "mc", 
         "files": [

--- a/MetaData/data/Era2018_legacy_v1_Summer20UL/datasets_9.json
+++ b/MetaData/data/Era2018_legacy_v1_Summer20UL/datasets_9.json
@@ -3564,9 +3564,12 @@
                 "weights": 98109.109375
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 19894, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/VBFHToGG_M125_TuneCP5_13TeV-amcatnlo-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/220926_130814/0000/myMicroAODOutputFile_10.root", 
-                "nevents": 19894
+                "nevents": 19894, 
+                "totEvents": 19894, 
+                "weights": 80393.8671875
             }, 
             {
                 "bad": false, 
@@ -3617,9 +3620,12 @@
                 "weights": 45405.01171875
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24696, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/VBFHToGG_M125_TuneCP5_13TeV-amcatnlo-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/220926_130814/0000/myMicroAODOutputFile_36.root", 
-                "nevents": 24696
+                "nevents": 24696, 
+                "totEvents": 24696, 
+                "weights": 98524.7109375
             }, 
             {
                 "bad": false, 
@@ -3646,9 +3652,12 @@
                 "weights": 35430.453125
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24696, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/VBFHToGG_M125_TuneCP5_13TeV-amcatnlo-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/220926_130814/0000/myMicroAODOutputFile_37.root", 
-                "nevents": 24696
+                "nevents": 24696, 
+                "totEvents": 24696, 
+                "weights": 99277.9921875
             }, 
             {
                 "bad": false, 
@@ -3659,9 +3668,12 @@
                 "weights": 100031.28125
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24696, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/VBFHToGG_M125_TuneCP5_13TeV-amcatnlo-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/220926_130814/0000/myMicroAODOutputFile_85.root", 
-                "nevents": 24696
+                "nevents": 24696, 
+                "totEvents": 24696, 
+                "weights": 101459.9453125
             }, 
             {
                 "bad": false, 
@@ -3776,9 +3788,12 @@
                 "weights": 102135.3046875
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24696, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/VBFHToGG_M125_TuneCP5_13TeV-amcatnlo-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/220926_130814/0000/myMicroAODOutputFile_137.root", 
-                "nevents": 24696
+                "nevents": 24696, 
+                "totEvents": 24696, 
+                "weights": 98420.828125
             }, 
             {
                 "bad": false, 
@@ -3789,9 +3804,12 @@
                 "weights": 38079.9453125
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24696, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/VBFHToGG_M125_TuneCP5_13TeV-amcatnlo-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/220926_130814/0000/myMicroAODOutputFile_121.root", 
-                "nevents": 24696
+                "nevents": 24696, 
+                "totEvents": 24696, 
+                "weights": 97251.90625
             }, 
             {
                 "bad": false, 
@@ -3914,9 +3932,12 @@
                 "weights": 51405.32421875
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 8232, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/VBFHToGG_M125_TuneCP5_13TeV-amcatnlo-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/220926_130814/0000/myMicroAODOutputFile_29.root", 
-                "nevents": 8232
+                "nevents": 8232, 
+                "totEvents": 8232, 
+                "weights": 32677.0625
             }, 
             {
                 "bad": false, 
@@ -4047,9 +4068,12 @@
                 "weights": 99407.8671875
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24696, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/VBFHToGG_M125_TuneCP5_13TeV-amcatnlo-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/220926_130814/0000/myMicroAODOutputFile_172.root", 
-                "nevents": 24696
+                "nevents": 24696, 
+                "totEvents": 24696, 
+                "weights": 96680.453125
             }, 
             {
                 "bad": false, 
@@ -4084,9 +4108,12 @@
                 "weights": 104083.453125
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24696, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/VBFHToGG_M125_TuneCP5_13TeV-amcatnlo-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/220926_130814/0000/myMicroAODOutputFile_61.root", 
-                "nevents": 24696
+                "nevents": 24696, 
+                "totEvents": 24696, 
+                "weights": 98784.46875
             }, 
             {
                 "bad": false, 
@@ -4121,9 +4148,12 @@
                 "weights": 101070.3046875
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24696, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/VBFHToGG_M125_TuneCP5_13TeV-amcatnlo-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/220926_130814/0000/myMicroAODOutputFile_70.root", 
-                "nevents": 24696
+                "nevents": 24696, 
+                "totEvents": 24696, 
+                "weights": 97979.234375
             }, 
             {
                 "bad": false, 
@@ -4198,14 +4228,20 @@
                 "weights": 98498.7421875
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24696, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/VBFHToGG_M125_TuneCP5_13TeV-amcatnlo-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/220926_130814/0000/myMicroAODOutputFile_7.root", 
-                "nevents": 24696
+                "nevents": 24696, 
+                "totEvents": 24696, 
+                "weights": 98005.2109375
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24696, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/VBFHToGG_M125_TuneCP5_13TeV-amcatnlo-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/220926_130814/0000/myMicroAODOutputFile_90.root", 
-                "nevents": 24696
+                "nevents": 24696, 
+                "totEvents": 24696, 
+                "weights": 102966.5
             }, 
             {
                 "bad": false, 
@@ -4224,9 +4260,12 @@
                 "weights": 101745.6640625
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24696, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/VBFHToGG_M125_TuneCP5_13TeV-amcatnlo-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/220926_130814/0000/myMicroAODOutputFile_3.root", 
-                "nevents": 24696
+                "nevents": 24696, 
+                "totEvents": 24696, 
+                "weights": 99953.359375
             }, 
             {
                 "bad": false, 
@@ -4293,9 +4332,12 @@
                 "weights": 97797.40625
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24696, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/VBFHToGG_M125_TuneCP5_13TeV-amcatnlo-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/220926_130814/0000/myMicroAODOutputFile_113.root", 
-                "nevents": 24696
+                "nevents": 24696, 
+                "totEvents": 24696, 
+                "weights": 98316.90625
             }, 
             {
                 "bad": false, 
@@ -4482,9 +4524,12 @@
                 "weights": 96264.859375
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24696, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/VBFHToGG_M125_TuneCP5_13TeV-amcatnlo-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/220926_130814/0000/myMicroAODOutputFile_79.root", 
-                "nevents": 24696
+                "nevents": 24696, 
+                "totEvents": 24696, 
+                "weights": 102395.0546875
             }, 
             {
                 "bad": false, 
@@ -4599,9 +4644,12 @@
                 "weights": 98602.640625
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24696, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/VBFHToGG_M125_TuneCP5_13TeV-amcatnlo-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/220926_130814/0000/myMicroAODOutputFile_72.root", 
-                "nevents": 24696
+                "nevents": 24696, 
+                "totEvents": 24696, 
+                "weights": 96602.5625
             }, 
             {
                 "bad": false, 
@@ -4668,9 +4716,12 @@
                 "weights": 96914.2578125
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24696, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/VBFHToGG_M125_TuneCP5_13TeV-amcatnlo-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/220926_130814/0000/myMicroAODOutputFile_75.root", 
-                "nevents": 24696
+                "nevents": 24696, 
+                "totEvents": 24696, 
+                "weights": 102161.296875
             }, 
             {
                 "bad": false, 
@@ -4705,9 +4756,12 @@
                 "weights": 102031.390625
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24696, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/VBFHToGG_M125_TuneCP5_13TeV-amcatnlo-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/220926_130814/0000/myMicroAODOutputFile_173.root", 
-                "nevents": 24696
+                "nevents": 24696, 
+                "totEvents": 24696, 
+                "weights": 102421.015625
             }, 
             {
                 "bad": false, 
@@ -4734,14 +4788,20 @@
                 "weights": 98161.0546875
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 16464, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/VBFHToGG_M125_TuneCP5_13TeV-amcatnlo-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/220926_130814/0000/myMicroAODOutputFile_174.root", 
-                "nevents": 16464
+                "nevents": 16464, 
+                "totEvents": 16464, 
+                "weights": 66029.484375
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24696, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/VBFHToGG_M125_TuneCP5_13TeV-amcatnlo-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/220926_130814/0000/myMicroAODOutputFile_162.root", 
-                "nevents": 24696
+                "nevents": 24696, 
+                "totEvents": 24696, 
+                "weights": 99979.328125
             }, 
             {
                 "bad": false, 
@@ -5533,9 +5593,12 @@
                 "weights": 23788.046875
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 15195, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/ttHJetToGG_M125_TuneCP5_13TeV-amcatnloFXFX-madspin-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/220926_121757/0000/myMicroAODOutputFile_39.root", 
-                "nevents": 15195
+                "nevents": 15195, 
+                "totEvents": 15195, 
+                "weights": 13324.12109375
             }, 
             {
                 "bad": false, 
@@ -5618,9 +5681,12 @@
                 "weights": 20052.337890625
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 12833, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/ttHJetToGG_M125_TuneCP5_13TeV-amcatnloFXFX-madspin-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/220926_121757/0000/myMicroAODOutputFile_33.root", 
-                "nevents": 12833
+                "nevents": 12833, 
+                "totEvents": 12833, 
+                "weights": 12507.7255859375
             }, 
             {
                 "bad": false, 
@@ -5679,9 +5745,12 @@
                 "weights": 22864.673828125
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 24797, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/ttHJetToGG_M125_TuneCP5_13TeV-amcatnloFXFX-madspin-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/220926_121757/0000/myMicroAODOutputFile_34.root", 
-                "nevents": 24797
+                "nevents": 24797, 
+                "totEvents": 24797, 
+                "weights": 23149.00390625
             }, 
             {
                 "bad": false, 
@@ -5716,9 +5785,12 @@
                 "weights": 22870.306640625
             }, 
             {
-                "bad": true, 
+                "bad": false, 
+                "events": 19564, 
                 "name": "/store/group/phys_higgs/cmshgg/emanuele/flashgg/Era2018_legacy_v1_Summer20UL/legacyRunII/ttHJetToGG_M125_TuneCP5_13TeV-amcatnloFXFX-madspin-pythia8/Era2018_legacy_v1_Summer20UL-legacyRunII-v0-RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/220926_121757/0000/myMicroAODOutputFile_41.root", 
-                "nevents": 19564
+                "nevents": 19564, 
+                "totEvents": 19564, 
+                "weights": 18287.236328125
             }, 
             {
                 "bad": false, 


### PR DESCRIPTION
Two commits:
* re-run the check scripts to fix the MC catalogs invalidating the files which are now missing in Rome which were lost because of disks broke in April 2024
* add the sample ggH - qg interference for mH=120 GeV

