### PR TITLE
Add the missing dependence

### DIFF
--- a/MicroAOD/plugins/BuildFile.xml
+++ b/MicroAOD/plugins/BuildFile.xml
@@ -17,6 +17,7 @@
 <use   name="RecoBTag/FeatureTools"/>
 <use   name="PhysicsTools/ONNXRuntime"/>
 <use   name="roottmva"/>
+<use   name="json"/>
 <!-- <use   name="HiggsAnalysis/GBRLikelihoodEGTools"/> -->
 <flags   EDM_PLUGIN="1"/>
 </library>


### PR DESCRIPTION
Add the missing dependence that causes the compile failure when using the  ```cmssw-el7``` singularity environment. 